### PR TITLE
improve Landlock ABI error messages with actionable fix instructions

### DIFF
--- a/internal/sandboxrun/backend_linux.go
+++ b/internal/sandboxrun/backend_linux.go
@@ -27,6 +27,21 @@ func CheckPlatform() error {
 	return nil
 }
 
+// kernelVersionString returns the running kernel version string from
+// /proc/version (e.g. "6.1.0-28-amd64"). Returns "unknown" on failure.
+func kernelVersionString() string {
+	data, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return "unknown"
+	}
+	// Format: "Linux version 6.19.11-200.fc43.x86_64 (builder@...) ..."
+	fields := strings.Fields(string(data))
+	if len(fields) >= 3 {
+		return fields[2]
+	}
+	return strings.TrimSpace(string(data))
+}
+
 func firstLine(b []byte) string {
 	s := strings.TrimSpace(string(b))
 	if i := strings.IndexByte(s, '\n'); i >= 0 {
@@ -48,9 +63,13 @@ func BuildChildArgv(g *Grants, innerArgv []string) ([]string, error) {
 		g.NetworkMode == sandboxprofile.ModeBlocked
 	if needsLandlock && !LandlockNetSupported() {
 		return nil, fmt.Errorf(
-			"kernel-enforced network filtering needs Landlock ABI >= 4 (Linux >= 6.7); this kernel has ABI %d.\n"+
-				"Either upgrade the kernel or set network.enforcement to \"env-only\" in the sandbox profile (WARNING: advisory-only filtering)",
-			LandlockABI())
+			"kernel-enforced network filtering needs Landlock ABI >= 4 (Linux >= 6.7, e.g. Ubuntu 24.04 LTS, Fedora 40+);\n"+
+				"this kernel has ABI %d (%s).\n"+
+				"Fix A: upgrade to a kernel >= 6.7.\n"+
+				"Fix B: set enforcement to env-only in ~/.config/omac/sandbox-profiles/default.json:\n"+
+				"  {\"network\": {\"enforcement\": \"env-only\"}}\n"+
+				"(env-only: filtering via the omac proxy, not the kernel — advisory only)",
+			LandlockABI(), kernelVersionString())
 	}
 	self, err := os.Executable()
 	if err != nil {

--- a/internal/sandboxrun/doctor_linux.go
+++ b/internal/sandboxrun/doctor_linux.go
@@ -2,13 +2,26 @@
 
 package sandboxrun
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
+)
 
 // DoctorNotes returns extra platform diagnostics for `omac doctor`.
 func DoctorNotes() []string {
 	abi := LandlockABI()
 	if abi >= landlockNetABI {
 		return []string{fmt.Sprintf("[ok] Landlock ABI %d (network rules supported)", abi)}
+	}
+	envOnlyActive := false
+	if p, _, err := sandboxprofile.Resolve(""); err == nil {
+		envOnlyActive = p.Network.EffectiveEnforcement() == sandboxprofile.EnforceEnvOnly
+	}
+	if envOnlyActive {
+		return []string{fmt.Sprintf(
+			"[warn] Landlock ABI %d < %d (kernel < 6.7): network.enforcement is already \"env-only\" — advisory filtering active",
+			abi, landlockNetABI)}
 	}
 	return []string{
 		fmt.Sprintf(

--- a/internal/sandboxrun/doctor_linux.go
+++ b/internal/sandboxrun/doctor_linux.go
@@ -10,8 +10,14 @@ func DoctorNotes() []string {
 	if abi >= landlockNetABI {
 		return []string{fmt.Sprintf("[ok] Landlock ABI %d (network rules supported)", abi)}
 	}
-	return []string{fmt.Sprintf(
-		"[warn] Landlock ABI %d < %d (kernel < 6.7): kernel-enforced network filtering unavailable; "+
-			"filtered mode fails closed unless the sandbox profile sets network.enforcement to \"env-only\"",
-		abi, landlockNetABI)}
+	return []string{
+		fmt.Sprintf(
+			"[warn] Landlock ABI %d (%s): network enforcement needs ABI %d (Linux >= 6.7,"+
+				" e.g. Ubuntu 24.04 LTS, Fedora 40+); omac start will fail with the default profile.",
+			abi, kernelVersionString(), landlockNetABI),
+		"       Fix A: upgrade to a kernel >= 6.7.",
+		"       Fix B: set enforcement to env-only in ~/.config/omac/sandbox-profiles/default.json:",
+		`         {"network": {"enforcement": "env-only"}}`,
+		"       (env-only: filtering via the omac proxy, not the kernel — advisory only)",
+	}
 }


### PR DESCRIPTION
Both the omac doctor warn and the omac start hard-error now include the running kernel version string (from /proc/version), the required ABI, example distros that satisfy the requirement, and two explicit fix paths: upgrade the kernel or set enforcement to env-only with the exact JSON snippet and profile path.