### PR TITLE
Feature/install register separation

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -117,7 +117,7 @@ func commands() map[string]Command {
 	return map[string]Command{
 		"register":   {Name: "register", Short: "Register a skill's sidecar in this workdir.", Run: runRegister},
 		"deregister": {Name: "deregister", Short: "Deregister a skill's sidecar.", Run: runDeregister},
-		"list":       {Name: "list", Short: "List registered skills.", Run: runList},
+		"list":       {Name: "list", Short: "List installed and registered skills.", Run: runList},
 		"secrets":    {Name: "secrets", Short: "Manage skill secrets in the OS keychain.", Run: runSecrets},
 		"config":     {Name: "config", Short: "Show resolved config + secret fingerprints for a skill.", Run: runConfig},
 		"start":      {Name: "start", Short: "Start sidecars + facade + sandbox. Optional [harness]: opencode|claude.", Run: runStart},
@@ -140,13 +140,21 @@ func printUsage(w *os.File) {
 Usage:
   omac [--workdir <dir>] <subcommand> [flags] [args]
 
+Skill lifecycle (install → register → use → deregister):
+  A skill is "installed" when its directory exists on disk (.opencode/skills/<name>/).
+  It must also be "registered" (omac register) to be loaded by omac start.
+  Declare skills in .opencode/skills.yaml and omac start will install+register them automatically.
+  Use omac start --prune to also remove skills not listed in that file.
+  Remove a skill with omac deregister <skill> (add --purge-secrets --purge-fields --purge-defaults
+  for a full uninstall; user-global removals warn every other project once).
+
 Subcommands:
   register     Register a skill's sidecar in this workdir.
-  deregister   Deregister a skill's sidecar.
-  list         List registered skills.
+  deregister   Deregister a skill's sidecar (also deletes its directory when unregistered).
+  list         List installed and registered skills (STATUS column shows state).
   secrets      Manage skill secrets in the OS keychain.
   config       Show resolved config + secret fingerprints for a skill.
-  start        Start sidecars + facade + sandbox.       [harness]: opencode|claude
+  start        Start sidecars + facade + sandbox.       [harness]: opencode|claude  [--prune]
   serve        Long-lived multi-directory server.        [harness]: opencode|claude
   plugin       Install client-side bridge plugins (e.g. opencode-desktop).
   sandbox      Built-in kernel sandbox: omac sandbox run [flags] -- <cmd>.

--- a/internal/cli/deregister.go
+++ b/internal/cli/deregister.go
@@ -31,8 +31,10 @@ func runDeregister(args []string, env *Env) int {
 		fmt.Fprintln(env.Stderr, "Usage: omac deregister <skill> [--global] [--harness <name>] [--yes] [--purge-secrets] [--purge-fields] [--purge-defaults]")
 		fmt.Fprintln(env.Stderr, "       omac deregister --prune   # remove all stale registrations")
 		fmt.Fprintln(env.Stderr, "\nRemoves the skill from the registry. If the skill was never registered but")
-		fmt.Fprintln(env.Stderr, "still exists on disk (so `omac start` keeps flagging it), its source directory")
-		fmt.Fprintln(env.Stderr, "is deleted instead (after confirmation, or immediately with --yes).")
+		fmt.Fprintln(env.Stderr, "still exists on disk, its source directory is deleted instead (after")
+		fmt.Fprintln(env.Stderr, "confirmation, or immediately with --yes). Removing a user-global skill")
+		fmt.Fprintln(env.Stderr, "(--purge-secrets or directory deletion) records a tombstone so every other")
+		fmt.Fprintln(env.Stderr, "project that had it registered sees a one-time warning on its next omac start.")
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(reorderFlagsFirst(args)); err != nil {
@@ -128,20 +130,35 @@ func runDeregister(args []string, env *Env) int {
 			return ExitKeychainError
 		}
 		fmt.Fprintf(env.Stdout, "[ok] deregistered %s; deleted %d secret(s) from keychain", name, len(declared))
+		// A user-global skill being purged affects every project that has
+		// it registered: those projects will silently lose the skill on
+		// their next omac start because the directory is gone. Record a
+		// tombstone so each of those projects gets a one-time warning.
+		if global {
+			if err := recordGlobalRemoval(name); err != nil {
+				fmt.Fprintf(env.Stderr, "\nomac deregister: could not record removal for other projects: %v\n", err)
+			}
+		}
 	} else if existed {
 		fmt.Fprintf(env.Stdout, "[ok] deregistered %s; kept %d secret(s) in keychain (use --purge-secrets to remove)", name, len(declared))
 	} else {
 		// Not in the registry. The skill may still exist on disk as a
-		// discovered-but-unregistered skill (omac start refuses to run
-		// with those). `omac deregister <skill>` should still get rid of
-		// it: locate its source directory and remove it. This is
-		// destructive, so confirm unless --yes / a non-interactive
-		// stdin says otherwise.
-		if removed, dir, derr := deleteUnregisteredSource(env, name, harnessKey, *assumeYes); derr != nil {
+		// discovered-but-unregistered skill. `omac deregister <skill>`
+		// should still get rid of it: locate its source directory and
+		// remove it. This is destructive, so confirm unless --yes / a
+		// non-interactive stdin says otherwise.
+		removed, dir, globalOnDisk, derr := deleteUnregisteredSource(env, name, harnessKey, *assumeYes)
+		if derr != nil {
 			fmt.Fprintln(env.Stderr, "\nomac deregister:", derr)
 			return ExitIOError
 		} else if removed {
 			fmt.Fprintf(env.Stdout, "[ok] deleted unregistered skill %s (removed %s)", name, dir)
+			// Same tombstone for user-global on-disk skills.
+			if globalOnDisk {
+				if err := recordGlobalRemoval(name); err != nil {
+					fmt.Fprintf(env.Stderr, "\nomac deregister: could not record removal for other projects: %v\n", err)
+				}
+			}
 		} else if dir != "" {
 			// Found on disk but the user declined.
 			fmt.Fprintf(env.Stdout, "[noop] %s left in place at %s", name, dir)
@@ -194,17 +211,18 @@ func runDeregister(args []string, env *Env) int {
 
 // deleteUnregisteredSource handles `omac deregister <skill>` when the
 // skill has no registry entry but still exists on disk as a discovered
-// skill (which is exactly what makes `omac start` refuse to run). It
-// locates the skill's source directory and deletes it.
+// skill. It locates the skill's source directory and deletes it.
 //
-// Returns (removed, dir, err): removed is true when the directory was
-// deleted; dir is the source directory found (empty when no skill of
-// that name exists on disk); a non-nil err is an I/O failure.
+// Returns (removed, dir, global, err): removed is true when the directory
+// was deleted; dir is the source directory found (empty when no skill of
+// that name exists on disk); global is true when the resolved skill lives
+// under a user-global root (so the caller can write a tombstone); a
+// non-nil err is an I/O failure.
 //
 // harnessKey scopes discovery when the caller passed --harness; empty
 // means search every harness's scope so `omac deregister <skill>`
 // works without the user having to remember which harness owns it.
-func deleteUnregisteredSource(env *Env, name, harnessKey string, assumeYes bool) (bool, string, error) {
+func deleteUnregisteredSource(env *Env, name, harnessKey string, assumeYes bool) (bool, string, bool, error) {
 	harnesses := config.AllHarnesses()
 	if harnessKey != "" {
 		if h, ok := config.LookupHarness(harnessKey); ok {
@@ -212,14 +230,16 @@ func deleteUnregisteredSource(env *Env, name, harnessKey string, assumeYes bool)
 		}
 	}
 	dir := ""
+	global := false
 	for _, h := range harnesses {
-		if d, _, err := skillsource.Resolve(env.Workdir, h, name); err == nil {
+		if d, src, err := skillsource.Resolve(env.Workdir, h, name); err == nil {
 			dir = d
+			global = src.Kind == "user-global"
 			break
 		}
 	}
 	if dir == "" {
-		return false, "", nil
+		return false, "", false, nil
 	}
 	if !assumeYes {
 		fmt.Fprintf(env.Stdout, "%s is not registered but exists on disk at:\n  %s\nDelete this directory? [y/N] ", name, dir)
@@ -227,13 +247,107 @@ func deleteUnregisteredSource(env *Env, name, harnessKey string, assumeYes bool)
 		answer, _ := reader.ReadString('\n')
 		answer = strings.ToLower(strings.TrimSpace(answer))
 		if answer != "y" && answer != "yes" {
-			return false, dir, nil
+			return false, dir, global, nil
 		}
 	}
 	if err := os.RemoveAll(dir); err != nil {
-		return false, dir, fmt.Errorf("delete %s: %w", dir, err)
+		return false, dir, global, fmt.Errorf("delete %s: %w", dir, err)
 	}
-	return true, dir, nil
+	return true, dir, global, nil
+}
+
+// deregisterSkill removes a skill from the registry and, when purgeAll is
+// true, also wipes its secrets, config fields, and remembered defaults.
+// It does NOT remove the on-disk skill directory — callers handle that
+// separately (runDeregister via deleteUnregisteredSource, sync.go via
+// os.RemoveAll). The global flag forces the user-global layer; when false
+// the layer is auto-detected the same way runDeregister does it.
+//
+// Used by runDeregister (via --purge-secrets --purge-fields --purge-defaults)
+// and by the skills.yaml sync/prune path in sync.go so the two stay in sync.
+func deregisterSkill(name, harnessKey string, env *Env, global, purgeAll bool) int {
+	var declared []string
+	var removedFields int
+
+	if err := withRegistryLock(env.Workdir, global, func() error {
+		reg, err := loadRegistry(env.Workdir, global)
+		if err != nil {
+			return err
+		}
+		if e, _ := reg.FindForHarness(name, harnessKey); e != nil {
+			declared = e.DeclaredSecretNames
+		}
+		if harnessKey != "" {
+			reg.RemoveForHarness(name, harnessKey)
+		} else {
+			reg.Remove(name)
+		}
+		if err := saveRegistry(env.Workdir, global, reg); err != nil {
+			return err
+		}
+		if purgeAll {
+			store, err := loadSkillConfig(env.Workdir, global)
+			if err != nil {
+				return err
+			}
+			removedFields = len(store.FieldsFor(name))
+			if store.RemoveSkill(name) {
+				if err := saveSkillConfig(env.Workdir, global, store); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintln(env.Stderr, "omac deregister:", err)
+		return ExitIOError
+	}
+
+	if purgeAll {
+		if err := keychain.DeleteAll(name, declared); err != nil {
+			fmt.Fprintln(env.Stderr, "omac deregister: keychain:", err)
+			return ExitKeychainError
+		}
+		fmt.Fprintf(env.Stdout, "[ok] deregistered %s; deleted %d secret(s) from keychain", name, len(declared))
+		// Purge remembered global defaults.
+		_ = keychain.DeleteAllScoped(keychain.DefaultsScope, name, declared)
+		if err := registry.WithGlobalLock(func() error {
+			store, err := loadSkillConfig(env.Workdir, true)
+			if err != nil {
+				return err
+			}
+			if store.RemoveDefaults(name) {
+				return saveSkillConfig(env.Workdir, true, store)
+			}
+			return nil
+		}); err != nil {
+			fmt.Fprintln(env.Stderr, "\nomac deregister: purge defaults:", err)
+			return ExitIOError
+		}
+		// Record tombstone so other projects warn once.
+		if global {
+			if err := recordGlobalRemoval(name); err != nil {
+				fmt.Fprintf(env.Stderr, "\nomac deregister: could not record removal for other projects: %v\n", err)
+			}
+		}
+	} else {
+		fmt.Fprintf(env.Stdout, "[ok] deregistered %s; kept %d secret(s) in keychain (use --purge-secrets to remove)", name, len(declared))
+	}
+	if purgeAll {
+		fmt.Fprintf(env.Stdout, "; deleted %d config field(s); purged remembered defaults", removedFields)
+	}
+	fmt.Fprintln(env.Stdout)
+
+	if global {
+		if ok, msg := notifyReloadGlobal(); ok {
+			fmt.Fprintf(env.Stdout, "[ok] %s\n", msg)
+		}
+	} else {
+		if ok, msg := notifyReload(env.Workdir); ok {
+			fmt.Fprintf(env.Stdout, "[ok] %s\n", msg)
+		}
+	}
+	return ExitOK
 }
 
 // runDeregisterPrune removes every registry entry, in both the workdir

--- a/internal/cli/global_register_test.go
+++ b/internal/cli/global_register_test.go
@@ -112,7 +112,7 @@ func TestStartSeesGloballyRegisteredSkill(t *testing.T) {
 	// Merge the empty workdir registry with the global one, the way
 	// runStart does, then verify nothing is reported unregistered.
 	merged := mergeRegistries(greg, &registry.Registry{})
-	unreg, err := findUnregisteredSkills(wd, config.DefaultHarness(), merged)
+	_, unreg, err := findUnregisteredSkills(wd, config.DefaultHarness(), merged)
 	if err != nil {
 		t.Fatalf("findUnregisteredSkills: %v", err)
 	}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"text/tabwriter"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/registry"
+	"github.com/tngtech/oh-my-agentic-coder/internal/skillsource"
 )
 
 // wellKnownInterpreters is the set of command[0] values that indicate the
@@ -53,13 +55,23 @@ func skillArtifactCandidate(command []string) string {
 func runList(args []string, env *Env) int {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
 	fs.SetOutput(env.Stderr)
-	showAll := fs.Bool("all", false, "Also list stale registrations whose skill directory no longer exists on disk.")
+	harnessName := fs.String("harness", "", "Harness scope for discovering installed skills (opencode|claude). Default: opencode.")
 	fs.Usage = func() {
-		fmt.Fprintln(env.Stderr, "Usage: omac list [--all]")
+		fmt.Fprintln(env.Stderr, "Usage: omac list [--harness <name>]")
 		fs.PrintDefaults()
 	}
-	if err := fs.Parse(reorderFlagsFirst(args)); err != nil {
+	if err := fs.Parse(args); err != nil {
 		return ExitMisuse
+	}
+
+	harness := config.DefaultHarness()
+	if *harnessName != "" {
+		h, ok := config.LookupHarness(*harnessName)
+		if !ok {
+			fmt.Fprintln(env.Stderr, "omac list:", config.UnknownHarnessError(*harnessName))
+			return ExitMisuse
+		}
+		harness = h
 	}
 
 	workdirReg, err := registry.Load(env.Workdir)
@@ -79,16 +91,32 @@ func runList(args []string, env *Env) int {
 		workdirNames[e.Name] = struct{}{}
 	}
 	reg := mergeRegistries(globalReg, workdirReg)
-	if len(reg.Registered) == 0 {
-		fmt.Fprintln(env.Stdout, "(no skills registered in this workdir or globally)")
-		return ExitOK
+
+	// Discover on-disk skills (installed but possibly not registered).
+	discovered, err := skillsource.Discover(env.Workdir, harness)
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "omac list: scan skills:", err)
+		return ExitIOError
+	}
+	discoveredByName := map[string]skillsource.Entry{}
+	for _, d := range discovered {
+		discoveredByName[d.Name] = d
 	}
 
-	tw := tabwriter.NewWriter(env.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tSCOPE\tMOUNT\tSECRETS\tBINARY-PRESENT\tREGISTERED")
+	type listRow struct {
+		status        string // "registered" | "installed" | "missing"
+		name          string
+		scope         string // "workdir" | "global"
+		mount         string
+		secrets       int
+		binaryPresent string
+		registered    string // timestamp or "-"
+	}
 
-	var stale []staleEntry
-	shown := 0
+	rowsByName := map[string]*listRow{}
+	var order []string
+
+	// Registered skills first.
 	for _, e := range reg.Registered {
 		scope := "global"
 		if _, ok := workdirNames[e.Name]; ok {
@@ -103,21 +131,15 @@ func runList(args []string, env *Env) int {
 		}
 		metaPath := filepath.Join(absDir, config.MetaFileName)
 		m, metaErr := config.LoadMeta(metaPath)
-		// A skill whose directory / omac.yaml no longer exists is a
-		// stale registration: the on-disk skill is gone even though a
-		// registry entry (possibly in the global layer) survives. Do
-		// NOT list it as a live skill — that was the source of "deleted
-		// the .opencode dir but the skill still shows up".
-		if metaErr != nil || m.Sidecar == nil {
-			stale = append(stale, staleEntry{name: e.Name, scope: scope, dir: absDir})
-			if !*showAll {
-				continue
-			}
-		}
-
+		status := "registered"
 		var mount string
 		binaryPresent := "?"
-		if metaErr == nil && m.Sidecar != nil {
+		if metaErr != nil || m.Sidecar == nil {
+			// On-disk skill is gone even though a registry entry survives.
+			status = "missing"
+			mount = "(stale: skill directory missing)"
+			binaryPresent = "no"
+		} else {
 			mount = m.Sidecar.MountOrDefault(e.Name)
 			if candidate := skillArtifactCandidate(m.Sidecar.Command); candidate != "" {
 				abs := candidate
@@ -133,41 +155,97 @@ func runList(args []string, env *Env) int {
 					binaryPresent = "no"
 				}
 			}
-		} else {
-			mount = "(stale: skill directory missing)"
-			binaryPresent = "no"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t/%s/\t%d\t%s\t%s\n",
-			e.Name, scope, mount, len(e.DeclaredSecretNames), binaryPresent,
-			e.RegisteredAt.Format("2006-01-02 15:04"))
-		shown++
+		rowsByName[e.Name] = &listRow{
+			status:        status,
+			name:          e.Name,
+			scope:         scope,
+			mount:         mount,
+			secrets:       len(e.DeclaredSecretNames),
+			binaryPresent: binaryPresent,
+			registered:    e.RegisteredAt.Format("2006-01-02 15:04"),
+		}
+		order = append(order, e.Name)
+	}
+
+	// On-disk skills not in the registry (installed but not registered).
+	var installedNames []string
+	for _, d := range discovered {
+		if _, inReg := rowsByName[d.Name]; !inReg {
+			installedNames = append(installedNames, d.Name)
+		}
+	}
+	sort.Strings(installedNames)
+	for _, name := range installedNames {
+		d := discoveredByName[name]
+		mount := name
+		secrets := 0
+		binaryPresent := "?"
+		if m, err := config.LoadMeta(filepath.Join(d.Dir, config.MetaFileName)); err == nil && m.Sidecar != nil {
+			mount = m.Sidecar.MountOrDefault(name)
+			secrets = len(m.Sidecar.Secrets)
+			if candidate := skillArtifactCandidate(m.Sidecar.Command); candidate != "" {
+				abs := candidate
+				if !filepath.IsAbs(abs) {
+					abs = filepath.Join(d.Dir, abs)
+				}
+				if _, err := os.Stat(abs); err == nil {
+					binaryPresent = "yes"
+				} else if _, err := exec.LookPath(candidate); err == nil {
+					binaryPresent = "yes (on $PATH)"
+				} else {
+					binaryPresent = "no"
+				}
+			}
+		}
+		scope := "workdir"
+		if d.Kind == "user-global" {
+			scope = "global"
+		}
+		rowsByName[name] = &listRow{
+			status:        "installed",
+			name:          name,
+			scope:         scope,
+			mount:         mount,
+			secrets:       secrets,
+			binaryPresent: binaryPresent,
+			registered:    "-",
+		}
+		order = append(order, name)
+	}
+
+	if len(rowsByName) == 0 {
+		fmt.Fprintln(env.Stdout, "(no skills installed or registered in this workdir or globally)")
+		return ExitOK
+	}
+
+	tw := tabwriter.NewWriter(env.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "STATUS\tNAME\tSCOPE\tMOUNT\tSECRETS\tBINARY-PRESENT\tREGISTERED")
+	for _, name := range order {
+		r := rowsByName[name]
+		fmt.Fprintf(tw, "%s\t%s\t%s\t/%s/\t%d\t%s\t%s\n",
+			r.status, r.name, r.scope, r.mount, r.secrets, r.binaryPresent, r.registered)
 	}
 	tw.Flush()
 
-	if shown == 0 && !*showAll {
-		fmt.Fprintln(env.Stdout, "(no live skills; only stale registrations remain — see below)")
+	// Surface stale registrations (STATUS=missing) and how to clean them up.
+	var stale []string
+	for _, name := range order {
+		if rowsByName[name].status == "missing" {
+			stale = append(stale, name)
+		}
 	}
-
-	// Surface stale registrations and how to clean them up. These are
-	// hidden from the live list by default so a deleted skill stops
-	// appearing, but we tell the user they exist and how to remove them.
 	if len(stale) > 0 {
 		fmt.Fprintf(env.Stderr, "\nomac list: %d stale registration(s) whose skill directory no longer exists:\n", len(stale))
-		for _, s := range stale {
-			delCmd := "omac deregister " + s.name
-			if s.scope == "global" {
-				delCmd = "omac deregister --global " + s.name
+		for _, name := range stale {
+			r := rowsByName[name]
+			delCmd := "omac deregister " + name
+			if r.scope == "global" {
+				delCmd = "omac deregister --global " + name
 			}
-			fmt.Fprintf(env.Stderr, "  %s (%s, was %s) — remove with: %s\n", s.name, s.scope, s.dir, delCmd)
+			fmt.Fprintf(env.Stderr, "  %s (%s) — remove with: %s\n", name, r.scope, delCmd)
 		}
 		fmt.Fprintln(env.Stderr, "  or run `omac deregister --prune` to remove all stale registrations at once.")
 	}
 	return ExitOK
-}
-
-// staleEntry is a registry entry whose on-disk skill is gone.
-type staleEntry struct {
-	name  string
-	scope string // "workdir" | "global"
-	dir   string
 }

--- a/internal/cli/list_deregister_test.go
+++ b/internal/cli/list_deregister_test.go
@@ -99,12 +99,12 @@ func TestListAllShowsStale(t *testing.T) {
 		t.Fatal(err)
 	}
 	env, read := captureEnv(t, wd)
-	if code := runList([]string{"--all"}, env); code != ExitOK {
-		t.Fatalf("list --all code = %d", code)
+	if code := runList(nil, env); code != ExitOK {
+		t.Fatalf("list code = %d", code)
 	}
 	out, _ := read()
-	if !strings.Contains(out, "demo") || !strings.Contains(out, "stale") {
-		t.Errorf("--all should show the stale row: %q", out)
+	if !strings.Contains(out, "demo") || !strings.Contains(out, "missing") {
+		t.Errorf("stale row should show with STATUS=missing: %q", out)
 	}
 }
 

--- a/internal/cli/removallog.go
+++ b/internal/cli/removallog.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/registry"
+)
+
+const removalLogFilename = "skill-removals.json"
+const acknowledgedFilename = "acknowledged-removals.json"
+
+type removalLog struct {
+	Version  int               `json:"version"`
+	Removals map[string]string `json:"removals"` // skill name → RFC3339 removal timestamp
+}
+
+type acknowledgedRemovals struct {
+	Version      int               `json:"version"`
+	Acknowledged map[string]string `json:"acknowledged"` // skill name → RFC3339 acknowledgement timestamp
+}
+
+func globalRemovalLogPath() string {
+	dir := registry.GlobalDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, removalLogFilename)
+}
+
+func workdirAcknowledgedPath(workdir string) string {
+	return filepath.Join(workdir, ".opencode", acknowledgedFilename)
+}
+
+// recordGlobalRemoval records a skill removal in the global tombstone log.
+// Called by omac uninstall when a user-global skill is removed so that every
+// other project can warn once on its next omac start.
+func recordGlobalRemoval(name string) error {
+	path := globalRemovalLogPath()
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	log := &removalLog{Version: 1, Removals: map[string]string{}}
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, log)
+		if log.Removals == nil {
+			log.Removals = map[string]string{}
+		}
+	}
+	log.Removals[name] = time.Now().UTC().Format(time.RFC3339)
+	return writeRemovalLogJSON(path, log)
+}
+
+// warnUnacknowledgedRemovals compares the global removal log against a
+// per-workdir acknowledgement file. For every globally-uninstalled skill
+// not yet seen by this project it prints a one-time warning and marks it
+// acknowledged so subsequent omac start runs are silent.
+func warnUnacknowledgedRemovals(env *Env) {
+	logPath := globalRemovalLogPath()
+	if logPath == "" {
+		return
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return // no removals on record
+	}
+	var log removalLog
+	if err := json.Unmarshal(data, &log); err != nil || len(log.Removals) == 0 {
+		return
+	}
+
+	ackPath := workdirAcknowledgedPath(env.Workdir)
+	ack := &acknowledgedRemovals{Version: 1, Acknowledged: map[string]string{}}
+	if data, err := os.ReadFile(ackPath); err == nil {
+		_ = json.Unmarshal(data, ack)
+		if ack.Acknowledged == nil {
+			ack.Acknowledged = map[string]string{}
+		}
+	}
+
+	var warned bool
+	for name, removedAt := range log.Removals {
+		if _, seen := ack.Acknowledged[name]; seen {
+			continue
+		}
+		fmt.Fprintf(env.Stderr,
+			"[warn] global skill %q was uninstalled on %s and is no longer available.\n"+
+				"       Run `omac list` to see what is currently installed.\n",
+			name, removedAt)
+		ack.Acknowledged[name] = time.Now().UTC().Format(time.RFC3339)
+		warned = true
+	}
+	if !warned {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(ackPath), 0o700); err != nil {
+		return
+	}
+	_ = writeRemovalLogJSON(ackPath, ack)
+}
+
+func writeRemovalLogJSON(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -171,6 +171,9 @@ func runServe(args []string, env *Env) int {
 		global:        map[string]*skillRoute{},
 	}
 
+	// Warn once per project about globally-uninstalled skills (tombstone check).
+	warnUnacknowledgedRemovals(env)
+
 	// Cold start: global skills are a fixed, known set, so — unlike the lazy
 	// workdir-local skills — we validate them up front and refuse to start on
 	// drift, mirroring `omac start`. Workdir skills stay lazy/auto-registered.
@@ -564,22 +567,26 @@ func (s *serveServer) checkGlobalDrift() int {
 	sort.Strings(drifted)
 	sort.Strings(brokenMeta)
 
-	if len(unregistered) == 0 && len(drifted) == 0 && len(brokenMeta) == 0 {
+	// Unregistered global skills are installed but not activated — warn and
+	// continue. Only drifted/broken registered skills block startup.
+	if len(unregistered) > 0 {
+		fmt.Fprintln(s.env.Stderr, "omac serve: global skills installed but not registered (skipping, run omac register to activate):")
+		for _, n := range unregistered {
+			fmt.Fprintf(s.env.Stderr, "  %s\n", n)
+		}
+		fmt.Fprintln(s.env.Stderr)
+	}
+
+	if len(drifted) == 0 && len(brokenMeta) == 0 {
 		return ExitOK
 	}
 
-	total := len(unregistered) + len(drifted) + len(brokenMeta)
+	total := len(drifted) + len(brokenMeta)
 	fmt.Fprintf(s.env.Stderr, "omac serve: refusing to start, %d global-skill problem(s):\n", total)
 	if len(brokenMeta) > 0 {
 		fmt.Fprintln(s.env.Stderr, "\n  "+config.MetaFileName+" broken:")
 		for _, n := range brokenMeta {
 			fmt.Fprintf(s.env.Stderr, "    %s — re-register: omac register --force %s\n", n, n)
-		}
-	}
-	if len(unregistered) > 0 {
-		fmt.Fprintln(s.env.Stderr, "\n  global skill present but not registered:")
-		for _, n := range unregistered {
-			fmt.Fprintf(s.env.Stderr, "    %s — run: omac register %s\n", n, n)
 		}
 	}
 	if len(drifted) > 0 {
@@ -589,9 +596,6 @@ func (s *serveServer) checkGlobalDrift() int {
 		}
 	}
 	fmt.Fprintln(s.env.Stderr)
-	if len(unregistered) > 0 || len(brokenMeta) > 0 {
-		return ExitPrerequisiteMissing
-	}
 	return ExitConfigInvalid
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -356,17 +356,16 @@ func TestRediscoverPicksUpNewSkill(t *testing.T) {
 	}
 }
 
-func TestCheckGlobalDriftRefusesUnregistered(t *testing.T) {
+func TestCheckGlobalDriftWarnsUnregistered(t *testing.T) {
 	s := newServeServerForTest(t)
 	// Stage a global skill on disk but never register it.
 	stageUserGlobalSkill(t, "weather")
 
+	// Unregistered global skills no longer block startup; they are warned
+	// and skipped so installed-but-unregistered skills don't prevent serve.
 	code := s.checkGlobalDrift()
-	if code == ExitOK {
-		t.Fatal("expected serve to refuse on an unregistered global skill")
-	}
-	if code != ExitPrerequisiteMissing {
-		t.Errorf("exit code = %d, want ExitPrerequisiteMissing (%d)", code, ExitPrerequisiteMissing)
+	if code != ExitOK {
+		t.Errorf("expected ExitOK (unregistered warned, not fatal), got %d", code)
 	}
 }
 

--- a/internal/cli/skillmanifest.go
+++ b/internal/cli/skillmanifest.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const skillManifestRelPath = ".opencode/skills.yaml"
+
+// ManifestSkill is one entry in .opencode/skills.yaml.
+// Either ID, Name, or both must be set; if both are set the marketplace
+// response is checked and a warning is emitted when the canonical name
+// does not match Name.
+type ManifestSkill struct {
+	ID      string `yaml:"id"`
+	Name    string `yaml:"name"`
+	Version *int   `yaml:"version,omitempty"`
+}
+
+// SkillManifest is the parsed form of .opencode/skills.yaml.
+type SkillManifest struct {
+	Version int             `yaml:"version"`
+	Skills  []ManifestSkill `yaml:"skills"`
+}
+
+// LoadSkillManifest reads and parses the declarative skill manifest from
+// <workdir>/.opencode/skills.yaml. Returns (nil, false, nil) when no
+// manifest file exists — callers should skip the sync step entirely.
+func LoadSkillManifest(workdir string) (*SkillManifest, bool, error) {
+	path := filepath.Join(workdir, skillManifestRelPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, true, fmt.Errorf("read %s: %w", skillManifestRelPath, err)
+	}
+	var m SkillManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, true, fmt.Errorf("parse %s: %w", skillManifestRelPath, err)
+	}
+	if m.Version != 1 {
+		return nil, true, fmt.Errorf("%s: unsupported version %d (expected 1)", skillManifestRelPath, m.Version)
+	}
+	for i, s := range m.Skills {
+		if s.ID == "" && s.Name == "" {
+			return nil, true, fmt.Errorf("%s: entry at index %d has neither id nor name", skillManifestRelPath, i)
+		}
+	}
+	return &m, true, nil
+}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -34,6 +34,7 @@ func runStart(args []string, env *Env) int {
 		noSandbox          = fs.Bool("no-sandbox", false, "Run inner command directly, without a sandbox (debug only).")
 		keepRunning        = fs.Bool("keep-running", false, "Do not stop sidecars when the inner command exits.")
 		acceptSkillChanges = fs.Bool("accept-skill-changes", false, "Tolerate bundle_hash drift in registered skills (proceed even if the on-disk skill differs from what was registered).")
+		prune              = fs.Bool("prune", false, "Remove installed skills not listed in .opencode/skills.yaml (requires skills.yaml to be present).")
 		verbose            = fs.Bool("verbose", false, "Verbose lifecycle logging.")
 	)
 	fs.Usage = func() {
@@ -157,26 +158,24 @@ func runStart(args []string, env *Env) int {
 	// name.
 	reg := mergeRegistries(globalReg, workdirReg)
 
-	// 2b. Refuse if any unregistered skill exists under any of the
-	//     skill source roots (workdir-local .agents/skills and
-	//     .opencode/skills, plus the user-global layers — see the
-	//     skillsource package for the full list).
-	//     "Skill" here means a directory with a omac.yaml. The user
-	//     must explicitly register each one (so registration prompts,
-	//     keychain seeding, etc. don't get silently skipped).
-	unregistered, err := findUnregisteredSkills(env.Workdir, harness, reg)
+	// 2b. Warn (do not fail) if any installed skill is not registered.
+	//     Installed-but-unregistered skills are visible in `omac list`
+	//     (STATUS=installed) and can be activated later with `omac register`.
+	//     Only registered skills are loaded by this start run.
+	discovered, unregistered, err := findUnregisteredSkills(env.Workdir, harness, reg)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac start: scan skills:", err)
 		return ExitIOError
 	}
 	if len(unregistered) > 0 {
-		fmt.Fprintln(env.Stderr, "omac start: unregistered skills found in this workdir:")
+		fmt.Fprintln(env.Stderr, "omac start: installed skills not yet registered (skipping, run omac register to activate):")
 		for _, name := range unregistered {
-			fmt.Fprintf(env.Stderr, "  %s — register with: omac register %s\n", name, name)
+			fmt.Fprintf(env.Stderr, "  %s\n", name)
 		}
-		fmt.Fprintln(env.Stderr, "\nA skill you no longer want can be deleted with `omac deregister <skill>` (add --global for a user-global skill).")
-		return ExitPrerequisiteMissing
 	}
+
+	// Warn once per project about globally-uninstalled skills (tombstone check).
+	warnUnacknowledgedRemovals(env)
 
 	if len(reg.Registered) == 0 {
 		fmt.Fprintln(env.Stderr,
@@ -512,6 +511,14 @@ func runStart(args []string, env *Env) int {
 		fmt.Fprintf(env.Stderr, "[verbose] control plane: %s\n", controlURL)
 	}
 
+	// 7b. Sync declarative skill manifest (.opencode/skills.yaml) if present.
+	// This runs after sidecars are healthy so the marketplace sidecar is
+	// reachable. Non-fatal: a missing marketplace or absent secrets are warned
+	// and skipped; the session proceeds regardless.
+	if code := maybeSync(env, discovered, reg, tcpPort, *prune, harness); code != ExitOK {
+		return code
+	}
+
 	// 8. Build sandbox argv and exec.
 	//
 	// Resolve the inner command for the selected harness: an explicit
@@ -739,10 +746,10 @@ func filterRegistryByHarness(reg *registry.Registry, workdir string, harness con
 	return out
 }
 
-func findUnregisteredSkills(workdir string, harness config.Harness, reg *registry.Registry) ([]string, error) {
+func findUnregisteredSkills(workdir string, harness config.Harness, reg *registry.Registry) ([]skillsource.Entry, []string, error) {
 	discovered, err := skillsource.Discover(workdir, harness)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	registered := map[string]struct{}{}
 	for _, e := range reg.Registered {
@@ -755,7 +762,7 @@ func findUnregisteredSkills(workdir string, harness config.Harness, reg *registr
 		}
 	}
 	sort.Strings(out)
-	return out, nil
+	return discovered, out, nil
 }
 
 // createRuntimeDir creates ${TMPDIR}/omac-<workdir-hash>/{logs,pids}.

--- a/internal/cli/start_drift_test.go
+++ b/internal/cli/start_drift_test.go
@@ -144,7 +144,7 @@ func TestFindUnregisteredSkills_FindsNew(t *testing.T) {
 	reg := &registry.Registry{Registered: []registry.Entry{
 		{Name: "alpha"}, // bravo and charlie are unregistered
 	}}
-	got, err := findUnregisteredSkills(dir, config.DefaultHarness(), reg)
+	_, got, err := findUnregisteredSkills(dir, config.DefaultHarness(), reg)
 	if err != nil {
 		t.Fatalf("findUnregisteredSkills: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestFindUnregisteredSkills_AllRegistered(t *testing.T) {
 		{Name: "alpha"},
 		{Name: "bravo"},
 	}}
-	got, err := findUnregisteredSkills(dir, config.DefaultHarness(), reg)
+	_, got, err := findUnregisteredSkills(dir, config.DefaultHarness(), reg)
 	if err != nil {
 		t.Fatalf("findUnregisteredSkills: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestFindUnregisteredSkills_SkipsDirsWithoutMetaYaml(t *testing.T) {
 		t.Fatal(err)
 	}
 	reg := &registry.Registry{Registered: []registry.Entry{{Name: "alpha"}}}
-	got, err := findUnregisteredSkills(dir, config.DefaultHarness(), reg)
+	_, got, err := findUnregisteredSkills(dir, config.DefaultHarness(), reg)
 	if err != nil {
 		t.Fatalf("findUnregisteredSkills: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestFindUnregisteredSkills_NoSkillsDir(t *testing.T) {
 	// been installed.
 	isolateHome(t)
 	dir := t.TempDir()
-	got, err := findUnregisteredSkills(dir, config.DefaultHarness(), &registry.Registry{})
+	_, got, err := findUnregisteredSkills(dir, config.DefaultHarness(), &registry.Registry{})
 	if err != nil {
 		t.Fatalf("findUnregisteredSkills: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestFindUnregisteredSkills_SeesUserGlobal(t *testing.T) {
 	}
 
 	reg := &registry.Registry{Registered: []registry.Entry{{Name: "alpha"}}}
-	got, err := findUnregisteredSkills(wd, config.DefaultHarness(), reg)
+	_, got, err := findUnregisteredSkills(wd, config.DefaultHarness(), reg)
 	if err != nil {
 		t.Fatalf("findUnregisteredSkills: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestFindUnregisteredSkills_WorkdirHidesUserGlobalDup(t *testing.T) {
 	}
 
 	reg := &registry.Registry{Registered: []registry.Entry{{Name: "shared"}}}
-	got, err := findUnregisteredSkills(wd, config.DefaultHarness(), reg)
+	_, got, err := findUnregisteredSkills(wd, config.DefaultHarness(), reg)
 	if err != nil {
 		t.Fatalf("findUnregisteredSkills: %v", err)
 	}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1,0 +1,401 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/tngtech/oh-my-agentic-coder/internal/keychain"
+	"github.com/tngtech/oh-my-agentic-coder/internal/registry"
+	"github.com/tngtech/oh-my-agentic-coder/internal/skillsource"
+)
+
+// maybeSync loads .opencode/skills.yaml and, if present, ensures the declared
+// skills are installed and registered. Called from runStart after sidecars are
+// healthy and before the inner harness is exec'd.
+//
+// Returns ExitOK on success. The sync is non-blocking: a missing marketplace
+// sidecar or skills with absent required secrets are handled gracefully with
+// warnings; they do not abort the session.
+func maybeSync(env *Env, discovered []skillsource.Entry, reg *registry.Registry, tcpPort int, prune bool, harness config.Harness) int {
+	manifest, found, err := LoadSkillManifest(env.Workdir)
+	if err != nil {
+		fmt.Fprintf(env.Stderr, "[warn] omac start: skills.yaml: %v\n", err)
+		return ExitOK // non-fatal
+	}
+	if !found {
+		return ExitOK // no manifest — fast path, zero overhead
+	}
+
+	// Fast path: every manifest skill already on disk and in registry?
+	if allSynced(manifest, discovered, reg) && !prune {
+		return ExitOK
+	}
+
+	// Locate the marketplace sidecar port via the facade.
+	marketplaceURL := fmt.Sprintf("http://127.0.0.1:%d/skill-marketplace", tcpPort)
+	if !marketplaceReachable(marketplaceURL) {
+		fmt.Fprintln(env.Stderr, "[warn] omac start: .opencode/skills.yaml found but skill-marketplace is not registered — skipping sync")
+		return ExitOK
+	}
+
+	if err := syncManifest(env, manifest, discovered, reg, marketplaceURL, prune, harness); err != nil {
+		fmt.Fprintf(env.Stderr, "[warn] omac start: sync: %v\n", err)
+	}
+	return ExitOK
+}
+
+// allSynced reports whether every manifest skill is both installed on disk
+// and registered. When true the fast path skips all marketplace HTTP calls.
+func allSynced(manifest *SkillManifest, discovered []skillsource.Entry, reg *registry.Registry) bool {
+	onDisk := map[string]struct{}{}
+	for _, e := range discovered {
+		onDisk[e.Name] = struct{}{}
+	}
+	inReg := map[string]struct{}{}
+	for _, e := range reg.Registered {
+		inReg[e.Name] = struct{}{}
+	}
+	for _, s := range manifest.Skills {
+		name := s.Name
+		if name == "" {
+			name = s.ID // fallback label (ID-only entry)
+		}
+		if _, ok := onDisk[name]; !ok {
+			return false
+		}
+		if _, ok := inReg[name]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// marketplaceReachable does a lightweight probe to confirm the marketplace
+// sidecar is serving (avoids a confusing 502 from the facade when not running).
+func marketplaceReachable(baseURL string) bool {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(baseURL + "/health")
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode < 500
+}
+
+// syncManifest performs the full install-then-register loop over manifest.Skills.
+func syncManifest(env *Env, manifest *SkillManifest, discovered []skillsource.Entry, reg *registry.Registry, marketplaceURL string, prune bool, harness config.Harness) error {
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	onDisk := map[string]skillsource.Entry{}
+	for _, e := range discovered {
+		onDisk[e.Name] = e
+	}
+	inReg := map[string]struct{}{}
+	for _, e := range reg.Registered {
+		inReg[e.Name] = struct{}{}
+	}
+
+	manifestNames := map[string]struct{}{}
+
+	for _, ms := range manifest.Skills {
+		name, installErr := syncOne(env, client, ms, onDisk, inReg, marketplaceURL, harness)
+		if name != "" {
+			manifestNames[name] = struct{}{}
+		}
+		if installErr != nil {
+			fmt.Fprintf(env.Stderr, "[warn] omac start: sync %q: %v\n", nameOrID(ms), installErr)
+		}
+	}
+
+	if prune {
+		pruneExtras(env, onDisk, manifestNames, harness)
+	}
+	return nil
+}
+
+// syncOne ensures a single manifest skill is installed and registered.
+// Returns the resolved skill name (for prune bookkeeping) and any non-fatal error.
+func syncOne(env *Env, client *http.Client, ms ManifestSkill, onDisk map[string]skillsource.Entry, inReg map[string]struct{}, marketplaceURL string, harness config.Harness) (string, error) {
+	// Determine the key name for on-disk lookup.
+	resolvedName := ms.Name
+
+	entry, alreadyOnDisk := onDisk[resolvedName]
+
+	if !alreadyOnDisk {
+		// Need to install from marketplace.
+		artifactID := ms.ID
+		if artifactID == "" {
+			// Resolve name → UUID via search.
+			id, canonicalName, err := searchArtifact(client, marketplaceURL, ms.Name)
+			if err != nil {
+				return resolvedName, fmt.Errorf("search %q: %w", ms.Name, err)
+			}
+			artifactID = id
+			resolvedName = canonicalName
+		}
+
+		canonicalName, err := installArtifact(client, env, marketplaceURL, artifactID, ms.Version)
+		if err != nil {
+			return resolvedName, fmt.Errorf("install %q: %w", nameOrID(ms), err)
+		}
+
+		// Warn if supplied name diverges from the canonical name returned by marketplace.
+		if ms.Name != "" && ms.ID != "" && canonicalName != ms.Name {
+			fmt.Fprintf(env.Stderr,
+				"[warn] skills.yaml: id %q is artifact %q but manifest says name: %q\n"+
+					"       — update the name: field in .opencode/skills.yaml\n",
+				ms.ID, canonicalName, ms.Name)
+		}
+		if ms.ID == "" {
+			resolvedName = canonicalName
+		}
+		fmt.Fprintf(env.Stderr, "[info] installed %s from marketplace\n", resolvedName)
+
+		// Re-discover so we can register the newly-installed skill.
+		freshDiscovered, discErr := skillsource.Discover(env.Workdir, harness)
+		if discErr != nil {
+			return resolvedName, fmt.Errorf("rediscover after install: %w", discErr)
+		}
+		for _, e := range freshDiscovered {
+			if e.Name == resolvedName {
+				entry = e
+				alreadyOnDisk = true
+				break
+			}
+		}
+		if !alreadyOnDisk {
+			return resolvedName, fmt.Errorf("installed %q but could not find it on disk afterwards", resolvedName)
+		}
+	} else if ms.ID != "" && ms.Name != "" {
+		// Both provided and skill is already on disk — no install, but we can
+		// still warn about name divergence in a future enhancement. For now skip.
+	}
+
+	// Now ensure it's registered.
+	if _, registered := inReg[resolvedName]; !registered {
+		registered, skipReason, err := registerSkillForSync(entry, env, harness)
+		if err != nil {
+			return resolvedName, fmt.Errorf("register: %w", err)
+		}
+		if registered {
+			fmt.Fprintf(env.Stderr, "[info] registered %s\n", resolvedName)
+		} else if skipReason != "" {
+			fmt.Fprintf(env.Stderr, "[info] %s: installed but not registered — %s\n", resolvedName, skipReason)
+		}
+	}
+
+	return resolvedName, nil
+}
+
+// searchArtifact searches the marketplace for an exact name match and returns
+// its artifact UUID and canonical name. Errors when 0 or >1 exact matches are
+// found — the user should add an id: field to disambiguate.
+func searchArtifact(client *http.Client, marketplaceURL, name string) (string, string, error) {
+	body, _ := json.Marshal(map[string]any{"query": name, "top_k": 10})
+	resp, err := doPost(client, marketplaceURL+"/tools/search_published_artifacts", body)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("search HTTP %d: %s", resp.StatusCode, raw)
+	}
+
+	// The sidecar returns the MCP tool result directly — a plain JSON array.
+	var artifacts []struct {
+		ArtifactID string `json:"artifact_id"`
+		Name       string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &artifacts); err != nil {
+		return "", "", fmt.Errorf("decode search response: %w", err)
+	}
+
+	var matches []struct{ id, name string }
+	for _, a := range artifacts {
+		if a.Name == name {
+			matches = append(matches, struct{ id, name string }{a.ArtifactID, a.Name})
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", "", fmt.Errorf("no marketplace artifact with name %q — check the spelling or add an id: field", name)
+	case 1:
+		return matches[0].id, matches[0].name, nil
+	default:
+		return "", "", fmt.Errorf("multiple marketplace artifacts match name %q — add an id: field to disambiguate", name)
+	}
+}
+
+// installArtifact calls POST /install and returns the installed skill's canonical name.
+func installArtifact(client *http.Client, env *Env, marketplaceURL, artifactID string, version *int) (string, error) {
+	payload := map[string]any{"artifact_id": artifactID}
+	if version != nil {
+		payload["version_number"] = *version
+	}
+	body, _ := json.Marshal(payload)
+	resp, err := doPost(client, marketplaceURL+"/install", body)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("install HTTP %d: %s", resp.StatusCode, raw)
+	}
+
+	var result struct {
+		Upstream struct {
+			Name string `json:"name"`
+		} `json:"upstream"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil || result.Upstream.Name == "" {
+		// Fall back to artifact ID as the name if the response is unexpected.
+		return artifactID, nil
+	}
+	return result.Upstream.Name, nil
+}
+
+// doPost performs a POST with JSON body and returns the response.
+func doPost(client *http.Client, url string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return client.Do(req)
+}
+
+// registerSkillForSync registers a discovered skill non-interactively.
+// It checks the keychain for required secrets first; if any are absent the
+// skill is skipped (installed but unregistered) so the session starts cleanly.
+// Returns (registered bool, skipReason string, err error).
+func registerSkillForSync(entry skillsource.Entry, env *Env, harness config.Harness) (bool, string, error) {
+	metaPath := entry.Dir + "/" + config.MetaFileName
+	meta, err := config.LoadMeta(metaPath)
+	if err != nil {
+		return false, "", fmt.Errorf("load meta: %w", err)
+	}
+	if meta.Sidecar == nil {
+		return false, "no sidecar block in omac.yaml", nil
+	}
+
+	global := entry.Kind == "user-global"
+	secretScope := ""
+	if !global {
+		secretScope = keychain.WorkdirID(env.Workdir)
+	}
+
+	// Check required secrets. If any are absent, skip registration so the
+	// session does not fail on startup with a "required secret missing" error.
+	for _, spec := range meta.Sidecar.Secrets {
+		if !spec.IsRequired() {
+			continue
+		}
+		_, err := keychain.GetWithFallback(secretScope, entry.Name, spec.Name)
+		if err != nil {
+			if errors.Is(err, keychain.ErrNotFound) {
+				return false, fmt.Sprintf("required secret %q missing — run: omac register %s", spec.Name, entry.Name), nil
+			}
+			return false, "", fmt.Errorf("keychain: %w", err)
+		}
+	}
+
+	bundleHash, err := config.BundleHash(entry.Dir)
+	if err != nil {
+		return false, "", fmt.Errorf("bundle hash: %w", err)
+	}
+
+	declaredNames := make([]string, 0, len(meta.Sidecar.Secrets))
+	for _, s := range meta.Sidecar.Secrets {
+		declaredNames = append(declaredNames, s.Name)
+	}
+
+	// Preserve any previously-stored skipped lists so a later interactive
+	// `omac register` still benefits from the user's prior answers.
+	prevSkippedSecrets, prevSkippedFields := loadPrevSkipped(env.Workdir, entry.Name, global)
+	skippedSecrets := make([]string, 0, len(prevSkippedSecrets))
+	for n := range prevSkippedSecrets {
+		skippedSecrets = append(skippedSecrets, n)
+	}
+	skippedFields := make([]string, 0, len(prevSkippedFields))
+	for n := range prevSkippedFields {
+		skippedFields = append(skippedFields, n)
+	}
+
+	stored := entry.Dir
+	if entry.Kind == "workdir" {
+		stored = rel(env.Workdir, entry.Dir)
+	}
+
+	if err := withRegistryLock(env.Workdir, global, func() error {
+		reg, err := loadRegistry(env.Workdir, global)
+		if err != nil {
+			return err
+		}
+		reg.Upsert(registry.Entry{
+			Name:                entry.Name,
+			Harness:             harness.Name,
+			SkillDir:            stored,
+			BundleHash:          bundleHash,
+			RegisteredAt:        time.Now().UTC(),
+			DeclaredSecretNames: dedupSorted(declaredNames),
+			SkippedSecretNames:  dedupSorted(skippedSecrets),
+			SkippedConfigFields: dedupSorted(skippedFields),
+		})
+		return saveRegistry(env.Workdir, global, reg)
+	}); err != nil {
+		return false, "", fmt.Errorf("registry: %w", err)
+	}
+
+	return true, "", nil
+}
+
+// pruneExtras uninstalls discovered skills not listed in the manifest.
+func pruneExtras(env *Env, onDisk map[string]skillsource.Entry, manifestNames map[string]struct{}, harness config.Harness) {
+	for name, entry := range onDisk {
+		if _, keep := manifestNames[name]; keep {
+			continue
+		}
+		registered := false
+		global := false
+		if wReg, err := registry.Load(env.Workdir); err == nil {
+			if e, _ := wReg.FindForHarness(name, harness.Name); e != nil {
+				registered = true
+			}
+		}
+		if !registered {
+			if gReg, err := registry.LoadGlobal(); err == nil {
+				if e, _ := gReg.FindForHarness(name, harness.Name); e != nil {
+					registered = true
+					global = true
+				}
+			}
+		}
+		if registered {
+			if code := deregisterSkill(name, harness.Name, env, global, true); code != ExitOK {
+				fmt.Fprintf(env.Stderr, "[warn] omac start: prune: could not deregister %s\n", name)
+				continue
+			}
+		}
+		if err := os.RemoveAll(entry.Dir); err != nil {
+			fmt.Fprintf(env.Stderr, "[warn] omac start: prune: remove %s: %v\n", name, err)
+			continue
+		}
+		fmt.Fprintf(env.Stderr, "[info] pruned %s (not in %s)\n", name, skillManifestRelPath)
+	}
+}
+
+func nameOrID(ms ManifestSkill) string {
+	if ms.Name != "" {
+		return ms.Name
+	}
+	return ms.ID
+}


### PR DESCRIPTION
- Unregistered skills in a project do not block starting omac but give a warning
- Command to uninstall skills

-> if you installed a skill by accident (or you currently do not want to set it up but continue working) you are no longer blocked