### PR TITLE
fix: add ~/.bun to default sandbox allow list

### DIFF
--- a/internal/sandboxprofile/resolve.go
+++ b/internal/sandboxprofile/resolve.go
@@ -37,6 +37,8 @@ func DefaultProfile() *Profile {
 				"~/.config/opencode",
 				"~/.opencode/bin",
 				"~/.nvm",
+				"~/.bun/bin",
+				"~/.bun/install/global/node_modules/opencode-ai",
 				"~/.gitconfig",
 				"~/.gitignore_global",
 				"~/.claude.json",


### PR DESCRIPTION
opencode installed via Bun lives under ~/.bun/install/global/… which was not in the bwrap read-path grants, causing stage2 to fail with "no such file or directory" when exec-ing the inner command.