### PR TITLE
feat(sandbox): allow loopback IPC via open_port 0 (fixes Gradle in the sandbox)

### DIFF
--- a/internal/sandboxprofile/profile.go
+++ b/internal/sandboxprofile/profile.go
@@ -224,12 +224,17 @@ func (p *Profile) Validate() error {
 	for _, group := range []struct {
 		name  string
 		ports []int
+		// open_port alone accepts the 0 sentinel.
+		allowZero bool
 	}{
-		{"listen_port", p.Network.ListenPort},
-		{"allow_tcp_connect", p.Network.AllowTCPConnect},
-		{"open_port", p.Network.OpenPort},
+		{name: "listen_port", ports: p.Network.ListenPort},
+		{name: "allow_tcp_connect", ports: p.Network.AllowTCPConnect},
+		{name: "open_port", ports: p.Network.OpenPort, allowZero: true},
 	} {
 		for _, port := range group.ports {
+			if group.allowZero && port == 0 {
+				continue
+			}
 			if port < 1 || port > 65535 {
 				return fmt.Errorf("sandbox profile: network.%s contains invalid port %d", group.name, port)
 			}

--- a/internal/sandboxprofile/profile_test.go
+++ b/internal/sandboxprofile/profile_test.go
@@ -335,6 +335,24 @@ func TestMergeBlockNetOverrides(t *testing.T) {
 	}
 }
 
+func TestValidateOpenPortZeroSentinel(t *testing.T) {
+	p := &Profile{Network: Network{OpenPort: []int{0, 4097}}}
+	if err := p.Validate(); err != nil {
+		t.Errorf("open_port 0 sentinel rejected: %v", err)
+	}
+	// The sentinel is open_port-only; 0 stays invalid for the others.
+	if err := (&Profile{Network: Network{ListenPort: []int{0}}}).Validate(); err == nil {
+		t.Error("listen_port 0 must be rejected")
+	}
+	if err := (&Profile{Network: Network{AllowTCPConnect: []int{0}}}).Validate(); err == nil {
+		t.Error("allow_tcp_connect 0 must be rejected")
+	}
+	// Out-of-range ports are still rejected for open_port.
+	if err := (&Profile{Network: Network{OpenPort: []int{70000}}}).Validate(); err == nil {
+		t.Error("open_port 70000 must be rejected")
+	}
+}
+
 func TestEffectiveProtectedPaths(t *testing.T) {
 	t.Setenv("HOME", "/home/u")
 	b := Baseline{ProtectedPaths: []string{"~/.git-credentials", "~/.netrc", "~/.ssh"}}

--- a/internal/sandboxrun/sbpl.go
+++ b/internal/sandboxrun/sbpl.go
@@ -120,8 +120,18 @@ func generateSBPLNetwork(g *Grants) string {
 		for _, p := range g.AllowTCPConnect {
 			fmt.Fprintf(&b, "(allow network-outbound (remote tcp \"*:%d\"))\n", p)
 		}
+		// 0 is the "any loopback port" sentinel: for tools that connect
+		// back over a random ephemeral port they can't predeclare.
+		wildcardLoopback := false
 		for _, p := range g.OpenPorts {
+			if p == 0 {
+				wildcardLoopback = true
+				continue
+			}
 			fmt.Fprintf(&b, "(allow network-outbound (remote tcp \"localhost:%d\"))\n", p)
+		}
+		if wildcardLoopback {
+			b.WriteString("(allow network-outbound (remote tcp \"localhost:*\"))\n")
 		}
 		// Seatbelt cannot filter bind by port: any listen/open port
 		// grants bind+inbound generally (documented platform limit).

--- a/internal/sandboxrun/sbpl_test.go
+++ b/internal/sandboxrun/sbpl_test.go
@@ -158,6 +158,76 @@ func TestSBPLNoBindWithoutPorts(t *testing.T) {
 	}
 }
 
+func TestSBPLOpenPortZeroWildcard(t *testing.T) {
+	g := baseGrants()
+	g.OpenPorts = []int{0}
+	p := GenerateSBPL(g)
+	if !strings.Contains(p, `(allow network-outbound (remote tcp "localhost:*"))`) {
+		t.Error("open_port 0 sentinel must emit the localhost:* wildcard rule")
+	}
+	if strings.Contains(p, `localhost:0`) {
+		t.Error("open_port 0 must not emit the invalid localhost:0 literal")
+	}
+	// The blanket bind/inbound rules still apply with an open port present.
+	if !strings.Contains(p, "(allow network-bind)") || !strings.Contains(p, "(allow network-inbound)") {
+		t.Error("open_port 0 must keep blanket bind/inbound rules")
+	}
+	if strings.Contains(p, `remote tcp "*:*"`) {
+		t.Error("open_port 0 must not allow outbound to any host (remote tcp \"*:*\")")
+	}
+}
+
+// open_port 0 must never widen into non-loopback egress: no (local ip ...)
+// outbound (it matches every unbound socket) and no "*:*" allow.
+func TestSBPLOpenPortZeroNoEgressHole(t *testing.T) {
+	g := baseGrants()
+	g.OpenPorts = []int{0}
+	p := GenerateSBPL(g)
+	for _, forbidden := range []string{
+		`(allow network-outbound (local ip "*:*"))`,
+		`(allow network-outbound (local ip "localhost:*"))`,
+		`(allow network-outbound (local tcp "localhost:*"))`,
+		`(allow network-outbound (remote tcp "*:*"))`,
+		`(allow network-outbound (remote ip "*:*"))`,
+	} {
+		if strings.Contains(p, forbidden) {
+			t.Errorf("open_port 0 emitted an egress-opening rule: %q", forbidden)
+		}
+	}
+	if !strings.Contains(p, `(allow network-outbound (remote tcp "localhost:*"))`) {
+		t.Error("open_port 0 must keep the remote-scoped localhost:* allow")
+	}
+}
+
+func TestSBPLOpenPortZeroMixed(t *testing.T) {
+	g := baseGrants()
+	g.OpenPorts = []int{4097, 0}
+	p := GenerateSBPL(g)
+	for _, want := range []string{
+		`(allow network-outbound (remote tcp "localhost:4097"))`,
+		`(allow network-outbound (remote tcp "localhost:*"))`,
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("profile missing %q", want)
+		}
+	}
+	if strings.Contains(p, `localhost:0`) {
+		t.Error("mixed open_port set must not emit the invalid localhost:0 literal")
+	}
+}
+
+func TestSBPLOpenPortNonZeroNoWildcard(t *testing.T) {
+	g := baseGrants()
+	g.OpenPorts = []int{4097}
+	p := GenerateSBPL(g)
+	if !strings.Contains(p, `(allow network-outbound (remote tcp "localhost:4097"))`) {
+		t.Error("non-zero open_port must emit its per-port rule")
+	}
+	if strings.Contains(p, `(allow network-outbound (remote tcp "localhost:*"))`) {
+		t.Error("non-sentinel open_port set must not emit the wildcard rule")
+	}
+}
+
 func TestSBPLQuoteEscaping(t *testing.T) {
 	g := baseGrants()
 	g.ReadPaths = []string{`/path/with"quote`}


### PR DESCRIPTION
## Problem

Under `network.mode: filtered`, tools that fork a helper process and talk to it over a loopback socket on an OS-assigned ephemeral port are refused — the sandbox only allows explicitly-listed ports. The motivating case is **Gradle**: `./gradlew test` forks a build daemon and test-worker JVMs that connect back over random loopback ports (49152–65535), so the build fails with:

```
Could not connect to the Gradle daemon.
```

This affects any fork-and-talk-over-loopback tool, not just Gradle.

## Change

Treat `open_port: 0` as a sentinel meaning *"allow outbound TCP to any loopback port."* The SBPL generator emits a single

```
(allow network-outbound (remote tcp "localhost:*"))
```

instead of a per-port literal (Seatbelt rejects the invalid `localhost:0`). `Validate()` accepts `0` for `open_port` only; it stays invalid for `listen_port` / `allow_tcp_connect`.

## Security

The rule is **destination-scoped to `localhost`**, so non-loopback egress remains denied by the top-level `(deny network*)`. A guard test (`TestSBPLOpenPortZeroNoEgressHole`) locks this in: the path must never emit a `(local ip …)` outbound rule (it matches every *unbound* outbound socket and would allow arbitrary external connects) nor any `*:*` outbound allow. Both alternatives were tried and empirically opened external egress, so the test forbids them explicitly.

## Known limitation (documented in-code)

Seatbelt's `localhost` token matches `127.0.0.1` and `::1` but **not** the IPv4-mapped form `::ffff:127.0.0.1` that a dual-stack JVM emits when it connects to `127.0.0.1`. There is no safe pure-Seatbelt fix: the host field accepts only `*` or `localhost` (literal IPv6 is rejected), and the only construct that matches the mapped remote — `(local ip …)` — also matches every unbound outbound socket and would open egress. Affected tools must therefore dial a `localhost`-matchable form, e.g. run the JVM with `-Djava.net.preferIPv4Stack=true`.

## References

- Mirrors `nono#931` (treat `open_port 0` as a `localhost:*` outbound).
- Aligns with `anthropic-experimental/sandbox-runtime#316`, the corrected design (a `remote`-scoped loopback outbound plus forcing IPv4), and deliberately avoids the reverted, unsafe `#127` (`local ip "*:*"`, which opened egress).
- Cf. `anthropics/claude-code#18545` — the originating "Gradle in the sandbox" bug.

## Testing

Four new tests in `internal/sandboxrun` and `internal/sandboxprofile` cover: the `localhost:*` wildcard emission, the no-egress-hole guard, mixed sentinel+explicit ports, and that a non-sentinel `open_port` set does not emit the wildcard. Run with:

```
go test ./internal/sandboxrun/... ./internal/sandboxprofile/...
```

Validated end-to-end: with `open_port: [0]` added to a `filtered` profile, a real Gradle build (compile + tests) inside the sandbox connects to its daemon and forked workers and runs to completion — previously impossible. (Dual-stack loopback additionally requires `-Djava.net.preferIPv4Stack=true` on the build JVMs, per the *Known limitation* above; that is build-side config, not part of this change.)

---

## For colleagues with a similar Gradle setup

`open_port: 0` only unblocks the loopback *connection*. To actually run a full Gradle build in the sandbox I also needed three **build-side** additions (none belong in omac — they're local config):

1. **Force IPv4 on the build JVMs** — `~/.zshenv`: `export JDK_JAVA_OPTIONS="… -Djava.net.preferIPv4Stack=true"`. A dual-stack JVM dials `127.0.0.1` as `::ffff:127.0.0.1`, which Seatbelt's `localhost` can't match (see *Known limitation*). This reaches the daemon and the normally-forked test/compile workers, which inherit the env.
2. **Mockito inline mock-maker** — load `mockito-core` as a `-javaagent` on `Test` tasks (in `init.gradle`). The mock-maker otherwise self-attaches over a JVM attach socket the sandbox denies.
3. **Checkstyle** — run its CLI as a forked `JavaExec` "twin" task instead of the built-in `checkstyle*` task.

**On (3) — note this is *not* a Checkstyle problem, it's a Gradle worker problem.** Checkstyle/PMD/CodeNarc run in Gradle's **Worker-API process-isolation worker daemons**, which connect back to the daemon over the same dual-stack loopback *and* get a scrubbed environment with **no `jvmArgs` knob** — so the IPv4 flag from (1) can't reach them. `Test`/`JavaCompile` use *normally-forked* workers and are fine. The CLI twin sidesteps it by being a plain JVM that only reads files and prints violations — no worker messaging, no loopback.

Taken together, these build-side additions are what it currently takes to get a green Gradle build in the sandbox — pragmatic, but more moving parts than I'd like. If anyone finds a cleaner way to run Gradle inside the sandbox (daemon, forked workers, and the process-isolation worker tasks alike), I — and anyone on a similar client tech stack — would really appreciate hearing it.
