### PR TITLE
feat(setup): ship built-in omac-write-a-skill, auto-provision on launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ omac doctor
 omac register <skill>
 
 # 5. Launch — default sandbox (Seatbelt/bwrap) + default harness (opencode)
+#    (omac's built-in skills are auto-provisioned on launch; no extra step)
 omac start
 ```
 
@@ -70,6 +71,23 @@ under any harness. Adding a new agentic harness means registering one
 descriptor in `internal/config/harness.go` plus shipping its bridge; no
 command-dispatch code changes. See `CREATING_A_SKILL.md` and
 `docs/MULTI_DIR_DESKTOP.md`.
+
+### Built-in skills
+
+omac ships a small set of **built-in skills** embedded in the binary and
+**auto-provisions them on `omac start` / `omac serve`** — no separate step. On
+launch, omac idempotently writes them into the active harness's skills directory
+(`~/.config/opencode/skills`, `~/.claude/skills`); it stays silent when they're
+already current and never overwrites a same-named directory it doesn't own.
+
+Today the only built-in is **`omac-write-a-skill`** — a guidance-only skill
+(just a `SKILL.md`, no sidecar) carrying the `CREATING_A_SKILL.md` authoring
+guide, so the agent can author new omac skills in any project.
+
+`omac setup` is available to (re)provision **all** installed harnesses at once
+or to refresh after upgrading omac (`omac setup [harness] [--force]`), but you
+don't need to run it for the everyday flow. (This replaces the old external
+`opencode-nono/install.sh` skill-copy step.)
 
 ### Harness-scoped skill discovery
 

--- a/internal/builtinskills/assets/omac-write-a-skill/SKILL.md
+++ b/internal/builtinskills/assets/omac-write-a-skill/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: omac-write-a-skill
+description: >-
+  Author a new skill for the omac (oh-my-agentic-coder) execution shell — the
+  agentskills.io SKILL.md plus omac's omac.yaml sidecar contract, the OMAC_*
+  environment variables, the Unix-socket/loopback REST facade, secrets and
+  mounts, install scripts, and the harness-agnostic rules. Use this when the
+  user wants to create, scaffold, or package an omac skill (not a generic
+  Claude/agentskills skill): "write an omac skill", "add a sidecar skill",
+  "package this as an omac skill", "how do omac.yaml mounts/secrets work".
+  Not for authoring non-omac skills.
+license: Same as the omac repository
+compatibility: >-
+  Pure guidance skill — no sidecar, no omac.yaml, no network. Works unchanged
+  under any omac inner harness (OpenCode, Claude Code, …). Shipped with the omac
+  binary and provisioned by `omac setup`.
+metadata:
+  author: tngtech
+  version: "0.1.0"
+  omac-builtin: "true"
+---
+
+# omac-write-a-skill
+
+Authoring helper for building a **skill that plugs into omac**
+(`oh-my-agentic-coder`). This is omac-specific: it covers omac's runtime
+contract — the `omac.yaml` sidecar block, the `OMAC_*` env vars, the
+Unix-socket + loopback-TCP REST facade, secrets/config/mounts, install
+scripts, and the harness-agnostic rules — not generic agentskills or
+Claude-skill authoring.
+
+> Reach for this skill only when authoring an **omac** skill. For unrelated
+> "write a skill" requests, a generic authoring skill is the better fit.
+
+## How to use it
+
+The complete, authoritative guide is bundled alongside this file:
+
+**→ `references/creating-a-skill.md`** — read it before authoring.
+
+It walks through, in order:
+
+1. Why sidecars exist and how the sandbox boundary works.
+2. On-disk skill layout and naming rules.
+3. The `SKILL.md` format (agentskills.io discovery file).
+4. The `omac.yaml` schema (omac's runtime contract).
+5. Writing the HTTP sidecar (stdlib-only Python reference).
+6. Install scripts, route URL rewriting, and `OMAC_*` env wiring.
+7. Secrets vs. non-secret config, and best practices.
+8. Local development, testing, and the pre-shipping checklist.
+
+## Workflow
+
+1. Read `references/creating-a-skill.md` end to end (or jump to the section the
+   task needs — the headings map to the list above).
+2. Scaffold the skill directory with `SKILL.md` + `omac.yaml` (+ `scripts/`,
+   `install/` as needed), following the layout and schema in the guide.
+3. Implement the sidecar against the omac facade contract; keep it
+   harness-agnostic (only `OMAC_*` + REST, never a harness-specific path).
+4. Validate with `omac register <skill>` and a local round-trip before shipping.

--- a/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
+++ b/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
@@ -1,0 +1,908 @@
+# Creating a Skill for `omac`
+
+This guide explains how to author a skill that plugs into the
+`oh-my-agentic-coder` (`omac`) execution-shell. Skills are the unit of
+extension: each one ships a small **sidecar** HTTP service that runs **outside**
+the agent sandbox and is reached **inside** the sandbox through `omac`'s
+single Unix-domain-socket facade.
+
+omac skills are also valid [agentskills.io](https://agentskills.io/) skills:
+every skill ships a `SKILL.md` (the agentskills.io standard file — the
+agent uses its YAML frontmatter for progressive-disclosure discovery) **and**
+an `omac.yaml` (omac's runtime contract describing the sidecar process,
+secrets, mounts, and health probe). The two files cover non-overlapping
+concerns; see §3 below.
+
+> **Skills are harness-agnostic.** A skill targets only the omac contract —
+> the `OMAC_*` environment variables and the facade's REST routes — and MUST
+> NOT assume a particular inner harness (OpenCode, Claude Code, …), its plugin
+> API, or any harness-specific file path. The same skill, unmodified, runs
+> under every harness. omac selects the harness with a positional token
+> (`omac start opencode` / `omac start claude`); which one is active is
+> invisible to your skill. See [§0 Running under a harness](#0-running-under-a-harness).
+
+---
+
+## 0. Running under a harness
+
+You do not write anything harness-specific. omac launches an inner agentic
+coder inside the sandbox and exposes your skill to it identically regardless of
+which harness is chosen:
+
+- **Reaching your sidecar.** Inside the sandbox the agent reads
+  `OMAC_<MOUNT>_BASE` (a `http://127.0.0.1:<port>/<mount>` URL) — or
+  `OMAC_<MOUNT>_SOCKET_BASE` for the `http+unix://` form — and appends your
+  documented path. These names are the same under OpenCode and Claude Code.
+  Global skills also get `OMAC_G_<MOUNT>_BASE`.
+- **Discovery.** Each harness ships a *bridge* that surfaces a skills manifest
+  to the agent listing every ready skill's `base` URL. Under **OpenCode** this
+  is the plugin in `.opencode/plugins/`; under **Claude Code** it is the
+  `SessionStart` hook in `.claude/`. Both produce the same manifest content
+  from omac's control plane — you do not interact with either directly.
+- **Where skills live (harness-scoped).** Each harness reads `SKILL.md` from
+  its own skills dir, and omac scopes discovery to match:
+  - OpenCode → `.opencode/skills` (+ `~/.config/opencode/skills`)
+  - Claude Code → `.claude/skills` (+ `~/.claude/skills`)
+  - **Shared** → `.agents/skills` (+ `~/.config/agents/skills`), in scope for
+    every harness.
+
+  The active harness scans **its own dir + `.agents/skills`** and **never** the
+  other harness's dir. Put a skill under `.agents/skills` to make it usable by
+  every harness from one copy; put it under a harness's own dir to scope it to
+  that harness.
+- **Install location.** The marketplace `/install` defaults to the **active
+  harness's** skills dir (it reads `OMAC_HARNESS_SKILLS_DIR`, which omac
+  injects). Pass `target_path` to override — e.g. `.agents/skills` to install a
+  shared skill. Never hard-code a single harness's directory in skill logic.
+- **Registration.** A skill name can be registered once per harness. If a name
+  is ambiguous (present under multiple harnesses, or both workdir and global),
+  `omac register` stops and asks you to pick with `--harness` / `--global`.
+
+If your skill works under one harness it works under all of them — that is the
+contract. Test it the same way (the `echo-rest` reference skill is the smoke
+test) and it is automatically portable.
+
+---
+
+If you have not already, read:
+
+- [`README.md`](./README.md) — high-level workflow and CLI reference.
+- [`oh-my-agentic-coder.md`](./oh-my-agentic-coder.md) — full design doc.
+- [`.opencode/skills/echo-rest/`](./.opencode/skills/echo-rest/) — the
+  reference skill. Copy it as a starting point.
+- [agentskills.io specification](https://agentskills.io/specification) —
+  authoritative spec for `SKILL.md`'s frontmatter and progressive
+  disclosure semantics.
+
+> **Heads-up if you read an older version of this guide:** omac's
+> per-skill *runtime* metadata file is now `omac.yaml`, not `meta.yaml`.
+> The old name collided with the marketplace publishing pipeline's own
+> `meta.yaml`. A skill that wants to be both publishable and have an
+> omac sidecar should ship both files. See §7.1 of the design doc for
+> rationale. Separately, every skill should also ship a `SKILL.md` —
+> that is the agentskills.io discovery file the agent reads, and is
+> orthogonal to either `omac.yaml` or `meta.yaml`.
+
+---
+
+## 1. Why a sidecar?
+
+The agent runs in a sandbox (`nono` by default) that may have restricted
+network access and never sees your secrets. Each skill provides a sidecar
+that:
+
+- Holds the credentials (injected by `omac` from the OS keychain at start time).
+- Talks to the real out-of-sandbox service (Slack API, IMAP server, GitHub, …).
+- Exposes a small HTTP API on `127.0.0.1:$SIDECAR_PORT`.
+
+`omac` proxies sandbox-side requests on a Unix socket to the right sidecar
+based on the URL prefix (the `mount`). The sandbox never gets the secret;
+it only gets a socket path.
+
+```
+   inside sandbox                       outside sandbox (host)
+   ───────────────                      ───────────────────────
+   curl --unix-socket $OMAC_SOCKET \
+        http://x/<mount>/...   ─────►   omac facade  ─────►  sidecar
+                                                            (has secrets,
+                                                             talks to real
+                                                             upstream API)
+```
+
+---
+
+## 2. Skill on-disk layout
+
+A skill is a directory containing both a `SKILL.md` (the agentskills.io
+discovery/instructions file) and an `omac.yaml` (omac's runtime contract).
+omac looks in two layers, and within each layer it honors two parallel
+naming conventions: the agentskills.io-aligned `agents/skills` location
+and the legacy `opencode/skills` location.
+
+1. **Workdir-local** (always scanned, in this order):
+   1. `<workdir>/.agents/skills/<name>/` — the agentskills.io-aligned
+      layout most users will pick for new skills.
+   2. `<workdir>/.opencode/skills/<name>/` — the legacy layout; still
+      fully supported.
+2. **User-global** (only roots that exist on disk are scanned, in this
+   order):
+   1. `$XDG_CONFIG_HOME/agents/skills/<name>/` (if `$XDG_CONFIG_HOME`
+      is set; defaults to `~/.config/agents/skills/`)
+   2. `$XDG_CONFIG_HOME/opencode/skills/<name>/` (if set; defaults to
+      `~/.config/opencode/skills/`)
+   3. `~/.config/agents/skills/<name>/`
+   4. `~/.config/opencode/skills/<name>/`
+   5. `~/.agents/skills/<name>/` — legacy flat layout.
+   6. `~/.opencode/skills/<name>/` — legacy flat layout.
+
+`.agents/skills` ranks above `.opencode/skills` in every layer so a
+project can override an existing `.opencode/skills` entry by dropping
+a sibling under `.agents/skills`. Workdir-local always wins over
+user-global on name collision.
+
+Registration data — `sidecar.json`, `skill-config.yaml`, and OS
+keychain entries — always lives in the workdir, regardless of which
+layer the source came from. Each project explicitly opts into a
+user-global skill by running `omac register <name>` in that project's
+workdir.
+
+Inside either location the per-skill layout is the same:
+
+```
+<location>/skills/<name>/
+├── SKILL.md                  required — agentskills.io frontmatter + Markdown
+│                                       instructions (§3 below)
+├── omac.yaml                 required — sidecar/runtime schema (§4 below)
+├── scripts/                  bundled executables (agentskills.io convention)
+│   ├── sidecar.py            the sidecar entry-point referenced from
+│   │                         omac.yaml's `command:`. Any language as long as
+│   │                         it speaks HTTP on $SIDECAR_PORT (§5).
+│   └── …                     any other helper scripts the agent may invoke.
+├── references/               optional — agentskills.io convention; deeper
+│                             docs the agent loads on demand
+├── assets/                   optional — agentskills.io convention; templates,
+│                             schemas, lookup tables
+└── install/
+    ├── install.macos.sh      optional but recommended (host-side prerequisites)
+    └── install.linux.sh      optional but recommended
+```
+
+Two paths to be aware of:
+
+- **Sidecar entry-point**: by convention it lives at `scripts/sidecar.<ext>`
+  (Python, Node, Go binary, shell — whatever you ship). omac sets the
+  spawned process's working directory to the skill root, so the
+  `omac.yaml` `command:` value is `["python3", "scripts/sidecar.py"]`,
+  not the bare filename. Compiled-language skills typically have the
+  install script drop a binary at `scripts/sidecar` and reference
+  `["./scripts/sidecar"]`.
+- **`scripts/` is shared between two consumers**: the *omac supervisor*
+  spawns the sidecar entry-point as a long-running HTTP service outside
+  the sandbox; the *agent* may also invoke other helper scripts in this
+  directory during a task (the agentskills.io meaning of `scripts/`).
+  Both are fine; they are different lifecycles. Keep helper scripts
+  small and self-contained per the agentskills.io spec.
+
+Naming rules:
+
+- The directory name must match BOTH `SKILL.md`'s frontmatter `name:`
+  and `omac.yaml`'s top-level `name:`. omac validates the latter; the
+  agentskills.io [`skills-ref` validator](https://github.com/agentskills/agentskills/tree/main/skills-ref)
+  validates the former.
+- The agentskills.io `name` rules are stricter than omac's: 1–64
+  characters, lowercase a–z + digits + hyphens, no leading/trailing
+  hyphen, no consecutive hyphens. Pick a name that satisfies both.
+- `mount` (URL prefix on the omac facade) must match
+  `^[a-z0-9][a-z0-9-]*$`. It defaults to the skill name, which already
+  satisfies this regex if you followed the rule above.
+- Secret and config env-var names must match `^[A-Z_][A-Z0-9_]*$`.
+
+---
+
+## 3. `SKILL.md` (agentskills.io discovery file)
+
+Every skill ships a `SKILL.md` at its root. The agent — not omac — uses
+this file. omac never parses it; it is part of the bundle hash (so
+edits to it count as "the skill changed", in line with the bundle-drift
+rules in §8.4) but otherwise opaque to the runtime.
+
+`SKILL.md` is YAML frontmatter followed by Markdown body. Its purpose
+is **progressive disclosure** to the agent:
+
+1. **Discovery** (~100 tokens): at agent startup, only the frontmatter
+   `name` + `description` are loaded. They are how the agent decides
+   whether a skill is relevant to the current task.
+2. **Activation** (~5 000 tokens recommended): when a task matches, the
+   agent loads the full `SKILL.md` body into context.
+3. **Execution** (on demand): the agent loads files from `scripts/`,
+   `references/`, `assets/` only when a step calls for them.
+
+Keep the frontmatter description sharp and keyword-rich, and keep the
+body itself under 500 lines — move detailed reference material into
+`references/` files and link to them.
+
+### 3.1 Frontmatter schema
+
+```yaml
+---
+name: my-skill                       # required; matches directory name
+description: >                       # required; max 1024 chars
+  One- or two-sentence pitch covering BOTH what the skill does AND
+  when an agent should reach for it. Include keywords the agent can
+  match against user prompts. This is the most important field —
+  it is the only thing the agent sees during the discovery stage.
+license: Apache-2.0                  # optional; license name or path
+compatibility: >                     # optional; max 500 chars; environment
+  Requires the omac runtime, Python 3, and (for real skills) network
+  access to <upstream API>.
+metadata:                            # optional; arbitrary string-keyed map
+  author: your-org
+  version: "0.1.0"
+  omac-mount: my-skill               # mirror omac.yaml's mount/command for
+  omac-sidecar: "python3 scripts/sidecar.py" # discoverability; not authoritative
+allowed-tools: Bash(curl:*) Read     # optional; experimental; space-separated
+---
+```
+
+Frontmatter rules (from the agentskills.io
+[specification](https://agentskills.io/specification)):
+
+| Field           | Required | Constraints                                                                                 |
+| --------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `name`          | yes      | 1–64 chars, lowercase `a–z` + digits + `-`, no leading/trailing or consecutive hyphens.     |
+| `description`   | yes      | 1–1024 chars; non-empty; covers both *what* and *when*.                                     |
+| `license`       | no       | Short string (license name) or reference to a bundled file.                                 |
+| `compatibility` | no       | ≤ 500 chars; environment requirements (intended product, packages, network).                |
+| `metadata`      | no       | String-keyed map. Use unique-ish keys to avoid clashes between clients.                     |
+| `allowed-tools` | no       | Space-separated tool whitelist. Experimental — support varies across agents.                |
+
+Validate with the agentskills.io reference tool:
+
+```bash
+skills-ref validate ./.opencode/skills/<name>
+```
+
+### 3.2 Frontmatter and `omac.yaml` — who owns what
+
+The two files describe non-overlapping facets of the same skill. Treat
+them as a contract: keep the names in sync, but don't try to mirror the
+whole sidecar config into `SKILL.md`.
+
+| Concern                                | Lives in                | Notes                                                                                      |
+| -------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------ |
+| Skill identity (`name`)                | both                    | Must match each other and the directory name.                                              |
+| Human/agent-facing description         | `SKILL.md` frontmatter  | Authoritative for activation; `omac.yaml`'s `description` is just for `omac list` output.  |
+| When/why an agent should use the skill | `SKILL.md` body         | omac doesn't care.                                                                         |
+| HTTP API exposed via the facade        | `SKILL.md` body         | Endpoints, request/response shapes, example `curl` lines using `OMAC_<MOUNT>_BASE`.        |
+| Sidecar process command, port, mount   | `omac.yaml`             | Runtime-only; not duplicated in `SKILL.md` (mention it in `metadata:` if useful).          |
+| Secrets, config fields, health probe   | `omac.yaml`             | Reference them by *name* in `SKILL.md` so the agent knows what env vars to expect.         |
+| Per-OS install scripts                 | `omac.yaml` + `install/` | omac surfaces them at register time.                                                       |
+| Tool / capability whitelist            | `SKILL.md` `allowed-tools` | Hint to the agent runtime; not enforced by omac.                                        |
+
+### 3.3 Body content — recommended structure
+
+There is no spec-mandated structure for the Markdown body, but for an
+omac sidecar skill the following sections cover what an agent typically
+needs:
+
+1. **When to use this skill** — restate the trigger conditions in prose.
+2. **How to call it from inside the sandbox** — show `curl` lines using
+   `OMAC_<MOUNT>_BASE` (TCP, preferred) and `OMAC_SOCKET` (Unix, fallback).
+3. **Endpoints** — table of method/path/purpose for each route the
+   sidecar exposes.
+4. **Configuration surface** — list the env vars the sidecar reads
+   (declared in `omac.yaml`'s `secrets:` and `config:`), with a brief
+   pointer to §10 for the lifecycle.
+5. **Verifying the wiring** — a smoke-test recipe (e.g. "run
+   `demo-client.sh`", "look for `503 X-Omac-Reason: sidecar-down` in
+   logs at $TMPDIR/omac-…/logs/<skill>.log").
+
+The `echo-rest` reference skill's
+[`SKILL.md`](./.opencode/skills/echo-rest/SKILL.md) is a worked example
+of all five.
+
+---
+
+## 4. `omac.yaml` schema
+
+Minimal example (based on `echo-rest`):
+
+```yaml
+name: my-skill                    # required; must equal the directory name
+type: skill                       # informational
+version: 0.1.0
+description: One-line summary shown in `omac list`.
+author: you
+dependencies: []
+
+sidecar:
+  # argv to spawn the sidecar process. ${SIDECAR_PORT} is substituted by omac.
+  # Prefer reading $SIDECAR_PORT from env; argv is visible to all users via `ps`.
+  # The path is resolved relative to the skill root (omac sets the spawned
+  # process's cwd there), so by convention sidecars live under scripts/.
+  command: ["python3", "scripts/sidecar.py"]
+
+  # URL prefix on the bridge socket. Inside the sandbox the skill is reached at
+  #   curl --unix-socket "$OMAC_SOCKET" http://x/<mount>/...
+  # Optional; defaults to the skill name.
+  mount: my-skill
+
+  # Optional: pass through host env vars verbatim. Use sparingly — values
+  # leak from the invoking user's shell, not the OS keychain.
+  env_passthrough:
+    - SOMETHING_NONSECRET
+
+  # Declared secrets. `omac register` prompts (masked input), stores in the
+  # OS keychain under service "omac/<skill>", and injects at sidecar start.
+  secrets:
+    - name: MY_API_TOKEN
+      description: "Token for the upstream API."
+      required: true               # default is true
+      pattern: "^[A-Za-z0-9_-]{16,}$"   # optional regex validation
+      default_from_env: MY_API_TOKEN     # optional: pre-fill from env at prompt
+      multiline: false                   # optional: PEM keys etc.
+
+  # Declared non-secret config fields. `omac register` prompts (echoing input),
+  # stores in plain YAML under <workdir>/.opencode/skill-config.yaml, and
+  # injects at sidecar start as env vars exactly the same way as secrets.
+  # See §10 below for the full type system.
+  config:
+    - name: API_BASE_URL
+      type: string                          # default: string
+      description: "Base URL of the upstream API."
+      default: "https://api.example.com"
+      pattern: "^https://"
+    - name: ENABLE_DEBUG
+      type: bool
+      default: "false"
+      required: false
+    - name: REQUEST_TIMEOUT_MS
+      type: int
+      default: "5000"
+    - name: REGION
+      type: enum
+      choices: [eu-central-1, us-east-1, ap-northeast-1]
+      default: eu-central-1
+
+  # Liveness probe. omac waits for `path` to return 2xx before mounting routes.
+  health:
+    path: /status                  # default /status
+    initial_delay_ms: 100          # default 200
+    timeout_ms: 4000               # default 5000
+    interval_ms: 200               # default 500
+
+  # Per-OS install scripts. omac SURFACES these at register time
+  # (path + run-it-yourself hint); it never executes them, and as of
+  # the current omac it no longer dumps their contents to the terminal.
+  # Use them to document `brew install …` / `apt install …` / build steps.
+  install_scripts:
+    macos: install/install.macos.sh
+    linux: install/install.linux.sh
+
+  # Currently only "http" is meaningful.
+  protocols: ["http"]
+
+  # Optional: per-skill proxy limits.
+  limits:
+    max_body_bytes: 10485760       # 10 MiB
+    idle_timeout_secs: 300
+```
+
+See `internal/config/meta.go` for the authoritative struct definitions.
+
+---
+
+## 5. The sidecar HTTP server
+
+Your sidecar is a normal HTTP server. Requirements:
+
+1. **Bind on `127.0.0.1` only**, never `0.0.0.0`.
+2. **Read the port from the env var `SIDECAR_PORT`** (set by `omac`). Do
+   not take it from argv — argv is world-readable via `ps`.
+3. **Implement the health route** declared in `health.path` (default
+   `/status`). Return any 2xx body; e.g. `{"ok":true}`.
+4. **Read secrets from environment variables** named in `secrets` /
+   `env_passthrough`. They are injected into the sidecar process only.
+5. **Never echo secrets back** in responses or logs. Echoing a fingerprint
+   (e.g. `sha256(secret)[:12]`) is fine for debugging.
+
+`omac` also injects:
+
+| Env var          | Meaning                                                |
+| ---------------- | ------------------------------------------------------ |
+| `SIDECAR_PORT`   | TCP port the sidecar must bind on (loopback only).     |
+| `SIDECAR_SKILL`  | The skill name (handy for log lines).                  |
+| `OMAC_WORKDIR`   | Absolute path of the workdir omac was invoked in.      |
+| Each declared secret | The value from the keychain (or `env_passthrough` host env). |
+| Each declared config field | The value from `.opencode/skill-config.yaml` (canonicalized — see §10). |
+
+### Minimal Python sidecar
+
+```python
+#!/usr/bin/env python3
+import json, os, sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SKILL  = os.environ.get("SIDECAR_SKILL", "my-skill")
+PORT   = int(os.environ.get("SIDECAR_PORT", "0"))
+TOKEN  = os.environ.get("MY_API_TOKEN", "")
+
+class H(BaseHTTPRequestHandler):
+    def _json(self, code, body):
+        raw = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self):
+        if self.path == "/status":
+            return self._json(200, {"ok": True, "skill": SKILL})
+        # … your real routes here, calling the upstream API with TOKEN.
+        self._json(404, {"error": "not found"})
+
+if PORT == 0:
+    print("SIDECAR_PORT not set", file=sys.stderr); sys.exit(2)
+ThreadingHTTPServer(("127.0.0.1", PORT), H).serve_forever()
+```
+
+### Streaming (Server-Sent Events, long polls, WebSockets)
+
+The facade is a streaming reverse proxy. SSE works out of the box: set
+`Content-Type: text/event-stream`, do not set `Content-Length`, and call
+`flush()` after each frame. The facade adds `X-Accel-Buffering: no`
+automatically. See `echo-rest`'s `/tick` route for a worked example.
+
+---
+
+## 6. Install scripts
+
+`omac register <skill>` surfaces the path of `install/install.<os>.sh`
+and reminds the user to run it manually (it does NOT print the script
+body, and never executes it). Keep these scripts:
+
+- Idempotent.
+- Free of side effects on `$HOME` or globally installed packages where possible.
+- Self-contained: install language runtimes, fetch binaries, compile, etc.
+
+Example `install/install.macos.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v python3 >/dev/null; then
+  echo "python3 is required: brew install python" >&2
+  exit 1
+fi
+
+# Optional: create a venv and install requirements
+# python3 -m venv .venv
+# .venv/bin/pip install -r requirements.txt
+echo "my-skill: ready."
+```
+
+Mark them executable: `chmod +x install/install.*.sh`.
+
+---
+
+## 7. Routes the agent will see (URL rewriting)
+
+Inside the sandbox the agent calls:
+
+```
+curl --unix-socket "$OMAC_SOCKET" http://x/<mount>/<your-route>
+```
+
+The facade strips the `/<mount>` prefix and forwards `/<your-route>` to
+your sidecar, with header `X-Forwarded-Prefix: /<mount>`. So a sidecar
+that implements `GET /status` is reachable from the sandbox as
+`GET http://x/<mount>/status`.
+
+`omac start` also exports a set of env vars into the sandbox so agents
+can discover the facade without having to know its hash-derived path:
+
+| Env var | Value | Notes |
+| --- | --- | --- |
+| `OMAC_SOCKET` | `/tmp/omac-<hash>/bridge.sock` | Unix-domain socket path. |
+| `OMAC_HOST` | `127.0.0.1` | Loopback host the facade is bound to. |
+| `OMAC_PORT` | e.g. `41017` | Ephemeral TCP port. |
+| `OMAC_BASE` | `http://127.0.0.1:<port>/` | Facade root, TCP form. |
+| `OMAC_SKILLS` | e.g. `echo,slack,himalaya-email` | Comma-separated mount names. Empty when no skills are registered. |
+| `OMAC_VERSION` | e.g. `0.1.5` | The omac binary's version string. |
+| `OMAC_<MOUNT>_BASE` | `http://127.0.0.1:<port>/<mount>` | **TCP** URL for this skill, without a trailing slash. Prefer this one — it works under nono proxy mode on macOS, where Seatbelt's `(deny network*)` blocks Unix-socket `connect(2)`. |
+| `OMAC_<MOUNT>_SOCKET_BASE` | `http+unix://%2Ftmp%2Fomac-<hash>%2Fbridge.sock/<mount>` | Unix-socket form, without a trailing slash. Lower overhead when available; fails on macOS under nono proxy mode. |
+
+The `<MOUNT>` portion of the per-skill var names is derived from the
+mount string by uppercasing letters and replacing every non-alphanumeric
+character with `_`. Examples (pinned in
+`internal/sandbox/launcher_test.go`):
+
+| `mount:` in omac.yaml | Env var name |
+| --- | --- |
+| `echo` | `OMAC_ECHO_BASE` |
+| `himalaya-email` | `OMAC_HIMALAYA_EMAIL_BASE` |
+| `mail2` | `OMAC_MAIL2_BASE` |
+| `a-b_c` | `OMAC_A_B_C_BASE` |
+
+Both transports are advertised at the same time so a sandbox-aware
+client library can fall back from one to the other. As a rule of thumb
+inside the sandbox, **use the TCP form first**.
+
+---
+
+## 8. Develop & test the skill
+
+### 8.1 Validate the metadata
+
+```bash
+omac register --no-secrets my-skill   # validates omac.yaml + adds to registry
+omac doctor                           # runs sanity checks
+omac list                             # shows mount, secret count, binary status
+omac config show my-skill             # inspect resolved config + secret fingerprints
+```
+
+### 8.2 Run the stack outside the sandbox
+
+The fastest dev loop is `--no-sandbox`, which spawns sidecars + the facade
+but execs your inner command directly instead of `nono run …`:
+
+```bash
+omac start --no-sandbox --inner bash
+# inside the spawned shell:
+echo "$OMAC_SOCKET"
+curl --unix-socket "$OMAC_SOCKET" http://x/my-skill/status
+# or via the TCP form (works the same outside the sandbox):
+curl "$OMAC_MY_SKILL_BASE/status"
+```
+
+`omac start` runs successfully even with no skills registered yet — it
+will just bring up the facade with no upstream routes and exec the
+inner command. Useful when you're iterating on a sidecar before the
+first `omac register` of the day.
+
+### 8.3 Run the stack inside `nono`
+
+```bash
+omac start                    # default profile: nono
+omac start --sandbox nono-netprofile   # network-restricted variant
+```
+
+### 8.4 What `omac start` verifies before running
+
+`omac start` reconciles the on-disk state against what was registered
+and refuses to spawn anything if the gap is wider than the user has
+explicitly accepted. Four classes of drift, in the order they're
+checked:
+
+1. **Skill directory deleted** (registered skill no longer on disk).
+   Auto-deregistered silently, with a one-line `[info]` log message
+   and a hint about how to purge the leftover secrets/config:
+   ```
+   [info] my-skill: skill directory missing on disk; auto-deregistered.
+   Stored secrets and config remain. To purge: omac deregister
+   --purge-secrets --purge-fields my-skill
+   ```
+   `start` continues with whatever skills remain. The kept secrets +
+   config are insurance against an accidental `rm -rf` on the skills
+   tree.
+
+2. **Unregistered skill on disk** (a directory with an `omac.yaml` under
+   *either* skill source — the workdir-local layer or the user-global
+   layer, see §2 — that omac has never seen). Refuses to start;
+   prints the exact register command for each one. Re-registration is
+   mandatory because it's the only point at which secret-prompting and
+   config-prompting happen.
+
+3. **Bundle hash drift** (the registered skill's source files changed
+   since register). The bundle hash covers `omac.yaml` and every
+   sidecar source file (helper modules, install scripts) — but
+   excludes runtime artifacts like `__pycache__/`, `.venv/`,
+   `node_modules/`, `.git/`, `.DS_Store`, `*.pyc`, editor swap files,
+   so a `pip install` doesn't trip detection. Refuses unless
+   `--accept-skill-changes` is passed (or you re-register with
+   `omac register --force my-skill`). The flag exists for the case
+   where you've intentionally edited the skill in place during
+   development and don't want to re-prompt.
+
+4. **Missing required config field** (a `config:` entry with
+   `required: true` that has no stored value, no `default:`, and no
+   resolvable `default_from_env:`). Refuses with the list of missing
+   names and the exact register command:
+   ```
+   omac start: my-skill: required config field(s) missing: API_BASE_URL, REGION
+   Run: omac register --reprompt-fields my-skill
+   ```
+
+In all refusal cases the exit is non-zero so wrapper scripts can
+catch the condition and prompt the user.
+
+### 8.5 Inspect logs on failure
+
+If a request returns `503 X-Omac-Reason: sidecar-down`, look at:
+
+```
+$TMPDIR/omac-<workdir-hash>/logs/<skill>.log
+```
+
+That file captures the sidecar's stderr/stdout.
+
+### 8.6 Use a smoke-test client
+
+Model your manual smoke test on `demo-client.sh` in the repo root. It
+hits every route on the echo-rest reference skill via both the TCP and
+Unix-socket transports, and prints the values of every `OMAC_*` env var
+it received. Run it as the inner command:
+
+```bash
+omac start --no-sandbox --inner=./demo-client.sh
+```
+
+(Anything after `--` becomes argv for the inner command, so you can pass
+flags through if your client takes any.)
+
+---
+
+## 9. Secrets handling — best practices
+
+- **Always declare** real credentials under `sidecar.secrets`. They go
+  through the OS keychain (`omac/<skill>/<NAME>` service URI).
+- **Use `sidecar.config`** for non-secret operational values (URLs,
+  flags, region names) instead of overloading `secrets:` or
+  `env_passthrough:`. See §10 for the typed-field schema.
+- **Reserve `env_passthrough`** for the legacy fallback case: a value
+  that's normally a secret, but in some environments (CI runners
+  without a keychain) needs to come from the host shell. Document this
+  in your description.
+- **Validate with `pattern`** so users get an early failure at register
+  time rather than a 500 from the upstream API.
+- **Never log secrets**. Use a fingerprint (`sha256(secret)[:12]`) to
+  prove injection in `/whoami`-style debug routes.
+- **Rotate without re-registering** with `omac secrets set <skill> <NAME>`.
+
+---
+
+## 10. Configuration fields (non-secret config)
+
+Skills often have *operational* configuration that isn't a credential
+but still varies between users or deployments: an API base URL, a
+default region, a feature flag, a retry limit. Putting these in the
+keychain is overkill (and obscures them); hard-coding them in
+`omac.yaml` makes the skill un-reusable. Declare them under
+`sidecar.config:` instead.
+
+The lifecycle:
+
+1. `omac register` prompts for every declared field (echoing input
+   visibly, **not** masked — these are not secret).
+2. Values are stored in plain YAML under
+   `<workdir>/.opencode/skill-config.yaml`, mode `0600`.
+3. At `omac start` time the values are injected into the sidecar's
+   environment alongside secrets, so the sidecar reads them with
+   `os.environ.get("FIELD_NAME")` exactly like a secret.
+
+### 10.1 Field schema
+
+```yaml
+sidecar:
+  config:
+    - name: FIELD_NAME              # required; ^[A-Z_][A-Z0-9_]*$ (env-var name)
+      description: "Shown above the prompt."
+      type: string                  # one of: string (default) | bool | int | enum
+      required: true                # default true; false ⇒ stored only if user
+                                    #   types something
+      default: "..."                # pre-filled at the prompt; press Enter to accept
+      default_from_env: "..."       # if `default` is empty and this env var is set
+                                    #   in the host shell at register time, use it
+                                    #   as the default
+      pattern: "^https://"          # string-only; regex applied to input
+      choices: [a, b, c]            # enum-only; non-empty list
+```
+
+### 10.2 Type system
+
+| `type:` | Accepted input | Stored as |
+|---|---|---|
+| `string` (default) | any text; if `pattern` set, must match | input verbatim |
+| `bool` | `true / false / yes / no / y / n / 1 / 0 / on / off` (case-insensitive) | the canonical `"true"` or `"false"` |
+| `int` | base-10 64-bit integer (whitespace tolerated) | `strconv.FormatInt` rendering |
+| `enum` | exact match against one of `choices` | input verbatim |
+
+`pattern` is only valid with `type: string`; `choices` is required for
+`type: enum` and forbidden for the others. Defaults are validated at
+meta-load time using the same rules as input — an `int` default of
+`"twelve"` is a meta error, not a runtime surprise.
+
+### 10.3 Naming, collisions, and `env_passthrough`
+
+Field names share the env-var namespace with `secrets:` and
+`env_passthrough:`. The validation rules:
+
+- A field name colliding with a `secrets:` entry is rejected at
+  meta-load time. Pick one or the other; secrets are stricter.
+- A field name colliding with an `env_passthrough:` entry is rejected.
+  `env_passthrough` is for non-declared host env you want to opt
+  into; if the value is important enough to declare, declare it under
+  `config:` (or `secrets:`) instead.
+- A `secrets:` entry colliding with `env_passthrough` is **allowed**.
+  This is the established fallback pattern: declare the secret, but
+  also list it in `env_passthrough` so it works in environments where
+  the keychain is unavailable (sandboxed CI runners). At runtime the
+  keychain value wins over the host-env value when both are present.
+
+### 10.4 Updating values after registration
+
+Two ways:
+
+```bash
+omac register --reprompt-fields my-skill   # interactive, keeps secrets
+```
+
+…or edit `.opencode/skill-config.yaml` directly (mode 0600 — chmod it
+back if you `chown` it). Re-running `omac start` picks up the new
+values on the next sidecar spawn.
+
+For non-interactive flows (CI provisioning, scripted setup) the
+`omac register` command also accepts:
+
+- `--fields-from <file>` — read `KEY=VALUE` lines (same wire format as
+  `--secrets-from`).
+- `OMAC_CONFIG_<NAME>` env vars at register time, by analogy with
+  `OMAC_SECRET_<NAME>`.
+- `--no-fields` — skip field prompts entirely (the inverse of
+  `--no-secrets`).
+
+`omac deregister --purge-fields` drops a skill's entries from
+`skill-config.yaml` (in addition to `--purge-secrets` for the
+keychain).
+
+### 10.5 Inspecting resolved values
+
+`omac config show <skill>` is the host-side counterpart to a sidecar's
+`/whoami` endpoint: it shows what omac WOULD inject into the sidecar's
+environment if `omac start` ran right now, without actually spawning
+anything. Useful for "why isn't my sidecar seeing X?" debugging.
+
+```bash
+$ omac config show tng-email
+skill:   tng-email
+mount:   /tng-email/
+workdir: /Users/you/work/tng-sandbox
+
+config:
+  NAME                    TYPE    REQ  SOURCE                     VALUE
+  TNG_EMAIL_ADDRESS       string  yes  stored                     [email protected]
+  TNG_EMAIL_DISPLAY_NAME  string  yes  default_from_env:USER      jane
+  TNG_EMAIL_SIGNATURE     string  no   default                    Regards,
+  TNG_EMAIL_IMAP_HOST     string  yes  default                    mail.tngtech.com
+  TNG_EMAIL_IMAP_PORT     int     yes  default                    993
+  TNG_GPG_DEFAULT_KEY     string  no   missing-optional           <missing-optional>
+  TNG_GPG_REQUIRED        bool    no   stored                     false
+
+secrets:
+  NAME                REQ  FINGERPRINT
+  TNG_EMAIL_PASSWORD  yes  sha256:e3b0c44298fc
+  TNG_GPG_PASSPHRASE  no   <missing>
+```
+
+The `SOURCE` column tells you *which* of the resolution rungs in §10.3
+produced the displayed value. `--json` emits the same data as a single
+JSON object so it's pipeable into `jq`.
+
+`omac config get <skill> <field>` prints just the resolved value,
+suitable for shell-script substitution:
+
+```bash
+imap_port=$(omac config get tng-email TNG_EMAIL_IMAP_PORT)
+```
+
+This deliberately does NOT support fetching secrets — exposing a
+plaintext credential to stdout (and your shell's history) defeats the
+keychain. Use `omac config show --json` and inspect the fingerprint
+to verify a secret is the value you expect.
+
+The fingerprint format is `sha256(value)[:12]`, byte-for-byte
+identical to the reference `echo-rest` sidecar's `/whoami` route. So a
+quick visual diff between `omac config show` and `curl
+$OMAC_ECHO_BASE/whoami` confirms the value the sidecar is actually
+seeing matches the value omac thinks it should be injecting.
+
+### 10.6 When to use `secrets:` vs `config:`
+
+If the value would be embarrassing in a screenshot, use `secrets:`.
+If it would be embarrassing in `git log` of a private repo, use
+`secrets:`. Otherwise — base URLs, region names, retry limits, feature
+flags, log verbosity — use `config:`. Anything that gets typed into a
+public chat ("set my region to eu-central-1") is a config field.
+
+### 10.7 Example: reading a config field in Python
+
+```python
+import os
+GREETING = os.environ.get("ECHO_GREETING", "hello")     # string
+VERBOSE  = os.environ.get("ECHO_VERBOSE", "false") == "true"
+TIMEOUT  = int(os.environ.get("ECHO_MAX_TICK", "100"))  # int
+MODE     = os.environ.get("ECHO_MODE", "demo")          # enum: just a string
+```
+
+The reference skill `.opencode/skills/echo-rest/` exercises every type;
+its `/whoami` route echoes the resolved values back to the caller so
+you can verify omac injected them correctly.
+
+---
+
+## 11. Distributing the skill
+
+`omac` is the **runtime**, not an installer. The marketplace installer
+(e.g. `scripts/install.sh <skill>`) drops your skill directory under
+`.opencode/skills/<name>/`. To distribute:
+
+1. Pick a stable `name` (kebab-case, agentskills.io-compliant — see §3.1)
+   and `mount` (URL-safe; defaults to the name).
+2. Pin a `version` in `omac.yaml` and (optionally) in `SKILL.md`'s
+   `metadata.version`. Bump on breaking changes.
+3. Ship the source layout described in §2 — `SKILL.md` and `omac.yaml`
+   at the root, plus whichever of `scripts/`, `references/`, `assets/`,
+   `install/` you actually need.
+4. Validate: `skills-ref validate ./.opencode/skills/<name>` (agentskills.io
+   side) **and** `omac register --no-secrets <name>` (omac side).
+5. Make sure `install/install.<os>.sh` documents every host-side
+   dependency (interpreters, build tools, native libs).
+6. Test with at least:
+   - `omac register --no-secrets <skill>`
+   - `omac start --no-sandbox --inner bash` and a smoke-test script.
+   - `omac start` (full sandbox path) on macOS and Linux.
+
+Users will then:
+
+```bash
+scripts/install.sh <your-skill>     # marketplace pulls your tree
+omac register <your-skill>          # prompts for declared secrets
+bash .opencode/skills/<your-skill>/install/install.macos.sh
+omac start
+```
+
+---
+
+## 12. Checklist before shipping
+
+- [ ] `SKILL.md` exists at the skill root with valid agentskills.io
+      frontmatter (`name`, `description`; optionally `license`,
+      `compatibility`, `metadata`, `allowed-tools`). `skills-ref
+      validate` passes.
+- [ ] `SKILL.md`'s `name`, `omac.yaml`'s `name`, and the directory
+      name all match.
+- [ ] `SKILL.md`'s `description` covers both *what* the skill does
+      and *when* the agent should activate it; under 1024 chars.
+- [ ] `SKILL.md` body is under 500 lines (move deeper material into
+      `references/`).
+- [ ] `omac.yaml` validates (`omac register --no-secrets …` succeeds).
+- [ ] `mount` matches `^[a-z0-9][a-z0-9-]*$`.
+- [ ] Sidecar binds on `127.0.0.1:$SIDECAR_PORT` (not `0.0.0.0`).
+- [ ] Sidecar entry-point lives under `scripts/` and `omac.yaml`'s
+      `command:` references it via the relative path
+      (e.g. `["python3", "scripts/sidecar.py"]`).
+- [ ] `GET /status` returns 2xx within `health.timeout_ms`.
+- [ ] All credentials declared under `secrets:` (not just `env_passthrough`).
+- [ ] No secret value logged or returned in any response body.
+- [ ] `install/install.macos.sh` and `install/install.linux.sh` are
+      executable, idempotent, and exit non-zero on missing prerequisites.
+- [ ] Streaming endpoints (if any) use `Content-Type: text/event-stream`,
+      no `Content-Length`, and call `flush()` per frame.
+- [ ] Smoke-tested end-to-end with `omac start` (sandboxed) and the agent
+      reaching the sidecar via `$OMAC_SOCKET`.
+
+---
+
+## References inside this repo
+
+- Reference skill: [`.opencode/skills/echo-rest/`](./.opencode/skills/echo-rest/)
+- Reference `SKILL.md`: [`.opencode/skills/echo-rest/SKILL.md`](./.opencode/skills/echo-rest/SKILL.md)
+- agentskills.io spec: <https://agentskills.io/specification>
+- agentskills.io validator: <https://github.com/agentskills/agentskills/tree/main/skills-ref>
+- `omac.yaml` schema: [`internal/config/meta.go`](./internal/config/meta.go)
+- Sidecar lifecycle (env injection, port assignment): [`internal/supervisor/supervisor.go`](./internal/supervisor/supervisor.go)
+- Facade routing & SSE: [`internal/facade/facade.go`](./internal/facade/facade.go)
+- Sandbox launcher (`OMAC_*_BASE` env splat): [`internal/sandbox/launcher.go`](./internal/sandbox/launcher.go)
+- Smoke-test client: [`demo-client.sh`](./demo-client.sh)

--- a/internal/builtinskills/builtinskills.go
+++ b/internal/builtinskills/builtinskills.go
@@ -1,0 +1,333 @@
+// Package builtinskills ships skill bundles embedded in the omac binary and
+// materializes them onto disk.
+//
+// Today the only built-in is omac-write-a-skill, a guidance-only skill (a
+// SKILL.md, no omac.yaml). omac deliberately ignores SKILL.md-only directories
+// (see internal/skillsource), so these bundles are NOT registered or activated
+// by omac; they are placed into a harness's own native skills directory and
+// surfaced by that harness's loader directly. Provisioning is therefore pure
+// file placement — see `omac setup`.
+//
+// The bundles are embedded so `omac setup` works in any folder, independent of
+// the source tree the binary was built from, with no network access. Each
+// bundle carries an `omac-builtin: "true"` marker in its SKILL.md frontmatter
+// so re-provisioning can tell an omac-owned copy (safe to refresh) from a
+// user's or third party's same-named directory (left untouched).
+package builtinskills
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+)
+
+// assetsFS holds every built-in bundle under assets/<skill-name>/...
+//
+//go:embed all:assets
+var assetsFS embed.FS
+
+// assetsRoot is the embedded directory that holds the bundle subdirectories.
+const assetsRoot = "assets"
+
+// MarkerKey is the SKILL.md frontmatter metadata key that identifies a bundle
+// as omac-owned. Its presence with a truthy value means `omac setup` may
+// refresh the directory; its absence means the directory is foreign and must
+// not be overwritten.
+const MarkerKey = "omac-builtin"
+
+// Names returns the built-in skill names (the bundle directory names), sorted.
+func Names() []string {
+	entries, err := assetsFS.ReadDir(assetsRoot)
+	if err != nil {
+		// The assets tree is embedded at build time; a read failure is a
+		// programming error, not a runtime condition.
+		panic("builtinskills: read embedded assets: " + err.Error())
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// bundleFS returns an fs.FS rooted at the named bundle's directory.
+func bundleFS(name string) (fs.FS, error) {
+	sub, err := fs.Sub(assetsFS, filepath.ToSlash(filepath.Join(assetsRoot, name)))
+	if err != nil {
+		return nil, fmt.Errorf("builtinskills: no bundle %q: %w", name, err)
+	}
+	// Probe so an unknown name fails here rather than at first walk.
+	if _, err := fs.Stat(sub, "SKILL.md"); err != nil {
+		return nil, fmt.Errorf("builtinskills: bundle %q has no SKILL.md: %w", name, err)
+	}
+	return sub, nil
+}
+
+// Status describes what Materialize did (or would do) for one bundle.
+type Status string
+
+const (
+	// StatusCreated: the target did not exist and was written fresh.
+	StatusCreated Status = "created"
+	// StatusUpdated: an omac-owned target existed with different content and
+	// was refreshed to the embedded version.
+	StatusUpdated Status = "updated"
+	// StatusUnchanged: the target already matched the embedded version.
+	StatusUnchanged Status = "unchanged"
+	// StatusForeign: a same-named directory exists without the omac-builtin
+	// marker; it was left untouched (no write).
+	StatusForeign Status = "foreign"
+)
+
+// Result reports the outcome of materializing one bundle into one location.
+type Result struct {
+	Skill  string
+	Dir    string // absolute target bundle directory
+	Status Status
+}
+
+// State describes a bundle's on-disk state relative to the embedded version,
+// without modifying anything. Used by read-only callers like `omac doctor`.
+type State string
+
+const (
+	// StateMissing: no directory for the bundle exists.
+	StateMissing State = "missing"
+	// StateCurrent: an omac-owned bundle exists and matches the embedded version.
+	StateCurrent State = "current"
+	// StateStale: an omac-owned bundle exists but differs from the embedded
+	// version (e.g. omac was upgraded but `omac setup` not re-run).
+	StateStale State = "stale"
+	// StateForeign: a same-named directory exists without the omac-builtin marker.
+	StateForeign State = "foreign"
+)
+
+// Check reports the on-disk state of bundle `name` under skillsParentDir
+// without writing anything.
+func Check(name, skillsParentDir string) (State, error) {
+	src, err := bundleFS(name)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(skillsParentDir, name)
+	existed, err := isDir(dir)
+	if err != nil {
+		return "", err
+	}
+	if !existed {
+		return StateMissing, nil
+	}
+	owned, err := dirHasMarker(dir)
+	if err != nil {
+		return "", err
+	}
+	if !owned {
+		return StateForeign, nil
+	}
+	identical, err := treeMatches(src, dir)
+	if err != nil {
+		return "", err
+	}
+	if identical {
+		return StateCurrent, nil
+	}
+	return StateStale, nil
+}
+
+// Materialize writes the built-in skill `name` into skillsParentDir/<name>.
+//
+// It is marker-guarded: if the target directory already exists and is NOT
+// omac-owned (its SKILL.md lacks the omac-builtin marker), it is left untouched
+// and Status is StatusForeign — unless force is true, in which case it is
+// overwritten. An omac-owned (or absent) target is written/refreshed; an
+// already-current target is reported StatusUnchanged with no write.
+//
+// File writes are per-file atomic (temp file + rename). Directories are created
+// 0755 and files 0644 (embedded files carry no mode bits; the only built-in is
+// guidance-only text, so no executable bits are needed).
+func Materialize(name, skillsParentDir string, force bool) (Result, error) {
+	src, err := bundleFS(name)
+	if err != nil {
+		return Result{}, err
+	}
+	dir := filepath.Join(skillsParentDir, name)
+	res := Result{Skill: name, Dir: dir}
+
+	existed, err := isDir(dir)
+	if err != nil {
+		return res, err
+	}
+	if existed && !force {
+		owned, err := dirHasMarker(dir)
+		if err != nil {
+			return res, err
+		}
+		if !owned {
+			res.Status = StatusForeign
+			return res, nil
+		}
+	}
+
+	identical, err := treeMatches(src, dir)
+	if err != nil {
+		return res, err
+	}
+	if identical {
+		res.Status = StatusUnchanged
+		return res, nil
+	}
+
+	if err := writeTree(src, dir); err != nil {
+		return res, err
+	}
+	if existed {
+		res.Status = StatusUpdated
+	} else {
+		res.Status = StatusCreated
+	}
+	return res, nil
+}
+
+// isDir reports whether path is an existing directory.
+func isDir(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.IsDir(), nil
+}
+
+var markerRe = regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(MarkerKey) + `:\s*"?(?i:true)"?\s*$`)
+
+// dirHasMarker reports whether the SKILL.md in dir carries a truthy
+// omac-builtin marker in its YAML frontmatter.
+func dirHasMarker(dir string) (bool, error) {
+	b, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	fm, ok := frontmatter(b)
+	if !ok {
+		return false, nil
+	}
+	return markerRe.Match(fm), nil
+}
+
+// frontmatter extracts the bytes of the leading YAML frontmatter block
+// (between the first two `---` lines). ok is false when no frontmatter block
+// is present.
+func frontmatter(b []byte) ([]byte, bool) {
+	// Must start with a "---" line (allow a leading BOM/whitespace-free start).
+	if !bytes.HasPrefix(b, []byte("---\n")) && !bytes.HasPrefix(b, []byte("---\r\n")) {
+		return nil, false
+	}
+	rest := b[bytes.IndexByte(b, '\n')+1:]
+	end := bytes.Index(rest, []byte("\n---"))
+	if end < 0 {
+		return nil, false
+	}
+	return rest[:end], true
+}
+
+// treeMatches reports whether every file in the embedded bundle exists on disk
+// under dir with byte-identical content. Extra files on disk are ignored (a
+// user may have added notes); the check is "is the embedded content present and
+// current", which is what idempotent refresh cares about.
+func treeMatches(src fs.FS, dir string) (bool, error) {
+	match := true
+	err := fs.WalkDir(src, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		want, err := fs.ReadFile(src, p)
+		if err != nil {
+			return err
+		}
+		got, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(p)))
+		if err != nil {
+			if os.IsNotExist(err) {
+				match = false
+				return fs.SkipAll
+			}
+			return err
+		}
+		if !bytes.Equal(want, got) {
+			match = false
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return match, nil
+}
+
+// writeTree writes every file in the embedded bundle into dir, creating parent
+// directories as needed. Each file is written atomically (temp + rename).
+func writeTree(src fs.FS, dir string) error {
+	return fs.WalkDir(src, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dir, filepath.FromSlash(p))
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := fs.ReadFile(src, p)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return atomicWrite(target, data)
+	})
+}
+
+// atomicWrite writes data to path via a temp file in the same directory
+// followed by rename, so a concurrent reader never sees a partial file.
+func atomicWrite(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}

--- a/internal/builtinskills/builtinskills_test.go
+++ b/internal/builtinskills/builtinskills_test.go
@@ -1,0 +1,126 @@
+package builtinskills
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNamesIncludesWriteASkill(t *testing.T) {
+	found := false
+	for _, n := range Names() {
+		if n == "omac-write-a-skill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Names() = %v, want to include omac-write-a-skill", Names())
+	}
+}
+
+func TestMaterializeCreateUnchangedUpdate(t *testing.T) {
+	parent := t.TempDir()
+	skillMd := filepath.Join(parent, "omac-write-a-skill", "SKILL.md")
+	ref := filepath.Join(parent, "omac-write-a-skill", "references", "creating-a-skill.md")
+
+	// create
+	res, err := Materialize("omac-write-a-skill", parent, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusCreated {
+		t.Fatalf("status = %s, want created", res.Status)
+	}
+	for _, p := range []string{skillMd, ref} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected file written: %s: %v", p, err)
+		}
+	}
+
+	// unchanged on re-run
+	res, err = Materialize("omac-write-a-skill", parent, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusUnchanged {
+		t.Fatalf("status = %s, want unchanged", res.Status)
+	}
+
+	// drift an omac-owned file (marker stays in SKILL.md) → updated + restored
+	orig, err := os.ReadFile(skillMd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skillMd, append(append([]byte{}, orig...), []byte("\n<!-- drift -->\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err = Materialize("omac-write-a-skill", parent, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusUpdated {
+		t.Fatalf("status = %s, want updated", res.Status)
+	}
+	got, err := os.ReadFile(skillMd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, orig) {
+		t.Fatal("SKILL.md was not refreshed to the embedded version")
+	}
+}
+
+func TestMaterializeForeignGuard(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "omac-write-a-skill")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Same name, but no omac-builtin marker → foreign.
+	foreign := []byte("---\nname: omac-write-a-skill\n---\nsomeone else's skill\n")
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), foreign, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Materialize("omac-write-a-skill", parent, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusForeign {
+		t.Fatalf("status = %s, want foreign", res.Status)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, foreign) {
+		t.Fatal("foreign SKILL.md must be left untouched")
+	}
+
+	// --force overrides the guard.
+	res, err = Materialize("omac-write-a-skill", parent, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusUpdated {
+		t.Fatalf("status = %s, want updated under force", res.Status)
+	}
+}
+
+// TestBundleGuideMatchesRepoRoot is the single-source-of-truth guard: the
+// embedded reference copy must stay byte-identical to the repo-root
+// CREATING_A_SKILL.md. If this fails, re-copy the guide into the bundle.
+func TestBundleGuideMatchesRepoRoot(t *testing.T) {
+	root, err := os.ReadFile(filepath.Join("..", "..", "CREATING_A_SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundled, err := os.ReadFile(filepath.Join("assets", "omac-write-a-skill", "references", "creating-a-skill.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(root, bundled) {
+		t.Fatal("bundle references/creating-a-skill.md drifted from repo-root CREATING_A_SKILL.md; re-copy it")
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -122,6 +122,7 @@ func commands() map[string]Command {
 		"config":     {Name: "config", Short: "Show resolved config + secret fingerprints for a skill.", Run: runConfig},
 		"start":      {Name: "start", Short: "Start sidecars + facade + sandbox. Optional [harness]: opencode|claude.", Run: runStart},
 		"serve":      {Name: "serve", Short: "Long-lived multi-directory server. Optional [harness]: opencode|claude.", Run: runServe},
+		"setup":      {Name: "setup", Short: "Provision omac's built-in skills into installed harnesses' skills dirs.", Run: runSetup},
 		"plugin":     {Name: "plugin", Short: "Install client-side harness bridge plugins (e.g. opencode-desktop).", Run: runPlugin},
 		"sandbox":    {Name: "sandbox", Short: "Built-in kernel sandbox (run|stage2).", Run: runSandbox},
 		"doctor":     {Name: "doctor", Short: "Run sanity checks.", Run: runDoctor},
@@ -146,6 +147,7 @@ Subcommands:
   list         List registered skills.
   secrets      Manage skill secrets in the OS keychain.
   config       Show resolved config + secret fingerprints for a skill.
+  setup        Provision omac's built-in skills into installed harnesses.
   start        Start sidecars + facade + sandbox.       [harness]: opencode|claude
   serve        Long-lived multi-directory server.        [harness]: opencode|claude
   plugin       Install client-side bridge plugins (e.g. opencode-desktop).

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/builtinskills"
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/keychain"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt"
@@ -114,6 +115,9 @@ func runDoctor(args []string, env *Env) int {
 			status, e.Name, binOK, missingReq)
 	}
 
+	// Built-in skills provisioned by `omac setup`, per installed harness.
+	doctorBuiltinSkills(env)
+
 	// Sandbox binary.
 	lc, _, _ := config.LoadLauncher(env.Workdir)
 	profName := lc.Sandbox.DefaultProfile
@@ -133,6 +137,41 @@ func runDoctor(args []string, env *Env) int {
 		return ExitConfigInvalid
 	}
 	return ExitOK
+}
+
+// doctorBuiltinSkills reports whether omac's built-in skills (provisioned by
+// `omac setup`) are present and current in each installed harness's native
+// skills dir. It is advisory: a missing/stale/foreign bundle is a warning, not
+// a doctor failure.
+func doctorBuiltinSkills(env *Env) {
+	harnesses := installedHarnesses()
+	if len(harnesses) == 0 {
+		fmt.Fprintln(env.Stdout, "[warn] built-in skills: no harness detected on $PATH; run `omac setup` after installing one")
+		return
+	}
+	for _, h := range harnesses {
+		dir := h.GlobalSkillsDir()
+		if dir == "" {
+			continue
+		}
+		for _, name := range builtinskills.Names() {
+			st, err := builtinskills.Check(name, dir)
+			if err != nil {
+				fmt.Fprintf(env.Stdout, "  [warn] built-in %s (%s): %v\n", name, h.Name, err)
+				continue
+			}
+			switch st {
+			case builtinskills.StateCurrent:
+				fmt.Fprintf(env.Stdout, "  [ok] built-in %s (%s): present\n", name, h.Name)
+			case builtinskills.StateMissing:
+				fmt.Fprintf(env.Stdout, "  [warn] built-in %s (%s): missing — run `omac setup`\n", name, h.Name)
+			case builtinskills.StateStale:
+				fmt.Fprintf(env.Stdout, "  [warn] built-in %s (%s): out of date — run `omac setup`\n", name, h.Name)
+			case builtinskills.StateForeign:
+				fmt.Fprintf(env.Stdout, "  [warn] built-in %s (%s): a non-omac directory occupies that name\n", name, h.Name)
+			}
+		}
+	}
 }
 
 // doctorBuiltinSandbox reports the platform prerequisites of the

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -246,6 +246,11 @@ func runServe(args []string, env *Env) int {
 		return ExitOK
 	}
 
+	// Idempotently provision omac's built-in skills for this harness so they
+	// are available with no separate setup step. Quiet when already current;
+	// never blocks the launch.
+	ensureBuiltinSkills(env, harness)
+
 	// Build the inner argv. serve mode runs the selected harness's *server*
 	// form: the inner executable is resolved from the profile (or --inner, or
 	// the harness default), then the harness's ServerLaunch convention is

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os/exec"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/builtinskills"
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+// runSetup provisions omac's built-in skill bundles into the native skills
+// directory of each installed harness. Built-ins are guidance-only skills
+// (SKILL.md, no omac.yaml): omac neither registers nor activates them, so this
+// is pure file placement into the dir each harness's own loader reads.
+func runSetup(args []string, env *Env) int {
+	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	force := fs.Bool("force", false, "Overwrite a same-named skills directory even if it is not omac-owned.")
+	fs.Usage = func() {
+		fmt.Fprintln(env.Stderr, "Usage: omac setup [harness] [--force]")
+		fmt.Fprintln(env.Stderr, "")
+		fmt.Fprintln(env.Stderr, "Provision omac's built-in skills into each installed harness's skills dir.")
+		fmt.Fprintln(env.Stderr, "Optional [harness] (opencode|claude) narrows to one; default: all installed.")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(reorderFlagsFirst(args)); err != nil {
+		return ExitMisuse
+	}
+
+	var targets []config.Harness
+	switch fs.NArg() {
+	case 0:
+		targets = installedHarnesses()
+		if len(targets) == 0 {
+			// No harness on PATH (e.g. setup run before installing one). Land
+			// the bundle in every known harness's dir so it's there once a
+			// harness arrives, rather than silently doing nothing.
+			fmt.Fprintln(env.Stderr, "[warn] no harness detected on PATH; provisioning to all known harness skills dirs")
+			targets = config.AllHarnesses()
+		}
+	case 1:
+		h, ok := config.LookupHarness(fs.Arg(0))
+		if !ok {
+			fmt.Fprintln(env.Stderr, "omac setup:", config.UnknownHarnessError(fs.Arg(0)))
+			return ExitMisuse
+		}
+		targets = []config.Harness{h}
+	default:
+		fs.Usage()
+		return ExitMisuse
+	}
+
+	sOut := newStyler(env.Stdout)
+	okTag := sOut.paint("[ok]", ansiBold, ansiGreen)
+	skipTag := sOut.paint("[skip]", ansiBold, ansiYellow)
+	exit := ExitOK
+	foreign := false
+
+	for _, h := range targets {
+		dir := h.GlobalSkillsDir()
+		if dir == "" {
+			fmt.Fprintf(env.Stderr, "[warn] cannot resolve a global skills dir for %s; skipping\n", h.Name)
+			exit = ExitIOError
+			continue
+		}
+		for _, name := range builtinskills.Names() {
+			res, err := builtinskills.Materialize(name, dir, *force)
+			if err != nil {
+				fmt.Fprintf(env.Stderr, "omac setup: %s (%s): %v\n", name, h.Name, err)
+				exit = ExitIOError
+				continue
+			}
+			switch res.Status {
+			case builtinskills.StatusForeign:
+				foreign = true
+				fmt.Fprintf(env.Stdout, "%s %s (%s): a non-omac directory already exists at %s; left untouched\n",
+					skipTag, sOut.bold(name), h.Name, res.Dir)
+			case builtinskills.StatusUnchanged:
+				fmt.Fprintf(env.Stdout, "%s %s (%s) %s\n", okTag, sOut.bold(name), h.Name, sOut.gray("already up to date"))
+			case builtinskills.StatusCreated:
+				fmt.Fprintf(env.Stdout, "%s %s (%s) %s\n", okTag, sOut.bold(name), h.Name, sOut.gray("installed → "+res.Dir))
+			case builtinskills.StatusUpdated:
+				fmt.Fprintf(env.Stdout, "%s %s (%s) %s\n", okTag, sOut.bold(name), h.Name, sOut.gray("refreshed → "+res.Dir))
+			}
+		}
+	}
+
+	if foreign {
+		fmt.Fprintf(env.Stderr, "\n[hint] re-run with %s to overwrite the non-omac directories above.\n", sOut.bold("--force"))
+	}
+	return exit
+}
+
+// ensureBuiltinSkills idempotently provisions omac's built-in skills into the
+// active harness's native skills dir on launch, so they are available with no
+// separate setup step. It is quiet when nothing changes and never fails the
+// launch — a provisioning error (or a foreign same-named dir) is a warning, not
+// a hard stop. The explicit `omac setup` command remains for all-harness or
+// forced (re)provisioning.
+func ensureBuiltinSkills(env *Env, harness config.Harness) {
+	dir := harness.GlobalSkillsDir()
+	if dir == "" {
+		return
+	}
+	for _, name := range builtinskills.Names() {
+		res, err := builtinskills.Materialize(name, dir, false)
+		if err != nil {
+			fmt.Fprintf(env.Stderr, "[warn] could not provision built-in skill %s for %s: %v\n", name, harness.Name, err)
+			continue
+		}
+		switch res.Status {
+		case builtinskills.StatusCreated:
+			fmt.Fprintf(env.Stderr, "[ok] provisioned built-in skill %s for %s\n", name, harness.Name)
+		case builtinskills.StatusUpdated:
+			fmt.Fprintf(env.Stderr, "[ok] refreshed built-in skill %s for %s\n", name, harness.Name)
+		case builtinskills.StatusForeign:
+			fmt.Fprintf(env.Stderr, "[hint] a non-omac %q directory exists for %s; not overwriting (run `omac setup --force` to replace)\n", name, harness.Name)
+			// StatusUnchanged: stay silent — the common case on every launch.
+		}
+	}
+}
+
+// installedHarnesses returns the registered harnesses whose inner command
+// resolves on PATH.
+func installedHarnesses() []config.Harness {
+	var out []config.Harness
+	for _, h := range config.AllHarnesses() {
+		if len(h.InnerCmd) == 0 {
+			continue
+		}
+		if _, err := exec.LookPath(h.InnerCmd[0]); err == nil {
+			out = append(out, h)
+		}
+	}
+	return out
+}

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+func runSetupCapture(t *testing.T, workdir string, args []string) (stdout, stderr string, code int) {
+	t.Helper()
+	dir := t.TempDir()
+	outF, err := os.Create(filepath.Join(dir, "out"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	errF, err := os.Create(filepath.Join(dir, "err"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := &Env{Version: "test", Workdir: workdir, Stdout: outF, Stderr: errF, Stdin: os.Stdin}
+	code = runSetup(args, env)
+	outF.Close()
+	errF.Close()
+	o, _ := os.ReadFile(outF.Name())
+	e, _ := os.ReadFile(errF.Name())
+	return string(o), string(e), code
+}
+
+func TestRunSetupProvisionsAllHarnessesAndIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	// No harness on PATH → setup provisions to all known harnesses.
+	t.Setenv("PATH", "")
+
+	out, _, code := runSetupCapture(t, home, nil)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stdout = %s", code, out)
+	}
+	for _, p := range []string{
+		filepath.Join(home, ".config", "opencode", "skills", "omac-write-a-skill", "SKILL.md"),
+		filepath.Join(home, ".claude", "skills", "omac-write-a-skill", "SKILL.md"),
+	} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected provisioned file %s: %v", p, err)
+		}
+	}
+	if !strings.Contains(out, "installed") {
+		t.Fatalf("expected an install line, got: %s", out)
+	}
+
+	// Second run is idempotent.
+	out2, _, code2 := runSetupCapture(t, home, nil)
+	if code2 != ExitOK {
+		t.Fatalf("second run exit = %d", code2)
+	}
+	if !strings.Contains(out2, "already up to date") {
+		t.Fatalf("expected idempotent re-run, got: %s", out2)
+	}
+}
+
+func TestEnsureBuiltinSkillsProvisionsActiveHarness(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	cc, ok := config.LookupHarness("claude")
+	if !ok {
+		t.Fatal("claude harness not found")
+	}
+
+	dir := filepath.Join(t.TempDir(), "out")
+	errF, err := os.Create(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := &Env{Version: "test", Workdir: home, Stdout: errF, Stderr: errF, Stdin: os.Stdin}
+
+	// First launch provisions into the active (claude) harness dir only.
+	ensureBuiltinSkills(env, cc)
+	skill := filepath.Join(home, ".claude", "skills", "omac-write-a-skill", "SKILL.md")
+	if _, err := os.Stat(skill); err != nil {
+		t.Fatalf("expected auto-provisioned skill at %s: %v", skill, err)
+	}
+	// It targets only the active harness, not opencode.
+	if _, err := os.Stat(filepath.Join(home, ".config", "opencode", "skills", "omac-write-a-skill")); !os.IsNotExist(err) {
+		t.Fatalf("ensureBuiltinSkills should not touch a non-active harness dir, err=%v", err)
+	}
+
+	// Second launch is a no-op (idempotent) and must not error.
+	ensureBuiltinSkills(env, cc)
+}
+
+func TestRunSetupUnknownHarness(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	_, errOut, code := runSetupCapture(t, home, []string{"nope"})
+	if code != ExitMisuse {
+		t.Fatalf("exit = %d, want ExitMisuse", code)
+	}
+	if !strings.Contains(errOut, "unknown harness") {
+		t.Fatalf("expected unknown-harness error, got: %s", errOut)
+	}
+}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -184,6 +184,11 @@ func runStart(args []string, env *Env) int {
 				"starting sandbox without sidecars (run `omac register` to add some)")
 	}
 
+	// Idempotently provision omac's built-in skills for this harness so they
+	// are available with no separate setup step. Quiet when already current;
+	// never blocks the launch.
+	ensureBuiltinSkills(env, harness)
+
 	// 2c-d / 3. Per-skill validation + secret/config resolution.
 	//
 	// We do this in a single pass that accumulates every per-skill

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -53,6 +53,15 @@ type Harness struct {
 	// addition to the active harness's own base. Skill discovery NEVER scans
 	// another harness's own base — see internal/skillsource.
 	SkillsBase string
+
+	// UserConfigHome, when non-empty, is the harness's user-global config
+	// directory as a $HOME-relative path (e.g. ".claude" for Claude Code,
+	// whose config home is ~/.claude rather than ~/.config/claude). When
+	// empty, the harness follows the XDG convention and its user config dir is
+	// <userConfigRoot>/<SkillsBase> (i.e. ~/.config/<base>, honoring
+	// $XDG_CONFIG_HOME). GlobalSkillsDir derives "<config home>/skills" from
+	// this — the directory the harness's own loader reads global skills from.
+	UserConfigHome string
 }
 
 // SharedSkillsBase is the neutral, harness-independent skills directory base
@@ -105,6 +114,9 @@ func harnessRegistry() []Harness {
 			ServerLaunch: nil,
 			BridgeDir:    ".claude",
 			SkillsBase:   "claude",
+			// Claude Code's config home is ~/.claude, not ~/.config/claude,
+			// so its global skills live in ~/.claude/skills.
+			UserConfigHome: ".claude",
 		},
 	}
 }
@@ -252,6 +264,32 @@ func (h Harness) GlobalBridgeDir() string {
 		return ""
 	}
 	return filepath.Join(root, base, leaf)
+}
+
+// GlobalSkillsDir returns the absolute user-global skills directory that THIS
+// harness's own loader reads — the place a guidance-only skill must be written
+// to be surfaced by the harness (omac does not register or activate such
+// skills). OpenCode follows XDG (~/.config/opencode/skills, $XDG_CONFIG_HOME
+// honored); Claude Code uses ~/.claude/skills (see UserConfigHome).
+//
+// It returns "" when no home/config directory can be resolved.
+func (h Harness) GlobalSkillsDir() string {
+	base := h.SkillsBase
+	if base == "" {
+		base = SharedSkillsBase
+	}
+	if h.UserConfigHome != "" {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			return ""
+		}
+		return filepath.Join(home, h.UserConfigHome, "skills")
+	}
+	root := userConfigRoot()
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, base, "skills")
 }
 
 // userConfigRoot resolves the base user config directory, honoring

--- a/internal/config/harness_globalskills_test.go
+++ b/internal/config/harness_globalskills_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGlobalSkillsDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "") // force the ~/.config fallback
+
+	oc, ok := LookupHarness("opencode")
+	if !ok {
+		t.Fatal("opencode harness not found")
+	}
+	cc, ok := LookupHarness("claude")
+	if !ok {
+		t.Fatal("claude harness not found")
+	}
+
+	if got, want := oc.GlobalSkillsDir(), filepath.Join(home, ".config", "opencode", "skills"); got != want {
+		t.Fatalf("opencode GlobalSkillsDir = %q, want %q", got, want)
+	}
+	if got, want := cc.GlobalSkillsDir(), filepath.Join(home, ".claude", "skills"); got != want {
+		t.Fatalf("claude GlobalSkillsDir = %q, want %q", got, want)
+	}
+
+	// OpenCode honors $XDG_CONFIG_HOME; Claude Code does not (uses ~/.claude).
+	xdg := filepath.Join(home, "xdg")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	if got, want := oc.GlobalSkillsDir(), filepath.Join(xdg, "opencode", "skills"); got != want {
+		t.Fatalf("opencode GlobalSkillsDir (XDG) = %q, want %q", got, want)
+	}
+	if got, want := cc.GlobalSkillsDir(), filepath.Join(home, ".claude", "skills"); got != want {
+		t.Fatalf("claude GlobalSkillsDir (XDG set) = %q, want %q", got, want)
+	}
+}

--- a/openspec/changes/ship-write-a-skill/.openspec.yaml
+++ b/openspec/changes/ship-write-a-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/ship-write-a-skill/design.md
+++ b/openspec/changes/ship-write-a-skill/design.md
@@ -1,0 +1,118 @@
+## Context
+
+omac distinguishes two kinds of skills (`internal/skillsource`): a directory with an
+`omac.yaml` is an **omac sidecar skill** (omac discovers, registers, and activates it);
+a directory with only a `SKILL.md` "does not have an omac sidecar contract, so omac
+ignores it (no registration, no spawning)" — it is a **guidance-only skill** surfaced
+directly by the *harness's own loader* from its native skills dir
+(`~/.config/opencode/skills`, `~/.claude/skills`). The `openspec-*` and `caveman`
+skills are guidance-only; `skill-marketplace` is a sidecar skill.
+
+The authoring helper exists today only as `CREATING_A_SKILL.md` in the repo root — not
+as a shipped skill, and not on disk in any harness skills dir. Populating those dirs
+was `opencode-nono`'s `install.sh`, now retired. omac embeds only
+`internal/plugin/assets/omac-multidir.ts`; no skills are bundled.
+
+`omac-write-a-skill` exposes no API — it is pure authoring guidance — so it is a
+guidance-only skill. That means provisioning is **file placement only**: omac neither
+registers nor activates it, and it must land in each harness's *native* skills dir
+(not the shared `~/.config/agents/skills`, which omac scans but the harnesses do not
+read).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ship a guidance-only `omac-write-a-skill` bundle inside the omac binary.
+- Provide `omac setup` to write it into each installed harness's native skills dir,
+  idempotently — replacing the dead `install.sh` path.
+- Keep it omac-specific and collision-proof against third-party authoring skills.
+- Add a Quickstart `omac setup` step so a fresh install works out of the box.
+
+**Non-Goals:**
+- Any registry / skill-config / keychain / `serve` activation work — guidance skills
+  bypass all of it.
+- Anything marketplace-related (stage, base URL, the `skill-marketplace` bundle).
+- A general plugin/skill package manager — only this one built-in bundle.
+- Giving the skill an `omac.yaml`/sidecar.
+
+## Decisions
+
+### D1 — Embed the bundle with `go:embed` (a new `internal/builtinskills` package)
+Bundle the skill as a directory tree under
+`internal/builtinskills/assets/omac-write-a-skill/` and expose it via `embed.FS`,
+mirroring how `internal/plugin` embeds `omac-multidir.ts`, so it versions with omac.
+- *Alternative:* fetch from a release artifact at provision time → rejected: needs
+  network for something that should be self-contained and offline.
+
+### D2 — Auto-provision on launch; `omac setup` for explicit (re)provisioning
+Provisioning is folded into `omac start`/`omac serve`: on launch omac idempotently
+materializes the embedded bundle into the **active** harness's native skills dir, so
+there is **no extra setup step**. It is silent when already current and never fails the
+launch (a write error or a foreign same-named dir is a warning). No registration: omac
+ignores `SKILL.md`-only dirs, and the harness surfaces the skill itself.
+
+An explicit `omac setup [harness] [--force]` command remains for provisioning **all**
+installed harnesses at once and for force-refreshing after an upgrade — but the
+everyday flow needs no separate command.
+- *Decision rationale:* the user prioritized a minimal, single-step install. Auto-on-
+  launch achieves that; the cost is that `start`/`serve` write into the harness's
+  global skills dir as a side effect (idempotent, marker-guarded, scoped to the active
+  harness only).
+- *Alternatives:* an explicit-only `omac setup` step (rejected: adds a step to the
+  Quickstart); provision-on-first-run-only (rejected: needs extra "first run" state);
+  fold into `omac register` (rejected: register is for sidecar skills and requires an
+  `omac.yaml`).
+
+### D3 — Provision into each installed harness's native skills dir (all harnesses)
+A guidance skill is surfaced by the harness's own loader, which reads only its own
+native global skills dir — `~/.config/opencode/skills` for OpenCode (XDG honored),
+`~/.claude/skills` for Claude Code. The shared `~/.config/agents/skills` is an omac
+discovery convention the harnesses do not read natively, so it would NOT surface a
+guidance skill. Auto-provisioning on launch targets the **active** harness's native
+dir; the explicit `omac setup` writes a copy into **each installed harness's** native
+dir (detected via the harness's inner command on `PATH`), matching what `install.sh`
+did. Both use a per-harness "native global skills dir" resolver in `internal/config`
+(Claude Code's config home is `~/.claude`, not `~/.config/claude`).
+- *Alternative:* a single shared-dir copy (rejected: harnesses don't read it
+  natively); active-harness-only (rejected per product decision — want it everywhere).
+
+### D4 — Guidance-only bundle sourced from `CREATING_A_SKILL.md`, drift-guarded
+The bundle is a `SKILL.md` (frontmatter + concise overview) plus
+`references/creating-a-skill.md`, a byte-exact copy of the repo-root
+`CREATING_A_SKILL.md`. `go:embed` cannot reach above the package dir, so the copy
+lives in the bundle; a test asserts the two are byte-identical, keeping the repo root
+as the single source of truth.
+
+### D5 — omac-namespaced name + ownership marker (collision-proofing)
+omac/harness discovery key skills by **name**, and popular authoring skills already
+exist in global dirs (superpowers' `writing-skills`, Anthropic's `skill-creator`). To
+stay omac-specific and never clash:
+- The bundle's directory and SKILL.md `name` are **`omac-write-a-skill`**.
+- The SKILL.md `description` is scoped to *authoring omac skills* (the `SKILL.md` +
+  `omac.yaml` sidecar contract, `OMAC_*` env, REST facade), so the harness selects it
+  only for omac authoring.
+- Ownership is machine-readable: `metadata.author: tngtech` plus an
+  `metadata.omac-builtin: true` marker.
+- `omac setup` overwrites only a directory carrying the `omac-builtin` marker; a
+  foreign same-named directory is left untouched and the user is warned.
+- *Alternative:* a generic name (`write-a-skill` / `writing-skills`) — rejected: it
+  would shadow or be shadowed by popular skills, and reads as unowned.
+
+## Risks / Trade-offs
+
+- **R1: Claude Code's native global skills dir is nonstandard** (`~/.claude`, not
+  `~/.config/claude`). → The per-harness resolver (D3) encodes this explicitly and is
+  unit-tested; provisioning targets the dir each harness actually reads (verified
+  against where `skill-marketplace` already lives).
+- **R2: overwriting on re-run could clobber local edits**, or a foreign same-named
+  skill. → `omac setup` overwrites only a directory carrying the `omac-builtin` marker
+  (D5), refreshing omac-owned files and reporting what changed; a foreign same-named
+  directory is left untouched with a warning.
+- **R3: omac-write-a-skill / CREATING_A_SKILL.md drift.** → Byte-exact copy + a test
+  asserting equality (D4).
+
+## Open Questions
+
+- None outstanding. (Resolved: auto-provision on launch for a single-step install;
+  `omac setup` retained for all-harness/forced refresh; `omac doctor` reports per-
+  harness state.)

--- a/openspec/changes/ship-write-a-skill/proposal.md
+++ b/openspec/changes/ship-write-a-skill/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+A skill-authoring helper should be available in every omac installation, but today it
+only exists as the `CREATING_A_SKILL.md` guide in the repo root — there is no shipped
+skill and nothing puts it on disk. The harnesses surface guidance skills from their
+own skills directories, but nothing populates those on a fresh machine; that was
+`opencode-nono`'s `install.sh`, which is no longer used. So the authoring helper is
+not available in any project. omac needs to ship and provision this skill itself.
+
+## What Changes
+
+- omac **embeds an `omac-write-a-skill` skill bundle** in the binary (like the
+  existing `omac-multidir.ts` bridge), derived from `CREATING_A_SKILL.md`. It is a
+  **guidance-only** skill (a `SKILL.md`, no `omac.yaml` sidecar).
+- The skill is **omac-namespaced** (`omac-` prefixed name + omac-ownership metadata +
+  an omac-scoped description) so it never collides with, nor is confused for, popular
+  third-party authoring skills such as `writing-skills` or `skill-creator`.
+- **`omac start` / `omac serve` auto-provision** the embedded skill into the active
+  harness's native skills directory (e.g. `~/.config/opencode/skills`,
+  `~/.claude/skills`) on launch — **no extra setup step**. Provisioning is idempotent
+  (silent when already current), marker-guarded (never clobbers a foreign same-named
+  directory), and closes the gap left by `opencode-nono/install.sh`.
+- An explicit **`omac setup`** command is also available to (re)provision **all**
+  installed harnesses at once or to force-refresh after an upgrade — but it is not
+  required for the everyday flow.
+- No omac registration or activation is involved: omac deliberately ignores
+  `SKILL.md`-only directories, and the harness surfaces the guidance skill directly.
+
+## Capabilities
+
+### New Capabilities
+- `builtin-skill-provisioning`: omac ships the guidance-only `omac-write-a-skill`
+  bundle inside the binary and provisions it into each installed harness's native
+  skills directory, idempotently and without name clashes.
+
+### Modified Capabilities
+<!-- None: there is no openspec/specs/ archive yet, and no existing capability's
+     requirements change. -->
+
+## Impact
+
+- **New embedded asset**: an `omac-write-a-skill` skill bundle baked into the omac
+  binary.
+- **CLI surface**: auto-provisioning hooked into `omac start`/`serve`, plus a new
+  `omac setup` command for explicit all-harness / forced (re)provisioning.
+- **Harness model**: a way to resolve each harness's native user-global skills dir
+  (`internal/config`).
+- **Does NOT touch** the registry, skill-config, keychain, or `serve` activation —
+  guidance skills bypass all of that.
+- **Docs**: README Quickstart + skills sections, and `CREATING_A_SKILL.md`'s
+  relationship to the shipped `omac-write-a-skill` skill.
+- **Retires** the external `opencode-nono/install.sh` skill-copy step as the way this
+  skill reaches disk.

--- a/openspec/changes/ship-write-a-skill/specs/builtin-skill-provisioning/spec.md
+++ b/openspec/changes/ship-write-a-skill/specs/builtin-skill-provisioning/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: omac ships the omac-write-a-skill bundle in the binary
+
+omac SHALL embed the guidance-only `omac-write-a-skill` skill bundle (a `SKILL.md`,
+no `omac.yaml`) in the binary so it is available without any network access or
+external installer.
+
+#### Scenario: Bundle present in a downloaded binary
+
+- **WHEN** a user obtains omac via any supported distribution (brew, `.deb`, release
+  tarball, `go install`) on a machine with no skills on disk
+- **THEN** the `omac-write-a-skill` bundle is available from the binary itself, with no
+  dependency on `opencode-nono` or any other installer
+
+### Requirement: The shipped skill is omac-namespaced and collision-proof
+
+The shipped skill SHALL use the `omac-` prefixed name `omac-write-a-skill` for both
+its directory and its SKILL.md `name`, SHALL carry omac-ownership metadata (including
+an `omac-builtin` marker), and its description SHALL be scoped to authoring omac
+skills. It SHALL neither collide with nor be confused for third-party skill-authoring
+skills (e.g. `writing-skills`, `skill-creator`).
+
+#### Scenario: Coexists with a third-party authoring skill
+
+- **WHEN** a third-party skill-authoring skill (e.g. `writing-skills`) is present in
+  the same skills directory
+- **THEN** the omac skill is surfaced alongside it with no name collision, because its
+  name is `omac-write-a-skill`
+
+#### Scenario: Provisioning never clobbers a foreign same-named skill
+
+- **WHEN** `omac setup` runs and a directory of the same name exists that does NOT
+  carry the omac-builtin marker
+- **THEN** omac does not overwrite it and warns the user instead
+
+#### Scenario: Selected for omac authoring specifically
+
+- **WHEN** the agent is asked to author an omac skill
+- **THEN** the omac-scoped description leads the harness to select `omac-write-a-skill`
+  rather than a generic skill-writing skill
+
+### Requirement: omac auto-provisions the skill on launch
+
+`omac start` and `omac serve` SHALL idempotently write the embedded bundle into the
+native user-global skills directory that the **active** harness's own loader reads
+(e.g. `~/.config/opencode/skills` for OpenCode honoring `$XDG_CONFIG_HOME`,
+`~/.claude/skills` for Claude Code) — with no separate setup step. Provisioning SHALL
+NOT block or fail the launch, SHALL be silent when the bundle is already current, and
+SHALL NOT rely on omac registration or activation (omac ignores `SKILL.md`-only
+directories; the harness surfaces the skill itself).
+
+#### Scenario: Available after a plain launch
+
+- **WHEN** a user runs `omac start` (or `omac serve`) on a machine where the bundle is
+  not yet on disk
+- **THEN** the bundle directory (containing at least its `SKILL.md`) is written into
+  the active harness's native skills directory, and that harness surfaces
+  `omac-write-a-skill` — with no `omac register`, `omac setup`, or activation step
+
+#### Scenario: Launch is not blocked by provisioning
+
+- **WHEN** the bundle is already current, or its target cannot be written
+- **THEN** launch proceeds normally — an already-current bundle produces no output,
+  and a write failure is reported as a warning rather than aborting the launch
+
+### Requirement: `omac setup` provisions all installed harnesses explicitly
+
+omac SHALL provide an `omac setup` command that writes the embedded bundle into the
+native skills directory of **each installed harness** (optionally narrowed to one via a
+positional argument), for explicit or forced (re)provisioning after an upgrade.
+
+#### Scenario: Provisioned to all installed harnesses
+
+- **WHEN** a user runs `omac setup` with more than one harness installed
+- **THEN** the bundle directory is written into each installed harness's native skills
+  directory
+
+### Requirement: Provisioning is idempotent
+
+Re-running `omac setup` SHALL be safe: it overwrites only omac-owned bundle files
+(those under a directory carrying the omac-builtin marker) to their embedded version,
+leaves an already-current bundle unchanged, and reports what changed.
+
+#### Scenario: Re-run after an omac upgrade
+
+- **WHEN** the user runs `omac setup` again after upgrading omac
+- **THEN** the on-disk bundle is refreshed to the version embedded in the new binary;
+  re-running with no version change reports the bundle as unchanged
+
+### Requirement: omac-write-a-skill carries the authoring guide
+
+The `omac-write-a-skill` bundle SHALL make the skill-authoring guidance (the content
+of `CREATING_A_SKILL.md`) available to the agent, and the bundle content SHALL be kept
+byte-identical to the repository's authoring guide.
+
+#### Scenario: Authoring guidance available in any project
+
+- **WHEN** the agent needs to author a new skill in an arbitrary working directory
+- **THEN** the `omac-write-a-skill` skill provides the authoring guidance without the
+  user copying `CREATING_A_SKILL.md` into that project
+
+### Requirement: Fresh-install availability needs no extra step
+
+Following the README Quickstart on a clean machine SHALL yield a working
+`omac-write-a-skill` skill without any provisioning step beyond launching omac.
+
+#### Scenario: Following the Quickstart on a clean machine
+
+- **WHEN** a new user installs omac and runs `omac start` (no `omac setup` step)
+- **THEN** the `omac-write-a-skill` skill is present in the active harness's skills
+  directory and surfaced by it, with no reference to the retired `opencode-nono`
+  installer

--- a/openspec/changes/ship-write-a-skill/tasks.md
+++ b/openspec/changes/ship-write-a-skill/tasks.md
@@ -1,0 +1,37 @@
+## 1. Author the omac-write-a-skill bundle (guidance-only)
+
+- [x] 1.1 Create `internal/builtinskills/assets/omac-write-a-skill/SKILL.md`: frontmatter (`name: omac-write-a-skill`, omac-scoped `description`, metadata `author: tngtech` + `omac-builtin: true`) and a concise body pointing at the bundled guide
+- [x] 1.2 Add `internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md` as a byte-exact copy of repo-root `CREATING_A_SKILL.md`
+- [x] 1.3 Add a test asserting the bundle copy is byte-identical to repo-root `CREATING_A_SKILL.md` (single source of truth)
+
+## 2. Embed + materialize helpers
+
+- [x] 2.1 Create `internal/builtinskills` package: `//go:embed` the assets tree (`embed.FS`); expose the skill name(s) and a sub-FS accessor
+- [x] 2.2 Add a materialize helper that writes a bundle tree into a target skills dir (per-file atomic write, preserve modes, create parents)
+- [x] 2.3 Add marker helpers: detect the `omac-builtin` marker on an existing on-disk bundle; classify a target as created / updated / unchanged / foreign
+
+## 3. Provisioning: auto-on-launch + explicit `omac setup`
+
+- [x] 3.1 Add `omac setup` to the CLI dispatch (`internal/cli/`) with usage text and an optional `[harness]` positional to narrow (default: all installed)
+- [x] 3.2 Add a per-harness native global skills dir resolver in `internal/config` (`~/.config/opencode/skills` honoring `$XDG_CONFIG_HOME`; `~/.claude/skills`)
+- [x] 3.3 `omac setup`: detect installed harnesses (inner command on `PATH`); provision to each; if none detected, provision to all known harnesses with a warning
+- [x] 3.4 Materialize marker-guarded: refresh omac-owned dirs to the embedded version; skip + warn on a foreign same-named dir (unless `--force`); report created/updated/unchanged/skipped per harness
+- [x] 3.5 Auto-provision on launch: `omac start`/`serve` idempotently materialize the bundle into the active harness's dir; silent when current; never block the launch
+
+## 4. Discoverability (doctor report)
+
+- [x] 4.1 Have `omac doctor` report whether the built-in bundle is present/current per installed harness and point at `omac setup`
+- [x] 4.2 (Superseded by 3.5: launch auto-provisions rather than only warning.)
+
+## 5. Docs
+
+- [x] 5.1 Update README Quickstart: built-in skills auto-provision on launch (no extra step); document `omac setup` as the optional all-harness refresh
+- [x] 5.2 Update README skills sections + `CREATING_A_SKILL.md` to describe the shipped guidance-only `omac-write-a-skill` skill and the retired `opencode-nono/install.sh` path
+
+## 6. Tests & verification
+
+- [x] 6.1 Unit-test the materialize/marker helpers (files written, modes, created/updated/unchanged classification)
+- [x] 6.2 Test the marker guard: a foreign same-named directory is not overwritten and triggers a warning
+- [x] 6.3 Test `omac setup` idempotency: a second run reports unchanged and makes no edits
+- [x] 6.4 Test the per-harness native global skills dir resolver (OpenCode under `.config`, Claude Code under `~/.claude`, `$XDG_CONFIG_HOME` honored)
+- [x] 6.5 Test the `CREATING_A_SKILL.md` ↔ bundle sync guard (1.3)


### PR DESCRIPTION
## Why

omac had no way to put a skill on disk — it only registers/activates skills that *something else* already placed in a harness skills directory. That installer (`opencode-nono/install.sh`) is retired, so the skill-authoring helper (previously only the repo-root `CREATING_A_SKILL.md` guide) was unavailable in any project.

## What

Ship a **guidance-only** `omac-write-a-skill` skill (just a `SKILL.md`, no `omac.yaml`) embedded in the binary, and provision it with **no extra step**:

- **`internal/builtinskills`** — embeds the bundle via `go:embed`; idempotent, marker-guarded `Materialize`/`Check` (created / updated / unchanged / foreign).
- **Auto-provision on launch** — `omac start`/`serve` idempotently materialize the active harness's built-in skills (silent when current, never blocks the launch). So the everyday flow stays *install → `omac start`*.
- **`omac setup [harness] [--force]`** — optional explicit (re)provisioning of *all* installed harnesses / forced refresh after an upgrade. `omac doctor` reports per-harness state.
- **`config.Harness.GlobalSkillsDir`** — resolves each harness's native global skills dir (`~/.config/opencode/skills` honoring `$XDG_CONFIG_HOME`; `~/.claude/skills`).

### Collision-proofing
The skill is omac-namespaced — `omac-` prefixed name, `omac-builtin` ownership marker, and an omac-scoped description — so it never clashes with, nor is confused for, third-party authoring skills (`writing-skills`, `skill-creator`). Provisioning never overwrites a same-named directory it doesn't own (unless `--force`).

### Single source of truth
The bundled guide (`references/creating-a-skill.md`) is kept byte-identical to the repo-root `CREATING_A_SKILL.md` via a test.

## Notes
- No registry / skill-config / keychain / `serve` activation involved — omac deliberately ignores `SKILL.md`-only directories; the harness surfaces the guidance skill directly.
- Retires the external `opencode-nono/install.sh` skill-copy step.
- Planned with OpenSpec; artifacts under `openspec/changes/ship-write-a-skill/`.

## Testing
- `go build ./...`, `go vet`, `gofmt`, and `go test ./...` all pass.
- New unit tests: materialize lifecycle, marker/foreign guard, idempotency, per-harness dir resolver (incl. `$XDG_CONFIG_HOME`), launch auto-provision (active harness only), and the `CREATING_A_SKILL.md` ↔ bundle sync guard.
- Manually verified in a throwaway `HOME`: fresh provision to both harnesses, idempotent re-run, foreign-guard, and `--force`.