### PR TITLE
fix(sandbox): grant harness shim dir, not just symlink target

### DIFF
--- a/internal/sandboxrun/backend_linux.go
+++ b/internal/sandboxrun/backend_linux.go
@@ -134,30 +134,46 @@ func kernelVersionString() string {
 	return strings.TrimSpace(string(data))
 }
 
-// resolveInnerBinaryDir resolves the inner command's executable on the
-// host PATH and returns the directory holding its real (symlink-resolved)
-// file, or "" when the command cannot be found or resolved. It runs on
-// the supervisor (outside the namespace), so the lookup sees the user's
-// real PATH — the same resolution `which opencode` performs. Directories
-// already covered by the baseline (e.g. /usr/bin) are harmless: the
-// dedupe in BuildBwrapArgv collapses the duplicate grant.
-func resolveInnerBinaryDir(innerArgv []string) string {
+// resolveInnerBinaryDirs resolves the inner command's executable on the
+// host PATH and returns the directories that must be granted for it to be
+// reachable inside the namespace:
+//
+//   - the directory of the PATH entry itself, which is frequently a symlink
+//     or shim (e.g. ~/.bun/bin/opencode, a mise/asdf shim). stage2 re-runs
+//     LookPath inside the namespace, so this dir must be mounted and on PATH
+//     or the lookup fails even when the real binary is present elsewhere.
+//   - the directory of its symlink-resolved real file (e.g.
+//     ~/.bun/install/.../opencode-ai/bin/opencode.exe), so the link target
+//     and its sibling files (shared libs, node runtime) are reachable.
+//
+// Granting only the resolved dir (the historical behavior) left the shim on
+// PATH unmounted, breaking version-manager installs like bun where the
+// PATH entry and the real binary live in different trees. It runs on the
+// supervisor (outside the namespace), so the lookup sees the user's real
+// PATH — the same resolution `which opencode` performs. Directories already
+// covered by the baseline (e.g. /usr/bin) are harmless: the dedupe in
+// BuildBwrapArgv collapses duplicate grants. Returns nil when the command
+// cannot be found or resolved.
+func resolveInnerBinaryDirs(innerArgv []string) []string {
 	if len(innerArgv) == 0 || innerArgv[0] == "" {
-		return ""
+		return nil
 	}
 	// LookPath handles both bare PATH names and explicit (absolute or
 	// relative) paths, returning an error when nothing resolves.
 	resolved, err := exec.LookPath(innerArgv[0])
 	if err != nil {
-		return ""
+		return nil
 	}
 	if abs, aerr := filepath.Abs(resolved); aerr == nil {
 		resolved = abs
 	}
+	dirs := []string{filepath.Dir(resolved)}
 	if real, rerr := filepath.EvalSymlinks(resolved); rerr == nil {
-		resolved = real
+		if d := filepath.Dir(real); d != dirs[0] {
+			dirs = append(dirs, d)
+		}
 	}
-	return filepath.Dir(resolved)
+	return dirs
 }
 
 func firstLine(b []byte) string {
@@ -209,16 +225,15 @@ func BuildChildArgv(g *Grants, innerArgv []string) ([]string, error) {
 	// The inner harness binary (e.g. opencode / claude) must also be
 	// reachable inside the namespace. Harnesses are frequently installed
 	// outside the baseline trees — version managers like mise, asdf, nvm,
-	// or volta put them under ~/.local/share/<mgr>/installs/... — so a
+	// or volta put them under ~/.local/share/<mgr>/installs/..., and bun
+	// installs a ~/.bun/bin shim pointing into ~/.bun/install/... — so a
 	// plain ~/.local/bin grant is not enough. Resolve the binary on the
-	// host PATH (the same lookup `which opencode` performs), follow
-	// symlinks to the real file, and grant its containing directory
-	// read-only so sibling files (shared libs, node runtime, shims) are
-	// reachable too. dedupe in BuildBwrapArgv collapses it when an
-	// existing grant already covers it.
-	if dir := resolveInnerBinaryDir(innerArgv); dir != "" {
-		gz.ReadPaths = append(gz.ReadPaths, dir)
-	}
+	// host PATH (the same lookup `which opencode` performs) and grant both
+	// the PATH-entry (shim) directory and the symlink-resolved real
+	// directory read-only, so the shim is found on PATH and its target plus
+	// sibling files (shared libs, node runtime) are reachable too. dedupe
+	// in BuildBwrapArgv collapses any grant an existing one already covers.
+	gz.ReadPaths = append(gz.ReadPaths, resolveInnerBinaryDirs(innerArgv)...)
 
 	stage2 := []string{self, "sandbox", "stage2"}
 	stage2 = append(stage2, Stage2Args(&gz)...)

--- a/internal/sandboxrun/backend_linux.go
+++ b/internal/sandboxrun/backend_linux.go
@@ -151,9 +151,10 @@ func kernelVersionString() string {
 // PATH entry and the real binary live in different trees. It runs on the
 // supervisor (outside the namespace), so the lookup sees the user's real
 // PATH — the same resolution `which opencode` performs. Directories already
-// covered by the baseline (e.g. /usr/bin) are harmless: the dedupe in
-// BuildBwrapArgv collapses duplicate grants. Returns nil when the command
-// cannot be found or resolved.
+// covered by the baseline (e.g. /usr/bin) are harmless: bwrap re-binding a
+// path that a parent bind already covers is idempotent. (BuildBwrapArgv's
+// dedupe only drops exact-duplicate path strings, not child-of-parent
+// overlaps.) Returns nil when the command cannot be found or resolved.
 func resolveInnerBinaryDirs(innerArgv []string) []string {
 	if len(innerArgv) == 0 || innerArgv[0] == "" {
 		return nil
@@ -217,8 +218,9 @@ func BuildChildArgv(g *Grants, innerArgv []string) ([]string, error) {
 	// The omac binary itself must exist inside the mount namespace for
 	// bwrap to exec stage2. It commonly lives outside the granted
 	// trees (~/go/bin, ~/.local/bin, /opt/omac, ...), so grant it
-	// read-only explicitly; the dedupe in BuildBwrapArgv collapses it
-	// when an existing grant already covers it.
+	// read-only explicitly. If a baseline grant already covers it, the
+	// redundant bind is harmless (bwrap re-binding under a parent bind is
+	// idempotent; BuildBwrapArgv's dedupe drops only exact-duplicate paths).
 	gz := *g
 	gz.ReadPaths = append(append([]string{}, g.ReadPaths...), self)
 
@@ -231,8 +233,9 @@ func BuildChildArgv(g *Grants, innerArgv []string) ([]string, error) {
 	// host PATH (the same lookup `which opencode` performs) and grant both
 	// the PATH-entry (shim) directory and the symlink-resolved real
 	// directory read-only, so the shim is found on PATH and its target plus
-	// sibling files (shared libs, node runtime) are reachable too. dedupe
-	// in BuildBwrapArgv collapses any grant an existing one already covers.
+	// sibling files (shared libs, node runtime) are reachable too. Redundant
+	// grants are harmless (bwrap re-binding under a parent bind is idempotent;
+	// BuildBwrapArgv's dedupe drops only exact-duplicate paths, not overlaps).
 	gz.ReadPaths = append(gz.ReadPaths, resolveInnerBinaryDirs(innerArgv)...)
 
 	stage2 := []string{self, "sandbox", "stage2"}

--- a/internal/sandboxrun/backend_linux_test.go
+++ b/internal/sandboxrun/backend_linux_test.go
@@ -6,37 +6,40 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
 
-func TestResolveInnerBinaryDir(t *testing.T) {
+func TestResolveInnerBinaryDirs(t *testing.T) {
 	// Empty / blank argv resolves to nothing.
-	if got := resolveInnerBinaryDir(nil); got != "" {
-		t.Errorf("nil argv = %q, want empty", got)
+	if got := resolveInnerBinaryDirs(nil); got != nil {
+		t.Errorf("nil argv = %v, want nil", got)
 	}
-	if got := resolveInnerBinaryDir([]string{""}); got != "" {
-		t.Errorf("blank argv[0] = %q, want empty", got)
+	if got := resolveInnerBinaryDirs([]string{""}); got != nil {
+		t.Errorf("blank argv[0] = %v, want nil", got)
 	}
 
 	// A name not on PATH resolves to nothing rather than guessing.
-	if got := resolveInnerBinaryDir([]string{"definitely-not-a-real-binary-xyz"}); got != "" {
-		t.Errorf("missing binary = %q, want empty", got)
+	if got := resolveInnerBinaryDirs([]string{"definitely-not-a-real-binary-xyz"}); got != nil {
+		t.Errorf("missing binary = %v, want nil", got)
 	}
 
-	// A real binary on a version-manager-style path is resolved to its
-	// containing directory, following symlinks (mimicking a mise shim
-	// -> installs/<ver>/bin/<bin> layout).
+	// A shim whose symlink target lives in a different tree, with the
+	// real file renamed (mimicking bun: ~/.bun/bin/opencode ->
+	// ~/.bun/install/.../bin/opencode.exe). BOTH the shim dir (on PATH,
+	// needed by stage2's own LookPath) and the resolved real dir must be
+	// granted.
 	root := t.TempDir()
-	realDir := filepath.Join(root, "installs", "opencode", "1.2.3", "bin")
+	realDir := filepath.Join(root, "install", "opencode-ai", "bin")
 	if err := os.MkdirAll(realDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	realBin := filepath.Join(realDir, "opencode")
+	realBin := filepath.Join(realDir, "opencode.exe")
 	if err := os.WriteFile(realBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	shimDir := filepath.Join(root, "shims")
+	shimDir := filepath.Join(root, "bin")
 	if err := os.MkdirAll(shimDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -45,16 +48,30 @@ func TestResolveInnerBinaryDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Resolve via an absolute path to the shim: must follow the symlink
-	// to the real install dir, not return the shim dir.
-	if got := resolveInnerBinaryDir([]string{shim}); got != realDir {
-		t.Errorf("symlinked binary dir = %q, want %q", got, realDir)
+	wantBoth := []string{shimDir, realDir}
+
+	// Resolve via an absolute path to the shim.
+	if got := resolveInnerBinaryDirs([]string{shim}); !reflect.DeepEqual(got, wantBoth) {
+		t.Errorf("symlinked binary dirs = %v, want %v", got, wantBoth)
 	}
 
 	// Resolve via PATH lookup (the `which opencode` case).
 	t.Setenv("PATH", shimDir)
-	if got := resolveInnerBinaryDir([]string{"opencode"}); got != realDir {
-		t.Errorf("PATH-resolved binary dir = %q, want %q", got, realDir)
+	if got := resolveInnerBinaryDirs([]string{"opencode"}); !reflect.DeepEqual(got, wantBoth) {
+		t.Errorf("PATH-resolved binary dirs = %v, want %v", got, wantBoth)
+	}
+
+	// A non-symlinked binary yields a single dir (no duplicate grant).
+	plainDir := filepath.Join(root, "plain")
+	if err := os.MkdirAll(plainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plainBin := filepath.Join(plainDir, "tool")
+	if err := os.WriteFile(plainBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveInnerBinaryDirs([]string{plainBin}); !reflect.DeepEqual(got, []string{plainDir}) {
+		t.Errorf("plain binary dirs = %v, want %v", got, []string{plainDir})
 	}
 }
 


### PR DESCRIPTION
## Problem

`omac start` aborts before the harness even launches:

```
omac sandbox stage2: cannot run "opencode" inside the sandbox:
"opencode" not found in the sandbox filesystem.
```

…whenever the inner-harness binary on `PATH` is a **shim/symlink whose target lives in a different directory tree**. The case that exposed it is opencode installed via **bun**:

- `~/.bun/bin/opencode` — the entry on `PATH` (a symlink)
- → `~/.bun/install/global/node_modules/opencode-ai/bin/opencode.exe` — the real binary

## Root cause

`BuildChildArgv` already grants the harness binary's directory into the namespace (introduced in b358c9b *"grant inner harness binary dir so version-manager installs work"*). But `resolveInnerBinaryDir` returned **only the symlink-resolved** directory:

```go
resolved, _ := exec.LookPath(argv[0])      // ~/.bun/bin/opencode        (the shim)
resolved      = filepath.EvalSymlinks(...)  // ~/.bun/.../opencode-ai/bin/opencode.exe
return filepath.Dir(resolved)              // grants ONLY .../opencode-ai/bin
```

So the directory of the shim that is actually **on `PATH`** (`~/.bun/bin`) was never mounted. Inside the namespace, stage2 re-runs `LookPath("opencode")`, walks `PATH` to `~/.bun/bin` — which isn't there — and fails, even though the resolved binary's directory *was* granted.

## Fix

Grant **both** directories:

- the **PATH-entry (shim) dir**, so stage2's own `LookPath` finds the binary on `PATH`;
- the **symlink-resolved dir**, so the link target and its sibling files (shared libs, node runtime) are reachable.

`resolveInnerBinaryDir` → `resolveInnerBinaryDirs` returning `[]string` (deduped when the two coincide, e.g. a non-symlinked binary).

This removes the need for sandbox profiles to hand-enumerate version-manager paths — omac resolves wherever the harness actually lives, for bun, npm-global, brew, and similar layouts.

## Verification

- Updated unit test covers the bun-style **shim + `.exe` rename across trees** and the **non-symlink** (single-dir) case.
- End-to-end: with all `~/.bun/*` entries **removed** from the sandbox profile read-list, a patched omac runs `opencode --version` inside the sandbox successfully (`1.17.9`); the unpatched binary fails with the error above.
- `go build ./...`, `go vet ./internal/sandboxrun/`, and the sandboxrun test suite are clean.

## Known limitation

This covers **symlinked** installs (bun, npm-global, brew). Shims that are executable *scripts* re-exec'ing a version manager at runtime (some mise/asdf setups) resolve to the script itself; making those reachable would require granting the manager binary plus its install tree, which is out of scope here.
