### PR TITLE
feat(cli): omac continue and resume session commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ Supported harnesses (and aliases): `opencode` (`oc`), `claude-code`
 is rejected with the list of supported names. Inner arguments that happen to be
 barewords go after `--` (e.g. `omac start claude -- --model sonnet`).
 
+### Resuming prior work
+
+Two convenience subcommands re-enter earlier sessions through the same
+sandboxed launch pipeline as `start`:
+
+```bash
+omac continue          # reopen the last session for this folder (opencode)
+omac continue claude   # ...with Claude Code
+omac resume            # pick from this folder's recent sessions, then launch
+omac resume claude     # ...with Claude Code
+```
+
+`omac resume` lists only the current folder's sessions, newest first, and
+launches the one you pick inside omac. It reads each harness's own session
+store — opencode via `opencode session list`, Claude Code by reading
+`~/.claude/projects/<folder>/<id>.jsonl` (titles come from the session's
+`aiTitle`, and a file's embedded `cwd` decides which folder it belongs to).
+Both subcommands take the same flags and optional `[harness]` token as `start`.
+
 Each harness ships a small client-side **bridge** that wires the agent to
 omac's control plane (skill activation, the skills manifest, skill base URLs):
 
@@ -450,6 +469,19 @@ omac [--workdir <dir>] <subcommand> [flags] [args]
                  --skip-secret-pattern   don't enforce a secret's pattern
                                          on an env_passthrough value
                  --verbose               lifecycle logging
+
+  continue     Like `start`, but continue the most recent session for this
+               workdir (appends the harness's continue flag: opencode/claude
+               `--continue`). Accepts the same flags as `start` and an
+               optional [harness] token.
+
+  resume       List recent sessions for this workdir, show an interactive
+               numbered picker (title + relative time), and launch the
+               selected one inside omac (opencode `--session <id>`, claude
+               `--resume <id>`). Sessions come from the harness's own store
+               (opencode `session list`; Claude Code's ~/.claude/projects
+               files). Non-interactive stdin prints the list and exits.
+               Accepts the same flags as `start` and an optional [harness].
 
   doctor       Sanity checks: config, registry, binaries, secrets, sandbox.
   version

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ omac resume claude     # ...with Claude Code
 `omac resume` lists only the current folder's sessions, newest first, and
 launches the one you pick inside omac. It reads each harness's own session
 store — opencode via `opencode session list`, Claude Code by reading
-`~/.claude/projects/<folder>/<id>.jsonl` (titles come from the session's
-`aiTitle`, and a file's embedded `cwd` decides which folder it belongs to).
+`~/.claude/projects/<encoded-cwd>/<id>.jsonl` (where `<encoded-cwd>` is the
+folder path with non-alphanumerics replaced by `-`, the way Claude Code names
+it). Titles come from the session's `aiTitle`, and a file's embedded `cwd`
+decides which folder it belongs to.
 Both subcommands take the same flags and optional `[harness]` token as `start`.
 
 Each harness ships a small client-side **bridge** that wires the agent to

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -121,6 +121,8 @@ func commands() map[string]Command {
 		"secrets":    {Name: "secrets", Short: "Manage skill secrets in the OS keychain.", Run: runSecrets},
 		"config":     {Name: "config", Short: "Show resolved config + secret fingerprints for a skill.", Run: runConfig},
 		"start":      {Name: "start", Short: "Start sidecars + facade + sandbox. Optional [harness]: opencode|claude.", Run: runStart},
+		"continue":   {Name: "continue", Short: "Continue the last session for this workdir. Optional [harness].", Run: runContinue},
+		"resume":     {Name: "resume", Short: "Pick a recent session for this workdir and launch it. Optional [harness].", Run: runResume},
 		"serve":      {Name: "serve", Short: "Long-lived multi-directory server. Optional [harness]: opencode|claude.", Run: runServe},
 		"setup":      {Name: "setup", Short: "Provision omac's built-in skills into installed harnesses' skills dirs.", Run: runSetup},
 		"plugin":     {Name: "plugin", Short: "Install client-side harness bridge plugins (e.g. opencode-desktop).", Run: runPlugin},
@@ -149,6 +151,8 @@ Subcommands:
   config       Show resolved config + secret fingerprints for a skill.
   setup        Provision omac's built-in skills into installed harnesses.
   start        Start sidecars + facade + sandbox.       [harness]: opencode|claude
+  continue     Continue the last session for this workdir.   [harness]: opencode|claude
+  resume       Pick a recent session for this workdir, launch it. [harness]: opencode|claude
   serve        Long-lived multi-directory server.        [harness]: opencode|claude
   plugin       Install client-side bridge plugins (e.g. opencode-desktop).
   sandbox      Built-in kernel sandbox: omac sandbox run [flags] -- <cmd>.

--- a/internal/cli/continue.go
+++ b/internal/cli/continue.go
@@ -1,0 +1,36 @@
+package cli
+
+import "fmt"
+
+// runContinue implements `omac continue [harness] [flags] [-- inner args...]`:
+// re-launch the most recent session for the current workdir by appending the
+// harness's "continue" inner flag to the shared start pipeline.
+func runContinue(args []string, env *Env) int {
+	opts, code := buildContinueOpts(args, env)
+	if code != ExitOK {
+		return code
+	}
+	return runLaunch(env, opts)
+}
+
+// buildContinueOpts parses the continue command line (the same surface as
+// start) and prepends the resolved harness's continue flag to the inner args.
+// It returns the assembled opts and ExitOK, or a non-OK exit code (with a
+// message already written to stderr) on error.
+func buildContinueOpts(args []string, env *Env) (launchOpts, int) {
+	opts, ok := parseLaunchArgs("continue", args, env)
+	if !ok {
+		return launchOpts{}, ExitMisuse
+	}
+	sess := opts.harness.Session
+	if sess == nil || len(sess.ContinueArgs) == 0 {
+		fmt.Fprintf(env.Stderr,
+			"omac continue: harness %q does not support continuing sessions\n", opts.harness.Name)
+		return launchOpts{}, ExitMisuse
+	}
+	// Put the continue flag first, then any user-supplied inner args, so a
+	// trailing user positional (if any) is not mistaken for the flag's value.
+	inner := append([]string(nil), sess.ContinueArgs...)
+	opts.innerArgs = append(inner, opts.innerArgs...)
+	return opts, ExitOK
+}

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/tngtech/oh-my-agentic-coder/internal/session"
+)
+
+// devnullEnv builds an Env whose streams all point at /dev/null. Suitable for
+// the opts-building helpers, which never read stdin and only write diagnostics.
+func devnullEnv(t *testing.T) *Env {
+	t.Helper()
+	null, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open /dev/null: %v", err)
+	}
+	t.Cleanup(func() { null.Close() })
+	return &Env{Version: "test", Workdir: "/w", Stdout: null, Stderr: null, Stdin: null}
+}
+
+func TestBuildContinueOpts(t *testing.T) {
+	cases := []struct {
+		name          string
+		args          []string
+		wantHarness   string
+		wantInnerArgs []string
+		wantVerbose   bool
+		wantNoSandbox bool
+	}{
+		{"default harness", nil, "opencode", []string{"--continue"}, false, false},
+		{"claude token", []string{"claude"}, "claude-code", []string{"--continue"}, false, false},
+		{"start flags preserved", []string{"--verbose", "--no-sandbox"}, "opencode", []string{"--continue"}, true, true},
+		{"trailing inner args preserved", []string{"--", "--model", "anthropic/x"}, "opencode", []string{"--continue", "--model", "anthropic/x"}, false, false},
+		{"claude with flags and inner", []string{"claude", "--verbose", "--", "--foo"}, "claude-code", []string{"--continue", "--foo"}, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			opts, code := buildContinueOpts(c.args, devnullEnv(t))
+			if code != ExitOK {
+				t.Fatalf("code = %d, want ExitOK", code)
+			}
+			if opts.harness.Name != c.wantHarness {
+				t.Errorf("harness = %q, want %q", opts.harness.Name, c.wantHarness)
+			}
+			if !reflect.DeepEqual(opts.innerArgs, c.wantInnerArgs) {
+				t.Errorf("innerArgs = %v, want %v", opts.innerArgs, c.wantInnerArgs)
+			}
+			if opts.verbose != c.wantVerbose {
+				t.Errorf("verbose = %v, want %v", opts.verbose, c.wantVerbose)
+			}
+			if opts.noSandbox != c.wantNoSandbox {
+				t.Errorf("noSandbox = %v, want %v", opts.noSandbox, c.wantNoSandbox)
+			}
+		})
+	}
+}
+
+func TestBuildResumeInnerArgs(t *testing.T) {
+	oc, _ := config.LookupHarness("opencode")
+	cc, _ := config.LookupHarness("claude-code")
+
+	if got := buildResumeInnerArgs(oc.Session, "ses_X", nil); !reflect.DeepEqual(got, []string{"--session", "ses_X"}) {
+		t.Errorf("opencode resume args = %v, want [--session ses_X]", got)
+	}
+	if got := buildResumeInnerArgs(cc.Session, "uuid-1", nil); !reflect.DeepEqual(got, []string{"--resume", "uuid-1"}) {
+		t.Errorf("claude resume args = %v, want [--resume uuid-1]", got)
+	}
+	// User-supplied inner args follow the resume flag.
+	if got := buildResumeInnerArgs(oc.Session, "ses_X", []string{"--model", "y"}); !reflect.DeepEqual(got, []string{"--session", "ses_X", "--model", "y"}) {
+		t.Errorf("resume args with user inner = %v", got)
+	}
+}
+
+func TestParseSelection(t *testing.T) {
+	cases := []struct {
+		line    string
+		n       int
+		wantIdx int
+		wantOK  bool
+	}{
+		{"1", 3, 0, true},
+		{"3", 3, 2, true},
+		{"  2 ", 3, 1, true},
+		{"", 3, 0, false},   // cancel
+		{"0", 3, 0, false},  // out of range low
+		{"4", 3, 0, false},  // out of range high
+		{"x", 3, 0, false},  // non-numeric
+		{"-1", 3, 0, false}, // negative
+	}
+	for _, c := range cases {
+		idx, ok := parseSelection(c.line, c.n)
+		if idx != c.wantIdx || ok != c.wantOK {
+			t.Errorf("parseSelection(%q, %d) = (%d,%v), want (%d,%v)", c.line, c.n, idx, ok, c.wantIdx, c.wantOK)
+		}
+	}
+}
+
+func TestPickSessionNonTTY(t *testing.T) {
+	// Stdin from a pipe is not a TTY, so pickSession must print the list and
+	// return false without blocking on input.
+	r, _, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	null, _ := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	defer null.Close()
+	env := &Env{Version: "test", Workdir: "/w", Stdout: null, Stderr: null, Stdin: r}
+
+	sessions := []session.Session{{ID: "a", Title: "first"}, {ID: "b", Title: "second"}}
+	if _, ok := pickSession(env, "opencode", sessions); ok {
+		t.Error("non-TTY stdin should not yield a selection")
+	}
+}
+
+func TestRelativeTime(t *testing.T) {
+	if got := relativeTime(time.Time{}); got != "unknown" {
+		t.Errorf("zero time = %q, want unknown", got)
+	}
+	if got := relativeTime(time.Now().Add(-2 * time.Hour)); got != "2h ago" {
+		t.Errorf("2h ago = %q", got)
+	}
+	if got := relativeTime(time.Now().Add(-49 * time.Hour)); got != "2d ago" {
+		t.Errorf("2d ago = %q", got)
+	}
+}

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -105,13 +105,20 @@ func parseSelection(line string, n int) (int, bool) {
 func renderSessions(env *Env, st styler, harnessName string, sessions []session.Session) {
 	fmt.Fprintf(env.Stdout, "Recent sessions for %s (%s):\n\n",
 		st.bold(env.Workdir), harnessName)
-	// Width of the largest index, for alignment.
+	// Column widths for alignment: index and (variable-length) session id.
 	idxWidth := len(strconv.Itoa(len(sessions)))
+	idWidth := 0
+	for _, s := range sessions {
+		if len(s.ID) > idWidth {
+			idWidth = len(s.ID)
+		}
+	}
 	for i, s := range sessions {
 		num := fmt.Sprintf("%*d", idxWidth, i+1)
 		when := fmt.Sprintf("%-8s", relativeTime(s.When))
-		fmt.Fprintf(env.Stdout, "  %s  %s  %s\n",
-			st.cyan(num), st.gray(when), s.Title)
+		id := fmt.Sprintf("%-*s", idWidth, s.ID)
+		fmt.Fprintf(env.Stdout, "  %s  %s  %s  %s\n",
+			st.cyan(num), st.gray(when), st.gray(id), s.Title)
 	}
 }
 

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
 	"strconv"
 	"strings"
 	"time"
@@ -63,13 +65,14 @@ func buildResumeInnerArgs(sess *config.HarnessSession, id string, userInner []st
 
 // pickSession renders the session list and reads a 1-based selection from
 // stdin. It returns the chosen 0-based index and true, or false when the user
-// cancels (empty line / EOF), enters an invalid choice, or stdin is not a TTY
-// (in which case the list is still printed with a hint).
+// cancels (empty line / EOF / Ctrl-C), enters an invalid choice, or the
+// session is not interactive (in which case the list is still printed with a
+// hint). Interactivity requires BOTH stdin and stdout to be a TTY.
 func pickSession(env *Env, harnessName string, sessions []session.Session) (int, bool) {
 	st := newStyler(env.Stdout)
 	renderSessions(env, st, harnessName, sessions)
 
-	if !term.IsTerminal(int(env.Stdin.Fd())) {
+	if !term.IsTerminal(int(env.Stdin.Fd())) || !term.IsTerminal(int(env.Stdout.Fd())) {
 		fmt.Fprintln(env.Stderr,
 			"\nomac resume: run in an interactive terminal to select a session "+
 				"(or use `omac continue`).")
@@ -77,12 +80,31 @@ func pickSession(env *Env, harnessName string, sessions []session.Session) (int,
 	}
 
 	fmt.Fprintf(env.Stdout, "\nSelect a session [1-%d] (Enter to cancel): ", len(sessions))
-	line, _ := bufio.NewReader(env.Stdin).ReadString('\n')
-	idx, ok := parseSelection(line, len(sessions))
-	if !ok && strings.TrimSpace(line) != "" {
-		fmt.Fprintf(env.Stderr, "omac resume: invalid selection %q\n", strings.TrimSpace(line))
+
+	// Treat Ctrl-C during the prompt as cancel (exit OK), not a process kill.
+	// We intercept SIGINT only for the duration of the read; the default
+	// handler is restored on return via signal.Stop.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+
+	lineCh := make(chan string, 1)
+	go func() {
+		line, _ := bufio.NewReader(env.Stdin).ReadString('\n')
+		lineCh <- line
+	}()
+
+	select {
+	case <-sigCh:
+		fmt.Fprintln(env.Stdout) // finish the prompt line the ^C interrupted
+		return 0, false
+	case line := <-lineCh:
+		idx, ok := parseSelection(line, len(sessions))
+		if !ok && strings.TrimSpace(line) != "" {
+			fmt.Fprintf(env.Stderr, "omac resume: invalid selection %q\n", strings.TrimSpace(line))
+		}
+		return idx, ok
 	}
-	return idx, ok
 }
 
 // parseSelection interprets a picker input line against a list of n items. It

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/tngtech/oh-my-agentic-coder/internal/session"
+)
+
+// runResume implements `omac resume [harness] [flags]`: list the recent
+// sessions for the current workdir, let the user pick one in an interactive
+// numbered picker, and launch it inside omac via the shared start pipeline
+// with the harness's "resume by id" inner flag.
+func runResume(args []string, env *Env) int {
+	opts, ok := parseLaunchArgs("resume", args, env)
+	if !ok {
+		return ExitMisuse
+	}
+	h := opts.harness
+	if h.Session == nil || h.Session.ResumeByIDArgs == nil {
+		fmt.Fprintf(env.Stderr,
+			"omac resume: harness %q does not support resuming sessions; try `omac continue %s`\n", h.Name, h.Name)
+		return ExitOK
+	}
+
+	sessions, err := session.List(h, env.Workdir)
+	if errors.Is(err, session.ErrUnsupported) {
+		fmt.Fprintf(env.Stderr,
+			"omac resume: listing sessions is not supported for harness %q; try `omac continue %s`\n", h.Name, h.Name)
+		return ExitOK
+	}
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "omac resume: list sessions:", err)
+		return ExitIOError
+	}
+	if len(sessions) == 0 {
+		fmt.Fprintf(env.Stdout, "No resumable sessions for this directory (%s).\n", env.Workdir)
+		return ExitOK
+	}
+
+	idx, ok := pickSession(env, h.Name, sessions)
+	if !ok {
+		return ExitOK // cancelled, or non-interactive stdin
+	}
+
+	opts.innerArgs = buildResumeInnerArgs(h.Session, sessions[idx].ID, opts.innerArgs)
+	return runLaunch(env, opts)
+}
+
+// buildResumeInnerArgs puts the harness's resume-by-id flag first, then any
+// user-supplied inner args.
+func buildResumeInnerArgs(sess *config.HarnessSession, id string, userInner []string) []string {
+	inner := append([]string(nil), sess.ResumeByIDArgs(id)...)
+	return append(inner, userInner...)
+}
+
+// pickSession renders the session list and reads a 1-based selection from
+// stdin. It returns the chosen 0-based index and true, or false when the user
+// cancels (empty line / EOF), enters an invalid choice, or stdin is not a TTY
+// (in which case the list is still printed with a hint).
+func pickSession(env *Env, harnessName string, sessions []session.Session) (int, bool) {
+	st := newStyler(env.Stdout)
+	renderSessions(env, st, harnessName, sessions)
+
+	if !term.IsTerminal(int(env.Stdin.Fd())) {
+		fmt.Fprintln(env.Stderr,
+			"\nomac resume: run in an interactive terminal to select a session "+
+				"(or use `omac continue`).")
+		return 0, false
+	}
+
+	fmt.Fprintf(env.Stdout, "\nSelect a session [1-%d] (Enter to cancel): ", len(sessions))
+	line, _ := bufio.NewReader(env.Stdin).ReadString('\n')
+	idx, ok := parseSelection(line, len(sessions))
+	if !ok && strings.TrimSpace(line) != "" {
+		fmt.Fprintf(env.Stderr, "omac resume: invalid selection %q\n", strings.TrimSpace(line))
+	}
+	return idx, ok
+}
+
+// parseSelection interprets a picker input line against a list of n items. It
+// returns the 0-based index and true for a valid 1..n choice; an empty line
+// (cancel) or any out-of-range/non-numeric input returns false.
+func parseSelection(line string, n int) (int, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return 0, false
+	}
+	v, err := strconv.Atoi(line)
+	if err != nil || v < 1 || v > n {
+		return 0, false
+	}
+	return v - 1, true
+}
+
+// renderSessions prints a numbered, styled list of sessions (index, relative
+// time, title) under a header naming the workdir and harness.
+func renderSessions(env *Env, st styler, harnessName string, sessions []session.Session) {
+	fmt.Fprintf(env.Stdout, "Recent sessions for %s (%s):\n\n",
+		st.bold(env.Workdir), harnessName)
+	// Width of the largest index, for alignment.
+	idxWidth := len(strconv.Itoa(len(sessions)))
+	for i, s := range sessions {
+		num := fmt.Sprintf("%*d", idxWidth, i+1)
+		when := fmt.Sprintf("%-8s", relativeTime(s.When))
+		fmt.Fprintf(env.Stdout, "  %s  %s  %s\n",
+			st.cyan(num), st.gray(when), s.Title)
+	}
+}
+
+// relativeTime renders t as a compact "time ago" string (e.g. "2h", "3d").
+// A zero time renders as "unknown".
+func relativeTime(t time.Time) string {
+	if t.IsZero() {
+		return "unknown"
+	}
+	d := time.Since(t)
+	switch {
+	case d < 0:
+		return "just now"
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -25,8 +25,31 @@ import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/supervisor"
 )
 
-func runStart(args []string, env *Env) int {
-	fs := flag.NewFlagSet("start", flag.ContinueOnError)
+// launchOpts carries everything runLaunch needs: the resolved harness, the
+// parsed start-family flags, and the inner args to append to the resolved
+// inner command. `omac start`, `omac continue`, and `omac resume` all build
+// one of these and call runLaunch, so the launch pipeline has a single
+// implementation.
+type launchOpts struct {
+	harness            config.Harness
+	profile            string
+	innerCmdOverride   string
+	noSandbox          bool
+	keepRunning        bool
+	acceptSkillChanges bool
+	verbose            bool
+	// innerArgs are appended to the resolved inner command (user-supplied
+	// trailing `-- args` plus any command-specific flags like --continue).
+	innerArgs []string
+}
+
+// parseLaunchArgs parses the shared start-family command line: an optional
+// leading positional harness token, the start flags, and trailing `-- inner
+// args`. cmdName is used in usage/error text (e.g. "start", "continue"). It
+// returns the assembled opts and true on success; on a parse/usage error it
+// prints to stderr and returns false (callers map that to ExitMisuse).
+func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool) {
+	fs := flag.NewFlagSet(cmdName, flag.ContinueOnError)
 	fs.SetOutput(env.Stderr)
 	var (
 		profile            = fs.String("sandbox", "", "Name of a sandbox profile from the launcher config.")
@@ -38,7 +61,7 @@ func runStart(args []string, env *Env) int {
 		verbose            = fs.Bool("verbose", false, "Verbose lifecycle logging.")
 	)
 	fs.Usage = func() {
-		fmt.Fprintln(env.Stderr, "Usage: omac start [harness] [flags] [-- inner args...]")
+		fmt.Fprintf(env.Stderr, "Usage: omac %s [harness] [flags] [-- inner args...]\n", cmdName)
 		fmt.Fprintf(env.Stderr, "\nharness: one of %s (default: %s)\n\n",
 			strings.Join(config.HarnessNames(), ", "), config.DefaultHarness().Name)
 		fs.PrintDefaults()
@@ -62,13 +85,45 @@ func runStart(args []string, env *Env) int {
 	// flags (+ any non-flag positionals, which become inner args).
 	harness, ourArgs, err := splitHarnessToken(ourArgs)
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start:", err)
-		return ExitMisuse
+		fmt.Fprintf(env.Stderr, "omac %s: %v\n", cmdName, err)
+		return launchOpts{}, false
 	}
 	if err := fs.Parse(reorderFlagsFirst(ourArgs)); err != nil {
-		return ExitMisuse
+		return launchOpts{}, false
 	}
 	innerArgs = append(fs.Args(), innerArgs...)
+	return launchOpts{
+		harness:            harness,
+		profile:            *profile,
+		innerCmdOverride:   *innerCmdOverride,
+		noSandbox:          *noSandbox,
+		keepRunning:        *keepRunning,
+		acceptSkillChanges: *acceptSkillChanges,
+		verbose:            *verbose,
+		innerArgs:          innerArgs,
+	}, true
+}
+
+func runStart(args []string, env *Env) int {
+	opts, ok := parseLaunchArgs("start", args, env)
+	if !ok {
+		return ExitMisuse
+	}
+	return runLaunch(env, opts)
+}
+
+// runLaunch is the shared start pipeline: load config, reconcile the registry,
+// spawn sidecars + facade + control plane, build the sandbox argv, and exec
+// the inner command. It is invoked by `start`, `continue`, and `resume`.
+func runLaunch(env *Env, opts launchOpts) int {
+	harness := opts.harness
+	profile := opts.profile
+	innerCmdOverride := opts.innerCmdOverride
+	noSandbox := opts.noSandbox
+	keepRunning := opts.keepRunning
+	acceptSkillChanges := opts.acceptSkillChanges
+	verbose := opts.verbose
+	innerArgs := opts.innerArgs
 
 	// 1. Load launcher config.
 	lc, cfgPath, err := config.LoadLauncher(env.Workdir)
@@ -76,15 +131,15 @@ func runStart(args []string, env *Env) int {
 		fmt.Fprintln(env.Stderr, "omac start: launcher config:", err)
 		return ExitConfigInvalid
 	}
-	if *verbose && cfgPath != "" {
+	if verbose && cfgPath != "" {
 		fmt.Fprintf(env.Stderr, "[verbose] loaded launcher config: %s\n", cfgPath)
 	}
-	profName := *profile
+	profName := profile
 	if profName == "" {
 		profName = lc.Sandbox.DefaultProfile
 	}
 	prof, ok := lc.Sandbox.Profiles[profName]
-	if !ok && !*noSandbox {
+	if !ok && !noSandbox {
 		fmt.Fprintf(env.Stderr, "omac start: unknown sandbox profile %q\n", profName)
 		return ExitConfigInvalid
 	}
@@ -273,7 +328,7 @@ func runStart(args []string, env *Env) int {
 
 		// Bundle hash. Excluded from scanning when the user has
 		// explicitly opted in to drift via --accept-skill-changes.
-		if !*acceptSkillChanges {
+		if !acceptSkillChanges {
 			bundle, err := config.BundleHash(absDir)
 			if err != nil {
 				// I/O errors during hashing are class-level (we can't
@@ -437,7 +492,7 @@ func runStart(args []string, env *Env) int {
 		fmt.Fprintln(env.Stderr, "omac start: runtime dir:", err)
 		return ExitIOError
 	}
-	if *verbose {
+	if verbose {
 		fmt.Fprintf(env.Stderr, "[verbose] runtime dir: %s\n", rtDir)
 	}
 	socketPath := filepath.Join(rtDir, "bridge.sock")
@@ -453,14 +508,14 @@ func runStart(args []string, env *Env) int {
 		return ExitIOError
 	}
 	defer os.RemoveAll(sandboxTmp)
-	if *verbose {
+	if verbose {
 		fmt.Fprintf(env.Stderr, "[verbose] sandbox TMPDIR: %s\n", sandboxTmp)
 	}
 
 	// 5. Spawn sidecars.
 	sup := supervisor.New(lc.Facade.BaseEnvPassthrough)
 	defer func() {
-		if !*keepRunning {
+		if !keepRunning {
 			sup.ShutdownAll(5 * time.Second)
 		}
 	}()
@@ -533,7 +588,7 @@ func runStart(args []string, env *Env) int {
 	}
 	defer f.Close()
 	tcpPort := f.TCPPort()
-	if *verbose {
+	if verbose {
 		fmt.Fprintf(env.Stderr, "[verbose] facade listening on %s and 127.0.0.1:%d (%d route(s))\n",
 			socketPath, tcpPort, len(routes))
 	}
@@ -543,7 +598,7 @@ func runStart(args []string, env *Env) int {
 	// restart (mirrors serve). Non-fatal if it can't bind.
 	reloader := &startReloader{
 		env: env, facade: f, sup: sup, ctx: ctx,
-		rtDir: rtDir, socket: socketPath, tcpPort: tcpPort, verbose: *verbose,
+		rtDir: rtDir, socket: socketPath, tcpPort: tcpPort, verbose: verbose,
 		mounted: map[string]string{},
 	}
 	for i, a := range armed {
@@ -551,7 +606,7 @@ func runStart(args []string, env *Env) int {
 	}
 	controlURL, closeControl, controlOK := startControlPlane(reloader)
 	defer closeControl()
-	if controlOK && *verbose {
+	if controlOK && verbose {
 		fmt.Fprintf(env.Stderr, "[verbose] control plane: %s\n", controlURL)
 	}
 
@@ -560,13 +615,13 @@ func runStart(args []string, env *Env) int {
 	// Resolve the inner command for the selected harness: an explicit
 	// --inner override wins, else the profile's inner_cmd, else the
 	// harness's default InnerCmd (config.Harness.ResolveInnerCmd).
-	inner := harness.ResolveInnerCmd(prof.InnerCmd, *innerCmdOverride)
+	inner := harness.ResolveInnerCmd(prof.InnerCmd, innerCmdOverride)
 	if len(innerArgs) > 0 {
 		inner = append(inner, innerArgs...)
 	}
 
 	var argv []string
-	if *noSandbox {
+	if noSandbox {
 		argv = inner
 	} else {
 		argv, err = sandbox.Expand(prof, sandbox.Inputs{
@@ -590,7 +645,7 @@ func runStart(args []string, env *Env) int {
 			}
 		}
 	}
-	if *verbose {
+	if verbose {
 		fmt.Fprintf(env.Stderr, "[verbose] sandbox argv: %v\n", argv)
 	}
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -31,12 +31,17 @@ import (
 // one of these and call runLaunch, so the launch pipeline has a single
 // implementation.
 type launchOpts struct {
+	// label is the invoking subcommand name ("start", "continue", "resume").
+	// runLaunch uses it to prefix diagnostics so a failure surfaced via
+	// `omac continue`/`omac resume` is not mislabeled as `omac start:`.
+	label              string
 	harness            config.Harness
 	profile            string
 	innerCmdOverride   string
 	noSandbox          bool
 	keepRunning        bool
 	acceptSkillChanges bool
+	skipSecretPattern  bool
 	verbose            bool
 	// innerArgs are appended to the resolved inner command (user-supplied
 	// trailing `-- args` plus any command-specific flags like --continue).
@@ -93,12 +98,14 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 	}
 	innerArgs = append(fs.Args(), innerArgs...)
 	return launchOpts{
+		label:              cmdName,
 		harness:            harness,
 		profile:            *profile,
 		innerCmdOverride:   *innerCmdOverride,
 		noSandbox:          *noSandbox,
 		keepRunning:        *keepRunning,
 		acceptSkillChanges: *acceptSkillChanges,
+		skipSecretPattern:  *skipSecretPattern,
 		verbose:            *verbose,
 		innerArgs:          innerArgs,
 	}, true
@@ -122,13 +129,22 @@ func runLaunch(env *Env, opts launchOpts) int {
 	noSandbox := opts.noSandbox
 	keepRunning := opts.keepRunning
 	acceptSkillChanges := opts.acceptSkillChanges
+	skipSecretPattern := opts.skipSecretPattern
 	verbose := opts.verbose
 	innerArgs := opts.innerArgs
+
+	// Diagnostics are prefixed with the invoking subcommand so a failure
+	// surfaced through `omac continue`/`omac resume` is not mislabeled.
+	label := opts.label
+	if label == "" {
+		label = "start"
+	}
+	prefix := "omac " + label
 
 	// 1. Load launcher config.
 	lc, cfgPath, err := config.LoadLauncher(env.Workdir)
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: launcher config:", err)
+		fmt.Fprintln(env.Stderr, prefix+": launcher config:", err)
 		return ExitConfigInvalid
 	}
 	if verbose && cfgPath != "" {
@@ -140,7 +156,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	}
 	prof, ok := lc.Sandbox.Profiles[profName]
 	if !ok && !noSandbox {
-		fmt.Fprintf(env.Stderr, "omac start: unknown sandbox profile %q\n", profName)
+		fmt.Fprintf(env.Stderr, prefix+": unknown sandbox profile %q\n", profName)
 		return ExitConfigInvalid
 	}
 
@@ -166,12 +182,12 @@ func runLaunch(env *Env, opts launchOpts) int {
 	// on the workdir layer only — see autoDeregisterMissing.
 	workdirReg, err := registry.Load(env.Workdir)
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: registry:", err)
+		fmt.Fprintln(env.Stderr, prefix+": registry:", err)
 		return ExitIOError
 	}
 	globalReg, err := registry.LoadGlobal()
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: global registry:", err)
+		fmt.Fprintln(env.Stderr, prefix+": global registry:", err)
 		return ExitIOError
 	}
 
@@ -184,12 +200,12 @@ func runLaunch(env *Env, opts launchOpts) int {
 	//     purge them later.
 	pruned, err := autoDeregisterMissing(env, workdirReg, false)
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: auto-deregister:", err)
+		fmt.Fprintln(env.Stderr, prefix+": auto-deregister:", err)
 		return ExitIOError
 	}
 	globalPruned, err := autoDeregisterMissing(env, globalReg, true)
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: auto-deregister (global):", err)
+		fmt.Fprintln(env.Stderr, prefix+": auto-deregister (global):", err)
 		return ExitIOError
 	}
 	for _, p := range append(pruned, globalPruned...) {
@@ -222,11 +238,11 @@ func runLaunch(env *Env, opts launchOpts) int {
 	//     keychain seeding, etc. don't get silently skipped).
 	unregistered, err := findUnregisteredSkills(env.Workdir, harness, reg)
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: scan skills:", err)
+		fmt.Fprintln(env.Stderr, prefix+": scan skills:", err)
 		return ExitIOError
 	}
 	if len(unregistered) > 0 {
-		fmt.Fprintln(env.Stderr, "omac start: unregistered skills found in this workdir:")
+		fmt.Fprintln(env.Stderr, prefix+": unregistered skills found in this workdir:")
 		for _, name := range unregistered {
 			fmt.Fprintf(env.Stderr, "  %s — register with: omac register %s\n", name, name)
 		}
@@ -236,7 +252,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 
 	if len(reg.Registered) == 0 {
 		fmt.Fprintln(env.Stderr,
-			"omac start: no skills registered in this workdir; "+
+			prefix+": no skills registered in this workdir; "+
 				"starting sandbox without sidecars (run `omac register` to add some)")
 	}
 
@@ -278,12 +294,12 @@ func runLaunch(env *Env, opts launchOpts) int {
 
 	workdirCfg, err := skillconfig.Load(env.Workdir)
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: skill-config:", err)
+		fmt.Fprintln(env.Stderr, prefix+": skill-config:", err)
 		return ExitIOError
 	}
 	globalCfg, err := skillconfig.LoadGlobal()
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: global skill-config:", err)
+		fmt.Fprintln(env.Stderr, prefix+": global skill-config:", err)
 		return ExitIOError
 	}
 	// Merge config the same way as the registry: workdir values
@@ -334,7 +350,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 				// I/O errors during hashing are class-level (we can't
 				// produce useful per-skill diagnostics if the directory
 				// is unreadable). Abort immediately.
-				fmt.Fprintln(env.Stderr, "omac start: bundle hash:", err)
+				fmt.Fprintln(env.Stderr, prefix+": bundle hash:", err)
 				return ExitIOError
 			}
 			if bundle != e.BundleHash {
@@ -375,7 +391,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 					// is the escape hatch for a stale pattern: the raw value
 					// is still passed through, just not vetted here.
 					if envVal, ok := secretFromEnv(spec.Name, envPassthrough); ok {
-						if !*skipSecretPattern {
+						if !skipSecretPattern {
 							if perr := validatePattern(spec, envVal); perr != nil {
 								invalidSecrets = append(invalidSecrets,
 									invalidSecretProblem{skill: e.Name, secret: spec.Name, reason: perr.Error()})
@@ -392,7 +408,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 				// Keychain I/O failure is class-level (likely auth
 				// rejection on macOS); the user fixes it once and
 				// retries. No point continuing.
-				fmt.Fprintln(env.Stderr, "omac start: keychain:", err)
+				fmt.Fprintln(env.Stderr, prefix+": keychain:", err)
 				return ExitKeychainError
 			}
 			secMap[spec.Name] = val
@@ -438,7 +454,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	// (grouped by problem class) and abort.
 	if len(bundleDrifts) > 0 || len(missingSecrets) > 0 || len(invalidSecrets) > 0 || len(missingFields) > 0 || len(metaProblems) > 0 {
 		total := len(bundleDrifts) + len(missingSecrets) + len(invalidSecrets) + len(missingFields) + len(metaProblems)
-		fmt.Fprintf(env.Stderr, "omac start: refusing to start, found %d problem(s):\n", total)
+		fmt.Fprintf(env.Stderr, prefix+": refusing to start, found %d problem(s):\n", total)
 
 		if len(metaProblems) > 0 {
 			fmt.Fprintln(env.Stderr, "\n  "+config.MetaFileName+" broken:")
@@ -489,7 +505,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	// 4. Create runtime directory.
 	rtDir, err := createRuntimeDir(env.Workdir)
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: runtime dir:", err)
+		fmt.Fprintln(env.Stderr, prefix+": runtime dir:", err)
 		return ExitIOError
 	}
 	if verbose {
@@ -504,7 +520,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	// fresh, isolated dir per launch and remove it on exit.
 	sandboxTmp, err := os.MkdirTemp("", "omac-sandbox-tmp-")
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: sandbox temp dir:", err)
+		fmt.Fprintln(env.Stderr, prefix+": sandbox temp dir:", err)
 		return ExitIOError
 	}
 	defer os.RemoveAll(sandboxTmp)
@@ -542,7 +558,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	defer cancel()
 	running, err := sup.StartAll(ctx, specs)
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start:", err)
+		fmt.Fprintln(env.Stderr, prefix+":", err)
 		return ExitSidecarHealthcheckFail
 	}
 
@@ -583,7 +599,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 		env.Version,
 	)
 	if err := f.Start(ctx); err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: facade:", err)
+		fmt.Fprintln(env.Stderr, prefix+": facade:", err)
 		return ExitIOError
 	}
 	defer f.Close()
@@ -633,7 +649,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 			TmpDir:   sandboxTmp,
 		})
 		if err != nil {
-			fmt.Fprintln(env.Stderr, "omac start: sandbox argv:", err)
+			fmt.Fprintln(env.Stderr, prefix+": sandbox argv:", err)
 			return ExitConfigInvalid
 		}
 		// Whitelist the control-plane port into the sandbox so the inner
@@ -690,7 +706,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 
 	code, err := sandbox.ExecWithReady(argv, extra, nil)
 	if err != nil {
-		fmt.Fprintln(env.Stderr, "omac start: exec:", err)
+		fmt.Fprintln(env.Stderr, prefix+": exec:", err)
 		return ExitSandboxAbnormal
 	}
 	return code

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -62,6 +62,47 @@ type Harness struct {
 	// $XDG_CONFIG_HOME). GlobalSkillsDir derives "<config home>/skills" from
 	// this — the directory the harness's own loader reads global skills from.
 	UserConfigHome string
+
+	// Session, when non-nil, declares how omac re-enters prior sessions of
+	// this harness for `omac continue` and `omac resume`. A nil Session means
+	// the harness exposes no session continue/resume support, and those
+	// subcommands report it as unsupported. See HarnessSession.
+	Session *HarnessSession
+}
+
+// SessionListKind selects how omac enumerates a harness's prior sessions for
+// `omac resume`. The actual listing logic lives in the session package (so
+// config stays free of CLI/filesystem dependencies); this enum is the data
+// that keys it.
+type SessionListKind int
+
+const (
+	// SessionListNone means the harness has no way to list sessions; `omac
+	// resume` reports listing unsupported (continue may still work).
+	SessionListNone SessionListKind = iota
+	// SessionListOpenCodeCLI lists via `opencode session list --format json`.
+	SessionListOpenCodeCLI
+	// SessionListClaudeFiles lists by reading Claude Code's per-project
+	// session store under ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl.
+	SessionListClaudeFiles
+)
+
+// HarnessSession encodes the harness-specific knowledge `omac continue` and
+// `omac resume` need: the inner flags that re-enter sessions, and how to
+// enumerate prior sessions for the picker. It is pure data so the harness
+// registry stays declarative (the I/O lives in the session package, keyed on
+// ListKind).
+type HarnessSession struct {
+	// ContinueArgs are appended to the inner command to continue the most
+	// recent session for the current workdir (opencode/claude: ["--continue"]).
+	ContinueArgs []string
+
+	// ResumeByIDArgs builds the inner args that resume a specific session id
+	// (opencode: ["--session", id]; claude: ["--resume", id]).
+	ResumeByIDArgs func(id string) []string
+
+	// ListKind selects the strategy `omac resume` uses to enumerate sessions.
+	ListKind SessionListKind
 }
 
 // SharedSkillsBase is the neutral, harness-independent skills directory base
@@ -102,6 +143,11 @@ func harnessRegistry() []Harness {
 			ServerLaunch: &ServerLaunch{Subcommand: "serve"},
 			BridgeDir:    filepath.Join(".opencode", "plugins"),
 			SkillsBase:   "opencode",
+			Session: &HarnessSession{
+				ContinueArgs:   []string{"--continue"},
+				ResumeByIDArgs: func(id string) []string { return []string{"--session", id} },
+				ListKind:       SessionListOpenCodeCLI,
+			},
 		},
 		{
 			Name:    "claude-code",
@@ -117,6 +163,11 @@ func harnessRegistry() []Harness {
 			// Claude Code's config home is ~/.claude, not ~/.config/claude,
 			// so its global skills live in ~/.claude/skills.
 			UserConfigHome: ".claude",
+			Session: &HarnessSession{
+				ContinueArgs:   []string{"--continue"},
+				ResumeByIDArgs: func(id string) []string { return []string{"--resume", id} },
+				ListKind:       SessionListClaudeFiles,
+			},
 		},
 	}
 }

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -227,3 +227,43 @@ func TestGlobalBridgeDir(t *testing.T) {
 		t.Errorf("claude GlobalBridgeDir = %q, want empty", got)
 	}
 }
+
+func TestHarnessSessionMetadata(t *testing.T) {
+	oc, _ := LookupHarness("opencode")
+	if oc.Session == nil {
+		t.Fatal("opencode Session is nil, want session metadata")
+	}
+	if !reflect.DeepEqual(oc.Session.ContinueArgs, []string{"--continue"}) {
+		t.Errorf("opencode ContinueArgs = %v, want [--continue]", oc.Session.ContinueArgs)
+	}
+	if got := oc.Session.ResumeByIDArgs("ses_X"); !reflect.DeepEqual(got, []string{"--session", "ses_X"}) {
+		t.Errorf("opencode ResumeByIDArgs = %v, want [--session ses_X]", got)
+	}
+	if oc.Session.ListKind != SessionListOpenCodeCLI {
+		t.Errorf("opencode ListKind = %v, want SessionListOpenCodeCLI", oc.Session.ListKind)
+	}
+
+	cc, _ := LookupHarness("claude-code")
+	if cc.Session == nil {
+		t.Fatal("claude Session is nil, want session metadata")
+	}
+	if !reflect.DeepEqual(cc.Session.ContinueArgs, []string{"--continue"}) {
+		t.Errorf("claude ContinueArgs = %v, want [--continue]", cc.Session.ContinueArgs)
+	}
+	if got := cc.Session.ResumeByIDArgs("abc-123"); !reflect.DeepEqual(got, []string{"--resume", "abc-123"}) {
+		t.Errorf("claude ResumeByIDArgs = %v, want [--resume abc-123]", got)
+	}
+	if cc.Session.ListKind != SessionListClaudeFiles {
+		t.Errorf("claude ListKind = %v, want SessionListClaudeFiles", cc.Session.ListKind)
+	}
+}
+
+// TestHarnessSessionNilIsSafe documents that a harness with no Session block
+// (the zero default for any future descriptor) is tolerated: callers must
+// nil-check before using session metadata.
+func TestHarnessSessionNilIsSafe(t *testing.T) {
+	var h Harness // zero value: Session == nil
+	if h.Session != nil {
+		t.Fatal("zero Harness should have nil Session")
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,0 +1,290 @@
+// Package session enumerates an inner harness's prior sessions for the
+// current workdir, powering `omac resume`. Each supported harness exposes
+// sessions differently, so listing dispatches on the harness's
+// config.SessionListKind:
+//
+//   - OpenCode: parse `opencode session list --format json`.
+//   - Claude Code: read ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl.
+//
+// All listing is best-effort: a missing harness CLI, a missing session store,
+// or unparseable state yields an empty list (or ErrUnsupported when the
+// harness declares no listing strategy), never a hard failure that would
+// block the user.
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+// Session is one resumable session, normalized across harnesses.
+type Session struct {
+	ID    string    // harness-native session id (opencode "ses_…", claude UUID)
+	Title string    // human-readable title for the picker
+	When  time.Time // last-activity time; zero when unknown
+}
+
+// ErrUnsupported is returned when the harness declares no way to list
+// sessions (nil Session block or config.SessionListNone). Continue may still
+// work even when listing does not.
+var ErrUnsupported = errors.New("session listing not supported for this harness")
+
+// runner runs a command and returns its stdout. Swappable in tests.
+type runner func(name string, args ...string) ([]byte, error)
+
+// execRunner is the production runner: it shells out to the named binary.
+func execRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// List returns harness's prior sessions for workdir, most-recent first.
+// workdir SHOULD be absolute; it is cleaned before comparison.
+func List(h config.Harness, workdir string) ([]Session, error) {
+	return list(h, workdir, execRunner, claudeProjectsRoot())
+}
+
+// list is the testable core: callers inject the command runner and the Claude
+// projects root.
+func list(h config.Harness, workdir string, run runner, claudeRoot string) ([]Session, error) {
+	if h.Session == nil {
+		return nil, ErrUnsupported
+	}
+	workdir = filepath.Clean(workdir)
+	switch h.Session.ListKind {
+	case config.SessionListOpenCodeCLI:
+		return listOpenCode(workdir, run), nil
+	case config.SessionListClaudeFiles:
+		return listClaude(workdir, claudeRoot), nil
+	default:
+		return nil, ErrUnsupported
+	}
+}
+
+// sortNewestFirst orders sessions by When descending (unknown times sink to
+// the end), with ID as a stable tiebreaker.
+func sortNewestFirst(s []Session) {
+	sort.SliceStable(s, func(i, j int) bool {
+		if s[i].When.Equal(s[j].When) {
+			return s[i].ID < s[j].ID
+		}
+		return s[i].When.After(s[j].When)
+	})
+}
+
+// --- OpenCode backend -------------------------------------------------------
+
+// ocRecord is the subset of `opencode session list --format json` we use.
+type ocRecord struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Updated   int64  `json:"updated"` // epoch milliseconds
+	Directory string `json:"directory"`
+}
+
+// listOpenCode runs the opencode CLI and keeps records for workdir. A missing
+// CLI, non-zero exit, or unparseable output yields nil (best-effort).
+func listOpenCode(workdir string, run runner) []Session {
+	out, err := run("opencode", "session", "list", "--format", "json")
+	if err != nil {
+		return nil
+	}
+	var recs []ocRecord
+	if json.Unmarshal(out, &recs) != nil {
+		return nil
+	}
+	var sessions []Session
+	for _, r := range recs {
+		if r.ID == "" || filepath.Clean(r.Directory) != workdir {
+			continue
+		}
+		var when time.Time
+		if r.Updated > 0 {
+			when = time.UnixMilli(r.Updated)
+		}
+		sessions = append(sessions, Session{ID: r.ID, Title: r.Title, When: when})
+	}
+	sortNewestFirst(sessions)
+	return sessions
+}
+
+// --- Claude Code backend ----------------------------------------------------
+
+// claudeProjectsRoot returns ~/.claude/projects, or "" when no home dir
+// resolves (best-effort: an empty root yields no sessions).
+func claudeProjectsRoot() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".claude", "projects")
+}
+
+// encodeProjectDir mirrors Claude Code's per-project directory naming: every
+// non-alphanumeric rune in the absolute path becomes '-'. The encoding is
+// lossy (distinct paths can collide), so callers MUST still confirm a session
+// belongs to workdir via its embedded cwd — see listClaude.
+func encodeProjectDir(path string) string {
+	var b strings.Builder
+	for _, r := range path {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
+}
+
+// listClaude reads workdir's Claude session files. The encoded directory name
+// is only a lookup hint; membership is decided authoritatively by each file's
+// embedded cwd. Missing root/dir or unreadable files yield nil.
+func listClaude(workdir, projectsRoot string) []Session {
+	if projectsRoot == "" {
+		return nil
+	}
+	dir := filepath.Join(projectsRoot, encodeProjectDir(workdir))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var sessions []Session
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		s, ok := parseClaudeSession(path, workdir)
+		if !ok {
+			continue
+		}
+		sessions = append(sessions, s)
+	}
+	sortNewestFirst(sessions)
+	return sessions
+}
+
+// claudeLine is the union of fields we read from a session's JSONL records.
+type claudeLine struct {
+	Type      string          `json:"type"`
+	AiTitle   string          `json:"aiTitle"`
+	Cwd       string          `json:"cwd"`
+	Timestamp string          `json:"timestamp"`
+	Message   json.RawMessage `json:"message"`
+}
+
+// parseClaudeSession reads one <session-id>.jsonl file. It returns false when
+// the file's cwd does not match workdir (or cannot be determined). The id is
+// the filename sans extension; the title is the latest aiTitle (falling back
+// to the first user message, then the id); the time is the latest record
+// timestamp (falling back to file mtime). Malformed lines are skipped.
+func parseClaudeSession(path, workdir string) (Session, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Session{}, false
+	}
+	defer f.Close()
+
+	id := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	var (
+		cwd       string
+		title     string
+		firstUser string
+		latest    time.Time
+	)
+	sc := bufio.NewScanner(f)
+	// Session lines can be large (tool output); raise the token limit.
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec claudeLine
+		if json.Unmarshal(line, &rec) != nil {
+			continue
+		}
+		if cwd == "" && rec.Cwd != "" {
+			cwd = rec.Cwd
+		}
+		if rec.AiTitle != "" {
+			title = rec.AiTitle
+		}
+		if firstUser == "" && rec.Type == "user" {
+			firstUser = firstUserText(rec.Message)
+		}
+		if rec.Timestamp != "" {
+			if t, err := time.Parse(time.RFC3339, rec.Timestamp); err == nil {
+				latest = t
+			}
+		}
+	}
+	if filepath.Clean(cwd) != workdir {
+		return Session{}, false
+	}
+	if title == "" {
+		title = firstUser
+	}
+	if title == "" {
+		title = id
+	}
+	if latest.IsZero() {
+		if fi, err := os.Stat(path); err == nil {
+			latest = fi.ModTime()
+		}
+	}
+	return Session{ID: id, Title: title, When: latest}, true
+}
+
+// firstUserText extracts a short plain-text preview from a user message whose
+// content is either a string or an array of content blocks ({type,text}).
+// Returns "" when no text is found.
+func firstUserText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var msg struct {
+		Content json.RawMessage `json:"content"`
+	}
+	if json.Unmarshal(raw, &msg) != nil {
+		return ""
+	}
+	// content as a plain string
+	var s string
+	if json.Unmarshal(msg.Content, &s) == nil {
+		return truncate(s)
+	}
+	// content as an array of blocks
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(msg.Content, &blocks) == nil {
+		for _, b := range blocks {
+			if b.Text != "" {
+				return truncate(b.Text)
+			}
+		}
+	}
+	return ""
+}
+
+// truncate collapses whitespace and caps a preview at 80 runes.
+func truncate(s string) string {
+	s = strings.TrimSpace(strings.Join(strings.Fields(s), " "))
+	const max = 80
+	r := []rune(s)
+	if len(r) > max {
+		return string(r[:max-1]) + "…"
+	}
+	return s
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -223,7 +223,9 @@ func parseClaudeSession(path, workdir string) (Session, bool) {
 			firstUser = firstUserText(rec.Message)
 		}
 		if rec.Timestamp != "" {
-			if t, err := time.Parse(time.RFC3339, rec.Timestamp); err == nil {
+			// RFC3339Nano accepts both fractional (e.g. ...:57.378Z) and
+			// whole-second timestamps; Claude emits the fractional form.
+			if t, err := time.Parse(time.RFC3339Nano, rec.Timestamp); err == nil {
 				latest = t
 			}
 		}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,0 +1,179 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+func opencodeHarness(t *testing.T) config.Harness {
+	t.Helper()
+	h, ok := config.LookupHarness("opencode")
+	if !ok {
+		t.Fatal("opencode harness not registered")
+	}
+	return h
+}
+
+func claudeHarness(t *testing.T) config.Harness {
+	t.Helper()
+	h, ok := config.LookupHarness("claude-code")
+	if !ok {
+		t.Fatal("claude harness not registered")
+	}
+	return h
+}
+
+func TestListUnsupported(t *testing.T) {
+	// Harness with no Session block.
+	if _, err := list(config.Harness{}, "/w", nil, ""); !errors.Is(err, ErrUnsupported) {
+		t.Errorf("nil Session: err = %v, want ErrUnsupported", err)
+	}
+	// Harness whose Session declares no listing strategy.
+	h := config.Harness{Session: &config.HarnessSession{ListKind: config.SessionListNone}}
+	if _, err := list(h, "/w", nil, ""); !errors.Is(err, ErrUnsupported) {
+		t.Errorf("SessionListNone: err = %v, want ErrUnsupported", err)
+	}
+}
+
+func TestListOpenCodeParseAndFilter(t *testing.T) {
+	const wd = "/home/u/proj"
+	run := func(name string, args ...string) ([]byte, error) {
+		return []byte(`[
+			{"id":"ses_new","title":"newest","updated":2000,"directory":"/home/u/proj"},
+			{"id":"ses_old","title":"oldest","updated":1000,"directory":"/home/u/proj"},
+			{"id":"ses_other","title":"elsewhere","updated":3000,"directory":"/home/u/other"}
+		]`), nil
+	}
+	got, err := list(opencodeHarness(t), wd, run, "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d sessions, want 2 (filtered to workdir): %+v", len(got), got)
+	}
+	if got[0].ID != "ses_new" || got[1].ID != "ses_old" {
+		t.Errorf("order = [%s,%s], want newest-first [ses_new,ses_old]", got[0].ID, got[1].ID)
+	}
+	if !got[0].When.Equal(time.UnixMilli(2000)) {
+		t.Errorf("ses_new When = %v, want epoch-ms 2000", got[0].When)
+	}
+}
+
+func TestListOpenCodeCLIFailureIsEmpty(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) { return nil, errors.New("not found") }
+	got, err := list(opencodeHarness(t), "/w", run, "")
+	if err != nil {
+		t.Fatalf("CLI failure should not error, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("CLI failure should yield nil sessions, got %+v", got)
+	}
+}
+
+func TestEncodeProjectDir(t *testing.T) {
+	cases := map[string]string{
+		"/home/u/oh-my-agentic-coder":      "-home-u-oh-my-agentic-coder",
+		"/home/u/proj/.claude/worktrees/x": "-home-u-proj--claude-worktrees-x",
+	}
+	for in, want := range cases {
+		if got := encodeProjectDir(in); got != want {
+			t.Errorf("encodeProjectDir(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// writeJSONL writes a session fixture file and returns the workdir it claims.
+func writeClaudeFixture(t *testing.T, root, workdir, id string, lines []string) {
+	t.Helper()
+	dir := filepath.Join(root, encodeProjectDir(workdir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, id+".jsonl"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListClaudeTitleTimeAndCwdMatch(t *testing.T) {
+	root := t.TempDir()
+	const wd = "/home/u/proj"
+
+	// Session A: has an aiTitle and timestamps; cwd matches.
+	writeClaudeFixture(t, root, wd, "aaaa-1111", []string{
+		`{"type":"user","cwd":"/home/u/proj","timestamp":"2026-01-01T10:00:00Z","message":{"content":"hello there"}}`,
+		`{"type":"ai-title","aiTitle":"First title","sessionId":"aaaa-1111"}`,
+		`{"type":"assistant","timestamp":"2026-01-01T10:05:00Z"}`,
+		`{"type":"ai-title","aiTitle":"Final title","sessionId":"aaaa-1111"}`,
+		`not valid json — must be skipped`,
+	})
+	// Session B: no aiTitle → falls back to first user message text; cwd matches.
+	writeClaudeFixture(t, root, wd, "bbbb-2222", []string{
+		`{"type":"user","cwd":"/home/u/proj","timestamp":"2026-01-02T09:00:00Z","message":{"content":[{"type":"text","text":"fix the bug please"}]}}`,
+	})
+
+	got := listClaude(wd, root)
+	if len(got) != 2 {
+		t.Fatalf("got %d sessions, want 2: %+v", len(got), got)
+	}
+	// B is newer (Jan 2) → first.
+	if got[0].ID != "bbbb-2222" {
+		t.Errorf("newest-first: got[0] = %s, want bbbb-2222", got[0].ID)
+	}
+	byID := map[string]Session{got[0].ID: got[0], got[1].ID: got[1]}
+	if byID["aaaa-1111"].Title != "Final title" {
+		t.Errorf("session A title = %q, want last aiTitle 'Final title'", byID["aaaa-1111"].Title)
+	}
+	if byID["bbbb-2222"].Title != "fix the bug please" {
+		t.Errorf("session B title = %q, want first-user-message fallback", byID["bbbb-2222"].Title)
+	}
+	if !byID["aaaa-1111"].When.Equal(time.Date(2026, 1, 1, 10, 5, 0, 0, time.UTC)) {
+		t.Errorf("session A When = %v, want last timestamp 10:05", byID["aaaa-1111"].When)
+	}
+}
+
+func TestListClaudeCwdMismatchExcluded(t *testing.T) {
+	root := t.TempDir()
+	const wd = "/home/u/proj"
+	// File lives under the encoded dir for wd, but its embedded cwd differs
+	// (encoding collision). It MUST be excluded.
+	writeClaudeFixture(t, root, wd, "cccc-3333", []string{
+		`{"type":"user","cwd":"/home/u/different","timestamp":"2026-01-01T10:00:00Z","message":{"content":"x"}}`,
+	})
+	if got := listClaude(wd, root); len(got) != 0 {
+		t.Errorf("cwd mismatch should be excluded, got %+v", got)
+	}
+}
+
+func TestListClaudeMissingRootIsEmpty(t *testing.T) {
+	if got := listClaude("/home/u/proj", filepath.Join(t.TempDir(), "does-not-exist")); got != nil {
+		t.Errorf("missing root should yield nil, got %+v", got)
+	}
+	if got := listClaude("/home/u/proj", ""); got != nil {
+		t.Errorf("empty root should yield nil, got %+v", got)
+	}
+}
+
+func TestListClaudeMtimeFallback(t *testing.T) {
+	root := t.TempDir()
+	const wd = "/home/u/proj"
+	// No timestamp records → When falls back to file mtime.
+	writeClaudeFixture(t, root, wd, "dddd-4444", []string{
+		`{"type":"user","cwd":"/home/u/proj","message":{"content":"no timestamp here"}}`,
+	})
+	got := listClaude(wd, root)
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1", len(got))
+	}
+	if got[0].When.IsZero() {
+		t.Error("When should fall back to file mtime, got zero")
+	}
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -19,15 +19,6 @@ func opencodeHarness(t *testing.T) config.Harness {
 	return h
 }
 
-func claudeHarness(t *testing.T) config.Harness {
-	t.Helper()
-	h, ok := config.LookupHarness("claude-code")
-	if !ok {
-		t.Fatal("claude harness not registered")
-	}
-	return h
-}
-
 func TestListUnsupported(t *testing.T) {
 	// Harness with no Session block.
 	if _, err := list(config.Harness{}, "/w", nil, ""); !errors.Is(err, ErrUnsupported) {

--- a/oh-my-agentic-coder.md
+++ b/oh-my-agentic-coder.md
@@ -132,6 +132,8 @@ Single Rust binary. Subcommands (detailed in §10):
 - `omac deregister <skill>`
 - `omac list`
 - `omac start [-- …inner args]`
+- `omac continue [harness] [-- …inner args]`
+- `omac resume [harness]`
 - `omac doctor`
 - `omac version`
 
@@ -585,6 +587,35 @@ Common flags:
 - `--accept-skill-changes` — tolerate `bundle_hash` drift.
 - `--skip-secret-pattern` — do not enforce a secret's `pattern` against an `env_passthrough`-supplied value (escape hatch for an outdated pattern; the raw value is still passed through to the sidecar).
 - `--verbose`, `--log-level <level>`.
+
+### 10.4a `omac continue [harness] [-- …inner args]`
+
+Runs the full `omac start` lifecycle (§12) but re-enters the most recent
+session for the current workdir by appending the resolved harness's "continue"
+inner flag (opencode and Claude Code: `--continue`). Accepts the same flags and
+optional leading `[harness]` token as `start`. If the harness declares no
+session support, it exits with a clear message (code `2`).
+
+### 10.4b `omac resume [harness]`
+
+Lists the recent sessions scoped to the current workdir, presents an
+interactive numbered picker (index, relative time, title), and launches the
+selected session through the `start` lifecycle with the harness's "resume by
+id" inner flag (opencode `--session <id>`, Claude Code `--resume <id>`).
+
+Sessions are read from each harness's own store via a per-harness strategy:
+
+- **opencode** — parse `opencode session list --format json`, keep records
+  whose `directory` is the workdir.
+- **claude-code** — read `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`;
+  the id is the filename, the title is the latest `aiTitle` record (falling
+  back to the first user message, then the id), the time is the latest record
+  timestamp (falling back to file mtime). The lossy directory encoding is only
+  a lookup hint — membership is confirmed against each file's embedded `cwd`.
+
+Listing is best-effort: a missing CLI/store yields "no resumable sessions"
+rather than an error. With non-interactive stdin, the list is printed with a
+hint and no selection is made. Cancelling the picker exits without launching.
 
 ### 10.5 `omac doctor`
 

--- a/openspec/changes/omac-continue-resume/.openspec.yaml
+++ b/openspec/changes/omac-continue-resume/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-25

--- a/openspec/changes/omac-continue-resume/design.md
+++ b/openspec/changes/omac-continue-resume/design.md
@@ -1,0 +1,73 @@
+## Context
+
+omac launches an inner harness (opencode/claude) inside a sandbox via `omac start`. The launch pipeline in `runStart` (`internal/cli/start.go`) does registry reconciliation, spawns sidecars + facade + control plane, builds the sandbox argv, and execs. Inner args after `--` are passed verbatim, so `omac start opencode -- --continue` already works mechanically — but it is undiscoverable and offers no session selection.
+
+The two shipped harnesses expose sessions very differently:
+
+- **OpenCode** (v1.17+) keeps sessions in `~/.local/share/opencode/opencode.db` (no per-session JSON), but `opencode session list --format json` emits `{id, title, updated, created, projectId, directory}` records, and `opencode --continue` / `opencode --session <id>` re-enter sessions.
+- **Claude Code** has **no JSON session-list CLI**. It persists each session as `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` (session id = filename UUID). A title is carried by an `ai-title` record (`{"type":"ai-title","aiTitle":"…"}`); each line also carries `cwd` and ISO `timestamp` fields. It re-enters sessions via `claude --continue` / `claude --resume <id>`.
+
+The harness model in `internal/config/harness.go` already isolates all harness-specific knowledge as data on the `Harness` descriptor, so the listing difference is expressed as a per-harness strategy selector, not branching in the command code.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `omac continue` and `omac resume` as first-class subcommands that reuse the existing start pipeline unchanged in spirit.
+- Resume lists only the current workdir's sessions, newest first, in an interactive numbered picker.
+- Keep it harness-data-driven (opencode + claude), not opencode-hardcoded.
+
+**Non-Goals:**
+- Provenance coloring (omac-run vs. direct). Excluded — see the proposal's Out of Scope: omac has no authoritative signal short of a harness plugin, and the snapshot-diff alternative is a misattributing heuristic. Deferred to a plugin-based follow-up.
+- A full-screen arrow-key TUI picker. A numbered prompt is sufficient and dependency-free.
+- Session management beyond launch (no delete/rename/export — opencode already has those).
+- Multi-directory `omac serve` integration (these are `start`-pipeline commands).
+
+## Decisions
+
+### 1. Extract a shared `runLaunch` from `runStart`
+
+Refactor `runStart` so the post-parse pipeline (config load → registry reconcile → sidecars → facade → sandbox exec) lives in a `runLaunch(env, opts)` helper, where `opts` carries the parsed harness, start flags, and the resolved inner args. `runStart`, `runContinue`, and `runResume` all parse their own surface flags, decide the extra inner flags, then call `runLaunch`. This avoids duplicating the ~250-line pipeline and keeps a single source of truth for launch behavior.
+
+Alternative considered: have `continue`/`resume` shell out to `omac start` by re-invoking the dispatcher. Rejected — it loses type-safe arg passing and doubles process setup.
+
+### 2. Harness session metadata on the descriptor
+
+Add an optional `Session *HarnessSession` field to `config.Harness`:
+
+```
+type HarnessSession struct {
+    ContinueArgs   []string                  // e.g. ["--continue"]
+    ResumeByIDArgs func(id string) []string   // opencode: ["--session", id]; claude: ["--resume", id]
+    ListKind       SessionListKind           // SessionListOpenCodeCLI | SessionListClaudeFiles | SessionListNone
+}
+```
+
+opencode sets `ListKind = SessionListOpenCodeCLI`; claude-code sets `ResumeByIDArgs` to `["--resume", id]` and `ListKind = SessionListClaudeFiles`. A nil `Session` (or `SessionListNone`) means resume reports the harness doesn't support listing. The descriptor stays pure data (an enum, not a func or I/O) so `config` keeps no filesystem/CLI dependency — matching the existing `ServerLaunch`/`InnerCmd` pattern. The actual listing logic lives in the session package (Decision 3), keyed on `ListKind`.
+
+### 3. Per-harness session listing in a dedicated package
+
+A new package (extend `internal/opencodestate` or add `internal/sessions`) exposes `List(harness, workdir) ([]Session, error)` returning workdir-filtered, newest-first records (`{ID, Title, When}`). It switches on the harness's `ListKind`, and runs **outside** the sandbox (omac orchestration, like the existing `opencodestate` reads):
+
+- **`SessionListOpenCodeCLI`** — run `opencode session list --format json`, parse the JSON array, keep records whose `directory == workdir`. No SQLite driver / `sqlite3` binary dependency; correct across opencode storage-format changes.
+- **`SessionListClaudeFiles`** — locate the project dir under `~/.claude/projects/`. The encoded name is derived from the workdir (Claude replaces path separators and `.` with `-`), but because that encoding is lossy/ambiguous for paths containing literal `-`/`.`, omac treats each candidate file's embedded `cwd` as the source of truth: a session belongs to the workdir iff its `cwd == workdir`. For each `*.jsonl`: id = filename sans extension; title = the last `ai-title` record's `aiTitle` (fallback: first user message text, truncated; final fallback: the id); timestamp = the last record's `timestamp` (fallback: file mtime). Reading is best-effort and line-oriented — a malformed line is skipped, never fatal.
+
+Both backends yield the same `Session` shape, so the picker and launch code are harness-agnostic.
+
+### 4. Picker UI: numbered prompt reusing `style.go`
+
+Render a numbered list (index, title, relative time) then read a line from stdin and parse the index, reusing the existing `styler` (which already disables color for non-TTY/`NO_COLOR`). TTY detection uses `golang.org/x/term` as `style.go` already does. Non-TTY stdin prints the list + hint and exits without blocking. Empty input / EOF / Ctrl-C = cancel (exit OK, no launch).
+
+## Risks / Trade-offs
+
+- **`opencode session list` latency/availability** → Adds a subprocess call to opencode resume. Mitigation: only resume pays it, interactively; a missing harness/CLI yields an empty list, not an error.
+- **Claude `.jsonl` format drift** → The session store is an internal Claude Code format that could change (`ai-title` shape, line schema). Mitigation: parse defensively (skip unknown/malformed lines; layered title fallbacks; mtime fallback for time); listing failure degrades to "no resumable sessions", never a crash.
+- **Claude project-dir encoding is ambiguous** → Reverse-decoding `<encoded-cwd>` is lossy for paths with literal `-`/`.`. Mitigation: never trust the decoded name — match on each file's embedded `cwd` field as the authoritative directory.
+- **`runStart` refactor regressions** → Extracting `runLaunch` touches a large, well-tested function. Mitigation: keep `runStart`'s observable behavior identical and rely on the existing `start` test suite.
+
+## Migration Plan
+
+Purely additive: new subcommands and one new nil-safe `Harness.Session` field. No existing behavior changes; no state on disk; rollback is reverting the commit.
+
+## Open Questions
+
+- Should `omac resume` accept a non-interactive `--session <id>` / `-n <index>` shortcut for scripting? (Not required by the proposal; easy to add later.)

--- a/openspec/changes/omac-continue-resume/proposal.md
+++ b/openspec/changes/omac-continue-resume/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Re-entering work in omac is clumsy today. To pick up where you left off you must launch the harness and navigate its own session UI, and there is no omac-level way to continue the last session or choose from recent ones. omac already launches sessions inside its sandbox via `omac start`, so two thin subcommands — `omac continue` and `omac resume` — close the gap by reusing that launch pipeline (sandbox + sidecars + facade) while letting the user re-enter prior work in one step.
+
+## What Changes
+
+- Add `omac continue [harness] [flags] [-- inner args...]`: re-launch the **last session for the current workdir** inside omac. It runs the full `omac start` pipeline and appends the harness's "continue last session" inner flag (opencode/claude: `--continue`).
+- Add `omac resume [harness] [flags]`: list the **recent sessions for the current workdir**, present an interactive numbered picker (title + relative time), and launch the selected session inside omac (appending the harness's "resume specific session" inner flag — opencode `--session <id>`, claude `--resume <id>`). Non-interactive stdin falls back to printing the list with a hint.
+- Support **both shipped harnesses** with working continue *and* resume. The two harnesses expose sessions differently, so omac uses a per-harness listing strategy: opencode via its `session list --format json` CLI; Claude Code by reading its session store (`~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, title from the `aiTitle` record, directory confirmed via each file's embedded `cwd`).
+- Register both subcommands in the dispatcher and top-level usage; add per-harness session metadata (continue flag, resume-by-id flag, and which listing strategy to use) to the harness registry so the commands are not opencode-hardcoded.
+
+## Capabilities
+
+### New Capabilities
+- `session-continue`: The `omac continue` command — continue the most recent session for the current workdir inside the omac sandbox, delegating to the existing start pipeline with a harness-specific "continue" inner flag.
+- `session-resume`: The `omac resume` command — list recent sessions scoped to the current workdir, render an interactive numbered picker, and launch the chosen session inside omac.
+
+### Modified Capabilities
+<!-- inner-harness is defined in the not-yet-archived support-claude-code-harness change; this change adds session metadata to that registry but does not alter its existing requirements, so no delta spec is needed here. -->
+
+## Impact
+
+- **Code (Go):** new `internal/cli/continue.go` and `internal/cli/resume.go`; `internal/cli/cli.go` (register `continue`/`resume`, usage text); refactor `internal/cli/start.go` so its launch pipeline is callable with caller-supplied extra inner args (extract the body of `runStart` into a shared `runLaunch`); a new session-listing package (or extension of `internal/opencodestate`) with two backends — opencode (parse `opencode session list --format json`) and Claude Code (read `~/.claude/projects/<encoded-cwd>/*.jsonl`) — both returning workdir-filtered, newest-first records.
+- **Harness registry (`internal/config/harness.go`):** add per-harness session metadata (continue-flag argv, resume-by-id flag builder, and a listing-strategy selector). opencode and claude both populated; a nil session block means continue/resume report the harness doesn't support them.
+- **Interactive UI:** reuse `internal/cli/style.go` color helpers and terminal detection for the numbered picker; respect non-TTY by degrading gracefully.
+- **Docs:** `README.md` (new subcommands + usage), `oh-my-agentic-coder.md` CLI section.
+- **Backward compatibility:** purely additive — new subcommands only; existing commands, layouts, and harness behavior are unchanged. Omitting the harness token defaults to `opencode` as elsewhere.
+
+## Out of Scope / Future Work
+
+- **Provenance coloring** (showing which sessions were previously run through omac vs. opened directly): deliberately excluded. omac has no authoritative signal for this — it would require either a best-effort session-list snapshot-diff (a heuristic that can misattribute) or, done properly, an opencode-plugin/bridge that tags sessions from inside the harness. Defer to a follow-up that takes the plugin-based approach if the hint proves wanted.

--- a/openspec/changes/omac-continue-resume/specs/session-continue/spec.md
+++ b/openspec/changes/omac-continue-resume/specs/session-continue/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Continue subcommand
+
+omac SHALL provide an `omac continue [harness] [flags] [-- inner args...]` subcommand that re-launches the most recent session for the current workdir inside the omac sandbox. It SHALL reuse the full `omac start` launch pipeline (registry reconciliation, sidecars, facade, sandbox) and append the resolved harness's "continue last session" inner flag to the inner command.
+
+#### Scenario: Continue the last session in the default harness
+
+- **WHEN** the user runs `omac continue` in a workdir that has at least one prior session
+- **THEN** omac SHALL run the same launch pipeline as `omac start opencode` and SHALL append `--continue` to the opencode inner command so the harness reopens the last session for that workdir
+
+#### Scenario: Explicit harness token
+
+- **WHEN** the user runs `omac continue claude`
+- **THEN** omac SHALL launch the `claude` harness with that harness's continue flag (`--continue`) appended
+
+#### Scenario: Continue accepts the same flags as start
+
+- **WHEN** the user runs `omac continue --no-sandbox --verbose`
+- **THEN** omac SHALL honor those start flags identically to `omac start` and still append the continue inner flag
+
+#### Scenario: Extra inner args are preserved
+
+- **WHEN** the user runs `omac continue -- --model anthropic/claude-opus`
+- **THEN** omac SHALL pass `--continue` together with the user-supplied inner args verbatim to the inner harness command

--- a/openspec/changes/omac-continue-resume/specs/session-resume/spec.md
+++ b/openspec/changes/omac-continue-resume/specs/session-resume/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Resume subcommand lists workdir sessions
+
+omac SHALL provide an `omac resume [harness] [flags]` subcommand that lists recent sessions scoped to the current workdir and lets the user select one to launch inside omac. Sessions SHALL be obtained using the resolved harness's listing strategy and filtered to those whose recorded directory equals the current workdir. The list SHALL be ordered most-recently-updated first. Each listed session SHALL carry an id, a human-readable title, and a timestamp.
+
+#### Scenario: Only the current workdir's sessions are shown
+
+- **WHEN** the user runs `omac resume` in workdir `/a` and the harness has sessions for `/a` and `/b`
+- **THEN** the picker SHALL list only the sessions whose directory is `/a`
+
+#### Scenario: OpenCode sessions are listed via its CLI
+
+- **WHEN** the resolved harness is opencode
+- **THEN** omac SHALL obtain sessions by parsing `opencode session list --format json` and matching each record's `directory` against the workdir
+
+#### Scenario: Claude Code sessions are listed from its session store
+
+- **WHEN** the resolved harness is claude-code
+- **THEN** omac SHALL obtain sessions by reading the per-project session files under `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, deriving the id from the filename, the title from the session's `aiTitle` record (falling back to the first user message), and the timestamp from the latest record (falling back to file mtime), and confirming the directory via each file's embedded `cwd`
+
+#### Scenario: No sessions for this workdir
+
+- **WHEN** the user runs `omac resume` and there are no sessions for the current workdir
+- **THEN** omac SHALL print a message stating there are no resumable sessions for this directory and SHALL exit without launching the harness
+
+#### Scenario: Harness without a listing strategy
+
+- **WHEN** the resolved harness declares no session-listing strategy
+- **THEN** omac SHALL print that resume listing is unsupported for that harness and suggest `omac continue`, and SHALL NOT error obscurely
+
+### Requirement: Interactive picker
+
+When stdin and stdout are a TTY, `omac resume` SHALL present an interactive picker of the listed sessions, each entry showing at least an index, the session title, and a relative timestamp. Selecting an entry SHALL launch that session inside omac using the existing `omac start` pipeline with the harness's "resume specific session" inner flag (opencode `--session <id>`, claude-code `--resume <id>`). Cancelling the picker SHALL exit without launching.
+
+#### Scenario: Selecting an opencode session launches it in omac
+
+- **WHEN** the resolved harness is opencode and the user selects entry N for session `ses_X`
+- **THEN** omac SHALL run the start pipeline for opencode and SHALL append `--session ses_X` to the inner command
+
+#### Scenario: Selecting a Claude Code session launches it in omac
+
+- **WHEN** the resolved harness is claude-code and the user selects entry N for session `<uuid>`
+- **THEN** omac SHALL run the start pipeline for claude-code and SHALL append `--resume <uuid>` to the inner command
+
+#### Scenario: Cancelling the picker
+
+- **WHEN** the user cancels the picker (e.g. Ctrl-C or empty selection)
+- **THEN** omac SHALL exit without launching any session and SHALL return a non-error (cancelled) exit code
+
+#### Scenario: Non-interactive stdin
+
+- **WHEN** stdin is not a TTY
+- **THEN** omac SHALL print the numbered session list and a hint that selection requires an interactive terminal, and SHALL NOT block waiting for input

--- a/openspec/changes/omac-continue-resume/tasks.md
+++ b/openspec/changes/omac-continue-resume/tasks.md
@@ -1,42 +1,42 @@
 ## 1. Harness session metadata
 
-- [ ] 1.1 Add a `HarnessSession` struct + `SessionListKind` enum (`SessionListNone`/`SessionListOpenCodeCLI`/`SessionListClaudeFiles`) and a `Session *HarnessSession` field to `config.Harness` in `internal/config/harness.go` (`ContinueArgs`, `ResumeByIDArgs func(id string) []string`, `ListKind`).
-- [ ] 1.2 Populate `Session` for the `opencode` descriptor (`ContinueArgs: ["--continue"]`, `ResumeByIDArgs: id -> ["--session", id]`, `ListKind: SessionListOpenCodeCLI`).
-- [ ] 1.3 Populate `Session` for the `claude-code` descriptor (`ContinueArgs: ["--continue"]`, `ResumeByIDArgs: id -> ["--resume", id]`, `ListKind: SessionListClaudeFiles`).
-- [ ] 1.4 Add unit tests asserting each registered harness's session metadata (and that a nil `Session`/`SessionListNone` is handled).
+- [x] 1.1 Add a `HarnessSession` struct + `SessionListKind` enum (`SessionListNone`/`SessionListOpenCodeCLI`/`SessionListClaudeFiles`) and a `Session *HarnessSession` field to `config.Harness` in `internal/config/harness.go` (`ContinueArgs`, `ResumeByIDArgs func(id string) []string`, `ListKind`).
+- [x] 1.2 Populate `Session` for the `opencode` descriptor (`ContinueArgs: ["--continue"]`, `ResumeByIDArgs: id -> ["--session", id]`, `ListKind: SessionListOpenCodeCLI`).
+- [x] 1.3 Populate `Session` for the `claude-code` descriptor (`ContinueArgs: ["--continue"]`, `ResumeByIDArgs: id -> ["--resume", id]`, `ListKind: SessionListClaudeFiles`).
+- [x] 1.4 Add unit tests asserting each registered harness's session metadata (and that a nil `Session`/`SessionListNone` is handled).
 
 ## 2. Session listing
 
-- [ ] 2.1 Add a session package (extend `internal/opencodestate` or add `internal/sessions`) exposing `List(harness, workdir) ([]Session, error)` with `Session{ID, Title, When}`, dispatching on `ListKind` and returning workdir-filtered, newest-first records.
-- [ ] 2.2 Implement the `SessionListOpenCodeCLI` backend: run `opencode session list --format json`, parse the array, keep records whose `directory == workdir`.
-- [ ] 2.3 Implement the `SessionListClaudeFiles` backend: read `~/.claude/projects/<encoded-cwd>/*.jsonl`; id = filename, title = last `aiTitle` record (fallback first user message, then id), time = last record `timestamp` (fallback mtime); confirm membership via each file's embedded `cwd == workdir` (do not trust the decoded dir name).
-- [ ] 2.4 Make a missing harness/CLI, missing store, or parse failure yield an empty list + a typed "unsupported / unavailable" signal, never a hard error; skip malformed `.jsonl` lines.
-- [ ] 2.5 Unit-test both backends: opencode JSON parsing + workdir filter (fake command runner); claude `.jsonl` parsing, title/time fallbacks, `cwd` matching, and malformed-line tolerance (temp fixture dir); plus the unsupported-harness path.
+- [x] 2.1 Add a session package (extend `internal/opencodestate` or add `internal/sessions`) exposing `List(harness, workdir) ([]Session, error)` with `Session{ID, Title, When}`, dispatching on `ListKind` and returning workdir-filtered, newest-first records.
+- [x] 2.2 Implement the `SessionListOpenCodeCLI` backend: run `opencode session list --format json`, parse the array, keep records whose `directory == workdir`.
+- [x] 2.3 Implement the `SessionListClaudeFiles` backend: read `~/.claude/projects/<encoded-cwd>/*.jsonl`; id = filename, title = last `aiTitle` record (fallback first user message, then id), time = last record `timestamp` (fallback mtime); confirm membership via each file's embedded `cwd == workdir` (do not trust the decoded dir name).
+- [x] 2.4 Make a missing harness/CLI, missing store, or parse failure yield an empty list + a typed "unsupported / unavailable" signal, never a hard error; skip malformed `.jsonl` lines.
+- [x] 2.5 Unit-test both backends: opencode JSON parsing + workdir filter (fake command runner); claude `.jsonl` parsing, title/time fallbacks, `cwd` matching, and malformed-line tolerance (temp fixture dir); plus the unsupported-harness path.
 
 ## 3. Shared launch pipeline
 
-- [ ] 3.1 Extract the body of `runStart` (config → registry reconcile → sidecars → facade → control plane → sandbox exec) into a reusable `runLaunch(env, opts)` in `internal/cli/start.go`, where `opts` carries harness, start flags, and resolved extra inner args.
-- [ ] 3.2 Re-implement `runStart` as a thin parser that builds `opts` and calls `runLaunch`; confirm existing `start` tests still pass.
+- [x] 3.1 Extract the body of `runStart` (config → registry reconcile → sidecars → facade → control plane → sandbox exec) into a reusable `runLaunch(env, opts)` in `internal/cli/start.go`, where `opts` carries harness, start flags, and resolved extra inner args.
+- [x] 3.2 Re-implement `runStart` as a thin parser that builds `opts` and calls `runLaunch`; confirm existing `start` tests still pass.
 
 ## 4. `omac continue`
 
-- [ ] 4.1 Add `internal/cli/continue.go` with `runContinue` that parses the optional harness token + the same surface flags as `start`, resolves the harness, and errors clearly if the harness has no `Session.ContinueArgs`.
-- [ ] 4.2 Build `opts` with `ContinueArgs` appended to inner args (preserving trailing `--` inner args) and call `runLaunch`.
-- [ ] 4.3 Register `continue` in `commands()` and add it to `printUsage` in `internal/cli/cli.go`.
-- [ ] 4.4 Add tests: continue appends the harness continue flag and preserves start flags + trailing `--` inner args.
+- [x] 4.1 Add `internal/cli/continue.go` with `runContinue` that parses the optional harness token + the same surface flags as `start`, resolves the harness, and errors clearly if the harness has no `Session.ContinueArgs`.
+- [x] 4.2 Build `opts` with `ContinueArgs` appended to inner args (preserving trailing `--` inner args) and call `runLaunch`.
+- [x] 4.3 Register `continue` in `commands()` and add it to `printUsage` in `internal/cli/cli.go`.
+- [x] 4.4 Add tests: continue appends the harness continue flag and preserves start flags + trailing `--` inner args.
 
 ## 5. `omac resume`
 
-- [ ] 5.1 Add `internal/cli/resume.go` with `runResume` that parses the optional harness token + flags, resolves the harness, and reports clearly when the harness has no listing strategy (`SessionListNone`).
-- [ ] 5.2 List + filter sessions to the current workdir, newest first; if none, print "no resumable sessions for this directory" and exit OK without launching.
-- [ ] 5.3 Render the picker: numbered entries with relative time + title, reusing `style.go`'s `styler`.
-- [ ] 5.4 Read and validate the selected index from stdin; on empty/EOF/cancel exit OK without launching; on non-TTY stdin print the list + hint and exit without blocking.
-- [ ] 5.5 On selection, build `opts` with `ResumeByIDArgs(id)` appended and call `runLaunch`.
-- [ ] 5.6 Register `resume` in `commands()` and add it to `printUsage`.
-- [ ] 5.7 Add tests: workdir filtering, empty-list message, index parsing/cancel, non-TTY fallback, and that selection appends the correct resume-by-id flag per harness (opencode `--session`, claude `--resume`).
+- [x] 5.1 Add `internal/cli/resume.go` with `runResume` that parses the optional harness token + flags, resolves the harness, and reports clearly when the harness has no listing strategy (`SessionListNone`).
+- [x] 5.2 List + filter sessions to the current workdir, newest first; if none, print "no resumable sessions for this directory" and exit OK without launching.
+- [x] 5.3 Render the picker: numbered entries with relative time + title, reusing `style.go`'s `styler`.
+- [x] 5.4 Read and validate the selected index from stdin; on empty/EOF/cancel exit OK without launching; on non-TTY stdin print the list + hint and exit without blocking.
+- [x] 5.5 On selection, build `opts` with `ResumeByIDArgs(id)` appended and call `runLaunch`.
+- [x] 5.6 Register `resume` in `commands()` and add it to `printUsage`.
+- [x] 5.7 Add tests: workdir filtering, empty-list message, index parsing/cancel, non-TTY fallback, and that selection appends the correct resume-by-id flag per harness (opencode `--session`, claude `--resume`).
 
 ## 6. Docs & verification
 
-- [ ] 6.1 Update `README.md` with `omac continue` / `omac resume` usage.
-- [ ] 6.2 Update the CLI section of `oh-my-agentic-coder.md` to document both subcommands.
-- [ ] 6.3 Run `go build ./...` and `go test ./...`; manually verify `omac continue` and `omac resume` against a real workdir for **both** harnesses — `omac resume` (opencode) and `omac resume claude` (interactive picker, launch).
+- [x] 6.1 Update `README.md` with `omac continue` / `omac resume` usage.
+- [x] 6.2 Update the CLI section of `oh-my-agentic-coder.md` to document both subcommands.
+- [x] 6.3 Run `go build ./...` and `go test ./...`; manually verify `omac continue` and `omac resume` against a real workdir for **both** harnesses — `omac resume` (opencode) and `omac resume claude` (interactive picker, launch).

--- a/openspec/changes/omac-continue-resume/tasks.md
+++ b/openspec/changes/omac-continue-resume/tasks.md
@@ -1,0 +1,42 @@
+## 1. Harness session metadata
+
+- [ ] 1.1 Add a `HarnessSession` struct + `SessionListKind` enum (`SessionListNone`/`SessionListOpenCodeCLI`/`SessionListClaudeFiles`) and a `Session *HarnessSession` field to `config.Harness` in `internal/config/harness.go` (`ContinueArgs`, `ResumeByIDArgs func(id string) []string`, `ListKind`).
+- [ ] 1.2 Populate `Session` for the `opencode` descriptor (`ContinueArgs: ["--continue"]`, `ResumeByIDArgs: id -> ["--session", id]`, `ListKind: SessionListOpenCodeCLI`).
+- [ ] 1.3 Populate `Session` for the `claude-code` descriptor (`ContinueArgs: ["--continue"]`, `ResumeByIDArgs: id -> ["--resume", id]`, `ListKind: SessionListClaudeFiles`).
+- [ ] 1.4 Add unit tests asserting each registered harness's session metadata (and that a nil `Session`/`SessionListNone` is handled).
+
+## 2. Session listing
+
+- [ ] 2.1 Add a session package (extend `internal/opencodestate` or add `internal/sessions`) exposing `List(harness, workdir) ([]Session, error)` with `Session{ID, Title, When}`, dispatching on `ListKind` and returning workdir-filtered, newest-first records.
+- [ ] 2.2 Implement the `SessionListOpenCodeCLI` backend: run `opencode session list --format json`, parse the array, keep records whose `directory == workdir`.
+- [ ] 2.3 Implement the `SessionListClaudeFiles` backend: read `~/.claude/projects/<encoded-cwd>/*.jsonl`; id = filename, title = last `aiTitle` record (fallback first user message, then id), time = last record `timestamp` (fallback mtime); confirm membership via each file's embedded `cwd == workdir` (do not trust the decoded dir name).
+- [ ] 2.4 Make a missing harness/CLI, missing store, or parse failure yield an empty list + a typed "unsupported / unavailable" signal, never a hard error; skip malformed `.jsonl` lines.
+- [ ] 2.5 Unit-test both backends: opencode JSON parsing + workdir filter (fake command runner); claude `.jsonl` parsing, title/time fallbacks, `cwd` matching, and malformed-line tolerance (temp fixture dir); plus the unsupported-harness path.
+
+## 3. Shared launch pipeline
+
+- [ ] 3.1 Extract the body of `runStart` (config → registry reconcile → sidecars → facade → control plane → sandbox exec) into a reusable `runLaunch(env, opts)` in `internal/cli/start.go`, where `opts` carries harness, start flags, and resolved extra inner args.
+- [ ] 3.2 Re-implement `runStart` as a thin parser that builds `opts` and calls `runLaunch`; confirm existing `start` tests still pass.
+
+## 4. `omac continue`
+
+- [ ] 4.1 Add `internal/cli/continue.go` with `runContinue` that parses the optional harness token + the same surface flags as `start`, resolves the harness, and errors clearly if the harness has no `Session.ContinueArgs`.
+- [ ] 4.2 Build `opts` with `ContinueArgs` appended to inner args (preserving trailing `--` inner args) and call `runLaunch`.
+- [ ] 4.3 Register `continue` in `commands()` and add it to `printUsage` in `internal/cli/cli.go`.
+- [ ] 4.4 Add tests: continue appends the harness continue flag and preserves start flags + trailing `--` inner args.
+
+## 5. `omac resume`
+
+- [ ] 5.1 Add `internal/cli/resume.go` with `runResume` that parses the optional harness token + flags, resolves the harness, and reports clearly when the harness has no listing strategy (`SessionListNone`).
+- [ ] 5.2 List + filter sessions to the current workdir, newest first; if none, print "no resumable sessions for this directory" and exit OK without launching.
+- [ ] 5.3 Render the picker: numbered entries with relative time + title, reusing `style.go`'s `styler`.
+- [ ] 5.4 Read and validate the selected index from stdin; on empty/EOF/cancel exit OK without launching; on non-TTY stdin print the list + hint and exit without blocking.
+- [ ] 5.5 On selection, build `opts` with `ResumeByIDArgs(id)` appended and call `runLaunch`.
+- [ ] 5.6 Register `resume` in `commands()` and add it to `printUsage`.
+- [ ] 5.7 Add tests: workdir filtering, empty-list message, index parsing/cancel, non-TTY fallback, and that selection appends the correct resume-by-id flag per harness (opencode `--session`, claude `--resume`).
+
+## 6. Docs & verification
+
+- [ ] 6.1 Update `README.md` with `omac continue` / `omac resume` usage.
+- [ ] 6.2 Update the CLI section of `oh-my-agentic-coder.md` to document both subcommands.
+- [ ] 6.3 Run `go build ./...` and `go test ./...`; manually verify `omac continue` and `omac resume` against a real workdir for **both** harnesses — `omac resume` (opencode) and `omac resume claude` (interactive picker, launch).


### PR DESCRIPTION
## What

Two new subcommands that re-enter prior work through omac's existing sandboxed launch pipeline:

- **`omac continue [harness]`** — re-launch the most recent session for the current workdir (appends the harness continue flag: opencode/claude `--continue`).
- **`omac resume [harness]`** — list this workdir's recent sessions in an interactive numbered picker (index, relative time, session id, title) and launch the selected one (opencode `--session <id>`, claude `--resume <id>`).

Both shipped harnesses are first-class.

## How

- **`internal/config`** — harness descriptors gain a `Session` block (`ContinueArgs`, `ResumeByIDArgs`, `ListKind`) — pure data, no I/O.
- **`internal/session`** — new package listing sessions per harness, scoped to the workdir:
  - opencode: parse `opencode session list --format json`, keep records whose `directory` is the workdir.
  - Claude Code: read `~/.claude/projects/<encoded-cwd>/*.jsonl` (id = filename, title = latest `aiTitle` → first user message → id, time = latest record timestamp → mtime). The lossy dir encoding is only a lookup hint — membership is confirmed against each file's embedded `cwd`.
  - Best-effort throughout: a missing CLI/store yields an empty list, never a hard error.
- **`internal/cli/start.go`** — extracted `runLaunch` + `parseLaunchArgs` so `start`, `continue`, and `resume` share one launch implementation (behavior-preserving; existing start tests pass).
- **`internal/cli`** — `continue.go`, `resume.go` (numbered picker, non-TTY fallback, cancel handling), dispatcher + usage entries.

Designed and tracked via OpenSpec: `openspec/changes/omac-continue-resume/` (proposal, design, specs, tasks — all 25 tasks complete).

## Scope notes

- Sessions are scoped to the **exact** current workdir (path match, not prefix; symlinks not resolved).
- **Provenance coloring is intentionally out of scope** (which sessions were run in omac vs. directly) — omac has no authoritative signal short of a harness plugin; deferred to a follow-up. See the proposal's Out of Scope.

## Testing

- `go build ./...`, `go vet`, full `go test ./...` all pass; unit tests for both listing backends, the harness metadata, opts building, selection parsing, and the non-TTY fallback.
- Verified against the real stores on this machine: `omac resume` (opencode) and `omac resume claude` both list the correct workdir-scoped sessions, newest-first.
- Verified `continue` → launch wiring end-to-end (`omac continue --no-sandbox --inner /bin/echo -- hello` runs `echo --continue hello`).
- Not exercised in a real TTY here: the interactive selection keystroke path (piped stdin correctly falls back to the list + hint). The selection logic and launch path are unit-tested, but a hands-on terminal run is worth doing before merge.
