### PR TITLE
fix(start): let env_passthrough satisfy required secrets, validate pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ omac [--workdir <dir>] <subcommand> [flags] [args]
                  --no-sandbox            debug: run inner cmd directly
                  --keep-running          don't stop sidecars on exit
                  --accept-skill-changes  tolerate bundle_hash drift
+                 --skip-secret-pattern   don't enforce a secret's pattern
+                                         on an env_passthrough value
                  --verbose               lifecycle logging
 
   doctor       Sanity checks: config, registry, binaries, secrets, sandbox.

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -34,6 +34,7 @@ func runStart(args []string, env *Env) int {
 		noSandbox          = fs.Bool("no-sandbox", false, "Run inner command directly, without a sandbox (debug only).")
 		keepRunning        = fs.Bool("keep-running", false, "Do not stop sidecars when the inner command exits.")
 		acceptSkillChanges = fs.Bool("accept-skill-changes", false, "Tolerate bundle_hash drift in registered skills (proceed even if the on-disk skill differs from what was registered).")
+		skipSecretPattern  = fs.Bool("skip-secret-pattern", false, "Do not enforce a secret's pattern against an env_passthrough-supplied value (escape hatch for an outdated pattern; the raw value is still passed through).")
 		verbose            = fs.Bool("verbose", false, "Verbose lifecycle logging.")
 	)
 	fs.Usage = func() {
@@ -240,6 +241,7 @@ func runStart(args []string, env *Env) int {
 	// preserved by also tracking which classes saw any input.
 	type bundleDriftProblem struct{ skill string }
 	type missingSecretProblem struct{ skill, secret string }
+	type invalidSecretProblem struct{ skill, secret, pattern string }
 	type missingFieldProblem struct {
 		skill  string
 		fields []string
@@ -248,6 +250,7 @@ func runStart(args []string, env *Env) int {
 
 	var bundleDrifts []bundleDriftProblem
 	var missingSecrets []missingSecretProblem
+	var invalidSecrets []invalidSecretProblem
 	var missingFields []missingFieldProblem
 	var metaProblems []metaProblem
 
@@ -292,11 +295,39 @@ func runStart(args []string, env *Env) int {
 		// (scoped per workdir) and legacy/global secrets (unscoped) both
 		// resolve. See docs/MULTI_DIR_DESKTOP.md §4.3.
 		secScope := keychain.WorkdirID(env.Workdir)
+		// A secret listed under env_passthrough is allowed to come from the
+		// host environment instead of the keychain — the documented fallback
+		// for keychain-less environments (CI runners, headless servers). The
+		// supervisor injects these at spawn time (see supervisor.buildEnv),
+		// so a required secret absent from the keychain is NOT missing when
+		// the shell already exports it. Without this check the preflight
+		// would refuse to start before runtime injection ever happens.
+		envPassthrough := map[string]struct{}{}
+		for _, k := range m.Sidecar.EnvPassthrough {
+			envPassthrough[k] = struct{}{}
+		}
 		secMap := map[string]secrets.Secret{}
 		for _, spec := range m.Sidecar.Secrets {
 			val, err := keychain.GetWithFallback(secScope, e.Name, spec.Name)
 			if err != nil {
 				if errors.Is(err, keychain.ErrNotFound) {
+					// Not in the keychain — see whether env_passthrough
+					// supplies it from the host at runtime. A value found
+					// there must still match the secret's pattern: keychain
+					// values were validated at register time, so this is the
+					// only chance to vet an env-supplied one before the
+					// sidecar gets a malformed token. --skip-secret-pattern
+					// is the escape hatch for a stale pattern: the raw value
+					// is still passed through, just not vetted here.
+					if envVal, ok := secretFromEnv(spec.Name, envPassthrough); ok {
+						if !*skipSecretPattern {
+							if perr := validatePattern(spec, envVal); perr != nil {
+								invalidSecrets = append(invalidSecrets,
+									invalidSecretProblem{skill: e.Name, secret: spec.Name, pattern: spec.Pattern})
+							}
+						}
+						continue
+					}
 					if spec.IsRequired() {
 						missingSecrets = append(missingSecrets,
 							missingSecretProblem{skill: e.Name, secret: spec.Name})
@@ -350,8 +381,8 @@ func runStart(args []string, env *Env) int {
 
 	// If anything went wrong above, render one consolidated report
 	// (grouped by problem class) and abort.
-	if len(bundleDrifts) > 0 || len(missingSecrets) > 0 || len(missingFields) > 0 || len(metaProblems) > 0 {
-		total := len(bundleDrifts) + len(missingSecrets) + len(missingFields) + len(metaProblems)
+	if len(bundleDrifts) > 0 || len(missingSecrets) > 0 || len(invalidSecrets) > 0 || len(missingFields) > 0 || len(metaProblems) > 0 {
+		total := len(bundleDrifts) + len(missingSecrets) + len(invalidSecrets) + len(missingFields) + len(metaProblems)
 		fmt.Fprintf(env.Stderr, "omac start: refusing to start, found %d problem(s):\n", total)
 
 		if len(metaProblems) > 0 {
@@ -373,6 +404,13 @@ func runStart(args []string, env *Env) int {
 					p.skill, p.secret, p.skill, p.secret)
 			}
 		}
+		if len(invalidSecrets) > 0 {
+			fmt.Fprintln(env.Stderr, "\n  secret from environment does not match required pattern (pass --skip-secret-pattern if the pattern is outdated):")
+			for _, p := range invalidSecrets {
+				fmt.Fprintf(env.Stderr, "    %s/%s — $%s does not match /%s/ (fix the exported value, or run omac secrets set %s %s)\n",
+					p.skill, p.secret, p.secret, p.pattern, p.skill, p.secret)
+			}
+		}
 		if len(missingFields) > 0 {
 			fmt.Fprintln(env.Stderr, "\n  required config field missing:")
 			for _, p := range missingFields {
@@ -387,7 +425,7 @@ func runStart(args []string, env *Env) int {
 		// the former usually a one-command fix). Bundle drift is
 		// strictly config-invalid because the user hasn't explicitly
 		// accepted the change yet. Meta problems are config-invalid.
-		if len(missingSecrets) > 0 || len(missingFields) > 0 {
+		if len(missingSecrets) > 0 || len(invalidSecrets) > 0 || len(missingFields) > 0 {
 			return ExitSecretRefused
 		}
 		return ExitConfigInvalid
@@ -601,6 +639,25 @@ func runStart(args []string, env *Env) int {
 		return ExitSandboxAbnormal
 	}
 	return code
+}
+
+// secretFromEnv returns the host value that will satisfy a keychain-absent
+// secret at runtime, if any. It returns ok=true only when the secret is
+// listed under sidecar.env_passthrough AND the shell exports a non-empty
+// value for it — the conditions under which the supervisor injects the var
+// from the host at spawn time (see supervisor.buildEnv). In that case the
+// secret is genuinely available at runtime and the preflight must not
+// refuse to start. See the skainet skills' omac.yaml for the canonical
+// "keychain or env_passthrough" fallback contract.
+func secretFromEnv(name string, envPassthrough map[string]struct{}) (string, bool) {
+	if _, ok := envPassthrough[name]; !ok {
+		return "", false
+	}
+	v, ok := os.LookupEnv(name)
+	if !ok || v == "" {
+		return "", false
+	}
+	return v, true
 }
 
 // autoDeregisterMissing prunes registry entries whose skill directory

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -241,7 +241,7 @@ func runStart(args []string, env *Env) int {
 	// preserved by also tracking which classes saw any input.
 	type bundleDriftProblem struct{ skill string }
 	type missingSecretProblem struct{ skill, secret string }
-	type invalidSecretProblem struct{ skill, secret, pattern string }
+	type invalidSecretProblem struct{ skill, secret, reason string }
 	type missingFieldProblem struct {
 		skill  string
 		fields []string
@@ -323,7 +323,7 @@ func runStart(args []string, env *Env) int {
 						if !*skipSecretPattern {
 							if perr := validatePattern(spec, envVal); perr != nil {
 								invalidSecrets = append(invalidSecrets,
-									invalidSecretProblem{skill: e.Name, secret: spec.Name, pattern: spec.Pattern})
+									invalidSecretProblem{skill: e.Name, secret: spec.Name, reason: perr.Error()})
 							}
 						}
 						continue
@@ -405,10 +405,10 @@ func runStart(args []string, env *Env) int {
 			}
 		}
 		if len(invalidSecrets) > 0 {
-			fmt.Fprintln(env.Stderr, "\n  secret from environment does not match required pattern (pass --skip-secret-pattern if the pattern is outdated):")
+			fmt.Fprintln(env.Stderr, "\n  secret from environment failed pattern validation (pass --skip-secret-pattern if the pattern is outdated):")
 			for _, p := range invalidSecrets {
-				fmt.Fprintf(env.Stderr, "    %s/%s — $%s does not match /%s/ (fix the exported value, or run omac secrets set %s %s)\n",
-					p.skill, p.secret, p.secret, p.pattern, p.skill, p.secret)
+				fmt.Fprintf(env.Stderr, "    %s/%s — %s (fix the exported value, or run omac secrets set %s %s)\n",
+					p.skill, p.secret, p.reason, p.skill, p.secret)
 			}
 		}
 		if len(missingFields) > 0 {
@@ -644,11 +644,13 @@ func runStart(args []string, env *Env) int {
 // secretFromEnv returns the host value that will satisfy a keychain-absent
 // secret at runtime, if any. It returns ok=true only when the secret is
 // listed under sidecar.env_passthrough AND the shell exports a non-empty
-// value for it — the conditions under which the supervisor injects the var
-// from the host at spawn time (see supervisor.buildEnv). In that case the
-// secret is genuinely available at runtime and the preflight must not
-// refuse to start. See the skainet skills' omac.yaml for the canonical
-// "keychain or env_passthrough" fallback contract.
+// value for it. The supervisor passes env_passthrough vars to the sidecar
+// at spawn time (see supervisor.buildEnv) whenever the var is present, even
+// if empty; here we deliberately treat an empty value as not satisfying a
+// required secret, since an empty token is no token. In that case the
+// secret is genuinely usable at runtime and the preflight must not refuse
+// to start. See the skainet skills' omac.yaml for the canonical "keychain
+// or env_passthrough" fallback contract.
 func secretFromEnv(name string, envPassthrough map[string]struct{}) (string, bool) {
 	if _, ok := envPassthrough[name]; !ok {
 		return "", false

--- a/internal/cli/start_drift_test.go
+++ b/internal/cli/start_drift_test.go
@@ -76,6 +76,65 @@ func makeEnv(workdir string) *Env {
 	}
 }
 
+// secretFromEnv governs whether a required secret absent from the keychain
+// can instead be supplied by the host env via env_passthrough. This is the
+// fallback the skainet skills' omac.yaml documents ("keychain or
+// env_passthrough"); without it `omac start` refuses to launch even though
+// the supervisor would inject the var at runtime.
+func TestSecretFromEnv(t *testing.T) {
+	const name = "SKAINET_TOKEN"
+	passthrough := map[string]struct{}{name: {}}
+	none := map[string]struct{}{}
+
+	t.Run("passthrough listed and env set", func(t *testing.T) {
+		t.Setenv(name, "tngai_abcdefgh")
+		v, ok := secretFromEnv(name, passthrough)
+		if !ok || v != "tngai_abcdefgh" {
+			t.Errorf("want (tngai_abcdefgh, true) for a secret in env_passthrough with a non-empty host value, got (%q, %v)", v, ok)
+		}
+	})
+
+	t.Run("passthrough listed but env unset", func(t *testing.T) {
+		os.Unsetenv(name)
+		if _, ok := secretFromEnv(name, passthrough); ok {
+			t.Error("want ok=false: env_passthrough lists it but the shell exports nothing")
+		}
+	})
+
+	t.Run("passthrough listed but env empty", func(t *testing.T) {
+		t.Setenv(name, "")
+		if _, ok := secretFromEnv(name, passthrough); ok {
+			t.Error("want ok=false: an empty value is no value")
+		}
+	})
+
+	t.Run("env set but not in passthrough", func(t *testing.T) {
+		t.Setenv(name, "tngai_abcdefgh")
+		if _, ok := secretFromEnv(name, none); ok {
+			t.Error("want ok=false: host env alone must not satisfy a secret the skill never opted into passing through")
+		}
+	})
+}
+
+// validatePattern is what gates an env-supplied secret's shape in the
+// preflight: a keychain value was vetted at register time, but an
+// env_passthrough value reaches the sidecar unvalidated unless start
+// checks it. These cases mirror the skainet SKAINET_TOKEN pattern.
+func TestValidatePattern_EnvSuppliedSecret(t *testing.T) {
+	spec := config.SecretSpec{Name: "SKAINET_TOKEN", Pattern: `^tngai_[A-Za-z0-9_-]{8,}$`}
+
+	if err := validatePattern(spec, "tngai_abcdefgh"); err != nil {
+		t.Errorf("well-formed token should pass, got %v", err)
+	}
+	if err := validatePattern(spec, "not-a-token"); err == nil {
+		t.Error("malformed token should fail the pattern")
+	}
+	// A secret with no pattern accepts anything (can't validate shape).
+	if err := validatePattern(config.SecretSpec{Name: "X"}, "anything"); err != nil {
+		t.Errorf("empty pattern should accept any value, got %v", err)
+	}
+}
+
 func TestAutoDeregisterMissing_DeletesGoneSkills(t *testing.T) {
 	dir := stageWorkdir(t, "alpha") // alpha exists on disk; bravo doesn't
 	reg := &registry.Registry{Registered: []registry.Entry{

--- a/internal/cli/start_drift_test.go
+++ b/internal/cli/start_drift_test.go
@@ -83,6 +83,14 @@ func makeEnv(workdir string) *Env {
 // the supervisor would inject the var at runtime.
 func TestSecretFromEnv(t *testing.T) {
 	const name = "SKAINET_TOKEN"
+	// The "env unset" subtest calls os.Unsetenv directly (t.Setenv can't
+	// unset a var), so restore whatever the surrounding env had to avoid
+	// leaking state into later tests in this package.
+	if orig, ok := os.LookupEnv(name); ok {
+		t.Cleanup(func() { os.Setenv(name, orig) })
+	} else {
+		t.Cleanup(func() { os.Unsetenv(name) })
+	}
 	passthrough := map[string]struct{}{name: {}}
 	none := map[string]struct{}{}
 

--- a/oh-my-agentic-coder.md
+++ b/oh-my-agentic-coder.md
@@ -583,6 +583,7 @@ Common flags:
 - `--no-sandbox` — run the inner command directly without a sandbox (dangerous; for debugging only).
 - `--keep-running` — do not stop sidecars when the inner command exits (useful when iterating on sidecar development).
 - `--accept-skill-changes` — tolerate `bundle_hash` drift.
+- `--skip-secret-pattern` — do not enforce a secret's `pattern` against an `env_passthrough`-supplied value (escape hatch for an outdated pattern; the raw value is still passed through to the sidecar).
 - `--verbose`, `--log-level <level>`.
 
 ### 10.5 `omac doctor`


### PR DESCRIPTION
## Problem

`omac start` refused to launch with `required secret missing` for skills like the skainet set, **even when the secret was exported in the shell and the skill declared it under `env_passthrough`**.

The skill manifests and `creating-a-skill.md` §10.3 document a "keychain **or** `env_passthrough`" contract: a shell that exports the token should keep working in keychain-less environments (CI runners, headless servers). At runtime `supervisor.buildEnv` honors this — it injects `env_passthrough` vars from the host. But the `omac start` **preflight** resolved required secrets from the **keychain only** (`start.go`), so it refused before runtime injection ever happened.

The tell: the config-field preflight right below it *does* honor `default_from_env` from the host env. The secret loop just lacked the equivalent check.

## Fix

1. **Honor the fallback** — a required secret absent from the keychain is no longer reported missing if it's listed under `sidecar.env_passthrough` *and* the shell exports a non-empty value (the exact conditions under which the supervisor injects it at runtime).
2. **Validate shape** — an `env_passthrough`-supplied value is checked against the secret's `pattern` (reusing the register flow's `validatePattern`). Keychain values were vetted at register time; this is the only point an env-supplied one gets vetted before the sidecar receives it. A mismatch is reported as its own problem class rather than a misleading "missing" message.
3. **Escape hatch** — `--skip-secret-pattern` bypasses the pattern check for the case where the declared pattern is outdated. The raw value is still passed through.

## Behavior for a keychain-absent secret

| Situation | Result |
|---|---|
| Not in env_passthrough / env unset / empty | `required secret missing` (unchanged) |
| In env_passthrough, value matches pattern | starts; supervisor injects at runtime |
| In env_passthrough, value present but fails pattern | refuses to start (new class); `--skip-secret-pattern` overrides |

## Tests

- `TestSecretFromEnv` — 4 cases (in passthrough + set; unset; empty; not in passthrough).
- `TestValidatePattern_EnvSuppliedSecret` — match / mismatch / no-pattern, using the skainet `SKAINET_TOKEN` shape.

`go build`, `go vet`, and the full `internal/cli` suite pass. Docs (`README.md`, `oh-my-agentic-coder.md`) updated to list the new flag.