### PR TITLE
test: de-flake macOS CI (TestPromptCoalescing race + facade health deadline)

### DIFF
--- a/internal/facade/integration_test.go
+++ b/internal/facade/integration_test.go
@@ -150,9 +150,12 @@ func TestEchoRestEndToEnd(t *testing.T) {
 		_ = cmd.Wait()
 	})
 
-	// Wait for /status to answer 2xx.
+	// Wait for /status to answer 2xx. The deadline is generous because a
+	// cold Python interpreter start on a loaded CI runner (notably macOS)
+	// can take well over 5s; a tight bound here flaked as "sidecar never
+	// became healthy" even though the sidecar was merely slow to boot.
 	sidecarURL := fmt.Sprintf("http://127.0.0.1:%d/status", sidecarPort)
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		resp, err := http.Get(sidecarURL)
 		if err == nil {

--- a/internal/netproxy/filter.go
+++ b/internal/netproxy/filter.go
@@ -85,6 +85,13 @@ type FilterConfig struct {
 	Resolve func(ctx context.Context, host string) ([]netip.Addr, error)
 	// Logf receives one line per decision; nil discards.
 	Logf func(format string, args ...any)
+
+	// onCoalesceWait, when non-nil, is called just before a request blocks
+	// on an in-flight prompt for the same host (the coalescing path). It is
+	// a test seam that lets a test deterministically observe that all
+	// followers have parked before releasing the leader's prompt; it is
+	// never set in production.
+	onCoalesceWait func()
 }
 
 // Filter decides host admission and pins DNS results.
@@ -239,6 +246,9 @@ func (f *Filter) promptCoalesced(host string, port int) (PromptResult, bool) {
 	f.promptMu.Lock()
 	if w, ok := f.inflight[host]; ok {
 		f.promptMu.Unlock()
+		if f.cfg.onCoalesceWait != nil {
+			f.cfg.onCoalesceWait()
+		}
 		<-w.done
 		return w.res, true
 	}

--- a/internal/netproxy/filter_test.go
+++ b/internal/netproxy/filter_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/netip"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -220,15 +221,27 @@ func TestPromptUnavailableFallback(t *testing.T) {
 }
 
 func TestPromptCoalescing(t *testing.T) {
+	const n = 5
 	block := make(chan struct{})
 	p := &blockingPrompter{block: block, res: PromptResult{Allow: true}}
+	// coalesced counts followers that have committed to waiting on the
+	// leader's in-flight prompt. Exactly one of the n goroutines becomes
+	// the leader (registers inflight, calls Prompt); the other n-1 take
+	// the coalescing path and bump this. Waiting for n-1 before releasing
+	// the leader makes the test deterministic: every follower has parked
+	// on the shared prompt — and so cannot start its own — by the time
+	// the leader's Prompt is allowed to return. (The old version released
+	// after merely started>=1, so a late follower could arrive after the
+	// leader cleared inflight and prompt a second time. Hence the flake.)
+	var coalesced atomic.Int32
 	f := NewFilter(FilterConfig{
-		PromptEnabled: true,
-		Prompter:      p,
-		Resolve:       staticResolver("93.184.216.34"),
+		PromptEnabled:  true,
+		Prompter:       p,
+		Resolve:        staticResolver("93.184.216.34"),
+		onCoalesceWait: func() { coalesced.Add(1) },
 	})
 	var wg sync.WaitGroup
-	for range 5 {
+	for range n {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -238,8 +251,8 @@ func TestPromptCoalescing(t *testing.T) {
 			}
 		}()
 	}
-	// Give the goroutines a chance to all reach the prompt.
-	waitUntil(t, func() bool { return p.started.Load() >= 1 })
+	// All followers have parked on the single in-flight prompt.
+	waitUntil(t, func() bool { return coalesced.Load() == n-1 })
 	close(block)
 	wg.Wait()
 	if got := p.started.Load(); got != 1 {


### PR DESCRIPTION
## Problem

`TestPromptCoalescing` (`internal/netproxy`) is flaky and intermittently fails CI — most visibly on the macOS runner — with:

```
filter_test.go:246: prompter called 3 times; want 1 (coalesced)
```

It reproduces locally in ~10% of runs under `-race`. It is unrelated to whatever PR happens to trigger it; it blocks any PR whose CI lands on an unlucky schedule.

## Root cause

The **production coalescing logic is correct**: a request that arrives while a prompt for the same host is in flight finds the `inflight` entry and waits on `w.done` (`filter.go`). The bug is in the **test's synchronization**.

The test launches 5 concurrent `Check`s for one host, then releases the leader's blocked prompt as soon as `started >= 1`:

```go
waitUntil(t, func() bool { return p.started.Load() >= 1 })
close(block)
```

But `started >= 1` only proves the *leader* reached `Prompt` — it says nothing about the other 4 goroutines. If a straggler reaches `promptCoalesced` *after* the leader's prompt returns and clears `inflight`, it registers a fresh prompt → `started == 2/3` → failure.

## Fix

The test needs to release the leader only once **all followers have parked** on the shared prompt. There's no way to observe that from outside without a seam, so:

- Add an unexported `onCoalesceWait func()` to `FilterConfig` — a test seam, **never set in production** — fired just before a request blocks on an in-flight prompt (the coalescing branch).
- The test counts followers via that hook and waits for all `n-1` to park before `close(block)`. Once a follower has called the hook, it is committed to `<-w.done` (the leader hasn't closed it yet), so it cannot start its own prompt. Deterministic.

No change to production behavior.

## Verification

- `go test -race -count=200 -run TestPromptCoalescing ./internal/netproxy/` → pass (was ~10% fail before).
- `go test -race -count=1 -timeout=5m ./...` (mirrors CI) → all pass.