### PR TITLE
feat(tui): show omac-vs-bare status indicator

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "statusLine": {
+    "type": "command",
+    "command": "\"$CLAUDE_PROJECT_DIR/.claude/statusline-omac.sh\""
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/statusline-omac.sh
+++ b/.claude/statusline-omac.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# omac status-line indicator for Claude Code
+# ============================================
+#
+# Prints a persistent bottom-bar marker showing whether Claude Code is
+# running under omac (and which version) or bare.
+#
+# Reads ONLY the OMAC_VERSION env var that omac injects at launch. It does
+# NOT parse the JSON payload Claude Code pipes on stdin, so future changes
+# to the statusLine JSON schema cannot break it. When the var is unset
+# (bare harness), it prints "bare".
+#
+# Registered via .claude/settings.json:
+#   "statusLine": { "type": "command", "command": "~/.claude/statusline-omac.sh" }
+#
+# See https://docs.claude.com/en/docs/claude-code/statusline
+
+# Drain stdin (Claude Code sends JSON we intentionally ignore).
+cat >/dev/null 2>&1
+
+if [ -n "${OMAC_VERSION:-}" ]; then
+  printf 'omac v%s' "$OMAC_VERSION"
+else
+  printf 'bare'
+fi

--- a/.opencode/plugins/omac-multidir.ts
+++ b/.opencode/plugins/omac-multidir.ts
@@ -251,7 +251,32 @@ export const OmacMultiDirPlugin: Plugin = async ({ client, directory, worktree }
       if (!enabled()) return
       const e: any = event
       switch (e?.type) {
-        case "session.created":
+        case "session.created": {
+          const info = e.properties?.info
+          const id: string | undefined = info?.id
+          const dir: string | undefined = info?.directory
+          if (id && dir) {
+            sessionDir.set(id, dir)
+            await activate(dir)
+          }
+          // Persistent-ish omac-vs-bare indicator: fire a toast once on
+          // session start. Not in the transcript, so it cannot confuse the
+          // model. Reads OMAC_VERSION (omac injects it; bare = no toast).
+          // tui.showToast is a documented SDK API (not experimental.*).
+          {
+            const ver = process.env.OMAC_VERSION
+            if (ver) {
+              try {
+                await (client as any).tui.showToast({
+                  body: { message: `omac v${ver}`, variant: "info" },
+                })
+              } catch {
+                // TUI client may be absent (headless/CI); ignore.
+              }
+            }
+          }
+          break
+        }
         case "session.updated": {
           const info = e.properties?.info
           const id: string | undefined = info?.id


### PR DESCRIPTION
## What

Persistent visual marker showing whether the running harness is under omac or bare.

- **Claude Code**: `statusLine` script (`.claude/statusline-omac.sh`) reading `$OMAC_VERSION` from env. Prints `omac v<x>` or `bare`. Ignores the JSON stdin payload so future statusLine schema changes cannot break it.
- **OpenCode**: `tui.showToast` on `session.created` in the existing `omac-multidir.ts` plugin. Same env var. Documented SDK API (not `experimental.*`), not in the transcript so it cannot confuse the model.

## Why

Users are sometimes unsure whether they are running under omac or just the bare harness. This adds a non-intrusive visual signal on each harness's native cleanest surface.

## Future-proofing

- Claude `statusLine` is a documented top-level feature with its own `/statusline` command. Reading env (not JSON) decouples from any schema evolution.
- OpenCode `tui.showToast` is in the SDK TUI API table (stable). The plugin already subscribes to `session.created` and uses `client.*`.
- Both guard on `OMAC_VERSION` presence \u2192 bare harness = silence, never an error.

## Verification

- `bash -n` on the statusline script: OK
- Manual run: `OMAC_VERSION=0.1.5 bash .claude/statusline-omac.sh < /dev/null` \u2192 `omac v0.1.5`; unset \u2192 `bare`
- `tsc --noEmit --strict --skipLibCheck` on the plugin: clean
