### PR TITLE
feat(sandbox): inject an always-on sandbox briefing into the harness

### DIFF
--- a/.opencode/plugins/omac-multidir.ts
+++ b/.opencode/plugins/omac-multidir.ts
@@ -278,9 +278,8 @@ export const OmacMultiDirPlugin: Plugin = async ({ client, directory, worktree }
     // --- 2: surface the per-dir skills to the model (§6.3) ---
     "experimental.chat.system.transform": async (input, output) => {
       // omac sandbox briefing: always-on, independent of the control plane.
-      // omac sets OMAC_SANDBOX_BRIEFING only inside the sandbox, so this is
-      // inert when opencode runs outside omac. Purely additive — never
-      // touches the user's instructions/config.
+      // Only omac sets OMAC_SANDBOX_BRIEFING (inside the sandbox), so this is
+      // inert outside omac and purely additive — never touches user config.
       const brief = process.env.OMAC_SANDBOX_BRIEFING
       if (brief && brief.trim().length > 0) output.system.push(brief)
       if (!enabled()) return

--- a/.opencode/plugins/omac-multidir.ts
+++ b/.opencode/plugins/omac-multidir.ts
@@ -277,6 +277,12 @@ export const OmacMultiDirPlugin: Plugin = async ({ client, directory, worktree }
 
     // --- 2: surface the per-dir skills to the model (§6.3) ---
     "experimental.chat.system.transform": async (input, output) => {
+      // omac sandbox briefing: always-on, independent of the control plane.
+      // omac sets OMAC_SANDBOX_BRIEFING only inside the sandbox, so this is
+      // inert when opencode runs outside omac. Purely additive — never
+      // touches the user's instructions/config.
+      const brief = process.env.OMAC_SANDBOX_BRIEFING
+      if (brief && brief.trim().length > 0) output.system.push(brief)
       if (!enabled()) return
       const dir = await dirForSession(input.sessionID)
       if (!dir) return

--- a/internal/cli/briefing.go
+++ b/internal/cli/briefing.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxbrief"
+)
+
+// briefingInjection decides whether omac should inject the sandbox briefing
+// into the inner harness, and returns the resolved briefing text when it
+// should.
+//
+// Injection is active only when a real sandbox wraps the inner command
+// (!noSandbox) AND the resolved inner executable is the selected harness's
+// own agent binary (inner[0] == harness.InnerCmd[0]). The latter excludes
+// profile-pinned/--inner-overridden commands such as the no-sandbox-debug
+// `bash` profile, so the briefing flag never lands on the wrong process.
+//
+// override is the value of config.yaml sandbox.briefing (empty = use the
+// embedded default).
+func briefingInjection(noSandbox bool, inner []string, harness config.Harness, override string) (string, bool) {
+	if noSandbox || len(inner) == 0 || len(harness.InnerCmd) == 0 {
+		return "", false
+	}
+	if inner[0] != harness.InnerCmd[0] {
+		return "", false
+	}
+	return sandboxbrief.Resolve(override), true
+}

--- a/internal/cli/briefing.go
+++ b/internal/cli/briefing.go
@@ -5,18 +5,14 @@ import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxbrief"
 )
 
-// briefingInjection decides whether omac should inject the sandbox briefing
-// into the inner harness, and returns the resolved briefing text when it
-// should.
+// briefingInjection reports whether omac should inject the sandbox briefing
+// and, if so, the resolved text (override is config.yaml sandbox.briefing;
+// empty uses the embedded default).
 //
-// Injection is active only when a real sandbox wraps the inner command
-// (!noSandbox) AND the resolved inner executable is the selected harness's
-// own agent binary (inner[0] == harness.InnerCmd[0]). The latter excludes
-// profile-pinned/--inner-overridden commands such as the no-sandbox-debug
-// `bash` profile, so the briefing flag never lands on the wrong process.
-//
-// override is the value of config.yaml sandbox.briefing (empty = use the
-// embedded default).
+// It injects only when a real sandbox wraps the inner command AND that command
+// is the harness's own agent binary. The latter excludes profile-pinned or
+// --inner-overridden commands such as the no-sandbox-debug `bash` profile, so
+// the briefing never lands on the wrong process.
 func briefingInjection(noSandbox bool, inner []string, harness config.Harness, override string) (string, bool) {
 	if noSandbox || len(inner) == 0 || len(harness.InnerCmd) == 0 {
 		return "", false

--- a/internal/cli/briefing_test.go
+++ b/internal/cli/briefing_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"testing"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
@@ -45,4 +46,19 @@ func TestBriefingInjectionSkippedForEmptyInner(t *testing.T) {
 	if _, ok := briefingInjection(false, nil, h, ""); ok {
 		t.Error("expected injection skipped for empty inner command")
 	}
+}
+
+func TestEnsureOpenCodePluginSkipsNonOpenCode(t *testing.T) {
+	// Claude has no bridge plugin (GlobalBridgeDir returns ""); the
+	// provisioner must be a no-op — no panic, no filesystem write. We use
+	// the Claude harness precisely so the test never touches
+	// ~/.config/opencode.
+	h := claudeHarness(t)
+	f, err := os.CreateTemp(t.TempDir(), "stderr-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	env := &Env{Stderr: f}
+	ensureOpenCodePlugin(env, h) // must simply return for a non-opencode harness
 }

--- a/internal/cli/briefing_test.go
+++ b/internal/cli/briefing_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+func claudeHarness(t *testing.T) config.Harness {
+	t.Helper()
+	h, ok := config.LookupHarness("claude")
+	if !ok {
+		t.Fatal("claude harness missing")
+	}
+	return h
+}
+
+func TestBriefingInjectionActiveForAgent(t *testing.T) {
+	h := claudeHarness(t)
+	text, ok := briefingInjection(false, []string{"claude"}, h, "OVERRIDE")
+	if !ok {
+		t.Fatal("expected injection to be active for the harness's own binary")
+	}
+	if text != "OVERRIDE" {
+		t.Errorf("text = %q; want the override", text)
+	}
+}
+
+func TestBriefingInjectionSkippedWhenNoSandbox(t *testing.T) {
+	h := claudeHarness(t)
+	if _, ok := briefingInjection(true, []string{"claude"}, h, ""); ok {
+		t.Error("expected injection skipped when noSandbox is true")
+	}
+}
+
+func TestBriefingInjectionSkippedForNonHarnessBinary(t *testing.T) {
+	h := claudeHarness(t)
+	if _, ok := briefingInjection(false, []string{"bash"}, h, ""); ok {
+		t.Error("expected injection skipped when inner command is not the harness binary")
+	}
+}
+
+func TestBriefingInjectionSkippedForEmptyInner(t *testing.T) {
+	h := claudeHarness(t)
+	if _, ok := briefingInjection(false, nil, h, ""); ok {
+		t.Error("expected injection skipped for empty inner command")
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -251,6 +251,12 @@ func runServe(args []string, env *Env) int {
 	// never blocks the launch.
 	ensureBuiltinSkills(env, harness)
 
+	// Idempotently provision omac's OpenCode bridge plugin (global) so the
+	// sandbox-briefing relay fires under serve too, even without a prior
+	// `omac plugin install`. No-op for non-OpenCode harnesses. Never blocks
+	// the launch.
+	ensureOpenCodePlugin(env, harness)
+
 	// Build the inner argv. serve mode runs the selected harness's *server*
 	// form: the inner executable is resolved from the profile (or --inner, or
 	// the harness default), then the harness's ServerLaunch convention is
@@ -267,6 +273,16 @@ func runServe(args []string, env *Env) int {
 	// `serve` when no subcommand is present). Harnesses without a server
 	// mode leave the inner command unchanged.
 	inner = harness.ApplyServerLaunch(inner, innerArgs)
+	// Inject the omac sandbox briefing on the same terms as `omac start`:
+	// only when a sandbox wraps the harness's own binary. Claude gets the
+	// --append-system-prompt flag (before user innerArgs so user args win);
+	// OpenCode has no such flag (SystemContextArgs nil) and instead receives
+	// OMAC_SANDBOX_BRIEFING via baseEnv below, which its plugin pushes into
+	// the system prompt.
+	briefingText, injectBriefing := briefingInjection(*noSandbox, inner, harness, lc.Sandbox.Briefing)
+	if injectBriefing && harness.SystemContextArgs != nil {
+		inner = append(inner, harness.SystemContextArgs(briefingText)...)
+	}
 	if len(innerArgs) > 0 {
 		inner = append(inner, innerArgs...)
 	}
@@ -275,6 +291,12 @@ func runServe(args []string, env *Env) int {
 	// per-skill OMAC_G_*/OMAC_D_* vars are added on top by serve as routes
 	// come and go; the static globals are set here once.
 	extra := srv.baseEnv()
+	if injectBriefing {
+		// Universal channel: the OpenCode plugin reads this from the sandbox
+		// env and pushes it into the system prompt. Only omac sets it, so it
+		// is inert outside the sandbox.
+		extra["OMAC_SANDBOX_BRIEFING"] = briefingText
+	}
 
 	var argv []string
 	if *noSandbox {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -251,10 +251,7 @@ func runServe(args []string, env *Env) int {
 	// never blocks the launch.
 	ensureBuiltinSkills(env, harness)
 
-	// Idempotently provision omac's OpenCode bridge plugin (global) so the
-	// sandbox-briefing relay fires under serve too, even without a prior
-	// `omac plugin install`. No-op for non-OpenCode harnesses. Never blocks
-	// the launch.
+	// Likewise provision the OpenCode bridge plugin that carries the briefing.
 	ensureOpenCodePlugin(env, harness)
 
 	// Build the inner argv. serve mode runs the selected harness's *server*
@@ -273,12 +270,7 @@ func runServe(args []string, env *Env) int {
 	// `serve` when no subcommand is present). Harnesses without a server
 	// mode leave the inner command unchanged.
 	inner = harness.ApplyServerLaunch(inner, innerArgs)
-	// Inject the omac sandbox briefing on the same terms as `omac start`:
-	// only when a sandbox wraps the harness's own binary. Claude gets the
-	// --append-system-prompt flag (before user innerArgs so user args win);
-	// OpenCode has no such flag (SystemContextArgs nil) and instead receives
-	// OMAC_SANDBOX_BRIEFING via baseEnv below, which its plugin pushes into
-	// the system prompt.
+	// Inject the sandbox briefing on the same terms as `omac start` (see there).
 	briefingText, injectBriefing := briefingInjection(*noSandbox, inner, harness, lc.Sandbox.Briefing)
 	if injectBriefing && harness.SystemContextArgs != nil {
 		inner = append(inner, harness.SystemContextArgs(briefingText)...)
@@ -292,9 +284,7 @@ func runServe(args []string, env *Env) int {
 	// come and go; the static globals are set here once.
 	extra := srv.baseEnv()
 	if injectBriefing {
-		// Universal channel: the OpenCode plugin reads this from the sandbox
-		// env and pushes it into the system prompt. Only omac sets it, so it
-		// is inert outside the sandbox.
+		// Consumed by the OpenCode plugin; see start.go.
 		extra["OMAC_SANDBOX_BRIEFING"] = briefingText
 	}
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/builtinskills"
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/tngtech/oh-my-agentic-coder/internal/plugin"
 )
 
 // runSetup provisions omac's built-in skill bundles into the native skills
@@ -118,6 +119,42 @@ func ensureBuiltinSkills(env *Env, harness config.Harness) {
 			fmt.Fprintf(env.Stderr, "[hint] a non-omac %q directory exists for %s; not overwriting (run `omac setup --force` to replace)\n", name, harness.Name)
 			// StatusUnchanged: stay silent — the common case on every launch.
 		}
+	}
+}
+
+// ensureOpenCodePlugin idempotently provisions omac's OpenCode bridge plugin
+// into the harness's GLOBAL plugins dir (~/.config/opencode/plugins) on
+// launch, so the sandbox-briefing relay (and the skills manifest) work even
+// when the user never ran `omac plugin install`. This mirrors the global
+// provisioning ensureBuiltinSkills already does for skills.
+//
+// Only the OpenCode harness has this plugin; other harnesses are skipped.
+// Uses force=false: an existing file with identical content is left
+// untouched (the quiet common path); a *different* existing file (foreign or
+// a stale omac copy) is NOT overwritten — instead the install returns an
+// error and we warn the user to resolve it manually (e.g. `omac plugin
+// install opencode-desktop --global`). A failure is a warning, never a launch
+// blocker.
+func ensureOpenCodePlugin(env *Env, harness config.Harness) {
+	if harness.Name != "opencode" {
+		return
+	}
+	dir := harness.GlobalBridgeDir()
+	if dir == "" {
+		return
+	}
+	res, err := plugin.InstallMultiDirIn(dir, false)
+	if err != nil {
+		fmt.Fprintf(env.Stderr, "[warn] could not provision the omac OpenCode plugin (%v); the sandbox briefing won't appear in OpenCode. Install it with: omac plugin install opencode-desktop --global\n", err)
+		return
+	}
+	switch {
+	case res.Unchanged:
+		// Common case on every launch — stay silent.
+	case res.Overwrote:
+		fmt.Fprintln(env.Stderr, "[ok] refreshed the omac OpenCode plugin")
+	default:
+		fmt.Fprintln(env.Stderr, "[ok] provisioned the omac OpenCode plugin")
 	}
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -123,18 +123,12 @@ func ensureBuiltinSkills(env *Env, harness config.Harness) {
 }
 
 // ensureOpenCodePlugin idempotently provisions omac's OpenCode bridge plugin
-// into the harness's GLOBAL plugins dir (~/.config/opencode/plugins) on
-// launch, so the sandbox-briefing relay (and the skills manifest) work even
-// when the user never ran `omac plugin install`. This mirrors the global
-// provisioning ensureBuiltinSkills already does for skills.
-//
-// Only the OpenCode harness has this plugin; other harnesses are skipped.
-// Uses force=false: an existing file with identical content is left
-// untouched (the quiet common path); a *different* existing file (foreign or
-// a stale omac copy) is NOT overwritten — instead the install returns an
-// error and we warn the user to resolve it manually (e.g. `omac plugin
-// install opencode-desktop --global`). A failure is a warning, never a launch
-// blocker.
+// into the harness's global plugins dir (~/.config/opencode/plugins) on
+// launch, so the sandbox-briefing relay works even when the user never ran
+// `omac plugin install`. Mirrors the global provisioning ensureBuiltinSkills
+// does for skills: OpenCode-only, quiet when unchanged, and a failure (or a
+// foreign same-named file, which InstallMultiDirIn refuses to clobber) is a
+// warning, never a launch blocker.
 func ensureOpenCodePlugin(env *Env, harness config.Harness) {
 	if harness.Name != "opencode" {
 		return
@@ -143,17 +137,14 @@ func ensureOpenCodePlugin(env *Env, harness config.Harness) {
 	if dir == "" {
 		return
 	}
+	// force=false, so an existing differing file yields an error (not an
+	// overwrite) and Unchanged covers the silent common path.
 	res, err := plugin.InstallMultiDirIn(dir, false)
 	if err != nil {
 		fmt.Fprintf(env.Stderr, "[warn] could not provision the omac OpenCode plugin (%v); the sandbox briefing won't appear in OpenCode. Install it with: omac plugin install opencode-desktop --global\n", err)
 		return
 	}
-	switch {
-	case res.Unchanged:
-		// Common case on every launch — stay silent.
-	case res.Overwrote:
-		fmt.Fprintln(env.Stderr, "[ok] refreshed the omac OpenCode plugin")
-	default:
+	if !res.Unchanged {
 		fmt.Fprintln(env.Stderr, "[ok] provisioned the omac OpenCode plugin")
 	}
 }

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -271,6 +271,11 @@ func runLaunch(env *Env, opts launchOpts) int {
 	// never blocks the launch.
 	ensureBuiltinSkills(env, harness)
 
+	// Idempotently provision omac's OpenCode bridge plugin (global) so the
+	// sandbox-briefing relay fires even without a prior `omac plugin install`.
+	// No-op for non-OpenCode harnesses. Never blocks the launch.
+	ensureOpenCodePlugin(env, harness)
+
 	// 2c-d / 3. Per-skill validation + secret/config resolution.
 	//
 	// We do this in a single pass that accumulates every per-skill

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -271,9 +271,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	// never blocks the launch.
 	ensureBuiltinSkills(env, harness)
 
-	// Idempotently provision omac's OpenCode bridge plugin (global) so the
-	// sandbox-briefing relay fires even without a prior `omac plugin install`.
-	// No-op for non-OpenCode harnesses. Never blocks the launch.
+	// Likewise provision the OpenCode bridge plugin that carries the briefing.
 	ensureOpenCodePlugin(env, harness)
 
 	// 2c-d / 3. Per-skill validation + secret/config resolution.
@@ -647,6 +645,8 @@ func runLaunch(env *Env, opts launchOpts) int {
 	// --inner override wins, else the profile's inner_cmd, else the
 	// harness's default InnerCmd (config.Harness.ResolveInnerCmd).
 	inner := harness.ResolveInnerCmd(prof.InnerCmd, innerCmdOverride)
+	// Inject the sandbox briefing: Claude via its --append-system-prompt flag
+	// (SystemContextArgs), OpenCode via OMAC_SANDBOX_BRIEFING set below.
 	briefingText, injectBriefing := briefingInjection(noSandbox, inner, harness, lc.Sandbox.Briefing)
 	if injectBriefing && harness.SystemContextArgs != nil {
 		inner = append(inner, harness.SystemContextArgs(briefingText)...)
@@ -723,10 +723,8 @@ func runLaunch(env *Env, opts launchOpts) int {
 		extra["OMAC_CONTROL_BASE"] = controlURL
 	}
 	if injectBriefing {
-		// Universal channel: the OpenCode plugin reads this from the
-		// sandbox env and pushes it into the system prompt. Harmless to
-		// harnesses (Claude) that get the briefing via --append-system-prompt
-		// instead. Only omac sets it, so it is inert outside the sandbox.
+		// The OpenCode plugin reads this and pushes it into the system prompt;
+		// Claude ignores it (it gets the briefing via the flag above).
 		extra["OMAC_SANDBOX_BRIEFING"] = briefingText
 	}
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -642,6 +642,10 @@ func runLaunch(env *Env, opts launchOpts) int {
 	// --inner override wins, else the profile's inner_cmd, else the
 	// harness's default InnerCmd (config.Harness.ResolveInnerCmd).
 	inner := harness.ResolveInnerCmd(prof.InnerCmd, innerCmdOverride)
+	briefingText, injectBriefing := briefingInjection(noSandbox, inner, harness, lc.Sandbox.Briefing)
+	if injectBriefing && harness.SystemContextArgs != nil {
+		inner = append(inner, harness.SystemContextArgs(briefingText)...)
+	}
 	if len(innerArgs) > 0 {
 		inner = append(inner, innerArgs...)
 	}
@@ -712,6 +716,13 @@ func runLaunch(env *Env, opts launchOpts) int {
 	}
 	if controlOK {
 		extra["OMAC_CONTROL_BASE"] = controlURL
+	}
+	if injectBriefing {
+		// Universal channel: the OpenCode plugin reads this from the
+		// sandbox env and pushes it into the system prompt. Harmless to
+		// harnesses (Claude) that get the briefing via --append-system-prompt
+		// instead. Only omac sets it, so it is inert outside the sandbox.
+		extra["OMAC_SANDBOX_BRIEFING"] = briefingText
 	}
 
 	code, err := sandbox.ExecWithReady(argv, extra, nil)

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -69,12 +69,11 @@ type Harness struct {
 	// subcommands report it as unsupported. See HarnessSession.
 	Session *HarnessSession
 
-	// SystemContextArgs builds the inner args that inject an always-on
-	// system-context briefing for harnesses that support a system-prompt
-	// flag (Claude Code: --append-system-prompt). Nil means the harness has
-	// no such flag and delivery happens via another channel — for OpenCode,
-	// its plugin reads the OMAC_SANDBOX_BRIEFING env var. Mirrors the
-	// existing func-field pattern (ResumeByIDArgs).
+	// SystemContextArgs builds the inner args that inject the always-on
+	// sandbox briefing for harnesses with a system-prompt flag (Claude:
+	// --append-system-prompt). Nil means no such flag — OpenCode instead
+	// delivers the briefing through its plugin via OMAC_SANDBOX_BRIEFING.
+	// Mirrors the ResumeByIDArgs func-field pattern.
 	SystemContextArgs func(briefing string) []string
 }
 

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -68,6 +68,14 @@ type Harness struct {
 	// the harness exposes no session continue/resume support, and those
 	// subcommands report it as unsupported. See HarnessSession.
 	Session *HarnessSession
+
+	// SystemContextArgs builds the inner args that inject an always-on
+	// system-context briefing for harnesses that support a system-prompt
+	// flag (Claude Code: --append-system-prompt). Nil means the harness has
+	// no such flag and delivery happens via another channel — for OpenCode,
+	// its plugin reads the OMAC_SANDBOX_BRIEFING env var. Mirrors the
+	// existing func-field pattern (ResumeByIDArgs).
+	SystemContextArgs func(briefing string) []string
 }
 
 // SessionListKind selects how omac enumerates a harness's prior sessions for
@@ -167,6 +175,9 @@ func harnessRegistry() []Harness {
 				ContinueArgs:   []string{"--continue"},
 				ResumeByIDArgs: func(id string) []string { return []string{"--resume", id} },
 				ListKind:       SessionListClaudeFiles,
+			},
+			SystemContextArgs: func(briefing string) []string {
+				return []string{"--append-system-prompt", briefing}
 			},
 		},
 	}

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -267,3 +267,28 @@ func TestHarnessSessionNilIsSafe(t *testing.T) {
 		t.Fatal("zero Harness should have nil Session")
 	}
 }
+
+func TestSystemContextArgsClaude(t *testing.T) {
+	h, ok := LookupHarness("claude")
+	if !ok {
+		t.Fatal("claude harness not found")
+	}
+	if h.SystemContextArgs == nil {
+		t.Fatal("claude SystemContextArgs is nil; want a flag builder")
+	}
+	got := h.SystemContextArgs("BRIEF")
+	want := []string{"--append-system-prompt", "BRIEF"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SystemContextArgs = %v; want %v", got, want)
+	}
+}
+
+func TestSystemContextArgsOpenCodeNil(t *testing.T) {
+	h, ok := LookupHarness("opencode")
+	if !ok {
+		t.Fatal("opencode harness not found")
+	}
+	if h.SystemContextArgs != nil {
+		t.Error("opencode SystemContextArgs should be nil (no system-prompt flag exists)")
+	}
+}

--- a/internal/config/launcher.go
+++ b/internal/config/launcher.go
@@ -26,11 +26,9 @@ type SandboxConfig struct {
 	DefaultProfile string                    `yaml:"default_profile" json:"default_profile"`
 	Profiles       map[string]SandboxProfile `yaml:"profiles"        json:"profiles"`
 
-	// Briefing optionally overrides the embedded sandbox briefing text that
-	// omac injects into the launched harness so it knows it runs inside the
-	// omac sandbox. Empty/unset uses the compiled-in default
-	// (sandboxbrief.Default). Resolution happens at launch in the start
-	// command, not here.
+	// Briefing optionally overrides the embedded sandbox briefing text.
+	// Empty/unset uses the compiled-in default (sandboxbrief.Default);
+	// resolution happens at launch, not here.
 	Briefing string `yaml:"briefing"        json:"briefing"`
 }
 

--- a/internal/config/launcher.go
+++ b/internal/config/launcher.go
@@ -25,6 +25,13 @@ type LauncherConfig struct {
 type SandboxConfig struct {
 	DefaultProfile string                    `yaml:"default_profile" json:"default_profile"`
 	Profiles       map[string]SandboxProfile `yaml:"profiles"        json:"profiles"`
+
+	// Briefing optionally overrides the embedded sandbox briefing text that
+	// omac injects into the launched harness so it knows it runs inside the
+	// omac sandbox. Empty/unset uses the compiled-in default
+	// (sandboxbrief.Default). Resolution happens at launch in the start
+	// command, not here.
+	Briefing string `yaml:"briefing"        json:"briefing"`
 }
 
 // SandboxProfile describes how to launch the sandbox for a given runtime.

--- a/internal/config/launcher_test.go
+++ b/internal/config/launcher_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestSandboxBriefingParsesFromYAML(t *testing.T) {
+	const in = `
+sandbox:
+  default_profile: tng-default
+  briefing: |
+    custom sandbox note
+`
+	var lc LauncherConfig
+	if err := yaml.Unmarshal([]byte(in), &lc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := "custom sandbox note\n"
+	if lc.Sandbox.Briefing != want {
+		t.Errorf("Sandbox.Briefing = %q; want %q", lc.Sandbox.Briefing, want)
+	}
+}
+
+func TestSandboxBriefingEmptyWhenAbsent(t *testing.T) {
+	var lc LauncherConfig
+	if err := yaml.Unmarshal([]byte("sandbox:\n  default_profile: builtin\n"), &lc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if lc.Sandbox.Briefing != "" {
+		t.Errorf("Sandbox.Briefing = %q; want empty", lc.Sandbox.Briefing)
+	}
+}

--- a/internal/plugin/assets/omac-multidir.ts
+++ b/internal/plugin/assets/omac-multidir.ts
@@ -278,9 +278,8 @@ export const OmacMultiDirPlugin: Plugin = async ({ client, directory, worktree }
     // --- 2: surface the per-dir skills to the model (§6.3) ---
     "experimental.chat.system.transform": async (input, output) => {
       // omac sandbox briefing: always-on, independent of the control plane.
-      // omac sets OMAC_SANDBOX_BRIEFING only inside the sandbox, so this is
-      // inert when opencode runs outside omac. Purely additive — never
-      // touches the user's instructions/config.
+      // Only omac sets OMAC_SANDBOX_BRIEFING (inside the sandbox), so this is
+      // inert outside omac and purely additive — never touches user config.
       const brief = process.env.OMAC_SANDBOX_BRIEFING
       if (brief && brief.trim().length > 0) output.system.push(brief)
       if (!enabled()) return

--- a/internal/plugin/assets/omac-multidir.ts
+++ b/internal/plugin/assets/omac-multidir.ts
@@ -277,6 +277,12 @@ export const OmacMultiDirPlugin: Plugin = async ({ client, directory, worktree }
 
     // --- 2: surface the per-dir skills to the model (§6.3) ---
     "experimental.chat.system.transform": async (input, output) => {
+      // omac sandbox briefing: always-on, independent of the control plane.
+      // omac sets OMAC_SANDBOX_BRIEFING only inside the sandbox, so this is
+      // inert when opencode runs outside omac. Purely additive — never
+      // touches the user's instructions/config.
+      const brief = process.env.OMAC_SANDBOX_BRIEFING
+      if (brief && brief.trim().length > 0) output.system.push(brief)
       if (!enabled()) return
       const dir = await dirForSession(input.sessionID)
       if (!dir) return

--- a/internal/sandboxbrief/brief.md
+++ b/internal/sandboxbrief/brief.md
@@ -1,0 +1,6 @@
+You are running inside the **omac sandbox** (oh-my-agentic-coder), an outer wrapper that mediates this session's filesystem and network access. This is **separate from and outside the control of your own built-in sandbox/permission settings.**
+
+- If a file, command, or network request is blocked, it's the omac sandbox policy — not a tool bug, and **not fixable by disabling or reconfiguring your own sandbox** (doing so has no effect on omac's restrictions).
+- Network egress may be filtered to an allowlist; some capabilities are exposed as omac *skills* (HTTP endpoints) instead of direct access.
+- Only the **user** can change what's allowed, by editing the omac sandbox profile (`~/.config/omac/sandbox-profiles/…`) outside this session and relaunching.
+- When you hit a restriction, report it as an omac policy limit and suggest the profile change — don't try to disable your own sandbox.

--- a/internal/sandboxbrief/brief.md
+++ b/internal/sandboxbrief/brief.md
@@ -1,6 +1,6 @@
-You are running inside the **omac sandbox** (oh-my-agentic-coder), an outer wrapper that mediates this session's filesystem and network access. This is **separate from and outside the control of your own built-in sandbox/permission settings.**
+You are running inside the **omac sandbox** (oh-my-agentic-coder): an outer wrapper that launches your harness inside a kernel-level sandbox (Seatbelt on macOS, bubblewrap + Landlock on Linux), mediating filesystem, network, and process access. The kernel enforces this *before* your harness starts, independently of your harness's own sandbox/permission settings — changing those has no effect on omac's restrictions. So a blocked operation here is policy, not a bug, and not something you can self-authorize.
 
-- If a file, command, or network request is blocked, it's the omac sandbox policy — not a tool bug, and **not fixable by disabling or reconfiguring your own sandbox** (doing so has no effect on omac's restrictions).
-- Network egress may be filtered to an allowlist; some capabilities are exposed as omac *skills* (HTTP endpoints) instead of direct access.
-- Only the **user** can change what's allowed, by editing the omac sandbox profile (`~/.config/omac/sandbox-profiles/…`) outside this session and relaunching.
-- When you hit a restriction, report it as an omac policy limit and suggest the profile change — don't try to disable your own sandbox.
+- **Filesystem:** only granted paths are reachable — typically the working directory and a temp dir; credentials and similar sensitive files stay denied even within otherwise-granted locations.
+- **Network:** loopback and omac's own ports are open. A *new* external host is neither silently allowed nor silently blocked — the request pauses while omac asks the **user** to allow or deny it, and the answer is remembered. You cannot unblock a host yourself.
+- **Capabilities:** some access is provided as omac *skills* — local HTTP endpoints listed in `OMAC_SKILLS` and reachable at `OMAC_<NAME>_BASE`.
+- **Changing the rules** is the user's action: they edit the sandbox profile (`~/.config/omac/sandbox-profiles/default.json`) and relaunch.

--- a/internal/sandboxbrief/sandboxbrief.go
+++ b/internal/sandboxbrief/sandboxbrief.go
@@ -1,0 +1,29 @@
+// Package sandboxbrief holds the single-source briefing text that omac
+// injects into a launched harness so the agent knows it runs inside the
+// omac sandbox. The text is embedded so it ships with the binary and is
+// edited in exactly one place (brief.md).
+package sandboxbrief
+
+import (
+	_ "embed"
+	"strings"
+)
+
+//go:embed brief.md
+var defaultBrief string
+
+// Default returns the compiled-in briefing text.
+func Default() string {
+	return defaultBrief
+}
+
+// Resolve returns override when it has non-whitespace content, otherwise
+// the embedded Default. This is the precedence rule for the optional
+// config.yaml `sandbox.briefing` value: any text wins; empty/unset uses
+// the default.
+func Resolve(override string) string {
+	if strings.TrimSpace(override) != "" {
+		return override
+	}
+	return Default()
+}

--- a/internal/sandboxbrief/sandboxbrief_test.go
+++ b/internal/sandboxbrief/sandboxbrief_test.go
@@ -1,0 +1,31 @@
+package sandboxbrief
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultNonEmpty(t *testing.T) {
+	got := Default()
+	if strings.TrimSpace(got) == "" {
+		t.Fatal("Default() returned empty briefing")
+	}
+	if !strings.Contains(got, "omac sandbox") {
+		t.Errorf("Default() missing expected phrase 'omac sandbox'; got:\n%s", got)
+	}
+}
+
+func TestResolveUsesOverrideWhenSet(t *testing.T) {
+	const custom = "custom briefing text"
+	if got := Resolve(custom); got != custom {
+		t.Errorf("Resolve(%q) = %q; want the override", custom, got)
+	}
+}
+
+func TestResolveFallsBackToDefault(t *testing.T) {
+	for _, in := range []string{"", "   ", "\n\t "} {
+		if got := Resolve(in); got != Default() {
+			t.Errorf("Resolve(%q) = %q; want Default()", in, got)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

An agent launched inside the omac sandbox has no idea it's sandboxed. When it
hits a denied filesystem path or a blocked network host, it misreads the failure
as a bug in its own code, retries it pointlessly, or tries to "self-authorize"
by flipping its harness's own permission/sandbox settings — which does nothing,
because omac enforces the sandbox at the kernel level (Seatbelt / bubblewrap +
Landlock) *before* the harness ever starts. Nothing told the agent, up front,
that it runs under omac, that a blocked operation is policy rather than a bug,
and that changing the rules is the user's job, not the agent's.

This PR gives every sandboxed launch an always-on briefing, injected into the
harness's system prompt, so the agent begins already knowing the ground rules.

## Context

- The briefing text lives in exactly one place — `internal/sandboxbrief/brief.md`
  — and is embedded into the binary, so it ships with omac and is edited from a
  single source.
- omac's two harnesses expose different system-prompt surfaces: Claude Code
  takes a CLI flag (`--append-system-prompt`); OpenCode has no such flag and
  instead receives context through its bridge plugin. The injection path forks
  accordingly.
- Injection is deliberately conservative: it fires only when a real sandbox
  wraps the inner command *and* that command is the harness's own agent binary,
  so the briefing never lands on an `--inner`-overridden or no-sandbox-debug
  `bash` process.

## Changes Overview

- **`internal/sandboxbrief`** (new) — embedded `brief.md` plus `Default()` and
  `Resolve(override)` (any override text wins; empty/whitespace falls back to the
  embedded default).
- **`internal/config`** — optional `sandbox.briefing` override field;
  `Harness.SystemContextArgs` adapter (Claude → `--append-system-prompt`,
  OpenCode → nil), mirroring the existing `ResumeByIDArgs` func-field pattern.
- **`internal/cli/briefing.go`** — `briefingInjection(...)` gate that decides
  whether (and with what text) to inject for a given launch.
- **`internal/cli/start.go` + `serve.go`** — wire the gate into both launch
  paths: Claude via the flag, OpenCode via the `OMAC_SANDBOX_BRIEFING` env var.
- **OpenCode plugin** (`.opencode/plugins/omac-multidir.ts` and the embedded
  `internal/plugin/assets` copy) — push `OMAC_SANDBOX_BRIEFING` into the system
  prompt; inert outside omac, purely additive, never touches user config.
- **`internal/cli/setup.go`** — `ensureOpenCodePlugin` auto-provisions the
  OpenCode bridge plugin globally on launch, so the relay works even if the user
  never ran `omac plugin install`.

## Diagram

```mermaid
flowchart TD
  A["omac start / omac serve"] --> B["briefingInjection(noSandbox, inner, harness, override)"]
  B -->|"no sandbox, empty inner,<br/>or inner ≠ harness agent binary"| X["skip — no briefing"]
  B -->|"sandboxed launch of<br/>the harness's own binary"| C["sandboxbrief.Resolve(override)"]
  C --> D{harness}
  D -->|Claude| E["SystemContextArgs →<br/>--append-system-prompt &lt;brief&gt;"]
  D -->|OpenCode| F["env OMAC_SANDBOX_BRIEFING=&lt;brief&gt;"]
  F --> G["bridge plugin pushes it into<br/>output.system (system prompt)"]
  E --> H["agent starts already knowing<br/>it's in the omac sandbox"]
  G --> H
```

## Deployment / Impact

- Purely additive and environment-gated. Outside omac nothing sets
  `OMAC_SANDBOX_BRIEFING`, so the OpenCode plugin branch is inert; the Claude
  flag is appended only on a sandboxed agent launch. No breaking changes to the
  config schema or CLI.
- New optional `sandbox.briefing` config key; absent/empty uses the embedded
  default.
- `omac start` / `serve` now write the OpenCode bridge plugin into
  `~/.config/opencode/plugins` on launch — idempotent, refuses to clobber a
  foreign same-named file, and any failure is a warning, never a launch blocker.

## Testing

- New unit tests: `sandboxbrief` (default non-empty, override vs. fallback),
  the `briefingInjection` gate (active for the agent binary; skipped for
  no-sandbox / non-harness-binary / empty-inner), `SystemContextArgs` (Claude
  flag builder, OpenCode nil), `sandbox.briefing` YAML parsing, and the
  non-OpenCode `ensureOpenCodePlugin` no-op.
- `go build ./...`, `go vet`, and `go test` on the changed packages
  (`internal/cli`, `internal/config`, `internal/sandboxbrief`) all pass locally
  (Go 1.25).
- Verified end-to-end on macOS for **both harnesses**: the briefing reaches the
  system prompt for Claude (via `--append-system-prompt`) and OpenCode (via the
  bridge plugin). **Linux verification still needed** — someone on Linux
  (bubblewrap + Landlock) should confirm the same end-to-end behavior.
