### PR TITLE
fix(sandbox): grant git-admin dirs for linked worktrees (#30)

### DIFF
--- a/internal/sandboxrun/grants.go
+++ b/internal/sandboxrun/grants.go
@@ -108,15 +108,11 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 		denyScan = append(denyScan, workdir)
 	}
 
-	// Linked-worktree grant. A linked worktree's .git is a *file* pointing
-	// at an admin dir under the shared common dir, which sits OUTSIDE the
-	// workdir — so git add/commit (which write the object store, refs,
-	// reflogs and the per-worktree index/HEAD) get EPERM from the sandbox.
-	// Restore plain-clone parity — where .git lives inside the granted
-	// workdir — by granting the commit-relevant common-dir subdirs at the
-	// workdir's access level, read-only on config/info/packed-refs, and a
-	// hard deny on hooks/. No-op for a plain clone or a non-worktree workdir
-	// (including a submodule, whose admin dir has no commondir).
+	// A linked worktree's .git is a *file* pointing at an admin dir under the
+	// shared common dir, which sits OUTSIDE the workdir — so git add/commit hit
+	// EPERM writing the object store, refs and per-worktree admin. Grant those
+	// common-dir subdirs at the workdir's access level to restore plain-clone
+	// parity. No-op for a plain clone or a submodule (no commondir).
 	var worktreeDeny []string
 	if p.Workdir.Access != "" && p.Workdir.Access != sandboxprofile.AccessNone {
 		if wr, wa, wd, ok := gitWorktreeGrants(workdir, p.Workdir.Access); ok {
@@ -170,26 +166,21 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 	return g, nil
 }
 
-// gitWorktreeGrants returns the extra grants a linked git worktree needs
-// so git operations work inside the sandbox. It returns ok=false unless
-// workdir is a linked worktree (its .git is a file pointing at an admin
-// dir under a shared common dir). The commit-write subdirs (objects, refs,
-// logs, and this worktree's admin dir) are granted at the workdir's access
-// level; config/info/packed-refs stay read-only (blocking core.hooksPath /
-// credential.helper mutation); hooks/ is denied (a writable hooks dir would
-// run un-sandboxed on the host's next commit).
+// gitWorktreeGrants returns the extra grants a linked git worktree needs so
+// git works inside the sandbox. ok=false unless workdir is a linked worktree
+// (.git is a file pointing at an admin dir under a shared common dir).
 //
-// The shared common-dir ROOT is deliberately never granted, only named
-// subdirs/files under it. One visible consequence: git's ref transaction
-// tries to create <common>/packed-refs.lock in that ungranted root on every
-// ref update, so a "cannot create packed-refs.lock" EPERM is printed — but
-// it is non-fatal (git 2.x writes the loose ref and the commit succeeds).
-// Granting packed-refs writable would NOT silence it (the lock is a sibling
-// in the root, not packed-refs itself), and granting the root writable would
-// expose config to a lock-file rename that defeats the core.hooksPath guard,
-// so the harmless noise is the accepted cost. `git gc`/`pack-refs` ref
-// packing (which does need that lock) therefore no-ops in the sandbox;
-// object packing under objects/ is unaffected.
+// objects/refs/logs and this worktree's admin dir are granted at the workdir's
+// access level (git writes them on commit); config/info/packed-refs/hooks stay
+// read-only — readable (so git reads config and RUNS host commit hooks inside
+// the sandbox) but never writable, so the agent can't plant a hook or mutate
+// core.hooksPath to run un-sandboxed on the host's next commit (the #30 vector).
+//
+// The common-dir ROOT is never granted. Consequence: git can't create
+// <common>/packed-refs.lock, so a non-fatal EPERM prints on ref updates (the
+// loose ref still writes, commit succeeds) and gc/pack-refs ref-packing no-ops.
+// Granting the root writable would expose config to a lock-rename that defeats
+// the read-only guard, so the noise is the accepted cost.
 func gitWorktreeGrants(workdir, access string) (readAdds, allowAdds, denyAdds []string, ok bool) {
 	common, admin, ok := resolveWorktreeCommonDir(workdir)
 	if !ok {
@@ -224,14 +215,12 @@ func gitWorktreeGrants(workdir, access string) (readAdds, allowAdds, denyAdds []
 	readOnly := contained(
 		filepath.Join(common, "config"),
 		filepath.Join(common, "info"),
-		// packed-refs is read-only: git reads it for status/log/committing
-		// onto a packed ref, but a normal add/commit only ever writes loose
-		// refs under refs/. Rewriting packed-refs (gc/pack-refs) needs a
-		// lock file in the ungranted common root anyway, so writable here
-		// buys nothing — see the note on this function.
 		filepath.Join(common, "packed-refs"),
+		// hooks MUST stay inside contained(): unlike a hard deny, a read grant
+		// on a planted `hooks -> secret` symlink would widen to the target (see
+		// TestResolveGrantsWorktreeHooksSymlinkEscape).
+		filepath.Join(common, "hooks"),
 	)
-	denyAdds = []string{filepath.Join(common, "hooks")}
 
 	switch access {
 	case sandboxprofile.AccessReadWrite, sandboxprofile.AccessWrite:

--- a/internal/sandboxrun/grants.go
+++ b/internal/sandboxrun/grants.go
@@ -183,7 +183,27 @@ func gitWorktreeGrants(workdir, access string) (readAdds, allowAdds, denyAdds []
 	if !ok {
 		return nil, nil, nil, false
 	}
-	writeSubdirs := []string{
+	// SECURITY: these grant paths are derived from in-workdir file content
+	// (.git, <admin>/commondir) that a prior sandboxed session could have
+	// tampered with, and both backends symlink-canonicalize every grant
+	// into a kernel rule. Resolve the common dir and admit only entries
+	// that physically live inside it, so a planted symlink (e.g. a crafted
+	// `objects` -> ~/.ssh) cannot widen a grant to an out-of-tree path and
+	// punch through the protected-path denials.
+	root, err := filepath.EvalSymlinks(common)
+	if err != nil {
+		return nil, nil, nil, false
+	}
+	contained := func(paths ...string) []string {
+		out := make([]string, 0, len(paths))
+		for _, p := range paths {
+			if pathWithinRoot(p, root) {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	writeSubdirs := contained(
 		filepath.Join(common, "objects"),
 		filepath.Join(common, "refs"),
 		filepath.Join(common, "logs"),
@@ -192,11 +212,11 @@ func gitWorktreeGrants(workdir, access string) (readAdds, allowAdds, denyAdds []
 		// writable — same trust level as refs/, which is already rw.
 		filepath.Join(common, "packed-refs"),
 		admin, // the per-worktree index, HEAD, ORIG_HEAD, COMMIT_EDITMSG, logs
-	}
-	readOnly := []string{
+	)
+	readOnly := contained(
 		filepath.Join(common, "config"),
 		filepath.Join(common, "info"),
-	}
+	)
 	denyAdds = []string{filepath.Join(common, "hooks")}
 
 	switch access {
@@ -242,7 +262,26 @@ func resolveWorktreeCommonDir(workdir string) (common, admin string, ok bool) {
 	if !filepath.IsAbs(common) {
 		common = filepath.Join(admin, common)
 	}
-	return filepath.Clean(common), admin, true
+	common = filepath.Clean(common)
+	// git invariant: the admin dir is exactly <common>/worktrees/<name>.
+	// Enforce it so a crafted commondir cannot point the grant root at an
+	// unrelated location (e.g. an absolute commondir aimed elsewhere).
+	if filepath.Base(filepath.Dir(admin)) != "worktrees" || filepath.Dir(filepath.Dir(admin)) != common {
+		return "", "", false
+	}
+	return common, admin, true
+}
+
+// pathWithinRoot reports whether path, with all symlinks resolved, is root
+// itself or lies inside it. A path that cannot be resolved (missing, or a
+// dangling/looping symlink) is treated as NOT contained: the grant is
+// dropped rather than risk canonicalizing to an out-of-tree location.
+func pathWithinRoot(path, root string) bool {
+	rp, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	return rp == root || strings.HasPrefix(rp, root+string(filepath.Separator))
 }
 
 // readGitdirPointer parses a linked worktree's .git file ("gitdir: <path>")

--- a/internal/sandboxrun/grants.go
+++ b/internal/sandboxrun/grants.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
 )
@@ -107,7 +108,37 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 		denyScan = append(denyScan, workdir)
 	}
 
+	// Linked-worktree grant. A linked worktree's .git is a *file* pointing
+	// at an admin dir under the shared common dir, which sits OUTSIDE the
+	// workdir — so git add/commit (which write the object store, refs,
+	// reflogs and the per-worktree index/HEAD) get EPERM from the sandbox.
+	// Restore plain-clone parity — where .git lives inside the granted
+	// workdir — by granting the commit-relevant common-dir subdirs at the
+	// workdir's access level, read-only on config/info, and a hard deny on
+	// hooks/. No-op for a plain clone or a non-worktree workdir (including a
+	// submodule, whose admin dir has no commondir).
+	var worktreeDeny []string
+	if p.Workdir.Access != "" && p.Workdir.Access != sandboxprofile.AccessNone {
+		if wr, wa, wd, ok := gitWorktreeGrants(workdir, p.Workdir.Access); ok {
+			// Existence-filter silently: these are omac-derived internal
+			// paths (a missing packed-refs is normal), not user grants, so
+			// a "skipping nonexistent path" notice would only confuse.
+			wr, err = sandboxprofile.ExpandExisting(wr, nil)
+			if err != nil {
+				return nil, err
+			}
+			wa, err = sandboxprofile.ExpandExisting(wa, nil)
+			if err != nil {
+				return nil, err
+			}
+			read = append(read, wr...)
+			allow = append(allow, wa...)
+			worktreeDeny = wd
+		}
+	}
+
 	protected := sandboxprofile.EffectiveProtectedPaths(base, p.Filesystem.OverrideDeny)
+	protected = append(protected, worktreeDeny...)
 
 	// User deny entries carve holes out of the granted trees. Path-form
 	// entries expand to an explicit path; basename globs (e.g. ".env")
@@ -137,6 +168,104 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 		}
 	}
 	return g, nil
+}
+
+// gitWorktreeGrants returns the extra grants a linked git worktree needs
+// so git operations work inside the sandbox. It returns ok=false unless
+// workdir is a linked worktree (its .git is a file pointing at an admin
+// dir under a shared common dir). The commit-write subdirs (objects,
+// refs, logs, packed-refs, and this worktree's admin dir) are granted at
+// the workdir's access level; config/info stay read-only (blocking
+// core.hooksPath / credential.helper mutation); hooks/ is denied (a
+// writable hooks dir would run un-sandboxed on the host's next commit).
+func gitWorktreeGrants(workdir, access string) (readAdds, allowAdds, denyAdds []string, ok bool) {
+	common, admin, ok := resolveWorktreeCommonDir(workdir)
+	if !ok {
+		return nil, nil, nil, false
+	}
+	writeSubdirs := []string{
+		filepath.Join(common, "objects"),
+		filepath.Join(common, "refs"),
+		filepath.Join(common, "logs"),
+		// packed-refs holds only ref->SHA mappings (no hook/exec/credential
+		// vector), and auto-gc / git pack-refs rewrite it, so it must be
+		// writable — same trust level as refs/, which is already rw.
+		filepath.Join(common, "packed-refs"),
+		admin, // the per-worktree index, HEAD, ORIG_HEAD, COMMIT_EDITMSG, logs
+	}
+	readOnly := []string{
+		filepath.Join(common, "config"),
+		filepath.Join(common, "info"),
+	}
+	denyAdds = []string{filepath.Join(common, "hooks")}
+
+	switch access {
+	case sandboxprofile.AccessReadWrite, sandboxprofile.AccessWrite:
+		// The write subdirs are granted read+write even when the workdir
+		// itself is write-only (AccessWrite): git must read the objects and
+		// refs it commits, so read-only here would break commit.
+		return readOnly, writeSubdirs, denyAdds, true
+	case sandboxprofile.AccessRead:
+		// Read-only workdir: git status/log/diff still read the common
+		// dir, but nothing under it may be written.
+		return append(writeSubdirs, readOnly...), nil, denyAdds, true
+	default:
+		return nil, nil, nil, false
+	}
+}
+
+// resolveWorktreeCommonDir inspects workdir/.git. For a linked worktree
+// it is a regular file "gitdir: <admin>"; the admin dir's commondir file
+// (a path relative to the admin dir, as git writes it) points at the
+// shared common dir. Returns (common, admin, true) only for a linked
+// worktree — a plain clone (.git is a directory) or a non-repo workdir
+// yields ok=false.
+func resolveWorktreeCommonDir(workdir string) (common, admin string, ok bool) {
+	dotgit := filepath.Join(workdir, ".git")
+	fi, err := os.Lstat(dotgit)
+	if err != nil || fi.IsDir() {
+		return "", "", false
+	}
+	admin, err = readGitdirPointer(dotgit)
+	if err != nil {
+		return "", "", false
+	}
+	data, err := os.ReadFile(filepath.Join(admin, "commondir"))
+	if err != nil {
+		return "", "", false
+	}
+	rel := strings.TrimSpace(string(data))
+	if rel == "" {
+		return "", "", false
+	}
+	common = rel
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(admin, common)
+	}
+	return filepath.Clean(common), admin, true
+}
+
+// readGitdirPointer parses a linked worktree's .git file ("gitdir: <path>")
+// and returns the absolute admin-dir path it points at. A relative pointer
+// is resolved against the .git file's directory (the workdir).
+func readGitdirPointer(dotgit string) (string, error) {
+	data, err := os.ReadFile(dotgit)
+	if err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(string(data))
+	const prefix = "gitdir:"
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf("%s: missing %q pointer", dotgit, prefix)
+	}
+	p := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if p == "" {
+		return "", fmt.Errorf("%s: empty gitdir pointer", dotgit)
+	}
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(filepath.Dir(dotgit), p)
+	}
+	return filepath.Clean(p), nil
 }
 
 // maxDenyScanEntries bounds the basename-glob walk so a deny like

--- a/internal/sandboxrun/grants.go
+++ b/internal/sandboxrun/grants.go
@@ -114,9 +114,9 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 	// reflogs and the per-worktree index/HEAD) get EPERM from the sandbox.
 	// Restore plain-clone parity — where .git lives inside the granted
 	// workdir — by granting the commit-relevant common-dir subdirs at the
-	// workdir's access level, read-only on config/info, and a hard deny on
-	// hooks/. No-op for a plain clone or a non-worktree workdir (including a
-	// submodule, whose admin dir has no commondir).
+	// workdir's access level, read-only on config/info/packed-refs, and a
+	// hard deny on hooks/. No-op for a plain clone or a non-worktree workdir
+	// (including a submodule, whose admin dir has no commondir).
 	var worktreeDeny []string
 	if p.Workdir.Access != "" && p.Workdir.Access != sandboxprofile.AccessNone {
 		if wr, wa, wd, ok := gitWorktreeGrants(workdir, p.Workdir.Access); ok {
@@ -173,11 +173,23 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 // gitWorktreeGrants returns the extra grants a linked git worktree needs
 // so git operations work inside the sandbox. It returns ok=false unless
 // workdir is a linked worktree (its .git is a file pointing at an admin
-// dir under a shared common dir). The commit-write subdirs (objects,
-// refs, logs, packed-refs, and this worktree's admin dir) are granted at
-// the workdir's access level; config/info stay read-only (blocking
-// core.hooksPath / credential.helper mutation); hooks/ is denied (a
-// writable hooks dir would run un-sandboxed on the host's next commit).
+// dir under a shared common dir). The commit-write subdirs (objects, refs,
+// logs, and this worktree's admin dir) are granted at the workdir's access
+// level; config/info/packed-refs stay read-only (blocking core.hooksPath /
+// credential.helper mutation); hooks/ is denied (a writable hooks dir would
+// run un-sandboxed on the host's next commit).
+//
+// The shared common-dir ROOT is deliberately never granted, only named
+// subdirs/files under it. One visible consequence: git's ref transaction
+// tries to create <common>/packed-refs.lock in that ungranted root on every
+// ref update, so a "cannot create packed-refs.lock" EPERM is printed — but
+// it is non-fatal (git 2.x writes the loose ref and the commit succeeds).
+// Granting packed-refs writable would NOT silence it (the lock is a sibling
+// in the root, not packed-refs itself), and granting the root writable would
+// expose config to a lock-file rename that defeats the core.hooksPath guard,
+// so the harmless noise is the accepted cost. `git gc`/`pack-refs` ref
+// packing (which does need that lock) therefore no-ops in the sandbox;
+// object packing under objects/ is unaffected.
 func gitWorktreeGrants(workdir, access string) (readAdds, allowAdds, denyAdds []string, ok bool) {
 	common, admin, ok := resolveWorktreeCommonDir(workdir)
 	if !ok {
@@ -207,15 +219,17 @@ func gitWorktreeGrants(workdir, access string) (readAdds, allowAdds, denyAdds []
 		filepath.Join(common, "objects"),
 		filepath.Join(common, "refs"),
 		filepath.Join(common, "logs"),
-		// packed-refs holds only ref->SHA mappings (no hook/exec/credential
-		// vector), and auto-gc / git pack-refs rewrite it, so it must be
-		// writable — same trust level as refs/, which is already rw.
-		filepath.Join(common, "packed-refs"),
 		admin, // the per-worktree index, HEAD, ORIG_HEAD, COMMIT_EDITMSG, logs
 	)
 	readOnly := contained(
 		filepath.Join(common, "config"),
 		filepath.Join(common, "info"),
+		// packed-refs is read-only: git reads it for status/log/committing
+		// onto a packed ref, but a normal add/commit only ever writes loose
+		// refs under refs/. Rewriting packed-refs (gc/pack-refs) needs a
+		// lock file in the ungranted common root anyway, so writable here
+		// buys nothing — see the note on this function.
+		filepath.Join(common, "packed-refs"),
 	)
 	denyAdds = []string{filepath.Join(common, "hooks")}
 

--- a/internal/sandboxrun/grants.go
+++ b/internal/sandboxrun/grants.go
@@ -108,17 +108,13 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 		denyScan = append(denyScan, workdir)
 	}
 
-	// A linked worktree's .git is a *file* pointing at an admin dir under the
-	// shared common dir, which sits OUTSIDE the workdir — so git add/commit hit
-	// EPERM writing the object store, refs and per-worktree admin. Grant those
-	// common-dir subdirs at the workdir's access level to restore plain-clone
-	// parity. No-op for a plain clone or a submodule (no commondir).
+	// A linked worktree's .git file points at an admin dir under a shared
+	// common dir OUTSIDE the workdir — grant those subdirs so git add/commit
+	// work. No-op for plain clones/submodules (no commondir).
 	var worktreeDeny []string
 	if p.Workdir.Access != "" && p.Workdir.Access != sandboxprofile.AccessNone {
 		if wr, wa, wd, ok := gitWorktreeGrants(workdir, p.Workdir.Access); ok {
-			// Existence-filter silently: these are omac-derived internal
-			// paths (a missing packed-refs is normal), not user grants, so
-			// a "skipping nonexistent path" notice would only confuse.
+			// Existence-filter silently: a missing packed-refs is normal here.
 			wr, err = sandboxprofile.ExpandExisting(wr, nil)
 			if err != nil {
 				return nil, err
@@ -166,33 +162,29 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 	return g, nil
 }
 
-// gitWorktreeGrants returns the extra grants a linked git worktree needs so
-// git works inside the sandbox. ok=false unless workdir is a linked worktree
-// (.git is a file pointing at an admin dir under a shared common dir).
+// gitWorktreeGrants returns the extra grants a linked git worktree needs.
+// ok=false unless workdir is a linked worktree (.git is a file pointing at an
+// admin dir under a shared common dir).
 //
-// objects/refs/logs and this worktree's admin dir are granted at the workdir's
-// access level (git writes them on commit); config/info/packed-refs/hooks stay
-// read-only — readable (so git reads config and RUNS host commit hooks inside
-// the sandbox) but never writable, so the agent can't plant a hook or mutate
-// core.hooksPath to run un-sandboxed on the host's next commit (the #30 vector).
+// objects/refs/logs and the per-worktree admin dir are granted at the workdir's
+// access level; config/info/packed-refs/hooks stay read-only — readable (so git
+// reads config and RUNS host commit hooks) but never writable, blocking the
+// #30 persistence vector (planting a hook or mutating core.hooksPath).
 //
-// The common-dir ROOT is never granted. Consequence: git can't create
-// <common>/packed-refs.lock, so a non-fatal EPERM prints on ref updates (the
-// loose ref still writes, commit succeeds) and gc/pack-refs ref-packing no-ops.
-// Granting the root writable would expose config to a lock-rename that defeats
-// the read-only guard, so the noise is the accepted cost.
+// The common-dir ROOT is never granted: git can't create <common>/packed-refs.lock,
+// so a non-fatal EPERM prints on ref updates (loose refs still write, commit
+// succeeds). Granting the root writable would let a lock-rename defeat the
+// read-only config guard.
 func gitWorktreeGrants(workdir, access string) (readAdds, allowAdds, denyAdds []string, ok bool) {
 	common, admin, ok := resolveWorktreeCommonDir(workdir)
 	if !ok {
 		return nil, nil, nil, false
 	}
-	// SECURITY: these grant paths are derived from in-workdir file content
-	// (.git, <admin>/commondir) that a prior sandboxed session could have
-	// tampered with, and both backends symlink-canonicalize every grant
-	// into a kernel rule. Resolve the common dir and admit only entries
-	// that physically live inside it, so a planted symlink (e.g. a crafted
-	// `objects` -> ~/.ssh) cannot widen a grant to an out-of-tree path and
-	// punch through the protected-path denials.
+	// SECURITY: grant paths derive from in-workdir files (.git, <admin>/commondir)
+	// a prior sandboxed session could have tampered with, and backends
+	// symlink-canonicalize every grant into a kernel rule. Admit only entries
+	// physically inside the common dir so a planted symlink (e.g. `objects` ->
+	// ~/.ssh) cannot widen a grant to an out-of-tree path.
 	root, err := filepath.EvalSymlinks(common)
 	if err != nil {
 		return nil, nil, nil, false
@@ -210,39 +202,34 @@ func gitWorktreeGrants(workdir, access string) (readAdds, allowAdds, denyAdds []
 		filepath.Join(common, "objects"),
 		filepath.Join(common, "refs"),
 		filepath.Join(common, "logs"),
-		admin, // the per-worktree index, HEAD, ORIG_HEAD, COMMIT_EDITMSG, logs
+		admin, // per-worktree index, HEAD, ORIG_HEAD, COMMIT_EDITMSG, logs
 	)
 	readOnly := contained(
 		filepath.Join(common, "config"),
 		filepath.Join(common, "info"),
 		filepath.Join(common, "packed-refs"),
-		// hooks MUST stay inside contained(): unlike a hard deny, a read grant
-		// on a planted `hooks -> secret` symlink would widen to the target (see
-		// TestResolveGrantsWorktreeHooksSymlinkEscape).
+		// hooks must stay in contained(): a read grant on a planted `hooks ->
+		// secret` symlink would otherwise widen to the target.
 		filepath.Join(common, "hooks"),
 	)
 
 	switch access {
 	case sandboxprofile.AccessReadWrite, sandboxprofile.AccessWrite:
-		// The write subdirs are granted read+write even when the workdir
-		// itself is write-only (AccessWrite): git must read the objects and
-		// refs it commits, so read-only here would break commit.
+		// Write subdirs get read+write even for AccessWrite: git must read
+		// the objects/refs it commits.
 		return readOnly, writeSubdirs, denyAdds, true
 	case sandboxprofile.AccessRead:
-		// Read-only workdir: git status/log/diff still read the common
-		// dir, but nothing under it may be written.
+		// Read-only workdir: git status/log/diff still read the common dir.
 		return append(writeSubdirs, readOnly...), nil, denyAdds, true
 	default:
 		return nil, nil, nil, false
 	}
 }
 
-// resolveWorktreeCommonDir inspects workdir/.git. For a linked worktree
-// it is a regular file "gitdir: <admin>"; the admin dir's commondir file
-// (a path relative to the admin dir, as git writes it) points at the
-// shared common dir. Returns (common, admin, true) only for a linked
-// worktree — a plain clone (.git is a directory) or a non-repo workdir
-// yields ok=false.
+// resolveWorktreeCommonDir inspects workdir/.git. For a linked worktree it is
+// a "gitdir: <admin>" file; <admin>/commondir points at the shared common dir.
+// Returns (common, admin, true) only for a linked worktree — plain clones and
+// non-repo workdirs yield ok=false.
 func resolveWorktreeCommonDir(workdir string) (common, admin string, ok bool) {
 	dotgit := filepath.Join(workdir, ".git")
 	fi, err := os.Lstat(dotgit)
@@ -266,19 +253,16 @@ func resolveWorktreeCommonDir(workdir string) (common, admin string, ok bool) {
 		common = filepath.Join(admin, common)
 	}
 	common = filepath.Clean(common)
-	// git invariant: the admin dir is exactly <common>/worktrees/<name>.
-	// Enforce it so a crafted commondir cannot point the grant root at an
-	// unrelated location (e.g. an absolute commondir aimed elsewhere).
+	// git invariant: admin dir is <common>/worktrees/<name>. Enforce it so a
+	// crafted commondir can't point the grant root elsewhere.
 	if filepath.Base(filepath.Dir(admin)) != "worktrees" || filepath.Dir(filepath.Dir(admin)) != common {
 		return "", "", false
 	}
 	return common, admin, true
 }
 
-// pathWithinRoot reports whether path, with all symlinks resolved, is root
-// itself or lies inside it. A path that cannot be resolved (missing, or a
-// dangling/looping symlink) is treated as NOT contained: the grant is
-// dropped rather than risk canonicalizing to an out-of-tree location.
+// pathWithinRoot reports whether path, symlinks resolved, is root or inside it.
+// An unresolvable path is treated as not contained (grant dropped).
 func pathWithinRoot(path, root string) bool {
 	rp, err := filepath.EvalSymlinks(path)
 	if err != nil {
@@ -288,8 +272,8 @@ func pathWithinRoot(path, root string) bool {
 }
 
 // readGitdirPointer parses a linked worktree's .git file ("gitdir: <path>")
-// and returns the absolute admin-dir path it points at. A relative pointer
-// is resolved against the .git file's directory (the workdir).
+// and returns the absolute admin-dir path. A relative pointer is resolved
+// against the .git file's directory (the workdir).
 func readGitdirPointer(dotgit string) (string, error) {
 	data, err := os.ReadFile(dotgit)
 	if err != nil {

--- a/internal/sandboxrun/grants_test.go
+++ b/internal/sandboxrun/grants_test.go
@@ -3,6 +3,7 @@ package sandboxrun
 import (
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -189,6 +190,225 @@ func TestResolveGrantsDeduplicates(t *testing.T) {
 
 func listenUnix(path string) (interface{ Close() error }, error) {
 	return net.Listen("unix", path)
+}
+
+// makeLinkedWorktree builds a minimal linked-worktree layout under a
+// temp dir and returns (workdir, commonDir), mirroring what
+// `git worktree add` produces: the workdir's .git is a *file*
+// ("gitdir: <admin>") and the admin dir's commondir file points back at
+// the shared common dir.
+func makeLinkedWorktree(t *testing.T) (workdir, common string) {
+	t.Helper()
+	base := t.TempDir()
+	common = filepath.Join(base, "repo", ".git")
+	admin := filepath.Join(common, "worktrees", "wt")
+	for _, d := range []string{
+		filepath.Join(common, "objects"),
+		filepath.Join(common, "refs"),
+		filepath.Join(common, "logs"),
+		filepath.Join(common, "info"),
+		filepath.Join(common, "hooks"),
+		admin,
+	} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(common, "config"))
+	writeFile(t, filepath.Join(common, "packed-refs"))
+	// commondir is relative to the admin dir, exactly as git writes it.
+	if err := os.WriteFile(filepath.Join(admin, "commondir"), []byte("../..\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	workdir = filepath.Join(base, "wt")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, ".git"), []byte("gitdir: "+admin+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return workdir, common
+}
+
+func TestResolveGrantsLinkedWorktreeReadWrite(t *testing.T) {
+	wd, common := makeLinkedWorktree(t)
+	p := &sandboxprofile.Profile{Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite}}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The subdirs git add/commit/gc actually write are read+write
+	// (packed-refs included — auto-gc/pack-refs rewrite it).
+	for _, sub := range []string{"objects", "refs", "logs", "packed-refs", filepath.Join("worktrees", "wt")} {
+		want := filepath.Join(common, sub)
+		if !slices.Contains(g.AllowPaths, want) {
+			t.Errorf("allow missing %s: %v", want, g.AllowPaths)
+		}
+	}
+	// config/info are read-only: readable but never writable
+	// (blocks core.hooksPath / credential.helper mutation).
+	for _, sub := range []string{"config", "info"} {
+		want := filepath.Join(common, sub)
+		if !slices.Contains(g.ReadPaths, want) {
+			t.Errorf("read missing %s: %v", want, g.ReadPaths)
+		}
+		if slices.Contains(g.AllowPaths, want) {
+			t.Errorf("%s must not be writable", want)
+		}
+	}
+	// hooks/ is denied outright (host-side un-sandboxed persistence vector).
+	if !slices.Contains(g.ProtectedPaths, filepath.Join(common, "hooks")) {
+		t.Errorf("hooks not protected: %v", g.ProtectedPaths)
+	}
+}
+
+func TestResolveGrantsLinkedWorktreeReadOnly(t *testing.T) {
+	wd, common := makeLinkedWorktree(t)
+	p := &sandboxprofile.Profile{Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessRead}}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Read-only workdir: git read ops (status/log/diff) still need the
+	// common dir, so everything is readable but nothing is writable.
+	for _, sub := range []string{"objects", "refs", "logs", "config", "info", "packed-refs", filepath.Join("worktrees", "wt")} {
+		want := filepath.Join(common, sub)
+		if !slices.Contains(g.ReadPaths, want) {
+			t.Errorf("read missing %s: %v", want, g.ReadPaths)
+		}
+	}
+	for _, ap := range g.AllowPaths {
+		if strings.HasPrefix(ap, common) {
+			t.Errorf("read-only workdir must not grant writes under common: %s", ap)
+		}
+	}
+}
+
+func TestResolveGrantsPlainCloneNoWorktreeGrants(t *testing.T) {
+	wd := t.TempDir()
+	// Plain clone: .git is a directory that lives inside the workdir, so
+	// it is already covered by the workdir grant — no extra paths added.
+	if err := os.MkdirAll(filepath.Join(wd, ".git", "objects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := &sandboxprofile.Profile{Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite}}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ap := range g.AllowPaths {
+		if ap != wd {
+			t.Errorf("plain clone must not add extra allow grants, got %s", ap)
+		}
+	}
+}
+
+// TestResolveGrantsRealGitWorktreePipeline drives the full resolve ->
+// backend-generation path against a worktree produced by real `git`, so
+// it catches any drift between the assumed .git/commondir format and what
+// git actually writes. (A live sandbox-exec/bwrap launch can't run in
+// this dev environment, so this is the end-to-end check below the process
+// boundary, matching TestDenyFullCLIPipeline.)
+func TestResolveGrantsRealGitWorktreePipeline(t *testing.T) {
+	git, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not available")
+	}
+	base := t.TempDir()
+	mainRepo := filepath.Join(base, "main")
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(git, args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t.t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t.t")
+		if out, cerr := cmd.CombinedOutput(); cerr != nil {
+			t.Fatalf("git %v: %v\n%s", args, cerr, out)
+		}
+	}
+	run(base, "init", "-q", mainRepo)
+	writeFile(t, filepath.Join(mainRepo, "a.txt"))
+	run(mainRepo, "add", "a.txt")
+	run(mainRepo, "commit", "-qm", "init")
+	wt := filepath.Join(base, "wt")
+	run(mainRepo, "worktree", "add", "-q", wt, "-b", "feature")
+
+	// git writes canonical (symlink-resolved) paths into its worktree
+	// metadata, and ResolveGrants canonicalizes grants too, so compare
+	// against the resolved common dir (/var -> /private/var on macOS).
+	common := filepath.Join(mainRepo, ".git")
+	if resolved, rerr := filepath.EvalSymlinks(common); rerr == nil {
+		common = resolved
+	}
+	p := &sandboxprofile.Profile{Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite}}
+	g, err := ResolveGrants(p, wt, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	admin := filepath.Join(common, "worktrees", "wt")
+	for _, want := range []string{
+		filepath.Join(common, "objects"),
+		filepath.Join(common, "refs"),
+		filepath.Join(common, "logs"),
+		admin,
+	} {
+		if !slices.Contains(g.AllowPaths, want) {
+			t.Errorf("allow missing %s: %v", want, g.AllowPaths)
+		}
+	}
+	if !slices.Contains(g.ReadPaths, filepath.Join(common, "config")) {
+		t.Errorf("read missing config: %v", g.ReadPaths)
+	}
+	if !slices.Contains(g.ProtectedPaths, filepath.Join(common, "hooks")) {
+		t.Errorf("hooks not protected: %v", g.ProtectedPaths)
+	}
+
+	// macOS backend: objects gets read+write; config read but not write;
+	// hooks denied.
+	sbpl := GenerateSBPL(g)
+	objects := filepath.Join(common, "objects")
+	if !strings.Contains(sbpl, "(allow file-write* (subpath \""+objects+"\"))") {
+		t.Errorf("SBPL missing write allow for objects:\n%s", sbpl)
+	}
+	config := filepath.Join(common, "config")
+	if strings.Contains(sbpl, "(allow file-write* (subpath \""+config+"\"))") {
+		t.Errorf("SBPL must not allow writing config")
+	}
+	hooks := filepath.Join(common, "hooks")
+	if !strings.Contains(sbpl, "(deny file-write* (subpath \""+hooks+"\"))") {
+		t.Errorf("SBPL missing hooks deny:\n%s", sbpl)
+	}
+
+	// Linux backend: objects bound rw (--bind), config read-only (--ro-bind).
+	argv, err := BuildBwrapArgv(g, []string{"x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(argv, " ")
+	if !strings.Contains(joined, "--bind "+objects+" "+objects) {
+		t.Errorf("bwrap argv missing rw bind for objects:\n%s", joined)
+	}
+	if !strings.Contains(joined, "--ro-bind "+config+" "+config) {
+		t.Errorf("bwrap argv missing ro bind for config:\n%s", joined)
+	}
+}
+
+func TestResolveGrantsWorktreeAccessNone(t *testing.T) {
+	wd, common := makeLinkedWorktree(t)
+	p := &sandboxprofile.Profile{Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessNone}}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, list := range [][]string{g.ReadPaths, g.AllowPaths} {
+		for _, x := range list {
+			if strings.HasPrefix(x, common) {
+				t.Errorf("access=none must not grant common paths: %s", x)
+			}
+		}
+	}
 }
 
 // writeFile is a tiny helper for the deny tests.

--- a/internal/sandboxrun/grants_test.go
+++ b/internal/sandboxrun/grants_test.go
@@ -192,11 +192,9 @@ func listenUnix(path string) (interface{ Close() error }, error) {
 	return net.Listen("unix", path)
 }
 
-// makeLinkedWorktree builds a minimal linked-worktree layout under a
-// temp dir and returns (workdir, commonDir), mirroring what
-// `git worktree add` produces: the workdir's .git is a *file*
-// ("gitdir: <admin>") and the admin dir's commondir file points back at
-// the shared common dir.
+// makeLinkedWorktree builds a minimal linked-worktree layout mirroring
+// `git worktree add`: .git is a "gitdir: <admin>" file, and <admin>/commondir
+// points back at the shared common dir.
 func makeLinkedWorktree(t *testing.T) (workdir, common string) {
 	t.Helper()
 	base := t.TempDir()
@@ -216,7 +214,7 @@ func makeLinkedWorktree(t *testing.T) (workdir, common string) {
 	}
 	writeFile(t, filepath.Join(common, "config"))
 	writeFile(t, filepath.Join(common, "packed-refs"))
-	// commondir is relative to the admin dir, exactly as git writes it.
+	// commondir is relative to the admin dir, as git writes it.
 	if err := os.WriteFile(filepath.Join(admin, "commondir"), []byte("../..\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -244,9 +242,8 @@ func TestResolveGrantsLinkedWorktreeReadWrite(t *testing.T) {
 			t.Errorf("allow missing %s: %v", want, g.AllowPaths)
 		}
 	}
-	// config/info/packed-refs are read-only: readable but never writable
-	// (blocks core.hooksPath / credential.helper mutation; a normal
-	// add/commit only writes loose refs, never packed-refs).
+	// config/info/packed-refs are read-only (blocks core.hooksPath/credential.helper
+	// mutation; add/commit only writes loose refs, never packed-refs).
 	for _, sub := range []string{"config", "info", "packed-refs"} {
 		want := filepath.Join(common, sub)
 		if !slices.Contains(g.ReadPaths, want) {
@@ -256,8 +253,7 @@ func TestResolveGrantsLinkedWorktreeReadWrite(t *testing.T) {
 			t.Errorf("%s must not be writable", want)
 		}
 	}
-	// hooks is read-only: readable+runnable, never writable, never hard-denied
-	// (rationale in gitWorktreeGrants).
+	// hooks: readable+runnable, never writable, never hard-denied.
 	hooks := filepath.Join(common, "hooks")
 	if !slices.Contains(g.ReadPaths, hooks) {
 		t.Errorf("hooks must be readable: %v", g.ReadPaths)
@@ -277,8 +273,7 @@ func TestResolveGrantsLinkedWorktreeReadOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Read-only workdir: git read ops (status/log/diff) still need the
-	// common dir, so everything is readable but nothing is writable.
+	// Read-only workdir: git read ops still need the common dir.
 	for _, sub := range []string{"objects", "refs", "logs", "config", "info", "packed-refs", filepath.Join("worktrees", "wt")} {
 		want := filepath.Join(common, sub)
 		if !slices.Contains(g.ReadPaths, want) {
@@ -294,8 +289,7 @@ func TestResolveGrantsLinkedWorktreeReadOnly(t *testing.T) {
 
 func TestResolveGrantsPlainCloneNoWorktreeGrants(t *testing.T) {
 	wd := t.TempDir()
-	// Plain clone: .git is a directory that lives inside the workdir, so
-	// it is already covered by the workdir grant — no extra paths added.
+	// Plain clone: .git is a directory inside the workdir, already covered.
 	if err := os.MkdirAll(filepath.Join(wd, ".git", "objects"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -311,12 +305,10 @@ func TestResolveGrantsPlainCloneNoWorktreeGrants(t *testing.T) {
 	}
 }
 
-// TestResolveGrantsRealGitWorktreePipeline drives the full resolve ->
-// backend-generation path against a worktree produced by real `git`, so
-// it catches any drift between the assumed .git/commondir format and what
-// git actually writes. (A live sandbox-exec/bwrap launch can't run in
-// this dev environment, so this is the end-to-end check below the process
-// boundary, matching TestDenyFullCLIPipeline.)
+// TestResolveGrantsRealGitWorktreePipeline drives resolve -> backend-generation
+// against a real `git worktree add`, catching any drift from git's actual
+// .git/commondir format. (A live sandbox-exec/bwrap launch can't run here, so
+// this is the end-to-end check below the process boundary.)
 func TestResolveGrantsRealGitWorktreePipeline(t *testing.T) {
 	git, err := exec.LookPath("git")
 	if err != nil {
@@ -342,9 +334,8 @@ func TestResolveGrantsRealGitWorktreePipeline(t *testing.T) {
 	wt := filepath.Join(base, "wt")
 	run(mainRepo, "worktree", "add", "-q", wt, "-b", "feature")
 
-	// git writes canonical (symlink-resolved) paths into its worktree
-	// metadata, and ResolveGrants canonicalizes grants too, so compare
-	// against the resolved common dir (/var -> /private/var on macOS).
+	// git writes canonical paths; ResolveGrants canonicalizes grants too,
+	// so compare against the resolved common dir (/var -> /private/var on macOS).
 	common := filepath.Join(mainRepo, ".git")
 	if resolved, rerr := filepath.EvalSymlinks(common); rerr == nil {
 		common = resolved
@@ -376,8 +367,7 @@ func TestResolveGrantsRealGitWorktreePipeline(t *testing.T) {
 		t.Errorf("hooks must not be hard-denied: %v", g.ProtectedPaths)
 	}
 
-	// macOS backend: objects read+write, config read-only, hooks read-only
-	// (readable, never write-allowed, never read-denied).
+	// macOS backend: objects rw, config read-only, hooks read-only.
 	sbpl := GenerateSBPL(g)
 	objects := filepath.Join(common, "objects")
 	if !strings.Contains(sbpl, "(allow file-write* (subpath \""+objects+"\"))") {
@@ -415,9 +405,8 @@ func TestResolveGrantsRealGitWorktreePipeline(t *testing.T) {
 	}
 }
 
-// TestResolveGrantsWorktreeHooksRunnableNotWritable pins the read-only hooks
-// policy (readable+runnable, never writable, never hard-denied) at both
-// writable and read-only workdir access.
+// TestResolveGrantsWorktreeHooksRunnableNotWritable pins the hooks policy
+// (readable+runnable, never writable, never hard-denied) at both access levels.
 func TestResolveGrantsWorktreeHooksRunnableNotWritable(t *testing.T) {
 	wd, common := makeLinkedWorktree(t)
 	hooks := filepath.Join(common, "hooks")
@@ -439,9 +428,9 @@ func TestResolveGrantsWorktreeHooksRunnableNotWritable(t *testing.T) {
 	}
 }
 
-// TestResolveGrantsWorktreeHooksSymlinkEscape guards the new hooks READ grant:
-// a planted `hooks -> <secret>` symlink must be dropped by the containment
-// check, not canonicalized into a read of the target.
+// TestResolveGrantsWorktreeHooksSymlinkEscape guards the hooks READ grant:
+// a planted `hooks -> <secret>` symlink must be dropped by containment,
+// not canonicalized into a read of the target.
 func TestResolveGrantsWorktreeHooksSymlinkEscape(t *testing.T) {
 	base := t.TempDir()
 	secret := filepath.Join(base, "secret")
@@ -495,15 +484,13 @@ func TestResolveGrantsWorktreeHooksSymlinkEscape(t *testing.T) {
 	}
 }
 
-// TestResolveGrantsWorktreeRejectsSymlinkEscape guards the sandbox
-// boundary: because the grant paths are derived from in-workdir file
-// content a prior sandboxed session could tamper with, and the backends
-// symlink-canonicalize every grant into a kernel rule, a planted symlink
-// under the common dir (e.g. objects -> a sensitive dir) must NOT widen
-// any grant to the symlink target.
+// TestResolveGrantsWorktreeRejectsSymlinkEscape guards the sandbox boundary:
+// grant paths derive from in-workdir files a prior sandboxed session could
+// tamper with, and backends symlink-canonicalize every grant. A planted
+// symlink under the common dir (e.g. objects -> secret) must NOT widen any
+// grant to the target.
 func TestResolveGrantsWorktreeRejectsSymlinkEscape(t *testing.T) {
 	base := t.TempDir()
-	// The sensitive dir the attacker aims a symlink at.
 	secret := filepath.Join(base, "secret")
 	if err := os.MkdirAll(secret, 0o755); err != nil {
 		t.Fatal(err)
@@ -550,8 +537,8 @@ func TestResolveGrantsWorktreeRejectsSymlinkEscape(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// No grant — nor its symlink-resolved form, which is what the kernel
-	// rules use — may reach the secret dir.
+	// No grant — nor its symlink-resolved form (what kernel rules use) —
+	// may reach the secret dir.
 	for _, list := range [][]string{g.ReadPaths, g.WritePaths, g.AllowPaths} {
 		for _, gp := range list {
 			resolved, rerr := filepath.EvalSymlinks(gp)
@@ -565,12 +552,11 @@ func TestResolveGrantsWorktreeRejectsSymlinkEscape(t *testing.T) {
 	}
 }
 
-// TestResolveGrantsWorktreeRejectsSpoofedCommondir ensures a commondir
-// that violates git's <common>/worktrees/<name> invariant (pointing the
-// grant root somewhere unrelated) yields no worktree grants at all.
+// TestResolveGrantsWorktreeRejectsSpoofedCommondir: a commondir violating
+// git's <common>/worktrees/<name> invariant yields no worktree grants.
 func TestResolveGrantsWorktreeRejectsSpoofedCommondir(t *testing.T) {
 	wd, _ := makeLinkedWorktree(t)
-	// Repoint commondir at an absolute, unrelated dir.
+	// Repoint commondir at an unrelated absolute dir.
 	elsewhere := t.TempDir()
 	admin := readAdminDir(t, wd)
 	if err := os.WriteFile(filepath.Join(admin, "commondir"), []byte(elsewhere+"\n"), 0o600); err != nil {
@@ -588,7 +574,7 @@ func TestResolveGrantsWorktreeRejectsSpoofedCommondir(t *testing.T) {
 			}
 		}
 	}
-	// Only the workdir itself should be the allow grant.
+	// Only the workdir itself should be allow-granted.
 	for _, ap := range g.AllowPaths {
 		if ap != wd {
 			t.Errorf("unexpected allow grant for spoofed worktree: %s", ap)

--- a/internal/sandboxrun/grants_test.go
+++ b/internal/sandboxrun/grants_test.go
@@ -256,9 +256,17 @@ func TestResolveGrantsLinkedWorktreeReadWrite(t *testing.T) {
 			t.Errorf("%s must not be writable", want)
 		}
 	}
-	// hooks/ is denied outright (host-side un-sandboxed persistence vector).
-	if !slices.Contains(g.ProtectedPaths, filepath.Join(common, "hooks")) {
-		t.Errorf("hooks not protected: %v", g.ProtectedPaths)
+	// hooks is read-only: readable+runnable, never writable, never hard-denied
+	// (rationale in gitWorktreeGrants).
+	hooks := filepath.Join(common, "hooks")
+	if !slices.Contains(g.ReadPaths, hooks) {
+		t.Errorf("hooks must be readable: %v", g.ReadPaths)
+	}
+	if slices.Contains(g.AllowPaths, hooks) || slices.Contains(g.WritePaths, hooks) {
+		t.Errorf("hooks must not be writable: allow=%v write=%v", g.AllowPaths, g.WritePaths)
+	}
+	if slices.Contains(g.ProtectedPaths, hooks) {
+		t.Errorf("hooks must not be hard-denied: %v", g.ProtectedPaths)
 	}
 }
 
@@ -361,12 +369,15 @@ func TestResolveGrantsRealGitWorktreePipeline(t *testing.T) {
 	if !slices.Contains(g.ReadPaths, filepath.Join(common, "config")) {
 		t.Errorf("read missing config: %v", g.ReadPaths)
 	}
-	if !slices.Contains(g.ProtectedPaths, filepath.Join(common, "hooks")) {
-		t.Errorf("hooks not protected: %v", g.ProtectedPaths)
+	if !slices.Contains(g.ReadPaths, filepath.Join(common, "hooks")) {
+		t.Errorf("hooks must be readable: %v", g.ReadPaths)
+	}
+	if slices.Contains(g.ProtectedPaths, filepath.Join(common, "hooks")) {
+		t.Errorf("hooks must not be hard-denied: %v", g.ProtectedPaths)
 	}
 
-	// macOS backend: objects gets read+write; config read but not write;
-	// hooks denied.
+	// macOS backend: objects read+write, config read-only, hooks read-only
+	// (readable, never write-allowed, never read-denied).
 	sbpl := GenerateSBPL(g)
 	objects := filepath.Join(common, "objects")
 	if !strings.Contains(sbpl, "(allow file-write* (subpath \""+objects+"\"))") {
@@ -377,8 +388,14 @@ func TestResolveGrantsRealGitWorktreePipeline(t *testing.T) {
 		t.Errorf("SBPL must not allow writing config")
 	}
 	hooks := filepath.Join(common, "hooks")
-	if !strings.Contains(sbpl, "(deny file-write* (subpath \""+hooks+"\"))") {
-		t.Errorf("SBPL missing hooks deny:\n%s", sbpl)
+	if !strings.Contains(sbpl, "(allow file-read* (subpath \""+hooks+"\"))") {
+		t.Errorf("SBPL missing hooks read allow:\n%s", sbpl)
+	}
+	if strings.Contains(sbpl, "(allow file-write* (subpath \""+hooks+"\"))") {
+		t.Errorf("SBPL must not allow writing hooks:\n%s", sbpl)
+	}
+	if strings.Contains(sbpl, "(deny file-read* (subpath \""+hooks+"\"))") {
+		t.Errorf("SBPL must not deny reading hooks (read-only, not hard-deny):\n%s", sbpl)
 	}
 
 	// Linux backend: objects bound rw (--bind), config read-only (--ro-bind).
@@ -392,6 +409,89 @@ func TestResolveGrantsRealGitWorktreePipeline(t *testing.T) {
 	}
 	if !strings.Contains(joined, "--ro-bind "+config+" "+config) {
 		t.Errorf("bwrap argv missing ro bind for config:\n%s", joined)
+	}
+	if !strings.Contains(joined, "--ro-bind "+hooks+" "+hooks) {
+		t.Errorf("bwrap argv missing ro bind for hooks:\n%s", joined)
+	}
+}
+
+// TestResolveGrantsWorktreeHooksRunnableNotWritable pins the read-only hooks
+// policy (readable+runnable, never writable, never hard-denied) at both
+// writable and read-only workdir access.
+func TestResolveGrantsWorktreeHooksRunnableNotWritable(t *testing.T) {
+	wd, common := makeLinkedWorktree(t)
+	hooks := filepath.Join(common, "hooks")
+	for _, access := range []string{sandboxprofile.AccessReadWrite, sandboxprofile.AccessRead} {
+		p := &sandboxprofile.Profile{Workdir: sandboxprofile.Workdir{Access: access}}
+		g, err := ResolveGrants(p, wd, nil)
+		if err != nil {
+			t.Fatalf("access %s: %v", access, err)
+		}
+		if !slices.Contains(g.ReadPaths, hooks) {
+			t.Errorf("access %s: hooks must be readable: %v", access, g.ReadPaths)
+		}
+		if slices.Contains(g.AllowPaths, hooks) || slices.Contains(g.WritePaths, hooks) {
+			t.Errorf("access %s: hooks must not be writable (allow=%v write=%v)", access, g.AllowPaths, g.WritePaths)
+		}
+		if slices.Contains(g.ProtectedPaths, hooks) {
+			t.Errorf("access %s: hooks must not be hard-denied: %v", access, g.ProtectedPaths)
+		}
+	}
+}
+
+// TestResolveGrantsWorktreeHooksSymlinkEscape guards the new hooks READ grant:
+// a planted `hooks -> <secret>` symlink must be dropped by the containment
+// check, not canonicalized into a read of the target.
+func TestResolveGrantsWorktreeHooksSymlinkEscape(t *testing.T) {
+	base := t.TempDir()
+	secret := filepath.Join(base, "secret")
+	if err := os.MkdirAll(secret, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	secretResolved, err := filepath.EvalSymlinks(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	common := filepath.Join(base, "repo", ".git")
+	admin := filepath.Join(common, "worktrees", "wt")
+	if err := os.MkdirAll(admin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, real := range []string{"objects", "refs", "logs", "info"} {
+		if err := os.MkdirAll(filepath.Join(common, real), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(common, "config"))
+	if err := os.WriteFile(filepath.Join(admin, "commondir"), []byte("../..\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The poisoned entry: hooks symlinked at the secret dir.
+	if err := os.Symlink(secret, filepath.Join(common, "hooks")); err != nil {
+		t.Fatal(err)
+	}
+	wd := filepath.Join(base, "wt")
+	if err := os.MkdirAll(wd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, ".git"), []byte("gitdir: "+admin+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := &sandboxprofile.Profile{Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite}}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, list := range [][]string{g.ReadPaths, g.WritePaths, g.AllowPaths} {
+		for _, gp := range list {
+			resolved, rerr := filepath.EvalSymlinks(gp)
+			if rerr != nil {
+				continue
+			}
+			if resolved == secretResolved || strings.HasPrefix(resolved, secretResolved+string(filepath.Separator)) {
+				t.Errorf("ESCAPE: grant %s resolves into the secret dir %s via hooks symlink", gp, secretResolved)
+			}
+		}
 	}
 }
 

--- a/internal/sandboxrun/grants_test.go
+++ b/internal/sandboxrun/grants_test.go
@@ -237,17 +237,17 @@ func TestResolveGrantsLinkedWorktreeReadWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The subdirs git add/commit/gc actually write are read+write
-	// (packed-refs included — auto-gc/pack-refs rewrite it).
-	for _, sub := range []string{"objects", "refs", "logs", "packed-refs", filepath.Join("worktrees", "wt")} {
+	// The subdirs git add/commit actually write are read+write.
+	for _, sub := range []string{"objects", "refs", "logs", filepath.Join("worktrees", "wt")} {
 		want := filepath.Join(common, sub)
 		if !slices.Contains(g.AllowPaths, want) {
 			t.Errorf("allow missing %s: %v", want, g.AllowPaths)
 		}
 	}
-	// config/info are read-only: readable but never writable
-	// (blocks core.hooksPath / credential.helper mutation).
-	for _, sub := range []string{"config", "info"} {
+	// config/info/packed-refs are read-only: readable but never writable
+	// (blocks core.hooksPath / credential.helper mutation; a normal
+	// add/commit only writes loose refs, never packed-refs).
+	for _, sub := range []string{"config", "info", "packed-refs"} {
 		want := filepath.Join(common, sub)
 		if !slices.Contains(g.ReadPaths, want) {
 			t.Errorf("read missing %s: %v", want, g.ReadPaths)

--- a/internal/sandboxrun/grants_test.go
+++ b/internal/sandboxrun/grants_test.go
@@ -395,6 +395,117 @@ func TestResolveGrantsRealGitWorktreePipeline(t *testing.T) {
 	}
 }
 
+// TestResolveGrantsWorktreeRejectsSymlinkEscape guards the sandbox
+// boundary: because the grant paths are derived from in-workdir file
+// content a prior sandboxed session could tamper with, and the backends
+// symlink-canonicalize every grant into a kernel rule, a planted symlink
+// under the common dir (e.g. objects -> a sensitive dir) must NOT widen
+// any grant to the symlink target.
+func TestResolveGrantsWorktreeRejectsSymlinkEscape(t *testing.T) {
+	base := t.TempDir()
+	// The sensitive dir the attacker aims a symlink at.
+	secret := filepath.Join(base, "secret")
+	if err := os.MkdirAll(secret, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	secretResolved, err := filepath.EvalSymlinks(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attacker-controlled common dir with git's structural shape.
+	common := filepath.Join(base, "evil", ".git")
+	admin := filepath.Join(common, "worktrees", "wt")
+	if err := os.MkdirAll(admin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, real := range []string{"logs", "info"} {
+		if err := os.MkdirAll(filepath.Join(common, real), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(common, "config"))
+	if err := os.WriteFile(filepath.Join(admin, "commondir"), []byte("../..\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The poisoned entries: objects/refs symlinked at the secret dir.
+	if err := os.Symlink(secret, filepath.Join(common, "objects")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(common, "refs")); err != nil {
+		t.Fatal(err)
+	}
+
+	wd := filepath.Join(base, "wt")
+	if err := os.MkdirAll(wd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, ".git"), []byte("gitdir: "+admin+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &sandboxprofile.Profile{Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite}}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No grant — nor its symlink-resolved form, which is what the kernel
+	// rules use — may reach the secret dir.
+	for _, list := range [][]string{g.ReadPaths, g.WritePaths, g.AllowPaths} {
+		for _, gp := range list {
+			resolved, rerr := filepath.EvalSymlinks(gp)
+			if rerr != nil {
+				continue
+			}
+			if resolved == secretResolved || strings.HasPrefix(resolved, secretResolved+string(filepath.Separator)) {
+				t.Errorf("ESCAPE: grant %s resolves into the secret dir %s", gp, secretResolved)
+			}
+		}
+	}
+}
+
+// TestResolveGrantsWorktreeRejectsSpoofedCommondir ensures a commondir
+// that violates git's <common>/worktrees/<name> invariant (pointing the
+// grant root somewhere unrelated) yields no worktree grants at all.
+func TestResolveGrantsWorktreeRejectsSpoofedCommondir(t *testing.T) {
+	wd, _ := makeLinkedWorktree(t)
+	// Repoint commondir at an absolute, unrelated dir.
+	elsewhere := t.TempDir()
+	admin := readAdminDir(t, wd)
+	if err := os.WriteFile(filepath.Join(admin, "commondir"), []byte(elsewhere+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := &sandboxprofile.Profile{Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite}}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, list := range [][]string{g.ReadPaths, g.AllowPaths} {
+		for _, gp := range list {
+			if strings.HasPrefix(gp, elsewhere) {
+				t.Errorf("spoofed commondir leaked a grant under %s: %s", elsewhere, gp)
+			}
+		}
+	}
+	// Only the workdir itself should be the allow grant.
+	for _, ap := range g.AllowPaths {
+		if ap != wd {
+			t.Errorf("unexpected allow grant for spoofed worktree: %s", ap)
+		}
+	}
+}
+
+// readAdminDir parses the admin-dir path out of a linked worktree's .git.
+func readAdminDir(t *testing.T, workdir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(workdir, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(data)), "gitdir:"))
+}
+
 func TestResolveGrantsWorktreeAccessNone(t *testing.T) {
 	wd, common := makeLinkedWorktree(t)
 	p := &sandboxprofile.Profile{Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessNone}}

--- a/internal/sandboxrun/integration_worktree_darwin_test.go
+++ b/internal/sandboxrun/integration_worktree_darwin_test.go
@@ -27,15 +27,15 @@ func gitInDir(t *testing.T, dir string, args ...string) {
 }
 
 // TestIntegrationWorktreeHooksRunButNotWritable is the real-Seatbelt proof of
-// the linked-worktree hooks policy: a host-authored prepare-commit-msg hook
-// RUNS during a sandboxed commit (the #30 bug was that it couldn't) and the
-// commit succeeds, yet the shared hooks dir is NOT writable — so the agent
-// cannot plant a hook that would run un-sandboxed on the host's next commit.
+// the linked-worktree hooks policy: a host-authored prepare-commit-msg hook RUNS
+// during a sandboxed commit (the #30 bug was that it couldn't) and the commit
+// succeeds, yet the shared hooks dir is NOT writable — so the agent can't plant
+// a hook that runs un-sandboxed on the host's next commit.
 //
-// The repo is rooted under $HOME on purpose: t.TempDir() lives under $TMPDIR,
-// which the sandbox baseline grants WRITE, and that blanket temp-write would
-// mask the read-only hooks grant and make the write-denied assertion a false
-// pass. $HOME is read-only baseline, so only the explicit git grants apply.
+// Repo under $HOME on purpose: t.TempDir() lives under $TMPDIR, which the
+// sandbox baseline grants WRITE — that blanket temp-write would mask the
+// read-only hooks grant and make the write-denied assertion a false pass. $HOME
+// is read-only baseline, so only the explicit git grants apply.
 func TestIntegrationWorktreeHooksRunButNotWritable(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
@@ -61,8 +61,8 @@ func TestIntegrationWorktreeHooksRunButNotWritable(t *testing.T) {
 	gitInDir(t, repo, "add", "seed")
 	gitInDir(t, repo, "commit", "-q", "-m", "seed")
 
-	// A host hook in the shared common hooks dir that appends a marker to the
-	// commit message — the marker lands in the commit only if the hook ran.
+	// A host hook that appends a marker to the commit message — the marker
+	// lands in the commit only if the hook ran.
 	hooksDir := filepath.Join(repo, ".git", "hooks")
 	hook := filepath.Join(hooksDir, "prepare-commit-msg")
 	if err := os.WriteFile(hook, []byte("#!/bin/sh\necho 'HOOK-RAN' >> \"$1\"\n"), 0o755); err != nil {

--- a/internal/sandboxrun/integration_worktree_darwin_test.go
+++ b/internal/sandboxrun/integration_worktree_darwin_test.go
@@ -1,0 +1,110 @@
+//go:build darwin
+
+package sandboxrun
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
+)
+
+// gitInDir runs git in dir during test setup (outside the sandbox), with a
+// hermetic identity and no host config.
+func gitInDir(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	c.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// TestIntegrationWorktreeHooksRunButNotWritable is the real-Seatbelt proof of
+// the linked-worktree hooks policy: a host-authored prepare-commit-msg hook
+// RUNS during a sandboxed commit (the #30 bug was that it couldn't) and the
+// commit succeeds, yet the shared hooks dir is NOT writable — so the agent
+// cannot plant a hook that would run un-sandboxed on the host's next commit.
+//
+// The repo is rooted under $HOME on purpose: t.TempDir() lives under $TMPDIR,
+// which the sandbox baseline grants WRITE, and that blanket temp-write would
+// mask the read-only hooks grant and make the write-denied assertion a false
+// pass. $HOME is read-only baseline, so only the explicit git grants apply.
+func TestIntegrationWorktreeHooksRunButNotWritable(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	base, err := os.MkdirTemp(home, ".omac-worktree-e2e-")
+	if err != nil {
+		t.Skipf("cannot create test dir under home: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(base) })
+
+	repo := filepath.Join(base, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitInDir(t, repo, "init", "-q")
+	if err := os.WriteFile(filepath.Join(repo, "seed"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInDir(t, repo, "add", "seed")
+	gitInDir(t, repo, "commit", "-q", "-m", "seed")
+
+	// A host hook in the shared common hooks dir that appends a marker to the
+	// commit message — the marker lands in the commit only if the hook ran.
+	hooksDir := filepath.Join(repo, ".git", "hooks")
+	hook := filepath.Join(hooksDir, "prepare-commit-msg")
+	if err := os.WriteFile(hook, []byte("#!/bin/sh\necho 'HOOK-RAN' >> \"$1\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Linked worktree: .git is a file, admin dir sits outside the workdir.
+	wt := filepath.Join(base, "wt")
+	gitInDir(t, repo, "worktree", "add", "-q", wt)
+
+	p := &sandboxprofile.Profile{
+		Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+		Network: sandboxprofile.Network{Mode: sandboxprofile.ModeBlocked},
+	}
+	g, err := ResolveGrants(p, wt, os.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit inside the sandbox: hook must run and the commit must succeed.
+	commit := "cd " + wt + " && date > f.txt && " +
+		"GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git -c user.name=t -c user.email=t@t add f.txt && " +
+		"GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git -c user.name=t -c user.email=t@t commit -m base"
+	if out, code := runSandboxed(t, g, "/bin/sh", "-c", commit); code != 0 {
+		t.Fatalf("sandboxed commit failed (exit %d) — #30 regressed:\n%s", code, out)
+	}
+	c := exec.Command("git", "log", "-1", "--format=%B")
+	c.Dir = wt
+	msg, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log: %v\n%s", err, msg)
+	}
+	if !strings.Contains(string(msg), "HOOK-RAN") {
+		t.Fatalf("prepare-commit-msg hook did not run inside the sandbox; msg=%q", msg)
+	}
+
+	// The shared hooks dir must NOT be writable from inside the sandbox.
+	evil := filepath.Join(hooksDir, "evil")
+	if _, code := runSandboxed(t, g, "/bin/sh", "-c", "echo pwn > "+evil); code == 0 {
+		t.Errorf("SECURITY: agent wrote %s inside the sandbox — persistence vector open", evil)
+	}
+	if _, err := os.Stat(evil); err == nil {
+		t.Errorf("SECURITY: %s exists — hooks dir was writable", evil)
+	}
+}


### PR DESCRIPTION
Fixes #30.

## Problem
`omac sandbox run` grants the workdir read+write. For a plain clone that covers
`.git` (it lives inside the workdir), so git works. For a **linked worktree**,
git splits state: the workdir is `<repo>/.worktrees/<name>/` but the git-admin
dir is `<repo>/.git/worktrees/<name>/` — a sibling *outside* the workdir. So
`git add`/`commit` hit EPERM writing the object store, refs, reflogs and the
per-worktree index/HEAD, and an agent can't commit from any linked worktree.

## Fix
Detect a linked worktree (`.git` is a file), resolve the shared common dir via
the admin dir's `commondir`, and grant the commit-relevant subdirs at the
workdir's access level:
- **rw:** `objects/`, `refs/`, `logs/`, `worktrees/<name>/`
- **ro:** `config`, `info`, `packed-refs` (blocks `core.hooksPath` / `credential.helper` mutation)
- **deny:** `hooks/` (a writable hooks dir would run un-sandboxed as the host user on the next host-side commit)

No-op for a plain clone or a submodule (whose admin dir has no `commondir`).

## Security hardening
Grant paths are derived from in-workdir file content (`.git`, `commondir`) a
prior sandboxed session could tamper with, and both backends symlink-canonicalize
grants into kernel rules. A planted `objects -> ~/.ssh` symlink would otherwise
emit a write-allow on the target and — since SBPL write-allows come after the
protected denies — punch through the `~/.ssh` deny (sandbox escape). Confined by
enforcing git's `<common>/worktrees/<name>` structural invariant and admitting
only entries whose symlink-resolved path physically lives inside the resolved
common dir.

## Verification
- Unit tests: full resolve->SBPL/bwrap pipeline against a real `git worktree`,
  plus regressions for the symlink-escape and spoofed-`commondir` vectors.
- End-to-end under real Seatbelt: bug reproduced on base (commit lost); fixed
  binary commits cleanly (exit 0, fsck clean); pre-hardening binary allowed the
  symlink escape, hardened binary denies it (secret untouched).

## Known limitation
`git branch -d/-D` and `git tag -d` fail inside a sandboxed worktree — git's
deletion transaction needs a lock in the ungranted common-dir root — but fail
cleanly (exit 1, ref preserved, no corruption). Commits emit a non-fatal
`packed-refs.lock` EPERM yet succeed; `gc`/`pack-refs` ref-packing no-ops. All
other operations (commit/amend/branch/checkout/rebase/stash) are unaffected.
