### PR TITLE
fix(e2e): use copilot BYOK path instead of GitHub PAT

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,6 @@ jobs:
       SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
       SKAINET_INTERNAL: ${{ secrets.SKAINET_INTERNAL }}
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       E2E_HARNESS: ${{ matrix.harness }}
     steps:
       - name: Checkout

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -12,7 +12,6 @@
 //   SKAINET_TOKEN         — API key for the model provider (all harnesses except claude-code)
 //   SKAINET_INTERNAL      — Model provider base URL (responses API; codex, copilot, opencode)
 //   ANTHROPIC_BASE_URL    — Anthropic-compatible proxy URL (claude-code only)
-//   COPILOT_GITHUB_TOKEN  — GitHub PAT with copilot scope (copilot only; falls back to GITHUB_TOKEN)
 //
 // The sandbox profile is derived at runtime from SKAINET_INTERNAL /
 // ANTHROPIC_BASE_URL so the proxy allows the model API host.
@@ -254,16 +253,25 @@ func buildAgentEnv(t *testing.T, h harnessConfig, home string) []string {
 			"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
 		)
 	case "copilot":
-		// Copilot requires GitHub auth even with a custom provider.
-		// Prefer a dedicated COPILOT_GITHUB_TOKEN secret (PAT with
-		// copilot scope); fall back to the CI GITHUB_TOKEN.
-		token := os.Getenv("COPILOT_GITHUB_TOKEN")
+		// BYOK path: COPILOT_PROVIDER_* routes inference to the skainet
+		// responses API and bypasses GitHub OAuth/PAT entirely. A GitHub
+		// token is only needed for /delegate, the GitHub MCP server, or
+		// GitHub Code Search — none of which this test exercises.
+		token := os.Getenv("SKAINET_TOKEN")
 		if token == "" {
-			token = os.Getenv("GITHUB_TOKEN")
+			t.Fatal("SKAINET_TOKEN not set")
 		}
-		if token != "" {
-			env = append(env, "COPILOT_GITHUB_TOKEN="+token)
+		baseURL := os.Getenv("SKAINET_INTERNAL")
+		if baseURL == "" {
+			t.Fatal("SKAINET_INTERNAL not set (CI secret for the responses API URL)")
 		}
+		env = append(env,
+			"COPILOT_PROVIDER_TYPE=openai",
+			"COPILOT_PROVIDER_BASE_URL="+baseURL,
+			"COPILOT_PROVIDER_API_KEY="+token,
+			"COPILOT_MODEL="+modelIDs["copilot"],
+			"COPILOT_PROVIDER_WIRE_API=responses",
+		)
 	}
 	return env
 }

--- a/internal/e2e/harnesses.go
+++ b/internal/e2e/harnesses.go
@@ -215,25 +215,20 @@ func copilotConfig() harnessConfig {
 		BinaryName: "copilot",
 		InstallCmd: []string{"npm", "install", "-g", pinnedPackage("copilot")},
 		ProviderSetup: func(t *testing.T, home string) {
-			token := os.Getenv("SKAINET_TOKEN")
-			if token == "" {
-				t.Fatal("SKAINET_TOKEN not set")
-			}
-			baseURL := os.Getenv("SKAINET_INTERNAL")
-			if baseURL == "" {
-				t.Fatal("SKAINET_INTERNAL not set (CI secret for the responses API URL)")
-			}
+			// Provider config (COPILOT_PROVIDER_*) is injected as process
+			// env vars in buildAgentEnv — copilot CLI reads them from the
+			// environment, not from a sourced file. ProviderSetup only
+			// pre-trusts the workdir so the first-run "trust this folder?"
+			// prompt doesn't block the non-interactive run.
 			copilotDir := filepath.Join(home, ".copilot")
 			if err := os.MkdirAll(copilotDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
-			// provider.env: copilot sources this at startup.
-			envContent := `export COPILOT_PROVIDER_BASE_URL=` + baseURL + `
-export COPILOT_PROVIDER_API_KEY=` + token + `
-export COPILOT_MODEL=` + modelIDs["copilot"] + `
-export COPILOT_PROVIDER_WIRE_API=responses
-`
-			if err := os.WriteFile(filepath.Join(copilotDir, "provider.env"), []byte(envContent), 0o600); err != nil {
+			config := map[string]any{
+				"trustedFolders": []string{home},
+			}
+			b, _ := json.Marshal(config)
+			if err := os.WriteFile(filepath.Join(copilotDir, "config.json"), b, 0o600); err != nil {
 				t.Fatal(err)
 			}
 		},


### PR DESCRIPTION
## Problem

The copilot e2e harness required a GitHub PAT (`COPILOT_GITHUB_TOKEN`) to authenticate, and wrote provider config to `~/.copilot/provider.env` — a file copilot CLI never sources.

## Fix

Per the asml `copilot-tester` pattern (`docker/copilot-tester/entrypoint.sh:48-62`), Copilot CLI's BYOK path (`COPILOT_PROVIDER_*`) bypasses GitHub OAuth/PAT entirely when set in the process environment. A GitHub token is only needed for `/delegate`, the GitHub MCP server, or GitHub Code Search — none of which this test exercises.

- **`harnesses.go`**: drop dead `provider.env`; write `~/.copilot/config.json` with `trustedFolders` (skip first-run trust prompt)
- **`e2e_test.go`**: export `COPILOT_PROVIDER_*` (`TYPE=openai`) in `buildAgentEnv`; remove `COPILOT_GITHUB_TOKEN`/`GITHUB_TOKEN` fallback; update header comment
- **`e2e.yml`**: drop `COPILOT_GITHUB_TOKEN` secret

## Open risk

`COPILOT_PROVIDER_TYPE=openai` is unverified — the asml sandbox uses `anthropic` against the Anthropic API; omac targets the OpenAI-compatible responses API. If copilot rejects it, the failure log will name the expected value.

## Tests

- `go vet ./internal/e2e/` — pass
- `go test ./internal/e2e/` (non-e2e unit tests) — pass
- Full e2e run pending — needs `e2e` build tag + secrets + harness installs. Verify on first CI run after merge.