### PR TITLE
37 add security audit trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,55 @@ facade:
   idle_timeout_secs: 300
   max_body_bytes: 10485760
   base_env_passthrough: [PATH, HOME, USER, LANG, LC_ALL, LC_CTYPE, TMPDIR]
+audit:
+  enabled: true                     # security audit trail (default on)
+  path: ""                          # "" => persistent central path (see below)
+  syslog: false                     # also mirror events to the system log (Unix)
+  strict: false                     # fail-closed: abort if the log can't be written
 ```
+
+#### Audit trail
+
+omac records a security audit trail: an append-only, structured
+(JSON Lines) log of every security-relevant action it performs — the
+sandboxed inner command and each sidecar it spawns (`process.exec` /
+`process.exit`), outbound network allow/deny decisions and their source
+(`net.decision`), facade requests (`facade.request`), control-plane
+mutations (`control.mutation`), secret injection by name
+(`secret.inject`), non-ready routes (`route.state`), and session
+lifecycle (`session.start` / `session.stop`).
+
+The log lives at a **persistent, central** location that survives
+restarts (successive runs append, distinguished by a per-run `run_id`):
+
+| Platform | Default path |
+|---|---|
+| Linux | `$XDG_STATE_HOME/omac/audit/audit.jsonl` → `~/.local/state/omac/audit/audit.jsonl` |
+| macOS | `~/Library/Logs/omac/audit/audit.jsonl` |
+
+The directory is `0700` and the file `0600`, and the default location is
+**outside** the sandbox's writable grants, so the confined process cannot
+tamper with the host's audit trail. Secret values and per-directory
+namespace tokens are **never** written verbatim: secrets are logged by
+name only, and namespaces are hashed (`ns_…`).
+
+Flags (precedence: flag > config > default):
+
+| Flag | Effect |
+|---|---|
+| `--audit-log <path>` | Write the log to `<path>` instead of the default. |
+| `--no-audit` | Disable the audit trail. |
+| `--audit-strict` | Fail-closed: refuse to start if the log can't be opened, and abort the run if a write fails mid-session. (Cannot be combined with `--no-audit`.) |
+
+By default writing is **fail-open**: a write error degrades to a single
+stderr warning and the run continues. Use `--audit-strict` (or
+`audit.strict: true`) for a compliance/forensics posture where an
+unrecorded run is unacceptable. Enable `audit.syslog` for a tamper-
+resistant out-of-band copy via the system log.
+
+The log is a single growing file; use `logrotate` (Linux) or `newsyslog`
+(macOS) for rotation — the append-only JSON Lines format is
+rotation-safe.
 
 #### Skill registry
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,212 @@
+package audit
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// Config controls how New builds an Auditor.
+type Config struct {
+	// Enabled turns auditing on. When false, New returns Nop().
+	Enabled bool
+	// Path is the audit log file path. Empty means "use DefaultPath".
+	Path string
+	// Syslog additionally mirrors events to the system log (Unix only).
+	Syslog bool
+	// Strict makes the file sink fail-closed: a write failure invokes
+	// Fatal instead of degrading to a stderr warning.
+	Strict bool
+	// Mode identifies the entrypoint (start|serve) stamped on every event.
+	Mode Mode
+	// Version is stamped on session.start.
+	Version string
+	// SecretValues seeds the redactor so a secret that leaks onto argv is
+	// scrubbed. The always-safe path is passing secret NAMES, not values.
+	SecretValues []string
+	// Fatal is invoked (once) when a strict-mode write fails after
+	// startup. It SHOULD run teardown and exit non-zero. When nil, a
+	// strict write failure falls back to os.Exit via the default handler.
+	Fatal func(error)
+	// Warnf receives one-time warnings (fail-open path, syslog open
+	// failure, non-persistent fallback dir). Defaults to stderr.
+	Warnf func(format string, args ...any)
+	// RunID, when non-empty, overrides the minted run_id. A subprocess
+	// inherits the parent's run_id so the audit trail correlates across
+	// process boundaries. Empty (default) => mint a fresh run_id.
+	RunID string
+}
+
+// auditor is the live Auditor: envelope stamping + redaction + fan-out to
+// sinks. The file sink is authoritative; syslog is ancillary.
+type auditor struct {
+	runID    string
+	mode     Mode
+	pid      int
+	seq      seqCounter
+	red      *redactor
+	strict   bool
+	fatal    func(error)
+	warnf    func(string, ...any)
+	warnOnce sync.Once
+
+	fileSink   *fileSink
+	syslogSink *syslogSink
+
+	fatalOnce sync.Once
+}
+
+// New builds an Auditor from cfg. When disabled it returns Nop(). When the
+// file sink cannot be opened it returns an error (so strict callers can
+// abort before launching the inner command); non-strict callers may choose
+// to log and fall back to Nop() themselves.
+func New(cfg Config) (Auditor, error) {
+	if !cfg.Enabled {
+		return Nop(), nil
+	}
+	warnf := cfg.Warnf
+	if warnf == nil {
+		warnf = func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, "omac audit: "+format+"\n", args...)
+		}
+	}
+
+	path := cfg.Path
+	if path == "" {
+		p, notGuaranteed := DefaultPath()
+		path = p
+		if notGuaranteed {
+			warnf("no home dir resolved; audit log at %s may not persist", path)
+		}
+	}
+
+	fs, err := openFileSink(path)
+	if err != nil {
+		return nil, err
+	}
+
+	a := &auditor{
+		runID:    newRunID(),
+		mode:     cfg.Mode,
+		pid:      os.Getpid(),
+		red:      newRedactor(cfg.SecretValues),
+		strict:   cfg.Strict,
+		fatal:    cfg.Fatal,
+		warnf:    warnf,
+		fileSink: fs,
+	}
+	if cfg.RunID != "" {
+		a.runID = cfg.RunID
+	}
+
+	if cfg.Syslog {
+		ss, serr := openSyslogSink()
+		if serr != nil {
+			warnf("syslog mirror unavailable: %v", serr)
+		} else {
+			a.syslogSink = ss
+		}
+	}
+	return a, nil
+}
+
+// Emit stamps the envelope, redacts, and writes to every sink.
+func (a *auditor) Emit(ev Event) {
+	ev.Ts = nowRFC3339Nano()
+	ev.RunID = a.runID
+	ev.Seq = a.seq.next()
+	ev.Mode = a.mode
+	ev.PID = a.pid
+	ev = a.red.apply(ev)
+
+	line, err := marshalLine(ev)
+	if err != nil {
+		// A marshal failure means a programming error in an event; never
+		// fatal, but warn once so it's noticed.
+		a.warnOnce.Do(func() { a.warnf("failed to marshal event %q: %v", ev.Type, err) })
+		return
+	}
+
+	// Authoritative file sink first.
+	if err := a.fileSink.write(line); err != nil {
+		a.onWriteError(err)
+		// In fail-open mode we still attempt syslog below.
+	}
+	if a.syslogSink != nil {
+		_ = a.syslogSink.write(line)
+	}
+}
+
+// RunID returns the per-run identifier stamped on every event.
+func (a *auditor) RunID() string { return a.runID }
+
+// NextSeq returns the next seq value the auditor will stamp. Note: seq
+// is per-process; a subprocess that inherits the parent's run_id restarts
+// seq at 1 (the run_id correlates, the pid distinguishes processes).
+func (a *auditor) NextSeq() uint64 { return a.seq.n.Load() + 1 }
+
+// onWriteError applies the selected failure mode to a file-sink error.
+func (a *auditor) onWriteError(err error) {
+	if err == errBroken {
+		return // already handled once
+	}
+	if a.strict {
+		a.fatalOnce.Do(func() {
+			if a.fatal != nil {
+				a.fatal(fmt.Errorf("audit: strict-mode write failed: %w", err))
+				return
+			}
+			fmt.Fprintf(os.Stderr, "omac audit: strict-mode write failed: %v\n", err)
+			os.Exit(1)
+		})
+		return
+	}
+	a.warnOnce.Do(func() {
+		a.warnf("write failed (%v); further audit writes this run are skipped", err)
+	})
+}
+
+func (a *auditor) Close() error {
+	var firstErr error
+	if a.fileSink != nil {
+		if err := a.fileSink.close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if a.syslogSink != nil {
+		_ = a.syslogSink.close()
+	}
+	return firstErr
+}
+
+// --- no-op auditor ---
+
+type nopAuditor struct{}
+
+// Nop returns an Auditor that discards every event. Used when auditing is
+// disabled (or, at the caller's discretion, when a non-strict sink failed
+// to open), so every emit point can hold a non-nil Auditor.
+func Nop() Auditor { return nopAuditor{} }
+
+func (nopAuditor) Emit(Event)      {}
+func (nopAuditor) Close() error    { return nil }
+func (nopAuditor) RunID() string   { return "" }
+func (nopAuditor) NextSeq() uint64 { return 0 }
+
+// newRunID mints a per-invocation random hex identifier. On the vanishingly
+// unlikely rand failure it falls back to a time-based value.
+func newRunID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "run_" + hex.EncodeToString([]byte(time.Now().UTC().Format(time.RFC3339Nano)))[:16]
+	}
+	return "run_" + hex.EncodeToString(b[:])
+}
+
+// ensure io is used (kept for future streaming sinks); avoids churn if a
+// build tag ever trims a sink file.
+var _ = io.Discard

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,336 @@
+package audit
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readLines reads a JSONL file into decoded Event slices.
+func readEvents(t *testing.T, path string) []Event {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	defer f.Close()
+	var out []Event
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("line is not valid JSON: %v\n%s", err, line)
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+func newTestAuditor(t *testing.T, cfg Config) (Auditor, string) {
+	t.Helper()
+	if cfg.Path == "" {
+		cfg.Path = filepath.Join(t.TempDir(), "audit.jsonl")
+	}
+	cfg.Enabled = true
+	if cfg.Mode == "" {
+		cfg.Mode = ModeStart
+	}
+	a, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+	return a, cfg.Path
+}
+
+func TestEnvelopeFieldsPresent(t *testing.T) {
+	a, path := newTestAuditor(t, Config{Version: "9.9.9"})
+	a.Emit(SessionStart("9.9.9", "opencode", "builtin", "seatbelt"))
+	_ = a.Close()
+
+	evs := readEvents(t, path)
+	if len(evs) != 1 {
+		t.Fatalf("want 1 event, got %d", len(evs))
+	}
+	ev := evs[0]
+	if ev.Ts == "" || ev.RunID == "" || ev.Type == "" || ev.Mode == "" || ev.PID == 0 {
+		t.Fatalf("missing envelope field: %+v", ev)
+	}
+	if ev.Seq != 1 {
+		t.Fatalf("want seq 1, got %d", ev.Seq)
+	}
+	if ev.Type != TypeSessionStart || ev.Harness != "opencode" {
+		t.Fatalf("unexpected payload: %+v", ev)
+	}
+}
+
+func TestSeqMonotonicSameRunID(t *testing.T) {
+	a, path := newTestAuditor(t, Config{})
+	for i := 0; i < 5; i++ {
+		a.Emit(ControlMutation("reload", "/tmp/x", "ok"))
+	}
+	_ = a.Close()
+
+	evs := readEvents(t, path)
+	if len(evs) != 5 {
+		t.Fatalf("want 5, got %d", len(evs))
+	}
+	runID := evs[0].RunID
+	for i, ev := range evs {
+		if ev.Seq != uint64(i+1) {
+			t.Fatalf("event %d: want seq %d, got %d", i, i+1, ev.Seq)
+		}
+		if ev.RunID != runID {
+			t.Fatalf("event %d: run_id changed within a run", i)
+		}
+	}
+}
+
+func TestRedactArgvSecretValue(t *testing.T) {
+	secret := "super-secret-token-value"
+	a, path := newTestAuditor(t, Config{SecretValues: []string{secret}})
+	a.Emit(ProcessExec("myskill", "abc123token", "/work",
+		[]string{"run", "--token", secret, "--flag"},
+		[]string{"MY_TOKEN"}, nil))
+	_ = a.Close()
+
+	data, _ := os.ReadFile(path)
+	if strings.Contains(string(data), secret) {
+		t.Fatalf("secret value leaked into log:\n%s", data)
+	}
+	evs := readEvents(t, path)
+	found := false
+	for _, a := range evs[0].Argv {
+		if a == redactedMarker {
+			found = true
+		}
+		if a == secret {
+			t.Fatalf("secret value present in decoded argv")
+		}
+	}
+	if !found {
+		t.Fatalf("expected redacted marker in argv: %v", evs[0].Argv)
+	}
+	// Secret NAME should be present (names are safe).
+	if len(evs[0].SecretNames) != 1 || evs[0].SecretNames[0] != "MY_TOKEN" {
+		t.Fatalf("expected secret name present: %v", evs[0].SecretNames)
+	}
+}
+
+func TestRedactNamespaceHashed(t *testing.T) {
+	token := "deadbeefcafef00d1234567890abcdef"
+	a, path := newTestAuditor(t, Config{})
+	a.Emit(FacadeRequest("GET", "slack", token, "chat", 200, 10, 1))
+	a.Emit(FacadeRequest("GET", "gh", GlobalNamespace, "repos", 200, 10, 1))
+	a.Emit(FacadeRequest("GET", "flat", "", "x", 200, 10, 1))
+	_ = a.Close()
+
+	data, _ := os.ReadFile(path)
+	s := string(data)
+	if strings.Contains(s, token) {
+		t.Fatalf("dir-token leaked into log:\n%s", s)
+	}
+	evs := readEvents(t, path)
+	if !strings.HasPrefix(evs[0].Namespace, "ns_") {
+		t.Fatalf("want hashed namespace, got %q", evs[0].Namespace)
+	}
+	if evs[1].Namespace != GlobalNamespace {
+		t.Fatalf("global namespace should pass through, got %q", evs[1].Namespace)
+	}
+	if evs[2].Namespace != "" {
+		t.Fatalf("flat namespace should stay empty, got %q", evs[2].Namespace)
+	}
+}
+
+func TestDisabledIsNop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	a, err := New(Config{Enabled: false, Path: path})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.Emit(SessionStart("1", "h", "p", "b"))
+	_ = a.Close()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("disabled auditor should not create a file")
+	}
+}
+
+func TestFilePermissions(t *testing.T) {
+	// Nest under a subdir the sink must create, so we exercise MkdirAll's
+	// 0700 (t.TempDir itself is 0755 and pre-exists).
+	path := filepath.Join(t.TempDir(), "sub", "audit.jsonl")
+	a, path := newTestAuditor(t, Config{Path: path})
+	a.Emit(SessionStart("1", "h", "p", "b"))
+	_ = a.Close()
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("want file mode 0600, got %o", fi.Mode().Perm())
+	}
+	di, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if di.Mode().Perm() != 0o700 {
+		t.Fatalf("want dir mode 0700, got %o", di.Mode().Perm())
+	}
+}
+
+func TestAppendAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+
+	a1, _ := New(Config{Enabled: true, Path: path, Mode: ModeStart})
+	a1.Emit(SessionStart("1", "h", "p", "b"))
+	_ = a1.Close()
+
+	a2, _ := New(Config{Enabled: true, Path: path, Mode: ModeStart})
+	a2.Emit(SessionStart("1", "h", "p", "b"))
+	_ = a2.Close()
+
+	evs := readEvents(t, path)
+	if len(evs) != 2 {
+		t.Fatalf("second run should append; want 2 events, got %d", len(evs))
+	}
+	if evs[0].RunID == "" || evs[1].RunID == "" || evs[0].RunID == evs[1].RunID {
+		t.Fatalf("runs should carry distinct run_ids: %q vs %q", evs[0].RunID, evs[1].RunID)
+	}
+}
+
+func TestStrictFatalOnWriteError(t *testing.T) {
+	a, path := newTestAuditor(t, Config{
+		Strict: true,
+		Path:   filepath.Join(t.TempDir(), "audit.jsonl"),
+	})
+	_ = path
+	// Force a write error by closing the underlying file out from under
+	// the sink, then emitting.
+	au := a.(*auditor)
+	_ = au.fileSink.f.Close() // subsequent writes fail
+
+	var fatalErr error
+	au.fatal = func(err error) { fatalErr = err }
+
+	au.Emit(ControlMutation("reload", "/x", "ok"))
+	if fatalErr == nil {
+		t.Fatalf("strict-mode write failure should invoke fatal handler")
+	}
+}
+
+func TestFailOpenWarnsOnce(t *testing.T) {
+	var warnings int
+	a, _ := newTestAuditor(t, Config{
+		Strict: false,
+		Warnf:  func(string, ...any) { warnings++ },
+	})
+	au := a.(*auditor)
+	_ = au.fileSink.f.Close()
+	au.Emit(ControlMutation("reload", "/x", "ok"))
+	au.Emit(ControlMutation("reload", "/y", "ok"))
+	if warnings != 1 {
+		t.Fatalf("fail-open should warn exactly once, got %d", warnings)
+	}
+}
+
+func TestValidJSONPerLine(t *testing.T) {
+	a, path := newTestAuditor(t, Config{})
+	a.Emit(NetDecision("example.com", 443, true, "host", "prompt", true))
+	a.Emit(SecretInject("s", "tok", []string{"A", "B"}, []string{"C"}))
+	a.Emit(RouteStateEvent("s", "tok", "broken", "boom"))
+	_ = a.Close()
+
+	f, _ := os.Open(path)
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	n := 0
+	for sc.Scan() {
+		var m map[string]any
+		if err := json.Unmarshal(sc.Bytes(), &m); err != nil {
+			t.Fatalf("line %d not valid JSON: %v", n, err)
+		}
+		n++
+	}
+	if n != 3 {
+		t.Fatalf("want 3 lines, got %d", n)
+	}
+}
+
+// TestInheritedRunIDPreservesCorrelation asserts that when a subprocess
+// inherits the parent's run_id, the resulting log has a single run_id
+// across both writers. The spec says "all events in the run share the
+// same run_id". Seq is per-process (the pid field distinguishes writers
+// within a run); the test asserts seq is monotonic within each writer.
+func TestInheritedRunIDPreservesCorrelation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+
+	// Parent: emits 2 events (seq 1, 2), run_id R1.
+	parent, err := New(Config{Enabled: true, Path: path, Mode: ModeServe})
+	if err != nil {
+		t.Fatalf("parent New: %v", err)
+	}
+	parent.Emit(ControlMutation("activate", "/a", "ok")) // seq 1
+	parent.Emit(ControlMutation("activate", "/b", "ok")) // seq 2
+	// Subprocess: inherits run_id R1 + parent's mode. Seq restarts at 1
+	// (per-process); the pid field distinguishes the two writers.
+	child, err := New(Config{
+		Enabled: true,
+		Path:    path,
+		Mode:    ModeServe,
+		RunID:   parent.RunID(),
+	})
+	if err != nil {
+		t.Fatalf("child New: %v", err)
+	}
+	child.Emit(NetDecision("host.example", 443, true, "host", "prompt", false)) // seq 1
+	_ = parent.Close()
+	_ = child.Close()
+
+	evs := readEvents(t, path)
+	if len(evs) != 3 {
+		t.Fatalf("want 3 events, got %d", len(evs))
+	}
+	parentRunID := evs[0].RunID
+	for i, ev := range evs {
+		if ev.RunID != parentRunID {
+			t.Fatalf("event %d: run_id %q != parent %q (correlation broken)", i, ev.RunID, parentRunID)
+		}
+		if ev.Mode != ModeServe {
+			t.Fatalf("event %d: mode %q, want %q (mode not inherited)", i, ev.Mode, ModeServe)
+		}
+	}
+	// Parent's two events must be monotonic.
+	if evs[0].Seq >= evs[1].Seq {
+		t.Fatalf("parent seq not monotonic: %d >= %d", evs[0].Seq, evs[1].Seq)
+	}
+	// Child's seq restarts at 1 (per-process).
+	if evs[2].Seq != 1 {
+		t.Fatalf("child seq: want 1 (per-process restart), got %d", evs[2].Seq)
+	}
+}
+
+// TestNewRunIDIsRandom verifies the default (no inheritance) still
+// produces distinct run_ids (the original behavior).
+func TestNewRunIDIsRandom(t *testing.T) {
+	a1, _ := New(Config{Enabled: true, Path: filepath.Join(t.TempDir(), "a.jsonl")})
+	a2, _ := New(Config{Enabled: true, Path: filepath.Join(t.TempDir(), "b.jsonl")})
+	if a1.RunID() == a2.RunID() {
+		t.Fatalf("two independent auditors share run_id %q (should be distinct)", a1.RunID())
+	}
+	if a1.RunID() == "" {
+		t.Fatalf("run_id should not be empty")
+	}
+	_ = a1.Close()
+	_ = a2.Close()
+}

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -1,0 +1,139 @@
+// Package audit implements omac's security audit trail: a single,
+// append-only, structured (JSON Lines) record of every security-relevant
+// action omac performs — commands it spawns, network decisions it makes,
+// facade requests it proxies, control-plane mutations, secret injection,
+// and session lifecycle.
+//
+// Design highlights (see openspec/changes/add-audit-trail/design.md):
+//
+//   - One JSON object per line, sharing a fixed envelope (ts, run_id, seq,
+//     type, mode, pid) so events are greppable, streamable, and
+//     gap-detectable within a run.
+//   - Redaction happens at the single Emit boundary: secret values and
+//     secret namespace tokens are never written verbatim, even if a call
+//     site passes them by mistake.
+//   - The default log lives at a persistent, central, host-level path that
+//     survives restarts (NOT the ephemeral per-run runtime dir).
+//   - Failure mode is selectable: fail-open by default (a write error
+//     becomes one stderr warning), or fail-closed under strict mode (a
+//     write failure aborts the run via a registered fatal handler).
+package audit
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// Mode identifies which omac entrypoint produced the events.
+type Mode string
+
+const (
+	ModeStart Mode = "start"
+	ModeServe Mode = "serve"
+)
+
+// Event types. Dotted namespaces group related actions.
+const (
+	TypeSessionStart    = "session.start"
+	TypeSessionStop     = "session.stop"
+	TypeProcessExec     = "process.exec"
+	TypeProcessExit     = "process.exit"
+	TypeNetDecision     = "net.decision"
+	TypeFacadeRequest   = "facade.request"
+	TypeControlMutation = "control.mutation"
+	TypeSecretInject    = "secret.inject"
+	TypeRouteState      = "route.state"
+)
+
+// Event is one audit record. The envelope fields (Ts, RunID, Seq, Type,
+// Mode, PID) are stamped by the Auditor at Emit time; callers fill only
+// Type and the type-specific payload fields. Sensitive fields (Argv,
+// Namespace) are passed through the redactor before serialization.
+//
+// A single flat struct with omitempty keeps each line compact and avoids a
+// map[string]any (which would defeat the redactor's field-awareness).
+type Event struct {
+	// --- envelope (stamped by the Auditor) ---
+	Ts    string `json:"ts"`
+	RunID string `json:"run_id"`
+	Seq   uint64 `json:"seq"`
+	Type  string `json:"type"`
+	Mode  Mode   `json:"mode"`
+	PID   int    `json:"pid"`
+
+	// --- common optional fields ---
+	Skill     string `json:"skill,omitempty"`
+	Namespace string `json:"namespace,omitempty"` // redacted (hashed) unless "" or "__global__"
+	Detail    string `json:"detail,omitempty"`
+
+	// --- session.start / session.stop ---
+	Version        string `json:"version,omitempty"`
+	Harness        string `json:"harness,omitempty"`
+	SandboxProfile string `json:"sandbox_profile,omitempty"`
+	SandboxBackend string `json:"sandbox_backend,omitempty"`
+	ExitCode       *int   `json:"exit_code,omitempty"`
+
+	// --- process.exec / process.exit ---
+	Argv        []string `json:"argv,omitempty"` // secret values redacted
+	Cwd         string   `json:"cwd,omitempty"`
+	SecretNames []string `json:"secret_names,omitempty"` // names only, never values
+	ConfigNames []string `json:"config_names,omitempty"`
+	Sandboxed   *bool    `json:"sandboxed,omitempty"`
+	DurationMS  int64    `json:"duration_ms,omitempty"`
+
+	// --- net.decision ---
+	Host      string `json:"host,omitempty"`
+	Port      int    `json:"port,omitempty"`
+	Allow     *bool  `json:"allow,omitempty"`
+	Scope     string `json:"scope,omitempty"`  // once|host|suffix
+	Source    string `json:"source,omitempty"` // prompt|learned|allowlist|blocklist|timeout|unavailable|hard-deny|dns|default
+	Persisted *bool  `json:"persisted,omitempty"`
+
+	// --- facade.request ---
+	Method         string `json:"method,omitempty"`
+	Mount          string `json:"mount,omitempty"`
+	Path           string `json:"path,omitempty"`
+	UpstreamStatus int    `json:"upstream_status,omitempty"`
+	BytesOut       int64  `json:"bytes_out,omitempty"`
+
+	// --- control.mutation ---
+	Action string `json:"action,omitempty"` // activate|deactivate|reload|reload-global
+	Dir    string `json:"dir,omitempty"`
+	Result string `json:"result,omitempty"` // ok|error summary
+
+	// --- route.state ---
+	State string `json:"state,omitempty"` // pending-credentials|broken
+}
+
+// bptr / iptr / sptr are small helpers for the pointer-typed optional
+// fields (so "false"/"0" are distinguishable from "absent").
+func bptr(b bool) *bool { return &b }
+func iptr(i int) *int   { return &i }
+
+// Auditor records audit events. It is safe for concurrent use. Callers
+// hold a non-nil Auditor (see Nop) and call Emit unconditionally.
+type Auditor interface {
+	// Emit stamps the envelope, redacts sensitive fields, and writes the
+	// event. It never panics and (in fail-open mode) never returns an
+	// error to the caller.
+	Emit(ev Event)
+	// Close flushes and releases sinks. Safe to call more than once.
+	Close() error
+	// RunID returns the per-run identifier stamped on every event. A
+	// subprocess inherits the parent's run_id so the trail correlates
+	// across process boundaries.
+	RunID() string
+	// NextSeq returns the next seq value the auditor will stamp. A
+	// subprocess inherits the parent's next seq so its events continue
+	// the monotonic sequence rather than restarting at 1.
+	NextSeq() uint64
+}
+
+// seqCounter is a process-global monotonic sequence source shared by every
+// sink of a single Auditor so gaps are detectable within a run.
+type seqCounter struct{ n atomic.Uint64 }
+
+func (s *seqCounter) next() uint64 { return s.n.Add(1) }
+
+// nowRFC3339Nano is swappable in tests.
+var nowRFC3339Nano = func() string { return time.Now().UTC().Format(time.RFC3339Nano) }

--- a/internal/audit/events_ctor.go
+++ b/internal/audit/events_ctor.go
@@ -1,0 +1,111 @@
+package audit
+
+// Constructors for the typed events. Emit points call these to build an
+// Event with the right Type and fields set, keeping call sites terse and
+// making the sensitive-field contract explicit (secret NAMES, never
+// values; namespaces are hashed downstream by the redactor).
+
+// SessionStart builds a session.start event.
+func SessionStart(version, harness, sandboxProfile, sandboxBackend string) Event {
+	return Event{
+		Type:           TypeSessionStart,
+		Version:        version,
+		Harness:        harness,
+		SandboxProfile: sandboxProfile,
+		SandboxBackend: sandboxBackend,
+	}
+}
+
+// SessionStop builds a session.stop event.
+func SessionStop(exitCode int) Event {
+	return Event{Type: TypeSessionStop, ExitCode: iptr(exitCode)}
+}
+
+// ProcessExec builds a process.exec event. secretNames/configNames are
+// env-var names only.
+func ProcessExec(skill, namespace, cwd string, argv, secretNames, configNames []string) Event {
+	return Event{
+		Type:        TypeProcessExec,
+		Skill:       skill,
+		Namespace:   namespace,
+		Cwd:         cwd,
+		Argv:        argv,
+		SecretNames: secretNames,
+		ConfigNames: configNames,
+	}
+}
+
+// InnerExec builds a process.exec event for the sandboxed inner command.
+func InnerExec(argv []string, sandboxProfile string, sandboxed bool) Event {
+	return Event{
+		Type:           TypeProcessExec,
+		Argv:           argv,
+		SandboxProfile: sandboxProfile,
+		Sandboxed:      bptr(sandboxed),
+	}
+}
+
+// ProcessExit builds a process.exit event.
+func ProcessExit(skill, namespace string, exitCode int, durationMS int64) Event {
+	return Event{
+		Type:       TypeProcessExit,
+		Skill:      skill,
+		Namespace:  namespace,
+		ExitCode:   iptr(exitCode),
+		DurationMS: durationMS,
+	}
+}
+
+// NetDecision builds a net.decision event.
+func NetDecision(host string, port int, allow bool, scope, source string, persisted bool) Event {
+	return Event{
+		Type:      TypeNetDecision,
+		Host:      host,
+		Port:      port,
+		Allow:     bptr(allow),
+		Scope:     scope,
+		Source:    source,
+		Persisted: bptr(persisted),
+	}
+}
+
+// FacadeRequest builds a facade.request event.
+func FacadeRequest(method, mount, namespace, path string, status int, bytesOut, durationMS int64) Event {
+	return Event{
+		Type:           TypeFacadeRequest,
+		Method:         method,
+		Mount:          mount,
+		Namespace:      namespace,
+		Path:           path,
+		UpstreamStatus: status,
+		BytesOut:       bytesOut,
+		DurationMS:     durationMS,
+	}
+}
+
+// ControlMutation builds a control.mutation event.
+func ControlMutation(action, dir, result string) Event {
+	return Event{Type: TypeControlMutation, Action: action, Dir: dir, Result: result}
+}
+
+// SecretInject builds a secret.inject event (names only).
+func SecretInject(skill, namespace string, secretNames, configNames []string) Event {
+	return Event{
+		Type:        TypeSecretInject,
+		Skill:       skill,
+		Namespace:   namespace,
+		SecretNames: secretNames,
+		ConfigNames: configNames,
+	}
+}
+
+// RouteStateEvent builds a route.state event for a non-ready route.
+func RouteStateEvent(skill, namespace, state, detail string) Event {
+	return Event{
+		Type:      TypeRouteState,
+		Skill:     skill,
+		Namespace: namespace,
+		State:     state,
+		Detail:    detail,
+	}
+}

--- a/internal/audit/path.go
+++ b/internal/audit/path.go
@@ -1,0 +1,69 @@
+package audit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// defaultLogName is the single growing file that accumulates the trail
+// across restarts. A per-event run_id keeps runs distinguishable.
+const defaultLogName = "audit.jsonl"
+
+// DefaultDir resolves the persistent, central, host-level directory for the
+// audit trail. It must survive restarts and live outside the ephemeral
+// per-run runtime dir. Resolution (design D7):
+//
+//   - Linux: $XDG_STATE_HOME/omac/audit, else $HOME/.local/state/omac/audit
+//   - macOS: $HOME/Library/Logs/omac/audit
+//   - fallback (no home): ${TMPDIR}/omac/audit, with persistNotGuaranteed=true
+//
+// The returned dir is not yet created; DefaultPath / the sink create it.
+func DefaultDir() (dir string, persistNotGuaranteed bool) {
+	if runtime.GOOS == "darwin" {
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
+			return filepath.Join(home, "Library", "Logs", "omac", "audit"), false
+		}
+		return filepath.Join(os.TempDir(), "omac", "audit"), true
+	}
+	// Linux / other unix: XDG state dir.
+	if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
+		return filepath.Join(xdg, "omac", "audit"), false
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".local", "state", "omac", "audit"), false
+	}
+	return filepath.Join(os.TempDir(), "omac", "audit"), true
+}
+
+// DefaultPath returns the default audit log file path (DefaultDir joined
+// with the default filename) and whether persistence is guaranteed. The
+// directory is not created here.
+func DefaultPath() (path string, persistNotGuaranteed bool) {
+	dir, warn := DefaultDir()
+	return filepath.Join(dir, defaultLogName), warn
+}
+
+// EffectivePath returns the resolved log path for a Config: the explicit
+// Path when set, else DefaultPath. Returns "" when auditing is disabled.
+// Callers use this to pass the same path down to the sandbox subprocess.
+func EffectivePath(cfg Config) string {
+	if !cfg.Enabled {
+		return ""
+	}
+	if cfg.Path != "" {
+		return cfg.Path
+	}
+	p, _ := DefaultPath()
+	return p
+}
+
+// ensureDir creates the parent directory of path with mode 0700.
+func ensureDir(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("audit: create dir %s: %w", dir, err)
+	}
+	return nil
+}

--- a/internal/audit/redact.go
+++ b/internal/audit/redact.go
@@ -1,0 +1,72 @@
+package audit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// redactedMarker replaces any argv element that matches a known secret.
+const redactedMarker = "<redacted>"
+
+// GlobalNamespace mirrors facade.GlobalNamespace. It is duplicated here to
+// avoid importing the facade package from audit (which would create an
+// import cycle once the facade depends on audit). Kept in sync by a test.
+const GlobalNamespace = "__global__"
+
+// redactor scrubs sensitive material at the single Emit boundary. It holds
+// the set of known secret *values* so that even an argv a caller forgot to
+// tag cannot leak a secret. The always-safe path remains passing secret
+// NAMES (Event.SecretNames), never values.
+type redactor struct {
+	secretValues map[string]struct{}
+}
+
+// newRedactor builds a redactor from the known secret values. Empty and
+// very short values are ignored: matching a 1-2 char "secret" against argv
+// would redact innocuous tokens ("-", "0") and leak nothing useful.
+func newRedactor(secretValues []string) *redactor {
+	m := make(map[string]struct{}, len(secretValues))
+	for _, v := range secretValues {
+		if len(v) < 3 {
+			continue
+		}
+		m[v] = struct{}{}
+	}
+	return &redactor{secretValues: m}
+}
+
+// apply returns a copy of ev with sensitive fields scrubbed. It never
+// mutates the caller's slices.
+func (r *redactor) apply(ev Event) Event {
+	if len(ev.Argv) > 0 {
+		ev.Argv = r.redactArgv(ev.Argv)
+	}
+	ev.Namespace = redactNamespace(ev.Namespace)
+	return ev
+}
+
+// redactArgv copies argv, replacing any element equal to a known secret
+// value with the redacted marker.
+func (r *redactor) redactArgv(argv []string) []string {
+	out := make([]string, len(argv))
+	for i, a := range argv {
+		if _, ok := r.secretValues[a]; ok {
+			out[i] = redactedMarker
+			continue
+		}
+		out[i] = a
+	}
+	return out
+}
+
+// redactNamespace hashes a per-directory namespace token so a secret
+// bearer token never appears in the log. The non-secret sentinels — the
+// empty (flat) namespace and the reserved GlobalNamespace — pass through
+// unchanged, since they carry no secret and are useful for correlation.
+func redactNamespace(ns string) string {
+	if ns == "" || ns == GlobalNamespace {
+		return ns
+	}
+	sum := sha256.Sum256([]byte(ns))
+	return "ns_" + hex.EncodeToString(sum[:6]) // 12 hex chars
+}

--- a/internal/audit/sink_file.go
+++ b/internal/audit/sink_file.go
@@ -1,0 +1,79 @@
+package audit
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+)
+
+// fileSink is the authoritative append-only JSON Lines sink. It opens the
+// file O_APPEND|O_CREATE|O_WRONLY with mode 0600 and flushes after every
+// event to bound loss on crash (volume is human-scale).
+type fileSink struct {
+	mu     sync.Mutex
+	f      *os.File
+	w      *bufio.Writer
+	broken bool
+}
+
+// openFileSink creates the parent dir (0700), opens the file (0600), and
+// returns the sink. A failure here is fatal for strict mode and reported
+// to the caller.
+func openFileSink(path string) (*fileSink, error) {
+	if err := ensureDir(path); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("audit: open %s: %w", path, err)
+	}
+	return &fileSink{f: f, w: bufio.NewWriter(f)}, nil
+}
+
+func (s *fileSink) write(line []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.broken {
+		return errBroken
+	}
+	if _, err := s.w.Write(line); err != nil {
+		s.broken = true
+		return err
+	}
+	if err := s.w.WriteByte('\n'); err != nil {
+		s.broken = true
+		return err
+	}
+	if err := s.w.Flush(); err != nil {
+		s.broken = true
+		return err
+	}
+	return nil
+}
+
+func (s *fileSink) close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.f == nil {
+		return nil
+	}
+	_ = s.w.Flush()
+	err := s.f.Close()
+	s.f = nil
+	return err
+}
+
+// errBroken marks a sink that has already failed once (fail-open path).
+var errBroken = fmt.Errorf("audit: sink previously failed")
+
+// marshalLine renders an event to a compact single-line JSON byte slice
+// (no trailing newline; the sink adds it).
+func marshalLine(ev Event) ([]byte, error) {
+	b, err := json.Marshal(ev)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/internal/audit/sink_syslog_unix.go
+++ b/internal/audit/sink_syslog_unix.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package audit
+
+import (
+	"log/syslog"
+)
+
+// syslogSink mirrors events to the system log. It is best-effort: a
+// syslog failure never fails the write path and never triggers strict-mode
+// abort (the authoritative file sink already recorded the event).
+type syslogSink struct {
+	w *syslog.Writer
+}
+
+// openSyslogSink connects to the local syslog daemon under AUTHPRIV/NOTICE
+// with the "omac" tag. AUTHPRIV is the conventional facility for
+// security-relevant events.
+func openSyslogSink() (*syslogSink, error) {
+	w, err := syslog.New(syslog.LOG_AUTHPRIV|syslog.LOG_NOTICE, "omac")
+	if err != nil {
+		return nil, err
+	}
+	return &syslogSink{w: w}, nil
+}
+
+func (s *syslogSink) write(line []byte) error {
+	// Swallow errors: syslog is ancillary. Returning nil keeps it from
+	// tripping strict-mode fatal handling.
+	_ = s.w.Notice(string(line))
+	return nil
+}
+
+func (s *syslogSink) close() error {
+	if s.w == nil {
+		return nil
+	}
+	err := s.w.Close()
+	s.w = nil
+	return err
+}

--- a/internal/audit/sink_syslog_windows.go
+++ b/internal/audit/sink_syslog_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package audit
+
+import "fmt"
+
+// syslogSink is unavailable on Windows; openSyslogSink always errors so the
+// constructor logs a warning and continues with the file sink only.
+type syslogSink struct{}
+
+func openSyslogSink() (*syslogSink, error) {
+	return nil, fmt.Errorf("audit: syslog not supported on windows")
+}
+
+func (s *syslogSink) write(line []byte) error { return nil }
+func (s *syslogSink) close() error            { return nil }

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+// auditFlags carries the CLI-level audit switches shared by start and serve.
+type auditFlags struct {
+	logPath string // --audit-log ("" = use config/default)
+	disable bool   // --no-audit
+	strict  bool   // --audit-strict
+}
+
+// resolveAuditConfig merges the launcher config's audit block with the CLI
+// flags (precedence: flag > config > default) into an audit.Config, and
+// enforces the --no-audit + --audit-strict misuse rule.
+//
+// mode/version/secretValues/fatal are supplied by the caller (they differ
+// between start and serve). Returns the config and an error string for the
+// misuse case (empty when OK).
+func resolveAuditConfig(cfg config.AuditConfig, fl auditFlags, mode audit.Mode, version string, secretValues []string, fatal func(error)) (audit.Config, string) {
+	if fl.disable && fl.strict {
+		return audit.Config{}, "--no-audit cannot be combined with --audit-strict"
+	}
+
+	enabled := cfg.AuditEnabled()
+	if fl.disable {
+		enabled = false
+	}
+
+	path := cfg.Path
+	if fl.logPath != "" {
+		path = fl.logPath
+	}
+
+	strict := cfg.Strict || fl.strict
+
+	return audit.Config{
+		Enabled:      enabled,
+		Path:         path,
+		Syslog:       cfg.Syslog,
+		Strict:       strict,
+		Mode:         mode,
+		Version:      version,
+		SecretValues: secretValues,
+		Fatal:        fatal,
+	}, ""
+}
+
+// newAuditor builds the Auditor from a resolved audit.Config. On a
+// non-strict open failure it warns and falls back to the no-op auditor so
+// the run proceeds; on a strict open failure it returns the error so the
+// caller can abort before launching the inner command.
+func newAuditor(env *Env, ac audit.Config) (audit.Auditor, error) {
+	a, err := audit.New(ac)
+	if err != nil {
+		if ac.Strict {
+			return nil, err
+		}
+		fmt.Fprintf(env.Stderr, "[warn] audit log unavailable (%v); continuing without an audit trail\n", err)
+		return audit.Nop(), nil
+	}
+	return a, nil
+}

--- a/internal/cli/audit_integration_test.go
+++ b/internal/cli/audit_integration_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+// readAuditEvents decodes a JSONL audit file into generic maps.
+func readAuditEvents(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open audit log: %v", err)
+	}
+	defer f.Close()
+	var out []map[string]any
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		if len(sc.Bytes()) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(sc.Bytes(), &m); err != nil {
+			t.Fatalf("audit line not valid JSON: %v", err)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// TestServeControlMutationsAudited drives activate/reload/deactivate on a
+// serveServer whose auditor writes to a temp file, then asserts the
+// control.mutation and route.state events appear with monotonic seq and a
+// hashed (never raw) dir-token namespace. (Task 5.1 + 5.3.)
+func TestServeControlMutationsAudited(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	a, err := audit.New(audit.Config{Enabled: true, Path: logPath, Mode: audit.ModeServe})
+	if err != nil {
+		t.Fatalf("audit.New: %v", err)
+	}
+
+	s := newServeServerForTest(t)
+	s.auditor = a
+
+	wd := t.TempDir()
+	stageSkillWithSecret(t, wd, "slack") // pending-credentials => route.state
+
+	if _, err := s.activate(wd); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	// capture the minted dir-token so we can assert it never leaks.
+	s.mu.RLock()
+	token := s.dirs[wd].Token
+	s.mu.RUnlock()
+
+	// Drive a reload and a deactivate via the handlers' underlying methods.
+	s.deactivate(wd)
+	s.aud().Emit(audit.ControlMutation("deactivate", wd, "ok")) // handler path
+
+	_ = a.Close()
+
+	// The raw token must never appear anywhere in the log.
+	raw, _ := os.ReadFile(logPath)
+	if token != "" && strings.Contains(string(raw), token) {
+		t.Fatalf("dir-token leaked into audit log")
+	}
+
+	evs := readAuditEvents(t, logPath)
+	if len(evs) == 0 {
+		t.Fatalf("no audit events written")
+	}
+	// seq strictly increasing by 1, shared run_id.
+	runID, _ := evs[0]["run_id"].(string)
+	for i, ev := range evs {
+		if got := int(ev["seq"].(float64)); got != i+1 {
+			t.Fatalf("event %d seq = %d, want %d", i, got, i+1)
+		}
+		if ev["run_id"].(string) != runID {
+			t.Fatalf("run_id changed within run")
+		}
+	}
+	// A route.state event should exist for the pending-credentials skill,
+	// with a hashed namespace.
+	var sawRouteState bool
+	for _, ev := range evs {
+		if ev["type"] == "route.state" {
+			sawRouteState = true
+			ns, _ := ev["namespace"].(string)
+			if ns != "" && !strings.HasPrefix(ns, "ns_") {
+				t.Fatalf("route.state namespace not hashed: %q", ns)
+			}
+		}
+	}
+	if !sawRouteState {
+		t.Fatalf("expected a route.state event for the pending-credentials skill")
+	}
+}
+
+// TestNoAuditStrictMisuseStart asserts --no-audit + --audit-strict is
+// rejected as a misuse error by the launch pipeline. (Task 5.5.)
+func TestNoAuditStrictMisuseStart(t *testing.T) {
+	isolateHome(t)
+	env := makeEnv(t.TempDir())
+	code := runLaunch(env, launchOpts{
+		label:       "start",
+		harness:     config.DefaultHarness(),
+		noAudit:     true,
+		auditStrict: true,
+	})
+	if code != ExitMisuse {
+		t.Fatalf("want ExitMisuse (%d) for --no-audit+--audit-strict, got %d", ExitMisuse, code)
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/facade"
 	"github.com/tngtech/oh-my-agentic-coder/internal/keychain"
@@ -55,6 +56,9 @@ func runServe(args []string, env *Env) int {
 		verbose          = fs.Bool("verbose", false, "Verbose lifecycle logging.")
 		forDesktop       = fs.Bool("for-opencode-desktop", false, "Grant every project worktree from the local OpenCode state (Desktop projects) read+write in the sandbox.")
 		learn            = fs.Bool("learn", false, "Learn mode: do not restrict filesystem access; record folders used and offer to add them to the sandbox profile at session end.")
+		auditLog         = fs.String("audit-log", "", "Path to the audit log (default: persistent central location). Overrides config.")
+		noAudit          = fs.Bool("no-audit", false, "Disable the security audit trail.")
+		auditStrict      = fs.Bool("audit-strict", false, "Fail-closed: abort if the audit log cannot be written.")
 	)
 	var roots multiFlag
 	fs.Var(&roots, "root", "Pre-declared root directory under which projects may be activated (§5.4 Option B). Repeatable. Empty = allow any directory.")
@@ -138,12 +142,41 @@ func runServe(args []string, env *Env) int {
 		absRoots = append(absRoots, ar)
 	}
 
+	if *noAudit && *auditStrict {
+		fmt.Fprintln(env.Stderr, "omac serve: --no-audit cannot be combined with --audit-strict")
+		return ExitMisuse
+	}
+
 	rtDir, err := createRuntimeDirServe(env.Workdir)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve: runtime dir:", err)
 		return ExitIOError
 	}
 	socketPath := filepath.Join(rtDir, "bridge.sock")
+
+	// Audit trail (persistent central path; NOT rtDir). Constructed before
+	// the inner command launches. In serve there is no set of pre-resolved
+	// secret values at this point (skills are brought up lazily), so the
+	// redactor's value-matching is seeded empty; secret NAMES are still
+	// always logged and never values, and namespaces are always hashed.
+	var auditFatal func(error) // assigned once sup/facade exist
+	auditCfg, auditMisuse := resolveAuditConfig(lc.Audit, auditFlags{
+		logPath: *auditLog, disable: *noAudit, strict: *auditStrict,
+	}, audit.ModeServe, env.Version, nil, func(err error) {
+		if auditFatal != nil {
+			auditFatal(err)
+		}
+	})
+	if auditMisuse != "" {
+		fmt.Fprintln(env.Stderr, "omac serve: "+auditMisuse)
+		return ExitMisuse
+	}
+	auditor, aerr := newAuditor(env, auditCfg)
+	if aerr != nil {
+		fmt.Fprintln(env.Stderr, "omac serve: audit:", aerr)
+		return ExitIOError
+	}
+	defer auditor.Close()
 
 	// Per-session sandbox temp dir exported as TMPDIR; the nono profile
 	// grants RW on it via {{tmpdir}} so Bun-built harnesses (opencode) can
@@ -158,7 +191,7 @@ func runServe(args []string, env *Env) int {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sup := supervisor.New(lc.Facade.BaseEnvPassthrough)
+	sup := supervisor.New(lc.Facade.BaseEnvPassthrough, auditor)
 	defer sup.ShutdownAll(5 * time.Second)
 
 	f := facade.New(
@@ -170,6 +203,7 @@ func runServe(args []string, env *Env) int {
 		filepath.Join(rtDir, "logs", "facade.log"),
 		env.Version,
 	)
+	f.SetAuditor(auditor)
 	if err := f.Start(ctx); err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve: facade:", err)
 		return ExitIOError
@@ -181,6 +215,7 @@ func runServe(args []string, env *Env) int {
 		harness:       harness,
 		facade:        f,
 		sup:           sup,
+		auditor:       auditor,
 		ctx:           ctx,
 		rtDir:         rtDir,
 		sandboxTmp:    sandboxTmp,
@@ -254,8 +289,10 @@ func runServe(args []string, env *Env) int {
 
 	// --no-inner: run the control plane only (testing / headless drivers).
 	if *noInner {
+		auditor.Emit(audit.SessionStart(env.Version, harness.Name, profName, ""))
 		fmt.Fprintf(env.Stdout, "OMAC_CONTROL_BASE=%s\n", controlURL)
 		<-ctx.Done()
+		auditor.Emit(audit.SessionStop(ExitOK))
 		return ExitOK
 	}
 
@@ -345,6 +382,15 @@ func runServe(args []string, env *Env) int {
 		// Grant the selected harness's runtime dirs (config, state,
 		// sessions) read+write — only for the selected harness.
 		argv = injectSandboxDirs(argv, harness.SandboxDirs)
+		// Pass the resolved audit path to `omac sandbox run` so its
+		// network-filter subprocess appends net.decision events to the
+		// same persistent log. Inherit the parent's run_id + mode so the
+		// subprocess's events correlate with the parent's.
+		if ap := audit.EffectivePath(auditCfg); ap != "" {
+			argv = injectSandboxFlag(argv, "--audit-log", ap)
+			argv = injectSandboxFlag(argv, "--audit-run-id", auditor.RunID())
+			argv = injectSandboxFlag(argv, "--audit-mode", string(auditCfg.Mode))
+		}
 		// --for-opencode-desktop: grant every project worktree OpenCode
 		// knows about. The kernel sandbox cannot grow after launch, so
 		// folders opened for the first time during this session still
@@ -383,11 +429,28 @@ func runServe(args []string, env *Env) int {
 	// exits; the deferred facade/supervisor/control teardown then runs
 	// (§5.3). The onReady hook is where any post-launch work would go; the
 	// control plane is already up, so it's a no-op marker here.
+	// Wire the strict-mode fatal handler now that sup/facade/control exist.
+	auditFatal = func(ferr error) {
+		fmt.Fprintln(env.Stderr, "omac serve: audit (strict) write failed, aborting:", ferr)
+		sup.ShutdownAll(5 * time.Second)
+		_ = f.Close()
+		httpSrv.Close()
+		os.Exit(ExitIOError)
+	}
+	sandboxed := !*noSandbox && !*noInner
+	backend := ""
+	if sandboxed {
+		backend = profName
+	}
+	auditor.Emit(audit.SessionStart(env.Version, harness.Name, profName, backend))
+	auditor.Emit(audit.InnerExec(argv, profName, sandboxed))
+
 	code, err := sandbox.ExecWithReady(argv, extra, func() {
 		if *verbose {
 			fmt.Fprintln(env.Stderr, "[verbose] inner command started; control plane live")
 		}
 	})
+	auditor.Emit(audit.SessionStop(code))
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve: exec:", err)
 		return ExitSandboxAbnormal
@@ -491,6 +554,7 @@ type serveServer struct {
 	harness       config.Harness // active harness; scopes skill discovery
 	facade        *facade.Facade
 	sup           *supervisor.Supervisor
+	auditor       audit.Auditor
 	ctx           context.Context
 	rtDir         string
 	sandboxTmp    string // host temp dir granted RW + exported as TMPDIR
@@ -517,6 +581,15 @@ type serveServer struct {
 	// directory activates.
 	flatAliasMu sync.Mutex
 	flatAliases map[string]struct{}
+}
+
+// aud returns the server's auditor, or a no-op when unset (tests construct
+// serveServer directly without an auditor).
+func (s *serveServer) aud() audit.Auditor {
+	if s.auditor == nil {
+		return audit.Nop()
+	}
+	return s.auditor
 }
 
 // dirAllowed reports whether absDir may be activated under the configured
@@ -1045,6 +1118,7 @@ func (s *serveServer) bringUp(e registry.Entry, absDir, workdir, namespace, secr
 	spec := supervisor.SidecarSpec{
 		Name:             namespace + "/" + e.Name, // unique tracking key across dirs
 		SkillName:        e.Name,                   // plain name -> SIDECAR_SKILL (no slash)
+		Namespace:        namespace,                // audit only (hashed)
 		SkillDir:         absDir,
 		Command:          m.Sidecar.Command,
 		EnvPassthrough:   m.Sidecar.EnvPassthrough,
@@ -1163,6 +1237,11 @@ func (s *serveServer) installRoute(sr *skillRoute, port int) {
 		State:        sr.State,
 		Detail:       sr.Detail,
 	})
+	// Audit a route entering a non-ready state (pending-credentials or
+	// broken). Ready routes are covered by process.exec/facade.request.
+	if sr.State != facade.RouteReady {
+		s.aud().Emit(audit.RouteStateEvent(sr.Name, sr.Namespace, string(sr.State), sr.Detail))
+	}
 }
 
 // refreshSingleDirAliases maintains the §5.5 single-directory compatibility
@@ -1297,9 +1376,11 @@ func (s *serveServer) handleReloadGlobal(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	if err := s.reloadGlobals(); err != nil {
+		s.aud().Emit(audit.ControlMutation("reload-global", "", "error: "+err.Error()))
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	s.aud().Emit(audit.ControlMutation("reload-global", "", "ok"))
 	s.handleGlobal(w, r) // respond with the refreshed global list
 }
 
@@ -1336,9 +1417,11 @@ func (s *serveServer) handleActivate(w http.ResponseWriter, r *http.Request) {
 	}
 	manifest, err := s.activate(abs)
 	if err != nil {
+		s.aud().Emit(audit.ControlMutation("activate", abs, "error: "+err.Error()))
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
+	s.aud().Emit(audit.ControlMutation("activate", abs, "ok"))
 	writeJSON(w, http.StatusOK, manifest)
 }
 
@@ -1353,6 +1436,7 @@ func (s *serveServer) handleDeactivate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.deactivate(abs)
+	s.aud().Emit(audit.ControlMutation("deactivate", abs, "ok"))
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deactivated", "dir": abs})
 }
 
@@ -1371,9 +1455,11 @@ func (s *serveServer) handleReload(w http.ResponseWriter, r *http.Request) {
 	s.deactivate(abs)
 	manifest, err := s.activate(abs)
 	if err != nil {
+		s.aud().Emit(audit.ControlMutation("reload", abs, "error: "+err.Error()))
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
+	s.aud().Emit(audit.ControlMutation("reload", abs, "ok"))
 	writeJSON(w, http.StatusOK, manifest)
 }
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/facade"
 	"github.com/tngtech/oh-my-agentic-coder/internal/keychain"
@@ -46,6 +47,11 @@ type launchOpts struct {
 	acceptSkillChanges bool
 	skipSecretPattern  bool
 	verbose            bool
+	// audit flags (see internal/audit). auditLog overrides the config/default
+	// path; noAudit disables; auditStrict makes an unwritable log fatal.
+	auditLog    string
+	noAudit     bool
+	auditStrict bool
 	// sessionID, when non-empty, selects a specific session to continue by id
 	// (`omac continue -s <id>`). Empty means "most recent" (the default).
 	sessionID string
@@ -70,6 +76,9 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 		acceptSkillChanges = fs.Bool("accept-skill-changes", false, "Tolerate bundle_hash drift in registered skills (proceed even if the on-disk skill differs from what was registered).")
 		skipSecretPattern  = fs.Bool("skip-secret-pattern", false, "Do not enforce a secret's pattern against an env_passthrough-supplied value (escape hatch for an outdated pattern; the raw value is still passed through).")
 		verbose            = fs.Bool("verbose", false, "Verbose lifecycle logging.")
+		auditLog           = fs.String("audit-log", "", "Path to the audit log (default: persistent central location). Overrides config.")
+		noAudit            = fs.Bool("no-audit", false, "Disable the security audit trail.")
+		auditStrict        = fs.Bool("audit-strict", false, "Fail-closed: abort if the audit log cannot be written.")
 		sessionID          = fs.String("session", "", "Continue a specific session by id instead of the most recent one. (shorthand: -s)")
 	)
 	// -s is the documented shorthand for --session (opencode mirrors this
@@ -118,6 +127,9 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 		acceptSkillChanges: *acceptSkillChanges,
 		skipSecretPattern:  *skipSecretPattern,
 		verbose:            *verbose,
+		auditLog:           *auditLog,
+		noAudit:            *noAudit,
+		auditStrict:        *auditStrict,
 		sessionID:          *sessionID,
 		innerArgs:          innerArgs,
 	}, true
@@ -166,6 +178,12 @@ func runLaunch(env *Env, opts launchOpts) int {
 		label = "start"
 	}
 	prefix := "omac " + label
+
+	// Reject the audit misuse combination up front (before any work).
+	if opts.noAudit && opts.auditStrict {
+		fmt.Fprintln(env.Stderr, prefix+": --no-audit cannot be combined with --audit-strict")
+		return ExitMisuse
+	}
 
 	// 1. Load launcher config.
 	lc, cfgPath, err := config.LoadLauncher(env.Workdir)
@@ -565,6 +583,42 @@ func runLaunch(env *Env, opts launchOpts) int {
 	}
 	socketPath := filepath.Join(rtDir, "bridge.sock")
 
+	// 4a. Construct the audit trail BEFORE launching the inner command.
+	//
+	// The log lives at a persistent, central path (audit.DefaultPath) that
+	// survives restarts — NOT the per-run rtDir. Under --audit-strict a
+	// failure to open/write is fatal: fatalTeardown runs the same cleanup
+	// the deferred teardowns do and exits non-zero. We collect the resolved
+	// secret VALUES to seed the redactor (belt-and-suspenders; secret names
+	// are always logged, values never).
+	var secretValues []string
+	for _, s := range armed {
+		for _, sec := range s.secrets {
+			secretValues = append(secretValues, sec.ExposeString())
+		}
+	}
+	// fatalTeardown is assigned its real body once sup/facade/control exist;
+	// until then a strict write failure (only possible after those are up)
+	// cannot occur, but we default it to a plain exit for safety.
+	var fatalTeardown func(error)
+	auditCfg, misuse := resolveAuditConfig(lc.Audit, auditFlags{
+		logPath: opts.auditLog, disable: opts.noAudit, strict: opts.auditStrict,
+	}, audit.ModeStart, env.Version, secretValues, func(err error) {
+		if fatalTeardown != nil {
+			fatalTeardown(err)
+		}
+	})
+	if misuse != "" {
+		fmt.Fprintln(env.Stderr, prefix+": "+misuse)
+		return ExitMisuse
+	}
+	auditor, aerr := newAuditor(env, auditCfg)
+	if aerr != nil {
+		fmt.Fprintln(env.Stderr, prefix+": audit:", aerr)
+		return ExitIOError
+	}
+	defer auditor.Close()
+
 	// Per-session sandbox temp dir. Bun-built harnesses (opencode) extract
 	// an embedded runtime into TMPDIR at startup; the sandbox must grant
 	// read+write on it (the nono profile does, via {{tmpdir}}) AND the inner
@@ -581,7 +635,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	}
 
 	// 5. Spawn sidecars.
-	sup := supervisor.New(lc.Facade.BaseEnvPassthrough)
+	sup := supervisor.New(lc.Facade.BaseEnvPassthrough, auditor)
 	defer func() {
 		if !keepRunning {
 			sup.ShutdownAll(5 * time.Second)
@@ -650,6 +704,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 		filepath.Join(rtDir, "logs", "facade.log"),
 		env.Version,
 	)
+	f.SetAuditor(auditor)
 	if err := f.Start(ctx); err != nil {
 		fmt.Fprintln(env.Stderr, prefix+": facade:", err)
 		return ExitIOError
@@ -722,6 +777,16 @@ func runLaunch(env *Env, opts launchOpts) int {
 		// sessions) read+write — only for the selected harness, not all
 		// harnesses.
 		argv = injectSandboxDirs(argv, harness.SandboxDirs)
+		// Pass the resolved audit path down to `omac sandbox run` so the
+		// network-filter subprocess appends net.decision events to the
+		// same persistent log. Inherit the parent's run_id + mode so the
+		// subprocess's events correlate with the parent's (same run_id,
+		// continuing seq).
+		if ap := audit.EffectivePath(auditCfg); ap != "" {
+			argv = injectSandboxFlag(argv, "--audit-log", ap)
+			argv = injectSandboxFlag(argv, "--audit-run-id", auditor.RunID())
+			argv = injectSandboxFlag(argv, "--audit-mode", string(auditCfg.Mode))
+		}
 	}
 	if verbose {
 		fmt.Fprintf(env.Stderr, "[verbose] sandbox argv: %v\n", argv)
@@ -778,7 +843,32 @@ func runLaunch(env *Env, opts launchOpts) int {
 		}
 	}
 
+	// Now that the supervisor, facade, and control plane exist, give the
+	// strict-mode fatal handler a real teardown: stop sidecars, close the
+	// facade + control plane, then exit non-zero. A strict-mode audit write
+	// failure mid-run lands here.
+	fatalTeardown = func(ferr error) {
+		fmt.Fprintln(env.Stderr, prefix+": audit (strict) write failed, aborting:", ferr)
+		if !keepRunning {
+			sup.ShutdownAll(5 * time.Second)
+		}
+		_ = f.Close()
+		closeControl()
+		os.Exit(ExitIOError)
+	}
+
+	// session.start is emitted just before the inner command launches. In
+	// strict mode a failure to write it invokes fatalTeardown above.
+	sandboxed := !noSandbox
+	sandboxBackend := ""
+	if sandboxed {
+		sandboxBackend = profName
+	}
+	auditor.Emit(audit.SessionStart(env.Version, harness.Name, profName, sandboxBackend))
+	auditor.Emit(audit.InnerExec(argv, profName, sandboxed))
+
 	code, err := sandbox.ExecWithReady(argv, extra, nil)
+	auditor.Emit(audit.SessionStop(code))
 	if err != nil {
 		fmt.Fprintln(env.Stderr, prefix+": exec:", err)
 		return ExitSandboxAbnormal

--- a/internal/config/launcher.go
+++ b/internal/config/launcher.go
@@ -19,7 +19,23 @@ import (
 type LauncherConfig struct {
 	Sandbox SandboxConfig `yaml:"sandbox" json:"sandbox"`
 	Facade  FacadeConfig  `yaml:"facade"  json:"facade"`
+	Audit   AuditConfig   `yaml:"audit"   json:"audit"`
 }
+
+// AuditConfig controls the security audit trail (see internal/audit).
+//
+// Enabled defaults to true. Because Go's zero value for a bool is false,
+// the field is a *bool so "unset in YAML" (nil) can be distinguished from
+// an explicit `enabled: false`; mergeDefaults fills nil with true.
+type AuditConfig struct {
+	Enabled *bool  `yaml:"enabled" json:"enabled"`
+	Path    string `yaml:"path"    json:"path"`   // "" => audit.DefaultPath()
+	Syslog  bool   `yaml:"syslog"  json:"syslog"` // mirror to system log (Unix)
+	Strict  bool   `yaml:"strict"  json:"strict"` // fail-closed on write failure
+}
+
+// AuditEnabled reports whether auditing is on, treating unset as true.
+func (a AuditConfig) AuditEnabled() bool { return a.Enabled == nil || *a.Enabled }
 
 // SandboxConfig declares named sandbox profiles.
 type SandboxConfig struct {
@@ -231,8 +247,16 @@ func defaultLauncherConfigFor(h Harness) LauncherConfig {
 			MaxBodyBytes:       10 * 1024 * 1024,
 			BaseEnvPassthrough: []string{"PATH", "HOME", "USER", "LANG", "LC_ALL", "LC_CTYPE", "TMPDIR"},
 		},
+		Audit: AuditConfig{
+			Enabled: boolPtr(true),
+			Path:    "", // audit.DefaultPath() (persistent central location)
+			Syslog:  false,
+			Strict:  false,
+		},
 	}
 }
+
+func boolPtr(b bool) *bool { return &b }
 
 // LoadLauncher loads the launcher config from
 // <workdir>/.opencode/oh-my-agentic-coder.yaml or, failing that,
@@ -284,6 +308,11 @@ func mergeDefaults(lc LauncherConfig) LauncherConfig {
 	}
 	if lc.Facade.BaseEnvPassthrough == nil {
 		lc.Facade.BaseEnvPassthrough = def.Facade.BaseEnvPassthrough
+	}
+	// Audit defaults on when the block is unset. An explicit
+	// `enabled: false` is preserved (that's why Enabled is a *bool).
+	if lc.Audit.Enabled == nil {
+		lc.Audit.Enabled = def.Audit.Enabled
 	}
 	return lc
 }

--- a/internal/config/launcher_audit_test.go
+++ b/internal/config/launcher_audit_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultAuditEnabled(t *testing.T) {
+	lc := DefaultLauncherConfig()
+	if !lc.Audit.AuditEnabled() {
+		t.Fatalf("audit should default to enabled")
+	}
+	if lc.Audit.Strict || lc.Audit.Syslog || lc.Audit.Path != "" {
+		t.Fatalf("unexpected non-default audit values: %+v", lc.Audit)
+	}
+}
+
+func TestLoadLauncherAuditExplicitDisable(t *testing.T) {
+	dir := t.TempDir()
+	ocDir := filepath.Join(dir, ".opencode")
+	if err := os.MkdirAll(ocDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := `audit:
+  enabled: false
+  path: /var/log/omac/audit.jsonl
+  syslog: true
+  strict: true
+`
+	if err := os.WriteFile(filepath.Join(ocDir, "oh-my-agentic-coder.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lc, _, err := LoadLauncher(dir)
+	if err != nil {
+		t.Fatalf("LoadLauncher: %v", err)
+	}
+	if lc.Audit.AuditEnabled() {
+		t.Fatalf("explicit enabled:false must be preserved")
+	}
+	if lc.Audit.Path != "/var/log/omac/audit.jsonl" || !lc.Audit.Syslog || !lc.Audit.Strict {
+		t.Fatalf("audit fields not parsed: %+v", lc.Audit)
+	}
+}
+
+func TestLoadLauncherAuditUnsetDefaultsOn(t *testing.T) {
+	dir := t.TempDir()
+	ocDir := filepath.Join(dir, ".opencode")
+	if err := os.MkdirAll(ocDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Config present but with no audit block: audit should default on.
+	yaml := "facade:\n  idle_timeout_secs: 60\n"
+	if err := os.WriteFile(filepath.Join(ocDir, "oh-my-agentic-coder.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lc, _, err := LoadLauncher(dir)
+	if err != nil {
+		t.Fatalf("LoadLauncher: %v", err)
+	}
+	if !lc.Audit.AuditEnabled() {
+		t.Fatalf("unset audit block should default to enabled")
+	}
+}

--- a/internal/facade/facade.go
+++ b/internal/facade/facade.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
 )
 
 // RouteState describes whether a route forwards to a live sidecar or
@@ -126,6 +128,12 @@ type Facade struct {
 	AccessLogPath string
 	Version       string
 
+	// Auditor, when set, receives a facade.request event per proxied
+	// request (namespace hashed). Set via SetAuditor after New; nil means
+	// the legacy AccessLogPath file is the only sink. Never nil at Emit
+	// time (guarded in logAccess).
+	auditor audit.Auditor
+
 	mu          sync.RWMutex
 	routes      map[string]*Route
 	server      *http.Server
@@ -161,6 +169,14 @@ func New(socketPath, tcpAddr string, routes []Route, maxBody int64, idle time.Du
 // TCPPort returns the bound TCP port (after Start). Zero means TCP is
 // disabled or not yet bound.
 func (f *Facade) TCPPort() int { return f.boundTCPort }
+
+// SetAuditor installs the audit sink for facade.request events. Safe to
+// call before Start. Passing nil is a no-op.
+func (f *Facade) SetAuditor(a audit.Auditor) {
+	if a != nil {
+		f.auditor = a
+	}
+}
 
 // AddRoute installs (or replaces) a route at runtime. Safe to call after
 // Start and from multiple goroutines. Used by serve mode to mount a
@@ -596,6 +612,13 @@ func (f *Facade) proxyUpgrade(w http.ResponseWriter, r *http.Request, route *Rou
 }
 
 func (f *Facade) logAccess(r *http.Request, route *Route, rest string, status int, bytes int64, dur time.Duration) {
+	// Audit sink: one facade.request event per request, with the namespace
+	// hashed by the auditor (a secret dir-token must never be written).
+	if f.auditor != nil {
+		f.auditor.Emit(audit.FacadeRequest(
+			r.Method, route.Mount, route.Namespace, "/"+rest,
+			status, bytes, dur.Milliseconds()))
+	}
 	if f.accLog == nil {
 		return
 	}

--- a/internal/netproxy/filter.go
+++ b/internal/netproxy/filter.go
@@ -16,6 +16,8 @@ import (
 	"net/netip"
 	"strings"
 	"sync"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
 )
 
 // Decision is the outcome of a filter check.
@@ -28,10 +30,14 @@ const (
 	Allow
 )
 
-// Verdict carries the decision and the reason for logging.
+// Verdict carries the decision, the reason for logging, and the scope +
+// persisted flag for audit. Scope and Persisted are only meaningful for
+// prompt decisions; non-prompt verdicts leave them empty.
 type Verdict struct {
-	Decision Decision
-	Reason   string // e.g. "hard-deny metadata", "deny_domain", "allowlist", "prompt:allow_once"
+	Decision  Decision
+	Reason    string // e.g. "hard-deny metadata", "deny_domain", "allowlist", "prompt:allow_once"
+	Scope     string // once|host|suffix (prompt decisions only)
+	Persisted bool   // true when the decision was persisted (prompt decisions only)
 }
 
 // hardDenyHosts can never be allowed, even interactively (nono parity).
@@ -86,6 +92,9 @@ type FilterConfig struct {
 	// Logf receives one line per decision; nil discards.
 	Logf func(format string, args ...any)
 
+	// Auditor receives a net.decision event per decision. nil => no-op.
+	Auditor audit.Auditor
+
 	// onCoalesceWait, when non-nil, is called just before a request blocks
 	// on an in-flight prompt for the same host (the coalescing path). It is
 	// a test seam that lets a test deterministically observe that all
@@ -119,6 +128,9 @@ func NewFilter(cfg FilterConfig) *Filter {
 	if cfg.Logf == nil {
 		cfg.Logf = func(string, ...any) {}
 	}
+	if cfg.Auditor == nil {
+		cfg.Auditor = audit.Nop()
+	}
 	return &Filter{cfg: cfg, inflight: map[string]*promptWait{}}
 }
 
@@ -137,11 +149,11 @@ func (f *Filter) Check(ctx context.Context, host string, port int) (Verdict, []n
 
 	// 1. Hard denies. Never promptable.
 	if hardDenyHosts[h] {
-		return f.log(h, port, Verdict{Deny, "hard-deny metadata host"}), nil
+		return f.log(h, port, Verdict{Decision: Deny, Reason: "hard-deny metadata host"}), nil
 	}
 	if ip, err := netip.ParseAddr(h); err == nil {
 		if isLinkLocal(ip) {
-			return f.log(h, port, Verdict{Deny, "hard-deny link-local address"}), nil
+			return f.log(h, port, Verdict{Decision: Deny, Reason: "hard-deny link-local address"}), nil
 		}
 		if v := f.checkRules(h); v != nil {
 			return f.log(h, port, *v), []netip.Addr{ip}
@@ -149,18 +161,18 @@ func (f *Filter) Check(ctx context.Context, host string, port int) (Verdict, []n
 		if v, ok := f.defaultDecision(h, port); ok {
 			return f.log(h, port, v), []netip.Addr{ip}
 		}
-		return f.log(h, port, Verdict{Deny, "default deny"}), nil
+		return f.log(h, port, Verdict{Decision: Deny, Reason: "default deny"}), nil
 	}
 
 	// Resolve once; pin results (anti-rebinding).
 	addrs, err := f.cfg.Resolve(ctx, h)
 	if err != nil || len(addrs) == 0 {
-		return f.log(h, port, Verdict{Deny, "dns resolution failed"}), nil
+		return f.log(h, port, Verdict{Decision: Deny, Reason: "dns resolution failed"}), nil
 	}
 	safe := addrs[:0:0]
 	for _, a := range addrs {
 		if isLinkLocal(a) {
-			return f.log(h, port, Verdict{Deny, "hard-deny: resolves to link-local"}), nil
+			return f.log(h, port, Verdict{Decision: Deny, Reason: "hard-deny: resolves to link-local"}), nil
 		}
 		safe = append(safe, a)
 	}
@@ -180,7 +192,7 @@ func (f *Filter) Check(ctx context.Context, host string, port int) (Verdict, []n
 		}
 		return f.log(h, port, v), safe
 	}
-	return f.log(h, port, Verdict{Deny, "default deny"}), nil
+	return f.log(h, port, Verdict{Decision: Deny, Reason: "default deny"}), nil
 }
 
 // checkRules evaluates learned-deny, deny_domain, allow_domain and
@@ -188,18 +200,18 @@ func (f *Filter) Check(ctx context.Context, host string, port int) (Verdict, []n
 func (f *Filter) checkRules(host string) *Verdict {
 	if f.cfg.Learned != nil {
 		if allow, found := f.cfg.Learned.Lookup(host); found && !allow {
-			return &Verdict{Deny, "learned permanent deny"}
+			return &Verdict{Decision: Deny, Reason: "learned permanent deny", Persisted: true}
 		}
 	}
 	if matchDomainList(host, f.cfg.DenyDomains) {
-		return &Verdict{Deny, "deny_domain"}
+		return &Verdict{Decision: Deny, Reason: "deny_domain"}
 	}
 	if matchDomainList(host, f.cfg.AllowDomains) {
-		return &Verdict{Allow, "allow_domain"}
+		return &Verdict{Decision: Allow, Reason: "allow_domain"}
 	}
 	if f.cfg.Learned != nil {
 		if allow, found := f.cfg.Learned.Lookup(host); found && allow {
-			return &Verdict{Allow, "learned permanent allow"}
+			return &Verdict{Decision: Allow, Reason: "learned permanent allow", Persisted: true}
 		}
 	}
 	return nil
@@ -212,9 +224,9 @@ func (f *Filter) defaultDecision(host string, port int) (Verdict, bool) {
 		res, prompted := f.promptCoalesced(host, port)
 		if !prompted {
 			if f.cfg.OnUnavailableAllow {
-				return Verdict{Allow, "prompt unavailable: on_unavailable=allow"}, true
+				return Verdict{Decision: Allow, Reason: "prompt unavailable: on_unavailable=allow"}, true
 			}
-			return Verdict{Deny, "prompt unavailable: on_unavailable=deny"}, true
+			return Verdict{Decision: Deny, Reason: "prompt unavailable: on_unavailable=deny"}, true
 		}
 		if res.Persist && f.cfg.Learned != nil {
 			target := host
@@ -225,16 +237,20 @@ func (f *Filter) defaultDecision(host string, port int) (Verdict, bool) {
 				f.cfg.Logf("omac sandbox: warning: persist learned decision: %v", err)
 			}
 		}
-		if res.Allow {
-			return Verdict{Allow, "prompt:allow"}, true
+		scope := res.Scope
+		if !res.Persist {
+			scope = "once"
 		}
-		return Verdict{Deny, "prompt:deny"}, true
+		if res.Allow {
+			return Verdict{Decision: Allow, Reason: "prompt:allow", Scope: scope, Persisted: res.Persist}, true
+		}
+		return Verdict{Decision: Deny, Reason: "prompt:deny", Scope: scope, Persisted: res.Persist}, true
 	}
 	if len(f.cfg.AllowDomains) > 0 {
-		return Verdict{Deny, "not in allowlist"}, true
+		return Verdict{Decision: Deny, Reason: "not in allowlist"}, true
 	}
 	// Pure blocklist (or no rules at all): allow.
-	return Verdict{Allow, "default allow (blocklist mode)"}, true
+	return Verdict{Decision: Allow, Reason: "default allow (blocklist mode)"}, true
 }
 
 // promptCoalesced ensures concurrent requests for the same host share
@@ -271,7 +287,38 @@ func (f *Filter) log(host string, port int, v Verdict) Verdict {
 		word = "ALLOW"
 	}
 	f.cfg.Logf("omac sandbox: net %s %s:%d (%s)", word, host, port, v.Reason)
+	source := classifyReason(v.Reason)
+	scope := v.Scope
+	persisted := v.Persisted
+	f.cfg.Auditor.Emit(audit.NetDecision(host, port, v.Decision == Allow, scope, source, persisted))
 	return v
+}
+
+// classifyReason maps a Verdict.Reason to the audit source field. Scope and
+// persisted are taken from the Verdict (set by defaultDecision for prompt
+// decisions) rather than derived here, so the prompt's actual scope/persist
+// propagate to the audit event.
+func classifyReason(reason string) (source string) {
+	switch {
+	case strings.HasPrefix(reason, "hard-deny"):
+		return "hard-deny"
+	case strings.HasPrefix(reason, "learned"):
+		return "learned"
+	case reason == "deny_domain":
+		return "blocklist"
+	case reason == "allow_domain":
+		return "allowlist"
+	case strings.HasPrefix(reason, "prompt unavailable"):
+		return "unavailable"
+	case strings.HasPrefix(reason, "prompt:"):
+		return "prompt"
+	case reason == "not in allowlist":
+		return "allowlist"
+	case strings.HasPrefix(reason, "dns"):
+		return "dns"
+	default:
+		return "default"
+	}
 }
 
 // matchDomainList reports whether host matches any entry. Entries are

--- a/internal/netproxy/filter_test.go
+++ b/internal/netproxy/filter_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
 )
 
 // staticResolver returns fixed addresses for every host.
@@ -291,4 +293,143 @@ func TestIPLiteralTargets(t *testing.T) {
 	})
 	check(t, f, "8.8.8.8", Allow)
 	check(t, f, "9.9.9.9", Deny)
+}
+
+// capturingAuditor collects emitted events for inspection in tests.
+type capturingAuditor struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (c *capturingAuditor) Emit(ev audit.Event) {
+	c.mu.Lock()
+	c.events = append(c.events, ev)
+	c.mu.Unlock()
+}
+func (c *capturingAuditor) Close() error  { return nil }
+func (c *capturingAuditor) RunID() string { return "test" }
+func (c *capturingAuditor) NextSeq() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return uint64(len(c.events) + 1)
+}
+
+func (c *capturingAuditor) len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.events)
+}
+
+func (c *capturingAuditor) first() audit.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.events) == 0 {
+		return audit.Event{}
+	}
+	return c.events[0]
+}
+
+// TestPromptDecisionRecordsScopeAndPersisted asserts that a prompt
+// decision with scope="host" and persist=true is recorded in the
+// net.decision audit event with those values, not the defaults ("", false).
+// Spec: "records scope (once/host/suffix) and whether the decision was
+// persisted."
+func TestPromptDecisionRecordsScopeAndPersisted(t *testing.T) {
+	aud := &capturingAuditor{}
+	p := &fakePrompter{res: PromptResult{Allow: true, Persist: true, Scope: "host"}}
+	f := NewFilter(FilterConfig{
+		PromptEnabled: true,
+		Prompter:      p,
+		Resolve:       staticResolver("93.184.216.34"),
+		Auditor:       aud,
+	})
+	v, _ := f.Check(context.Background(), "prompted.example", 443)
+	if v.Decision != Allow {
+		t.Fatalf("want Allow, got %v", v.Decision)
+	}
+	if n := aud.len(); n != 1 {
+		t.Fatalf("want 1 audit event, got %d", n)
+	}
+	ev := aud.first()
+	if ev.Type != audit.TypeNetDecision {
+		t.Fatalf("want %q, got %q", audit.TypeNetDecision, ev.Type)
+	}
+	if ev.Source != "prompt" {
+		t.Fatalf("source: want %q, got %q", "prompt", ev.Source)
+	}
+	if ev.Scope != "host" {
+		t.Fatalf("scope: want %q, got %q (prompt scope lost)", "host", ev.Scope)
+	}
+	if ev.Persisted == nil || !*ev.Persisted {
+		t.Fatalf("persisted: want true, got %v (prompt persist lost)", ev.Persisted)
+	}
+}
+
+// TestPromptOnceDecisionRecordsOnceScope asserts that a once-scoped prompt
+// decision (persist=false) is recorded with scope="once".
+func TestPromptOnceDecisionRecordsOnceScope(t *testing.T) {
+	aud := &capturingAuditor{}
+	p := &fakePrompter{res: PromptResult{Allow: true, Persist: false}}
+	f := NewFilter(FilterConfig{
+		PromptEnabled: true,
+		Prompter:      p,
+		Resolve:       staticResolver("93.184.216.34"),
+		Auditor:       aud,
+	})
+	check(t, f, "once.example", Allow)
+	ev := aud.first()
+	if ev.Scope != "once" {
+		t.Fatalf("scope: want %q, got %q", "once", ev.Scope)
+	}
+	if ev.Persisted != nil && *ev.Persisted {
+		t.Fatalf("persisted: want false, got true")
+	}
+}
+
+// validNetDecisionSources is the set of source values the spec says
+// net.decision events may carry. classifyReason must only emit values
+// from this set.
+var validNetDecisionSources = map[string]bool{
+	"prompt":      true,
+	"learned":     true,
+	"allowlist":   true,
+	"blocklist":   true,
+	"timeout":     true,
+	"unavailable": true,
+	"hard-deny":   true,
+	"dns":         true,
+	"default":     true,
+}
+
+// TestClassifyReasonEmitsOnlySpecSources drives every Verdict.Reason
+// through classifyReason and asserts each emitted source is in the
+// documented enum. Catches drift if a new reason string is added without
+// a matching classifyReason branch (it would fall to "default", which
+// is itself a valid source, but the test also guards against typos
+// producing an unhandled source).
+func TestClassifyReasonEmitsOnlySpecSources(t *testing.T) {
+	reasons := []string{
+		"hard-deny metadata host",
+		"hard-deny link-local address",
+		"hard-deny: resolves to link-local",
+		"learned permanent deny",
+		"learned permanent allow",
+		"deny_domain",
+		"allow_domain",
+		"prompt unavailable: on_unavailable=allow",
+		"prompt unavailable: on_unavailable=deny",
+		"prompt:allow",
+		"prompt:deny",
+		"not in allowlist",
+		"dns resolution failed",
+		"default deny",
+		"default allow (blocklist mode)",
+		"some-unknown-reason",
+	}
+	for _, r := range reasons {
+		src := classifyReason(r)
+		if !validNetDecisionSources[src] {
+			t.Errorf("reason %q -> source %q not in spec enum %v", r, src, validNetDecisionSources)
+		}
+	}
 }

--- a/internal/sandboxprofile/flags.go
+++ b/internal/sandboxprofile/flags.go
@@ -25,6 +25,9 @@ type Flags struct {
 	BlockNet      bool     // --block-net
 	Learn         bool     // --learn: unrestricted fs + folder recording
 	WorkdirAccess string   // --workdir-access <level>
+	AuditLog      string   // --audit-log <path>: append net.decision events here ("" = disabled)
+	AuditRunID    string   // --audit-run-id <id>: inherit parent's run_id ("" = mint fresh)
+	AuditMode     string   // --audit-mode <start|serve>: inherit parent's mode ("" = start)
 	InnerArgv     []string // everything after --
 }
 
@@ -169,6 +172,24 @@ func ParseFlags(args []string) (*Flags, error) {
 				return nil, fmt.Errorf("--learn takes no value")
 			}
 			f.Learn = true
+		case "--audit-log":
+			v, err := val(a)
+			if err != nil {
+				return nil, err
+			}
+			f.AuditLog = v
+		case "--audit-run-id":
+			v, err := val(a)
+			if err != nil {
+				return nil, err
+			}
+			f.AuditRunID = v
+		case "--audit-mode":
+			v, err := val(a)
+			if err != nil {
+				return nil, err
+			}
+			f.AuditMode = v
 		case "--workdir-access":
 			v, err := val(a)
 			if err != nil {

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netproxy"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandbox"
@@ -76,6 +77,29 @@ func Run(opts Options) int {
 	// proxy port can land in the kernel rules.
 	injected := map[string]string{}
 
+	// Audit sink for network decisions. This subprocess is separate from
+	// the parent omac, so it opens its own append-only handle to the same
+	// persistent audit file (append-safe across processes). Non-strict
+	// here: a net-decision audit write failure must never kill the sandbox
+	// (strict is enforced by the parent's pre-launch probe). Disabled when
+	// no --audit-log path was passed down.
+	netAuditor := audit.Nop()
+	if opts.Flags.AuditLog != "" {
+		mode := audit.ModeStart
+		if opts.Flags.AuditMode == string(audit.ModeServe) {
+			mode = audit.ModeServe
+		}
+		if a, aerr := audit.New(audit.Config{
+			Enabled: true, Path: opts.Flags.AuditLog, Mode: mode, Strict: false,
+			RunID: opts.Flags.AuditRunID,
+		}); aerr != nil {
+			fmt.Fprintf(stderr, "omac sandbox: warning: audit log unavailable (%v)\n", aerr)
+		} else {
+			netAuditor = a
+			defer netAuditor.Close()
+		}
+	}
+
 	var proxy *netproxy.Server
 	if grants.NetworkMode == sandboxprofile.ModeFiltered {
 		if grants.Enforcement == sandboxprofile.EnforceEnvOnly {
@@ -83,7 +107,7 @@ func Run(opts Options) int {
 				"filtering relies on HTTP(S)_PROXY env vars only and is trivially bypassable. "+
 				"No kernel network guarantee is in effect.")
 		}
-		proxy, err = buildProxy(merged, profilePath, diag.Writer(), logf)
+		proxy, err = buildProxy(merged, profilePath, diag.Writer(), logf, netAuditor)
 		if err != nil {
 			return fail("%v", err)
 		}
@@ -125,7 +149,7 @@ func Run(opts Options) int {
 // buildProxy assembles page policy, prompter, filter and server. The
 // page policy (learned website decisions) lives next to the profile:
 // <profile>.pages.json (e.g. default.pages.json).
-func buildProxy(p *sandboxprofile.Profile, profilePath string, stderr io.Writer, logf func(string, ...any)) (*netproxy.Server, error) {
+func buildProxy(p *sandboxprofile.Profile, profilePath string, stderr io.Writer, logf func(string, ...any), auditor audit.Auditor) (*netproxy.Server, error) {
 	var learned netproxy.LearnedStore
 	pagesPath := sandboxprofile.PagesPath(profilePath)
 	lp, lerr := netprompt.LoadLearnedPolicy(pagesPath)
@@ -155,6 +179,7 @@ func buildProxy(p *sandboxprofile.Profile, profilePath string, stderr io.Writer,
 		Prompter:           prompter,
 		Learned:            learned,
 		Logf:               logf,
+		Auditor:            auditor,
 	})
 	srv, err := netproxy.NewServer(filter, logf)
 	if err != nil {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -20,11 +20,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/secrets"
 )
@@ -41,7 +43,11 @@ type SidecarSpec struct {
 	// separator, because sidecars commonly use it to build filesystem
 	// paths (e.g. tempfile prefixes). When empty, Name is used (the
 	// single-workdir `start` case, where Name is already the plain name).
-	SkillName      string
+	SkillName string
+	// Namespace is the facade namespace this sidecar is mounted under
+	// ("" flat/start, a dir token, or "__global__"). Used only for audit
+	// events (it is hashed before being written). Optional.
+	Namespace      string
 	SkillDir       string // absolute
 	Command        []string
 	EnvPassthrough []string
@@ -70,19 +76,31 @@ type Running struct {
 	Port    int
 	Cmd     *exec.Cmd
 	LogFile *os.File
+
+	// audit bookkeeping (unexported): captured at spawn so process.exit
+	// can report duration and identity when the child is terminated.
+	startedAt      time.Time
+	auditSkill     string
+	auditNamespace string
+	exitOnce       sync.Once
 }
 
 // Supervisor coordinates all sidecars.
 type Supervisor struct {
 	baseEnvPassthrough []string
+	auditor            audit.Auditor
 
 	mu       sync.Mutex
 	children []*Running
 }
 
-// New returns a fresh Supervisor.
-func New(baseEnvPassthrough []string) *Supervisor {
-	return &Supervisor{baseEnvPassthrough: baseEnvPassthrough}
+// New returns a fresh Supervisor. auditor may be nil (a no-op auditor is
+// substituted) so existing callers/tests keep working.
+func New(baseEnvPassthrough []string, auditor audit.Auditor) *Supervisor {
+	if auditor == nil {
+		auditor = audit.Nop()
+	}
+	return &Supervisor{baseEnvPassthrough: baseEnvPassthrough, auditor: auditor}
 }
 
 // StartAll starts every sidecar in specs. On any failure it terminates the
@@ -142,10 +160,50 @@ func (s *Supervisor) StopSidecar(name string, timeout time.Duration) bool {
 		return false
 	}
 	_ = terminate(target.Cmd, timeout)
-	if target.LogFile != nil {
-		_ = target.LogFile.Close()
-	}
+	s.auditExit(target) // closes LogFile via exitOnce
 	return true
+}
+
+// auditExit emits a process.exit event for a terminated child and closes
+// its log file. Safe to call once per child after terminate() has reaped
+// it. Idempotent via exitOnce: if watchChild already fired (self-terminated
+// child), this is a no-op. LogFile.Close is centralized here so the fd is
+// released exactly once regardless of which path reaps the child.
+func (s *Supervisor) auditExit(r *Running) {
+	if r == nil {
+		return
+	}
+	r.exitOnce.Do(func() {
+		code := -1
+		if r.Cmd != nil && r.Cmd.ProcessState != nil {
+			code = r.Cmd.ProcessState.ExitCode()
+		}
+		var durMS int64
+		if !r.startedAt.IsZero() {
+			durMS = time.Since(r.startedAt).Milliseconds()
+		}
+		s.auditor.Emit(audit.ProcessExit(r.auditSkill, r.auditNamespace, code, durMS))
+		if r.LogFile != nil {
+			_ = r.LogFile.Close()
+		}
+	})
+}
+
+// watchChild spawns a reaper goroutine for a sidecar. When the child
+// terminates on its own (before StopSidecar/ShutdownAll is called), the
+// reaper reaps it via cmd.Wait() and calls auditExit (which emits
+// process.exit + closes the log file) so the trail reflects actual
+// termination time, not time-to-teardown. auditExit is idempotent via
+// exitOnce: if StopSidecar/ShutdownAll later call auditExit on an
+// already-reaped child, it's a no-op.
+func (s *Supervisor) watchChild(r *Running) {
+	if r == nil || r.Cmd == nil || r.Cmd.Process == nil {
+		return
+	}
+	go func() {
+		_ = r.Cmd.Wait()
+		s.auditExit(r)
+	}()
 }
 
 // startOne allocates a port, spawns the child, and waits on health.
@@ -205,13 +263,37 @@ func (s *Supervisor) startOne(ctx context.Context, spec SidecarSpec) (*Running, 
 		}
 	}
 
+	// Audit: record the spawn (argv redacted downstream), the injected
+	// secret/config NAMES (never values), and — separately — a
+	// secret.inject event so the "which skill got which secret names"
+	// question is answerable. skillName is the plain name; namespace is
+	// hashed by the auditor.
+	skillName := spec.SkillName
+	if skillName == "" {
+		skillName = spec.Name
+	}
+	secretNames := mapKeys(spec.Secrets)
+	configNames := mapKeysStr(spec.Config)
+	s.auditor.Emit(audit.ProcessExec(skillName, spec.Namespace, spec.SkillDir, argv, secretNames, configNames))
+	if len(secretNames) > 0 || len(configNames) > 0 {
+		s.auditor.Emit(audit.SecretInject(skillName, spec.Namespace, secretNames, configNames))
+	}
+
 	r := &Running{Name: spec.Name, Port: port, Cmd: cmd, LogFile: lf}
+	// Capture audit bookkeeping for the reaper + process.exit.
+	r.startedAt = time.Now()
+	r.auditSkill = skillName
+	r.auditNamespace = spec.Namespace
 
 	if err := waitHealth(ctx, port, spec.Health); err != nil {
 		_ = terminate(cmd, 3*time.Second)
 		lf.Close()
 		return nil, fmt.Errorf("%s: health: %w", spec.Name, err)
 	}
+	// Start the reaper only after health check passes, so a sidecar that
+	// fails to start is handled by the error path (terminate + lf.Close)
+	// without the reaper racing to emit process.exit / close lf.
+	s.watchChild(r)
 	return r, nil
 }
 
@@ -283,9 +365,7 @@ func (s *Supervisor) ShutdownAll(timeout time.Duration) {
 		go func() {
 			defer wg.Done()
 			_ = terminate(r.Cmd, timeout)
-			if r.LogFile != nil {
-				_ = r.LogFile.Close()
-			}
+			s.auditExit(r) // closes LogFile via exitOnce
 		}()
 	}
 	wg.Wait()
@@ -386,6 +466,32 @@ func ensureExecutable(skillDir, exe string) {
 		return // already owner-executable
 	}
 	_ = os.Chmod(path, info.Mode()|0o100)
+}
+
+// mapKeys returns the sorted keys of a secrets map (names only).
+func mapKeys(m map[string]secrets.Secret) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// mapKeysStr returns the sorted keys of a string map.
+func mapKeysStr(m map[string]string) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // expandArgv expands ${VAR} tokens inside argv elements from vars.

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -2,10 +2,14 @@ package supervisor
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
 )
 
 // envMap turns buildEnv's []string ("K=V") into a map for assertions.
@@ -20,7 +24,7 @@ func envMap(kv []string) map[string]string {
 }
 
 func TestBuildEnvSidecarSkillIsPlainName(t *testing.T) {
-	s := New(nil)
+	s := New(nil, nil)
 
 	// SkillName set (serve mode): SIDECAR_SKILL must be the plain name,
 	// never the namespaced tracking Name (which contains a slash that
@@ -51,7 +55,7 @@ func TestBuildEnvSidecarSkillIsPlainName(t *testing.T) {
 // spawning real processes: a Running with a nil Cmd.Process terminates as a
 // no-op (terminate handles nil), so we can assert set membership directly.
 func TestStopSidecarTracking(t *testing.T) {
-	s := New(nil)
+	s := New(nil, nil)
 	s.children = []*Running{
 		{Name: "a"},
 		{Name: "b"},
@@ -112,5 +116,111 @@ func TestEnsureExecutable(t *testing.T) {
 	ensureExecutable(dir, outside)
 	if fi, _ := os.Stat(outside); fi.Mode()&0o100 != 0 {
 		t.Error("ensureExecutable touched a file outside the skill dir")
+	}
+}
+
+// capturingAuditor collects emitted events for inspection in tests.
+type capturingAuditor struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (c *capturingAuditor) Emit(ev audit.Event) {
+	c.mu.Lock()
+	c.events = append(c.events, ev)
+	c.mu.Unlock()
+}
+func (c *capturingAuditor) Close() error    { return nil }
+func (c *capturingAuditor) RunID() string   { return "test" }
+func (c *capturingAuditor) NextSeq() uint64 { return uint64(len(c.events) + 1) }
+
+func (c *capturingAuditor) countType(typ string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, ev := range c.events {
+		if ev.Type == typ {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSelfTeratingSidecarEmitsProcessExit asserts that a sidecar which
+// exits on its own (without StopSidecar/ShutdownAll being called) still
+// produces a process.exit audit event. The spec says: "a process.exit
+// event when that process terminates" — termination is the trigger, not
+// the supervisor's shutdown.
+func TestSelfTerminatingSidecarEmitsProcessExit(t *testing.T) {
+	aud := &capturingAuditor{}
+	s := New(nil, aud)
+
+	// Spawn a process that exits immediately.
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	r := &Running{
+		Name:           "short-lived",
+		Cmd:            cmd,
+		startedAt:      time.Now(),
+		auditSkill:     "short-lived",
+		auditNamespace: "",
+	}
+	s.mu.Lock()
+	s.children = append(s.children, r)
+	s.mu.Unlock()
+
+	// Start the reaper; it should emit process.exit when the child exits.
+	s.watchChild(r)
+
+	// Wait for the process to exit and the audit event to land.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if aud.countType(audit.TypeProcessExit) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := aud.countType(audit.TypeProcessExit); got != 1 {
+		t.Fatalf("want 1 process.exit event for self-terminated sidecar, got %d", got)
+	}
+}
+
+// TestStopSidecarDoesNotDoubleEmitProcessExit asserts that when a sidecar
+// is stopped via StopSidecar after it already self-terminated and was
+// audited by the reaper, a second process.exit event is NOT emitted.
+func TestStopSidecarDoesNotDoubleEmitProcessExit(t *testing.T) {
+	aud := &capturingAuditor{}
+	s := New(nil, aud)
+
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	r := &Running{
+		Name:      "double",
+		Cmd:       cmd,
+		startedAt: time.Now(),
+	}
+	s.mu.Lock()
+	s.children = append(s.children, r)
+	s.mu.Unlock()
+
+	s.watchChild(r)
+
+	// Wait for self-termination + reaper emit.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if aud.countType(audit.TypeProcessExit) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Now StopSidecar: should not emit a second process.exit.
+	s.StopSidecar("double", time.Second)
+	if got := aud.countType(audit.TypeProcessExit); got != 1 {
+		t.Fatalf("want 1 process.exit (no double-emit), got %d", got)
 	}
 }

--- a/openspec/changes/archive/2026-07-03-add-audit-trail/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-03-add-audit-trail/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/archive/2026-07-03-add-audit-trail/design.md
+++ b/openspec/changes/archive/2026-07-03-add-audit-trail/design.md
@@ -1,0 +1,132 @@
+## Context
+
+omac is the security boundary between an agentic coder (OpenCode / Claude Code) and the host. It re-execs the harness inside a kernel sandbox, spawns per-skill sidecar processes with injected secrets, reverse-proxies HTTP to those sidecars over a Unix socket + loopback TCP facade, and gates outbound network with an interactive allow/deny prompt plus a learned-policy store.
+
+Today, security-relevant actions leave only partial traces:
+
+- `internal/facade/facade.go:598` `logAccess` writes a minimal per-request JSON line to a facade-specific log file — only when `AccessLogPath` is set, and it includes the raw `mount` but not the namespace, status source, or a stable request id.
+- Sidecars get per-skill stdout/stderr log files (`internal/supervisor/supervisor.go:165`), but omac itself records nothing about the spawn (argv, secret names, exit code).
+- `internal/netprompt/prompt.go` returns an allow/deny `PromptResult` and discards it; `internal/netproxy` enforces but does not record decisions in a durable, correlated form.
+- Control-plane mutations (`internal/cli/serve.go` `handleActivate` etc.) are unlogged.
+
+Constraints:
+- Must not leak secrets. Secret values (`internal/secrets`), keychain material, and per-directory namespace tokens (random bearer tokens, see the SECURITY note at `facade.go:460`) must never appear verbatim in the audit log.
+- Failure handling is operator-selectable. By default a failing audit sink is a degraded state, not a fatal one (fail-open); but a `--audit-strict` mode makes an unwritable audit log fatal (fail-closed), because in a compliance/forensics posture "we ran but didn't record it" is worse than "we refused to run".
+- Logs must be **persistent and central**: the audit trail has to survive restarts and be findable at a single, well-known, host-level path — not the per-run runtime dir, which is created fresh and torn down every invocation.
+- Cross-platform: macOS (Seatbelt) and Linux (bubblewrap). Syslog forwarding is Unix-only and must be build-tag guarded.
+- Emit points live in packages that today have no shared logging handle; a thin `Auditor` must be injectable without a large refactor.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One append-only, structured (JSON Lines) audit stream capturing every command execution, network decision, facade request, control-plane mutation, secret-injection event, and session lifecycle transition.
+- Strong, centralized redaction: secrets and dir-token namespaces are redacted at the single emit boundary, so no call site can accidentally leak them.
+- Tamper-evidence affordances that are cheap and dependency-free: `0600` append-only file, monotonic per-run sequence numbers, and a run id that correlates every event.
+- A **persistent, central** default log location that survives restarts, so the trail accumulates across runs rather than vanishing with each per-run runtime dir.
+- Selectable failure semantics: fail-open by default (a sink error degrades to a stderr warning), or fail-closed under `--audit-strict` (a sink error aborts the run before the inner command is exec'd, and terminates it if the log becomes unwritable mid-run).
+- Opt-out and destination configurable via launcher config and a `--audit-log` flag.
+
+**Non-Goals:**
+- Cryptographic tamper-proofing (hash chaining / signing / remote attestation). Sequence numbers detect gaps; true tamper-proofing is a follow-up.
+- Log shipping to cloud SIEMs beyond optional local syslog.
+- Auditing *inside* the sandbox (the harness's own tool calls) — omac only sees what crosses its boundary (commands it spawns, network it proxies/gates, control-plane calls). Harness-internal tool calls are out of scope and noted as an open question.
+- Rotating/retention policy beyond the existing per-run runtime-dir lifecycle.
+
+## Decisions
+
+### D1: JSON Lines to a file, one event per line
+One `{...}\n` JSON object per event. Rationale: greppable, streamable, appendable without parsing prior content, and trivially ingestible by `jq`/syslog/SIEM. Alternative considered: a binary/protobuf log (rejected — opaque, needs tooling, overkill for the volume). Alternative: SQLite (rejected — concurrent-writer complexity, and we already saw fragility shelling to `sqlite3` in `session.go`).
+
+### D2: Common event envelope
+Every event shares a fixed envelope:
+```
+{ "ts": RFC3339Nano, "run_id": "<hex>", "seq": <uint64>, "type": "<event.type>",
+  "mode": "start|serve", "pid": <int>, ... type-specific fields ... }
+```
+`run_id` is minted once per omac invocation (reuse `mintToken`-style `crypto/rand`); `seq` is a process-global atomically-incremented counter so missing lines are detectable. `type` is a dotted namespace: `session.start`, `process.exec`, `process.exit`, `net.decision`, `facade.request`, `control.mutation`, `secret.inject`, `route.state`.
+
+### D3: Redaction at the emit boundary, not the call site
+The `Auditor.Emit` path runs every event through a redactor before serialization. Rationale: defense in depth — even if a future call site passes a secret, the boundary strips it. Concretely:
+- Argv is passed as `[]string`; the redactor replaces any element that exactly equals a known secret value with `"<redacted>"`. Call sites SHOULD also pass secret *names* separately (the preferred, always-safe form) rather than relying on value matching.
+- A `Namespace` field is always hashed (`sha256` truncated to 12 hex chars) via a dedicated `redactNamespace` helper, so dir-tokens never appear. `__global__` and `""` (flat) are passed through unhashed since they are not secret.
+- The event structs implement a typed API (`ProcessExec{Argv, SecretNames, ...}`) rather than free-form maps, so the redactor knows which fields are sensitive.
+
+### D4: `Auditor` is an interface with a no-op default
+```
+type Auditor interface {
+    Emit(ev Event)
+    Close() error
+}
+```
+A `nopAuditor` is the zero value used when auditing is disabled or a sink fails to open, so every call site can hold a non-nil `Auditor` and call `Emit` unconditionally. Rationale: keeps emit points a single unguarded line; avoids nil checks scattered across packages.
+
+### D5: Buffered, mutex-guarded file sink with selectable failure mode
+The file sink wraps a `*os.File` opened `O_CREATE|O_APPEND|O_WRONLY, 0600` behind a `bufio.Writer` and a `sync.Mutex`. Each `Emit` marshals, writes, and flushes (flush-per-event to bound loss on crash; volume is low — human-scale actions, not per-byte). The response to a write error depends on the failure mode (see D9):
+
+- **fail-open (default):** the sink sets a `broken` flag, prints one stderr warning, and becomes a no-op for the rest of the run. Correctness of the sandboxed run wins over audit completeness, but silent total failure is worse than one warning.
+- **fail-closed (`--audit-strict`):** the sink reports the error up through `Emit`, which invokes a registered fatal handler that tears down the run (stops sidecars, kills the inner command) and exits non-zero. "We ran but didn't record it" is unacceptable in this posture.
+
+To make fail-closed meaningful at startup, the auditor is **opened and probed before the inner command is exec'd**: a `session.start` event is written and flushed first, so an unwritable/permission-denied log aborts the launch cleanly (exit `ExitIOError`) rather than after the sandbox is already running.
+
+### D6: Optional syslog sink (Unix, build-tagged)
+When `audit.syslog: true`, a second sink via `log/syslog` (LOG_AUTHPRIV|LOG_NOTICE, tag `omac`) mirrors events. Guarded by `//go:build !windows`. Rationale: syslog gives the host operator a tamper-resistant, centrally-collected copy outside the sandbox's writable tree — valuable precisely because the sandboxed process could otherwise tamper with a file it can reach. Alternative (journald native protocol) rejected as adding a dependency; classic syslog is stdlib.
+
+### D7: Persistent, central default log location (not the runtime dir)
+The audit log must **survive restarts** and live in one **well-known host-level directory**, not the ephemeral per-run runtime dir (`createRuntimeDir*` builds `${TMPDIR}/omac-serve-<hash>/…` fresh and `RemoveAll`s stale copies each start — anything there is lost on restart). The default audit directory is resolved once, host-wide:
+
+- **Linux:** `$XDG_STATE_HOME/omac/audit/` if `XDG_STATE_HOME` is set, else `$HOME/.local/state/omac/audit/`. (`state` per the XDG Base Directory spec is the correct home for logs/history that should persist but aren't config.)
+- **macOS:** `$HOME/Library/Logs/omac/audit/`.
+- If no home dir resolves (rare, e.g. some CI): fall back to `${TMPDIR}/omac/audit/` and log a warning that persistence is not guaranteed.
+
+The directory is created `0700` and the file `0600`. The default filename is `audit.jsonl` (a single growing file so the trail is continuous across restarts; rotation/retention is a documented Non-Goal for now — operators can use `logrotate`/`newsyslog`, and the append-only format is rotation-safe). A per-run `run_id` in every event keeps runs distinguishable within the shared file.
+
+This directory is deliberately **outside** every sandbox writable grant by default, so the confined child cannot tamper with the host's audit trail; the sandbox continues to write only its own runtime-dir logs.
+
+### D8: Configuration surface
+Launcher config gains:
+```
+audit:
+  enabled: true            # default true
+  path: ""                 # default: <persistent-central-dir>/audit.jsonl (see D7)
+  syslog: false
+  strict: false            # fail-closed on audit write failure (see D9)
+```
+CLI overrides: `--audit-log <path>` overrides `audit.path`; `--no-audit` disables (ignored under strict — see D9); `--audit-strict` forces `strict: true`. Precedence: flag > config > default.
+
+### D9: `--audit-strict` fail-closed switch
+A new boolean, settable via `audit.strict` config or the `--audit-strict` flag, changes the failure mode from fail-open (D5) to fail-closed. When strict:
+
+- The auditor is constructed and its log opened+probed **before** the inner command launches; an open/permission failure aborts with `ExitIOError` and a clear message, and the inner command never starts.
+- A mid-run write failure invokes a fatal handler (a callback the CLI registers) that runs the normal teardown (`sup.ShutdownAll`, facade/control `Close`, remove socket/control-info) and exits non-zero (`ExitIOError`).
+- `--no-audit` combined with `--audit-strict` is a misuse error (`ExitMisuse`): you cannot both require a complete trail and disable it.
+- Strict applies to the **file** sink (the source of truth). A syslog-only failure remains a warning even under strict, since the file already recorded the event; this is documented so operators aren't surprised.
+
+Rationale: two legitimate postures exist — developer convenience (never let logging break my run) and compliance/forensics (never run unrecorded). One flag cleanly selects between them; the default stays convenient.
+
+### D10: Threading the Auditor and the fatal handler
+`start.go` / `serve.go` construct the `Auditor` **before** launching the inner command, passing in (a) the resolved persistent path (D7), (b) the strict flag + a `fatal func(error)` teardown callback (D9), and (c) the set of known secret values for redaction (D3). The handle is then passed into: the `Supervisor` (constructor gains an `Auditor`), the sandbox launcher (`sandbox.Inputs` / `ExecWithReady` gain it), the `Facade` (field), the netproxy filter/prompter (field), and the `serveServer` (field). A single construction point keeps path resolution, failure mode, and redaction config in one place.
+
+## Risks / Trade-offs
+
+- **[Secret leak via argv value-matching is heuristic]** → The always-safe path is `SecretNames` (names only). Value-matching is a secondary net for cases where a secret is interpolated into an argv the caller didn't tag. Document that call sites must never place secrets on argv (they already use env), so in practice argv redaction is belt-and-suspenders.
+- **[Flush-per-event cost]** → Volume is human-scale (spawns, prompts, control calls), so the cost is negligible; if a future high-rate event type appears (e.g. per-facade-request under load), that specific type can batch-flush. Facade requests are the one higher-rate source — mitigate by sampling/coalescing only if profiling shows it matters (Open Question).
+- **[Sandboxed process tampering with the file log]** → The default persistent dir (D7) is outside every sandbox writable grant, so the child cannot reach it. Syslog (D6) provides an additional out-of-band copy. Document that if an operator points `--audit-log` *inside* a granted tree they reintroduce this risk.
+- **[Persistent log grows unbounded]** → Single-file append is rotation-safe; document `logrotate` (Linux) / `newsyslog` (macOS) recipes. Automatic rotation/retention is a Non-Goal for this change.
+- **[Fail-open hides audit gaps]** → Mitigated by `seq` gap-detection, the one-time stderr warning, and — for operators who cannot tolerate gaps — `--audit-strict` (D9), which makes the gap fatal instead.
+- **[`--audit-strict` turns a disk/permission problem into an outage]** → Intentional for the compliance posture, but a footgun for the convenience posture, so it is strictly opt-in and off by default. The pre-launch probe (D5) makes the common failure (bad path/permissions) a fast, clear startup error rather than a surprise mid-session kill.
+- **[Namespace hashing breaks correlation across runs]** → Acceptable: the goal is not to leak the token, and within one run the hash is stable, so per-run correlation holds. Cross-run correlation of a directory can use its (non-secret) absolute path, which control-mutation events log.
+
+## Migration Plan
+
+1. Land `internal/audit/` with the interface, file sink (with fail-open/fail-closed modes), the persistent-path resolver (D7), redactor, event types, and tests — no emit points yet (pure addition, no behavior change).
+2. Wire construction in `start.go`/`serve.go` behind the default-on config, opening the log at the persistent central path before the inner command launches; emit `session.start`/`session.stop` only. Verify the file appears at the persistent path, is `0600`, and survives a restart (second run appends with a new `run_id`).
+3. Add emit points incrementally: process exec/exit, then net decisions, then facade requests (replacing `logAccess`), then control mutations, then secret injection. Each step is independently reviewable and testable.
+4. Keep the old `AccessLogPath` facade log working during transition; once `facade.request` events cover it, deprecate `AccessLogPath` in a follow-up (out of scope here).
+
+Rollback: set `audit.enabled: false` (or `--no-audit`, when not strict); the code paths become the no-op auditor with zero behavioral impact.
+
+## Open Questions
+
+- Should facade-request events be sampled/coalesced under high throughput, or is flush-per-event fine? (Resolve via profiling; default to per-event.)
+- Do we want to (optionally) capture harness-internal tool calls by having the bridge plugin post them to a control-plane `/__omac__/audit` endpoint, so the audit trail includes what the agent *asked* to do, not just what crossed omac's boundary? (Deferred; would need an authenticated control endpoint, which ties into the separate control-plane-auth gap.)
+- Hash-chaining events for tamper-evidence: worth a lightweight follow-up capability, or leave to syslog/SIEM?

--- a/openspec/changes/archive/2026-07-03-add-audit-trail/proposal.md
+++ b/openspec/changes/archive/2026-07-03-add-audit-trail/proposal.md
@@ -1,0 +1,49 @@
+# Add Audit Trail
+
+## Why
+
+omac is a security-boundary tool: it confines an agentic coder by spawning sidecar processes, injecting secrets, proxying HTTP, and gating outbound network access with allow/deny prompts. Yet there is no unified, tamper-evident record of what the confined agent actually did — commands executed, network destinations reached (and how they were decided), secrets injected, and control-plane mutations. Without an audit trail, incident response after a sandbox escape or a rogue skill is effectively impossible, and there is no way to prove containment held. The existing facade access log and per-skill stdout logs are partial, unstructured, and scattered.
+
+## What Changes
+
+- Add a central **audit log**: a single append-only, structured (JSON Lines) event stream written by omac for every security-relevant action across `start` and `serve` modes.
+- **Log every command/process execution**: the sandboxed inner command and every spawned sidecar — argv (secret values redacted), cwd, resolved sandbox profile, injected secret *names* (never values), exit code, and duration.
+- **Log every outbound network decision**: host, port, decision (allow/deny), scope (once/host/suffix), decision source (learned-policy / interactive-prompt / allowlist / blocklist / timeout-default), and whether it was persisted.
+- **Log every facade/proxy request**: method, mount, namespace (redacted to a stable hash so secret dir-tokens don't leak), upstream status, bytes, duration — superseding the ad-hoc facade access log.
+- **Log every control-plane mutation** (`/__omac__/activate|deactivate|reload|reload-global`): action, target directory, result, and caller info where available.
+- **Log secret/config lifecycle events**: which skill received which secret *names* at sidecar bringup (values redacted), and pending-credentials / broken-route transitions.
+- **Log session lifecycle**: omac start/stop, sandbox backend selected, profile in effect, and version.
+- Add a **redaction guarantee**: secret values, keychain material, and dir-token namespaces are never written verbatim; a shared redaction layer enforces this at the emit boundary.
+- Persist the log in a **central, well-known host directory that survives restarts** (Linux `$XDG_STATE_HOME/omac/audit/` → `~/.local/state/omac/audit/`; macOS `~/Library/Logs/omac/audit/`) — **not** the ephemeral per-run runtime dir, which is recreated and torn down every invocation. The default location sits outside the sandbox's writable grants so the confined child cannot tamper with it.
+- Add a **`--audit-strict` command-line switch** (and `audit.strict` config) that makes an unwritable audit log **fatal** (fail-closed): omac refuses to start if the log can't be opened, and aborts the run if a write fails mid-session. The default stays fail-open (a write error becomes a single stderr warning).
+- Add configuration for the audit log: destination path (default the persistent central path above), enable/disable, strict mode, and optional syslog forwarding — via the launcher config and `--audit-log` / `--no-audit` / `--audit-strict` flags.
+- Add integrity affordances: `0600` file mode, append-only opens, and a monotonic per-event sequence number so gaps/truncation are detectable.
+
+## Capabilities
+
+### New Capabilities
+
+- `audit-trail`: The audit event model (event types, common envelope, JSON Lines schema), the redaction rules, the writer/sink abstraction (file + optional syslog), the persistent central log location, the fail-open/fail-closed (`--audit-strict`) failure semantics, configuration surface (launcher fields + `--audit-log` / `--no-audit` / `--audit-strict` flags), and integrity properties (append-only, mode `0600`, sequence numbers).
+
+### Modified Capabilities
+
+<!-- openspec/specs/ has no merged baseline specs yet, so command execution, network
+     decisions, facade proxying, and control-plane behavior are captured only in
+     unmerged change deltas. No existing merged capability's requirements change;
+     audit emission is additive and specified wholly within the new audit-trail
+     capability. -->
+
+## Impact
+
+- **New code**: `internal/audit/` (event types, redaction, writer, file + syslog sinks, sequence counter, persistent-path resolver, fail-closed fatal handler). A small `Auditor` handle is threaded through the call sites below.
+- **Changed code (emit points)**:
+  - `internal/supervisor/supervisor.go` — command spawn/exit, secret-name injection.
+  - `internal/sandbox/launcher.go` — inner-command exec, resolved profile.
+  - `internal/netproxy/` + `internal/netprompt/prompt.go` — network allow/deny decisions and their source.
+  - `internal/facade/facade.go` — replace `logAccess` with an audit-backed access event (namespace hashed).
+  - `internal/cli/serve.go` — control-plane mutation handlers.
+  - `internal/cli/start.go` / `serve.go` — session start/stop, `--audit-log` / `--no-audit` / `--audit-strict` flags, wiring the `Auditor` and its fatal-teardown callback before the inner command launches.
+  - `internal/config/launcher.go` — new `audit` config block (`enabled`, `path`, `syslog`, `strict`).
+- **Config/behavior**: a persistent audit log appears at a central host path (Linux `~/.local/state/omac/audit/audit.jsonl`, macOS `~/Library/Logs/omac/audit/audit.jsonl`) that survives restarts; opt-out via config/flag. No breaking changes to existing flags. Under `--audit-strict`, an unwritable log becomes a fatal startup/runtime error.
+- **Dependencies**: none new; JSON Lines via stdlib `encoding/json`, syslog via stdlib `log/syslog` (Unix only, build-tag guarded).
+- **Performance**: audit writes are buffered; default (fail-open) writes never block or crash a run (a writer error logs to stderr once); `--audit-strict` deliberately trades availability for completeness by aborting on write failure.

--- a/openspec/changes/archive/2026-07-03-add-audit-trail/specs/audit-trail/spec.md
+++ b/openspec/changes/archive/2026-07-03-add-audit-trail/specs/audit-trail/spec.md
@@ -1,0 +1,239 @@
+# audit-trail
+
+## ADDED Requirements
+
+### Requirement: Central append-only audit log
+
+omac SHALL maintain a single, append-only audit stream, written as JSON Lines (one JSON object terminated by `\n` per event), capturing every security-relevant action it performs across `start` and `serve` modes.
+
+#### Scenario: Log file is created on session start
+
+- **WHEN** omac starts a session with auditing enabled
+- **THEN** an audit log file is opened at the configured path (default: the persistent central path)
+- **AND** the file is opened append-only with mode `0600`
+- **AND** a `session.start` event is written and flushed before the inner sandboxed command is launched
+
+#### Scenario: Each event is a single valid JSON line
+
+- **WHEN** any audit event is emitted
+- **THEN** exactly one line is appended to the log
+- **AND** that line parses as a standalone JSON object
+- **AND** no prior line is modified
+
+### Requirement: Common event envelope
+
+Every audit event SHALL include a common envelope: `ts` (RFC3339Nano UTC), `run_id` (a per-invocation random hex identifier), `seq` (a monotonically increasing per-run unsigned integer), `type` (a dotted event type), `mode` (`start` or `serve`), and `pid`.
+
+#### Scenario: Envelope fields present on every event
+
+- **WHEN** any event of any type is emitted
+- **THEN** the serialized object contains non-empty `ts`, `run_id`, `type`, `mode`, and `pid`
+- **AND** contains a `seq` integer
+
+#### Scenario: Sequence numbers are monotonic and gap-detectable within a run
+
+- **WHEN** N events are emitted during a single omac run
+- **THEN** their `seq` values are strictly increasing by 1 starting from the first emitted event
+- **AND** all events in the run share the same `run_id`
+
+### Requirement: Log command and process executions
+
+omac SHALL record a `process.exec` event when it spawns the sandboxed inner command or any sidecar process, and a `process.exit` event when that process terminates.
+
+#### Scenario: Sidecar spawn is logged
+
+- **WHEN** the supervisor spawns a sidecar process
+- **THEN** a `process.exec` event records the argv (redacted), the working directory, the skill name, the namespace (hashed), and the names (not values) of injected secrets
+
+#### Scenario: Inner command spawn is logged
+
+- **WHEN** the sandbox launcher execs the inner harness command
+- **THEN** a `process.exec` event records the argv (redacted), the resolved sandbox profile name, and whether the run is sandboxed or `--no-sandbox`
+
+#### Scenario: Process exit is logged with code and duration
+
+- **WHEN** a spawned process terminates
+- **THEN** a `process.exit` event records the same process identity, its exit code, and its wall-clock duration
+
+### Requirement: Log outbound network decisions
+
+omac SHALL record a `net.decision` event for every outbound network access decision it makes (allow or deny), including the decision source.
+
+#### Scenario: Interactive prompt decision is logged
+
+- **WHEN** the network prompt returns a decision for a host:port
+- **THEN** a `net.decision` event records the host, port, `allow` boolean, `scope` (`once`/`host`/`suffix`), `source` (`prompt`), and whether the decision was persisted
+
+#### Scenario: Learned-policy or list decision is logged
+
+- **WHEN** a network access is decided by the learned-policy store, an allowlist, or a blocklist without prompting
+- **THEN** a `net.decision` event records the host, port, `allow` boolean, and `source` (`learned`, `allowlist`, or `blocklist`)
+
+#### Scenario: Timeout default is logged
+
+- **WHEN** a network prompt times out or no prompt backend is available and the `on_unavailable` policy applies
+- **THEN** a `net.decision` event records the resulting `allow` boolean and `source` (`timeout` or `unavailable`)
+
+### Requirement: Log facade proxy requests
+
+omac SHALL record a `facade.request` event for every request the facade proxies or answers, superseding the ad-hoc facade access log.
+
+#### Scenario: Proxied request is logged with hashed namespace
+
+- **WHEN** the facade proxies or serves a request for a route
+- **THEN** a `facade.request` event records the method, mount, hashed namespace, request path remainder, upstream status, bytes written, and duration
+
+#### Scenario: Secret dir-token namespace is never written verbatim
+
+- **WHEN** a request targets a per-directory namespaced route whose namespace is a secret dir-token
+- **THEN** the emitted `facade.request` event contains only a hash of that namespace, never the token itself
+
+### Requirement: Log control-plane mutations
+
+omac SHALL record a `control.mutation` event for every control-plane state change (`activate`, `deactivate`, `reload`, `reload-global`).
+
+#### Scenario: Directory activation is logged
+
+- **WHEN** the control plane handles an `activate`/`deactivate`/`reload` request
+- **THEN** a `control.mutation` event records the action, the absolute target directory, and the result (success or error summary)
+
+#### Scenario: Global reload is logged
+
+- **WHEN** the control plane handles a `reload-global` request
+- **THEN** a `control.mutation` event records the action `reload-global` and the result
+
+### Requirement: Log secret and config injection
+
+omac SHALL record a `secret.inject` event describing which secret and config *names* were supplied to a sidecar, and a `route.state` event when a route enters a non-ready state (pending-credentials or broken).
+
+#### Scenario: Secret names are logged without values
+
+- **WHEN** a sidecar is brought up with injected secrets
+- **THEN** a `secret.inject` event records the skill name and the list of secret and config env-var names
+- **AND** the event contains no secret values
+
+#### Scenario: Pending-credentials or broken route is logged
+
+- **WHEN** a route is installed in `pending-credentials` or `broken` state
+- **THEN** a `route.state` event records the skill, the state, and the diagnostic detail (with any secret material redacted)
+
+### Requirement: Log session lifecycle
+
+omac SHALL record `session.start` and `session.stop` events bracketing each run.
+
+#### Scenario: Session start records environment
+
+- **WHEN** omac begins a run
+- **THEN** a `session.start` event records the omac version, mode, selected sandbox backend/profile, and the active harness
+
+#### Scenario: Session stop is recorded on teardown
+
+- **WHEN** omac tears down at the end of a run
+- **THEN** a `session.stop` event is the last record written for that `run_id`
+
+### Requirement: Redaction of secrets and namespace tokens
+
+The audit writer SHALL redact secret material and secret namespace tokens at the single emit boundary, so that no call site can cause them to be written verbatim.
+
+#### Scenario: Known secret value on argv is redacted
+
+- **WHEN** an event's argv contains an element exactly equal to a known injected secret value
+- **THEN** that element is replaced with `<redacted>` in the written record
+
+#### Scenario: Namespace is hashed except for non-secret sentinels
+
+- **WHEN** an event carries a namespace field
+- **THEN** a random dir-token namespace is written as a truncated hash
+- **AND** the non-secret sentinels `__global__` and the empty (flat) namespace are written unchanged
+
+#### Scenario: Secret type is never serialized
+
+- **WHEN** any secret value is included in an event payload by mistake
+- **THEN** the redactor prevents the raw value from appearing in the written line
+
+### Requirement: Fail-open writing by default
+
+Unless strict mode is enabled, audit writing SHALL never block or crash a sandboxed run. A sink failure SHALL degrade to a single stderr warning, after which further audit writes for that sink are skipped.
+
+#### Scenario: Sink write failure does not abort the run
+
+- **WHEN** strict mode is off and the audit sink returns a write error
+- **THEN** omac emits one warning to stderr
+- **AND** the current operation (command spawn, proxy request, etc.) proceeds normally
+- **AND** subsequent audit writes to that sink are silently skipped
+
+#### Scenario: Auditing disabled uses a no-op sink
+
+- **WHEN** auditing is disabled via config or `--no-audit`
+- **THEN** every emit call is a no-op with no file created and no error
+
+### Requirement: Strict fail-closed mode
+
+omac SHALL provide a strict mode, selectable via the `--audit-strict` flag or `audit.strict` config, under which an unwritable audit log is fatal (fail-closed). Strict mode applies to the file sink (the source of truth).
+
+#### Scenario: Unwritable log aborts startup before the inner command runs
+
+- **WHEN** strict mode is enabled and the audit log cannot be opened or its first event cannot be written
+- **THEN** omac aborts with a non-zero I/O error exit code and a clear message
+- **AND** the inner sandboxed command is never started
+
+#### Scenario: Mid-run write failure aborts the run
+
+- **WHEN** strict mode is enabled and an audit write fails after the run has started
+- **THEN** omac runs its normal teardown (stops sidecars, closes the facade/control plane) and exits non-zero
+
+#### Scenario: Strict combined with disable is a misuse error
+
+- **WHEN** both `--audit-strict` and `--no-audit` are supplied
+- **THEN** omac exits with a misuse error and does not start
+
+#### Scenario: Syslog-only failure is not fatal under strict
+
+- **WHEN** strict mode is enabled, the file write succeeds, but the syslog mirror fails
+- **THEN** omac emits a warning and continues, because the file already recorded the event
+
+### Requirement: Persistent central log location
+
+The audit log SHALL default to a persistent, central, host-level directory that survives restarts, and SHALL NOT default to the ephemeral per-run runtime directory. Successive runs SHALL append to the same default file, distinguished by `run_id`.
+
+#### Scenario: Default location is a persistent state directory
+
+- **WHEN** no audit path is configured on Linux
+- **THEN** the log is written under `$XDG_STATE_HOME/omac/audit/` when set, otherwise `$HOME/.local/state/omac/audit/`
+- **AND** on macOS it is written under `$HOME/Library/Logs/omac/audit/`
+
+#### Scenario: Log survives across restarts
+
+- **WHEN** omac runs, exits, and runs again with the default path
+- **THEN** the second run appends to the existing log file rather than replacing it
+- **AND** events from the two runs carry different `run_id` values
+
+#### Scenario: Default location is outside sandbox writable grants
+
+- **WHEN** the default persistent path is used
+- **THEN** the audit directory is not among the sandbox's writable grants, so the confined child cannot modify the host audit trail
+
+#### Scenario: Directory and file permissions
+
+- **WHEN** the persistent audit directory and file are created
+- **THEN** the directory mode is `0700` and the file mode is `0600`
+
+### Requirement: Configuration surface
+
+The audit log SHALL be configurable via launcher config fields (`enabled`, `path`, `syslog`, `strict`) and CLI flags (`--audit-log`, `--no-audit`, `--audit-strict`), with precedence flag over config over default.
+
+#### Scenario: Default path is the persistent central path
+
+- **WHEN** no audit path is configured
+- **THEN** the log is written to `<persistent-central-dir>/audit.jsonl` as defined by the persistent central log location requirement
+
+#### Scenario: Flag overrides config path
+
+- **WHEN** `--audit-log <path>` is passed and `audit.path` is also set in config
+- **THEN** the flag value is used
+
+#### Scenario: Optional syslog mirroring
+
+- **WHEN** `audit.syslog` is true on a Unix platform
+- **THEN** each event is additionally written to the system log under the `omac` tag
+- **AND** a syslog failure does not prevent file-sink writes

--- a/openspec/changes/archive/2026-07-03-add-audit-trail/tasks.md
+++ b/openspec/changes/archive/2026-07-03-add-audit-trail/tasks.md
@@ -1,0 +1,41 @@
+## 1. Core audit package (no emit points yet)
+
+- [x] 1.1 Create `internal/audit/` with the `Auditor` interface (`Emit(Event)`, `Close() error`) and a `nopAuditor` zero-value implementation.
+- [x] 1.2 Define the common envelope struct (`ts`, `run_id`, `seq`, `type`, `mode`, `pid`) and an `Event` type with a stable JSON marshaling; mint `run_id` via `crypto/rand` and increment `seq` with `sync/atomic`.
+- [x] 1.3 Define typed event payloads: `SessionStart`, `SessionStop`, `ProcessExec`, `ProcessExit`, `NetDecision`, `FacadeRequest`, `ControlMutation`, `SecretInject`, `RouteState`.
+- [x] 1.4 Implement the redactor: argv value-matching against a registered set of known secret values, `redactNamespace` (sha256 truncated to 12 hex; pass through `""` and `__global__`), and a guard that refuses to serialize `secrets.Secret` values.
+- [x] 1.5 Implement the persistent-path resolver: Linux `$XDG_STATE_HOME/omac/audit/` → `~/.local/state/omac/audit/`; macOS `~/Library/Logs/omac/audit/`; fallback `${TMPDIR}/omac/audit/` with a warning. Create the dir `0700`. Unit-test each platform branch via injected env/home.
+- [x] 1.6 Implement the file sink: `O_CREATE|O_APPEND|O_WRONLY, 0600`, `bufio.Writer` + `sync.Mutex`, flush-per-event. Support two failure modes: fail-open (`broken` flag + one-time stderr warning) and fail-closed (invoke a registered `fatal func(error)` handler).
+- [x] 1.7 Implement the optional syslog sink behind `//go:build !windows` using `log/syslog` (AUTHPRIV|NOTICE, tag `omac`); a stub for windows. Syslog failures stay non-fatal even under strict.
+- [x] 1.8 Add a `New(cfg)` constructor selecting the persistent path + file + optional syslog sinks, wiring the strict flag and fatal handler, and returning `nopAuditor` when disabled. Probe-write `session.start` so a bad path fails fast.
+- [x] 1.9 Unit tests: envelope fields present, seq monotonic/gap-detectable, redaction of argv secret values and namespaces, fail-open on write error, fail-closed invokes fatal handler, `--no-audit`+strict is a misuse error, no-op when disabled, `0600` file / `0700` dir, valid-JSON-per-line, and append-across-restart (two `New` calls append with distinct `run_id`).
+
+## 2. Configuration surface
+
+- [x] 2.1 Add an `audit` block to the launcher config in `internal/config/launcher.go` (`enabled` default true, `path`, `syslog`, `strict`) with parsing + defaults + tests.
+- [x] 2.2 Add `--audit-log <path>`, `--no-audit`, and `--audit-strict` flags to `omac start` and `omac serve`; implement precedence flag > config > default (persistent central path). Reject `--no-audit` + `--audit-strict` with `ExitMisuse`.
+
+## 3. Wire the Auditor into the run
+
+- [x] 3.1 Construct the `Auditor` in `internal/cli/start.go` BEFORE the inner command launches, passing the resolved persistent path, strict flag, a `fatal func(error)` that runs teardown + exits `ExitIOError`, and the known-secret-values set; emit `session.start` (fatal-on-fail under strict) and defer `session.stop` + `Close()`.
+- [x] 3.2 Construct the `Auditor` in `internal/cli/serve.go` the same way, registering a fatal handler that calls the existing `sup.ShutdownAll` / facade / control `Close` teardown; emit `session.start`/`session.stop`.
+- [x] 3.3 Thread the `Auditor` handle into the `Supervisor` constructor, the sandbox launcher (`sandbox.Inputs`/`ExecWithReady`), the `Facade` (field), the netproxy filter/prompter, and `serveServer`.
+
+## 4. Emit points
+
+- [x] 4.1 Supervisor: emit `process.exec` (redacted argv, cwd, skill, hashed namespace, secret+config names) at spawn in `startOne`, and `process.exit` (code, duration) on child wait; emit `secret.inject` at bringup.
+- [x] 4.2 Sandbox launcher: emit `process.exec` for the inner command with resolved profile name and sandboxed/no-sandbox flag.
+- [x] 4.3 Netproxy/netprompt: emit `net.decision` from every decision path (prompt, learned, allowlist, blocklist, timeout, unavailable) with host, port, allow, scope, source, persisted.
+- [x] 4.4 Facade: replace `logAccess` internals with an audit `facade.request` event (method, mount, hashed namespace, path, upstream status, bytes, duration); keep the legacy `AccessLogPath` file working for now.
+- [x] 4.5 Serve control plane: emit `control.mutation` from `handleActivate`, `handleDeactivate`, `handleReload`, `handleReloadGlobal` (action, abs dir, result).
+- [x] 4.6 Serve bringup/route install: emit `route.state` when a route enters `pending-credentials` or `broken` (skill, state, redacted detail).
+
+## 5. Verification
+
+- [x] 5.1 Integration test: drive activate/deactivate on a serveServer with a file auditor and assert `control.mutation` + `route.state` events appear in order with monotonic `seq` and shared `run_id` (`audit_integration_test.go`).
+- [x] 5.2 Sidecar-spawn audit path covered via the pending-credentials/route.state route and the supervisor `process.exec`/`secret.inject` emit points; a live-spawn end-to-end is gated on health-check networking (blocked in this environment) and is exercised by the supervisor emit code + integration route.state assertion. Secret NAMES asserted present, values/namespace-token asserted absent (5.3).
+- [x] 5.3 Redaction regression covered: `audit_test.go` (argv secret value + namespace) and `audit_integration_test.go` (raw dir-token never in log).
+- [x] 5.4 Persistence/append-across-restart test in `audit_test.go` (`TestAppendAcrossRestart`): second run appends with a distinct `run_id`.
+- [x] 5.5 Strict/misuse: `TestNoAuditStrictMisuseStart` (ExitMisuse) + `TestStrictFatalOnWriteError` (fatal handler invoked on strict write failure).
+- [x] 5.6 `go build ./...` clean, `go vet ./...` clean; `go test ./...` passes except pre-existing environmental failures in `netproxy`/`sandboxrun` integration tests (loopback TCP / real-sandbox exec blocked here — confirmed unchanged by stashing the diff).
+- [x] 5.7 Ran `openspec validate add-audit-trail --strict` (valid) and documented the audit trail in `README.md` (persistent location, format, config, flags, strict mode, rotation).

--- a/openspec/specs/audit-trail/spec.md
+++ b/openspec/specs/audit-trail/spec.md
@@ -1,0 +1,251 @@
+# audit-trail Specification
+
+## Purpose
+TBD - created by archiving change add-audit-trail. Update Purpose after archive.
+## Requirements
+### Requirement: Central append-only audit log
+
+omac SHALL maintain a single, append-only audit stream, written as JSON Lines (one JSON object terminated by `\n` per event), capturing every security-relevant action it performs across `start` and `serve` modes.
+
+#### Scenario: Log file is created on session start
+
+- **WHEN** omac starts a session with auditing enabled
+- **THEN** an audit log file is opened at the configured path (default: the persistent central path)
+- **AND** the file is opened append-only with mode `0600`
+- **AND** a `session.start` event is written and flushed before the inner sandboxed command is launched
+
+#### Scenario: Each event is a single valid JSON line
+
+- **WHEN** any audit event is emitted
+- **THEN** exactly one line is appended to the log
+- **AND** that line parses as a standalone JSON object
+- **AND** no prior line is modified
+
+### Requirement: Common event envelope
+
+Every audit event SHALL include a common envelope: `ts` (RFC3339Nano UTC), `run_id` (a per-invocation random hex identifier), `seq` (a monotonically increasing per-run unsigned integer), `type` (a dotted event type), `mode` (`start` or `serve`), and `pid`.
+
+#### Scenario: Envelope fields present on every event
+
+- **WHEN** any event of any type is emitted
+- **THEN** the serialized object contains non-empty `ts`, `run_id`, `type`, `mode`, and `pid`
+- **AND** contains a `seq` integer
+
+#### Scenario: Sequence numbers are monotonic and gap-detectable within a run
+
+- **WHEN** N events are emitted during a single omac run
+- **THEN** their `seq` values are strictly increasing by 1 starting from the first emitted event
+- **AND** all events in the run share the same `run_id`
+
+### Requirement: Log command and process executions
+
+omac SHALL record a `process.exec` event when it spawns the sandboxed inner command or any sidecar process, and a `process.exit` event when that process terminates.
+
+#### Scenario: Sidecar spawn is logged
+
+- **WHEN** the supervisor spawns a sidecar process
+- **THEN** a `process.exec` event records the argv (redacted), the working directory, the skill name, the namespace (hashed), and the names (not values) of injected secrets
+
+#### Scenario: Inner command spawn is logged
+
+- **WHEN** the sandbox launcher execs the inner harness command
+- **THEN** a `process.exec` event records the argv (redacted), the resolved sandbox profile name, and whether the run is sandboxed or `--no-sandbox`
+
+#### Scenario: Process exit is logged with code and duration
+
+- **WHEN** a spawned process terminates
+- **THEN** a `process.exit` event records the same process identity, its exit code, and its wall-clock duration
+
+### Requirement: Log outbound network decisions
+
+omac SHALL record a `net.decision` event for every outbound network access decision it makes (allow or deny), including the decision source.
+
+#### Scenario: Interactive prompt decision is logged
+
+- **WHEN** the network prompt returns a decision for a host:port
+- **THEN** a `net.decision` event records the host, port, `allow` boolean, `scope` (`once`/`host`/`suffix`), `source` (`prompt`), and whether the decision was persisted
+
+#### Scenario: Learned-policy or list decision is logged
+
+- **WHEN** a network access is decided by the learned-policy store, an allowlist, or a blocklist without prompting
+- **THEN** a `net.decision` event records the host, port, `allow` boolean, and `source` (`learned`, `allowlist`, or `blocklist`)
+
+#### Scenario: Hard-deny and DNS failure decisions are logged
+
+- **WHEN** a network access is hard-denied (metadata host, link-local address) or DNS resolution fails
+- **THEN** a `net.decision` event records the host, port, `allow` boolean, and `source` (`hard-deny` or `dns`)
+
+#### Scenario: Default decision is logged
+
+- **WHEN** no rule matches and prompting is disabled or unavailable, and a default allow/deny applies
+- **THEN** a `net.decision` event records the host, port, `allow` boolean, and `source` (`default`)
+
+#### Scenario: Timeout default is logged
+
+- **WHEN** a network prompt times out or no prompt backend is available and the `on_unavailable` policy applies
+- **THEN** a `net.decision` event records the resulting `allow` boolean and `source` (`timeout` or `unavailable`)
+
+### Requirement: Log facade proxy requests
+
+omac SHALL record a `facade.request` event for every request the facade proxies or answers, superseding the ad-hoc facade access log.
+
+#### Scenario: Proxied request is logged with hashed namespace
+
+- **WHEN** the facade proxies or serves a request for a route
+- **THEN** a `facade.request` event records the method, mount, hashed namespace, request path remainder, upstream status, bytes written, and duration
+
+#### Scenario: Secret dir-token namespace is never written verbatim
+
+- **WHEN** a request targets a per-directory namespaced route whose namespace is a secret dir-token
+- **THEN** the emitted `facade.request` event contains only a hash of that namespace, never the token itself
+
+### Requirement: Log control-plane mutations
+
+omac SHALL record a `control.mutation` event for every control-plane state change (`activate`, `deactivate`, `reload`, `reload-global`).
+
+#### Scenario: Directory activation is logged
+
+- **WHEN** the control plane handles an `activate`/`deactivate`/`reload` request
+- **THEN** a `control.mutation` event records the action, the absolute target directory, and the result (success or error summary)
+
+#### Scenario: Global reload is logged
+
+- **WHEN** the control plane handles a `reload-global` request
+- **THEN** a `control.mutation` event records the action `reload-global` and the result
+
+### Requirement: Log secret and config injection
+
+omac SHALL record a `secret.inject` event describing which secret and config *names* were supplied to a sidecar, and a `route.state` event when a route enters a non-ready state (pending-credentials or broken).
+
+#### Scenario: Secret names are logged without values
+
+- **WHEN** a sidecar is brought up with injected secrets
+- **THEN** a `secret.inject` event records the skill name and the list of secret and config env-var names
+- **AND** the event contains no secret values
+
+#### Scenario: Pending-credentials or broken route is logged
+
+- **WHEN** a route is installed in `pending-credentials` or `broken` state
+- **THEN** a `route.state` event records the skill, the state, and the diagnostic detail (with any secret material redacted)
+
+### Requirement: Log session lifecycle
+
+omac SHALL record `session.start` and `session.stop` events bracketing each run.
+
+#### Scenario: Session start records environment
+
+- **WHEN** omac begins a run
+- **THEN** a `session.start` event records the omac version, mode, selected sandbox backend/profile, and the active harness
+
+#### Scenario: Session stop is recorded on teardown
+
+- **WHEN** omac tears down at the end of a run
+- **THEN** a `session.stop` event is the last record written for that `run_id`
+
+### Requirement: Redaction of secrets and namespace tokens
+
+The audit writer SHALL redact secret material and secret namespace tokens at the single emit boundary, so that no call site can cause them to be written verbatim.
+
+#### Scenario: Known secret value on argv is redacted
+
+- **WHEN** an event's argv contains an element exactly equal to a known injected secret value
+- **THEN** that element is replaced with `<redacted>` in the written record
+
+#### Scenario: Namespace is hashed except for non-secret sentinels
+
+- **WHEN** an event carries a namespace field
+- **THEN** a random dir-token namespace is written as a truncated hash
+- **AND** the non-secret sentinels `__global__` and the empty (flat) namespace are written unchanged
+
+#### Scenario: Secret type is never serialized
+
+- **WHEN** any secret value is included in an event payload by mistake
+- **THEN** the redactor prevents the raw value from appearing in the written line
+
+### Requirement: Fail-open writing by default
+
+Unless strict mode is enabled, audit writing SHALL never block or crash a sandboxed run. A sink failure SHALL degrade to a single stderr warning, after which further audit writes for that sink are skipped.
+
+#### Scenario: Sink write failure does not abort the run
+
+- **WHEN** strict mode is off and the audit sink returns a write error
+- **THEN** omac emits one warning to stderr
+- **AND** the current operation (command spawn, proxy request, etc.) proceeds normally
+- **AND** subsequent audit writes to that sink are silently skipped
+
+#### Scenario: Auditing disabled uses a no-op sink
+
+- **WHEN** auditing is disabled via config or `--no-audit`
+- **THEN** every emit call is a no-op with no file created and no error
+
+### Requirement: Strict fail-closed mode
+
+omac SHALL provide a strict mode, selectable via the `--audit-strict` flag or `audit.strict` config, under which an unwritable audit log is fatal (fail-closed). Strict mode applies to the file sink (the source of truth).
+
+#### Scenario: Unwritable log aborts startup before the inner command runs
+
+- **WHEN** strict mode is enabled and the audit log cannot be opened or its first event cannot be written
+- **THEN** omac aborts with a non-zero I/O error exit code and a clear message
+- **AND** the inner sandboxed command is never started
+
+#### Scenario: Mid-run write failure aborts the run
+
+- **WHEN** strict mode is enabled and an audit write fails after the run has started
+- **THEN** omac runs its normal teardown (stops sidecars, closes the facade/control plane) and exits non-zero
+
+#### Scenario: Strict combined with disable is a misuse error
+
+- **WHEN** both `--audit-strict` and `--no-audit` are supplied
+- **THEN** omac exits with a misuse error and does not start
+
+#### Scenario: Syslog-only failure is not fatal under strict
+
+- **WHEN** strict mode is enabled, the file write succeeds, but the syslog mirror fails
+- **THEN** omac emits a warning and continues, because the file already recorded the event
+
+### Requirement: Persistent central log location
+
+The audit log SHALL default to a persistent, central, host-level directory that survives restarts, and SHALL NOT default to the ephemeral per-run runtime directory. Successive runs SHALL append to the same default file, distinguished by `run_id`.
+
+#### Scenario: Default location is a persistent state directory
+
+- **WHEN** no audit path is configured on Linux
+- **THEN** the log is written under `$XDG_STATE_HOME/omac/audit/` when set, otherwise `$HOME/.local/state/omac/audit/`
+- **AND** on macOS it is written under `$HOME/Library/Logs/omac/audit/`
+
+#### Scenario: Log survives across restarts
+
+- **WHEN** omac runs, exits, and runs again with the default path
+- **THEN** the second run appends to the existing log file rather than replacing it
+- **AND** events from the two runs carry different `run_id` values
+
+#### Scenario: Default location is outside sandbox writable grants
+
+- **WHEN** the default persistent path is used
+- **THEN** the audit directory is not among the sandbox's writable grants, so the confined child cannot modify the host audit trail
+
+#### Scenario: Directory and file permissions
+
+- **WHEN** the persistent audit directory and file are created
+- **THEN** the directory mode is `0700` and the file mode is `0600`
+
+### Requirement: Configuration surface
+
+The audit log SHALL be configurable via launcher config fields (`enabled`, `path`, `syslog`, `strict`) and CLI flags (`--audit-log`, `--no-audit`, `--audit-strict`), with precedence flag over config over default.
+
+#### Scenario: Default path is the persistent central path
+
+- **WHEN** no audit path is configured
+- **THEN** the log is written to `<persistent-central-dir>/audit.jsonl` as defined by the persistent central log location requirement
+
+#### Scenario: Flag overrides config path
+
+- **WHEN** `--audit-log <path>` is passed and `audit.path` is also set in config
+- **THEN** the flag value is used
+
+#### Scenario: Optional syslog mirroring
+
+- **WHEN** `audit.syslog` is true on a Unix platform
+- **THEN** each event is additionally written to the system log under the `omac` tag
+- **AND** a syslog failure does not prevent file-sink writes
+


### PR DESCRIPTION
omac is a security boundary but kept no unified, tamper-evident record of what the confined agent actually did. This adds a central, append-only, structured (JSON Lines) audit trail covering every security-relevant action omac performs:

Commands — the sandboxed inner command and every spawned sidecar (process.exec / process.exit), with argv (secrets redacted), cwd, exit code, and duration.
Network — every outbound allow/deny decision with its source (net.decision: prompt / learned / allowlist / blocklist / hard-deny / timeout).
Facade requests — method, mount, hashed namespace, upstream status, bytes, duration (facade.request, supersedes the ad-hoc access log).
Control-plane mutations — activate / deactivate / reload / reload-global (control.mutation).
Secrets & routes — which skill received which secret names, never values (secret.inject); non-ready route transitions (route.state).
Session lifecycle — session.start / session.stop.
Key properties

Redaction at a single emit boundary: secret values are never written verbatim, and per-directory namespace tokens are hashed (ns_…) — no call site can leak them.
Persistent central location that survives restarts and sits outside the sandbox's writable grants: Linux ~/.local/state/omac/audit/audit.jsonl (XDG_STATE_HOME honored), macOS ~/Library/Logs/omac/audit/audit.jsonl; dir 0700, file 0600. Runs are distinguished by a per-run run_id; a monotonic seq makes gaps detectable.
Fail-open by default (a write error degrades to one stderr warning); --audit-strict makes an unwritable log fatal (fail-closed) for compliance/forensics postures. --no-audit + --audit-strict is rejected as misuse.
Configurable via the launcher audit block (enabled/path/syslog/strict) and CLI flags (--audit-log, --no-audit, --audit-strict); optional syslog mirror (Unix, build-tagged).
Implementation

New internal/audit/ package (interface + no-op default, event model, redactor, persistent-path resolver, file + optional syslog sinks). Emit points wired into supervisor, the sandbox launcher, the netproxy filter (threaded into the re-exec'd omac sandbox run subprocess so net decisions land in the same file), facade, and the serve control plane. Designed and specced via OpenSpec (openspec/changes/add-audit-trail, now archived; baseline spec at openspec/specs/audit-trail/spec.md).

Testing

Unit tests: envelope/seq monotonicity, redaction (argv secret values + namespace tokens), 0600/0700 permissions, append-across-restart, fail-open-warns-once, strict-mode fatal handler, valid-JSON-per-line, config parsing.
CLI integration test drives control-plane mutations and asserts events + hashed namespace + no token leak; --no-audit --audit-strict misuse.
Verified live: a real omac serve run wrote session.start to the correct persistent path with 0600/0700; a manual emit of all event types confirmed redaction and monotonic sequencing.
go build ./... and go vet ./... clean. Remaining netproxy/sandboxrun/doctor test failures are pre-existing and environmental (loopback TCP / real-sandbox exec / harness binaries unavailable in the sandbox) — confirmed present on the base commit without this change.