### PR TITLE
chore: add pre-commit hook mirroring CI gofmt gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,20 @@ See [`docs/NONO_SANDBOX.md`](docs/NONO_SANDBOX.md) for the full setup guide,
 transport details (TCP vs Unix socket under proxy mode), flag combinations,
 and debugging instructions.
 
+## Development
+
+CI (`.github/workflows/ci.yml`) gates on `gofmt`, `go vet`, `staticcheck`,
+build, and `go test -race`. To avoid pushing gofmt drift, install the local
+pre-commit hook — it auto-formats staged `.go` files and re-stages them:
+
+```sh
+scripts/install-hooks.sh
+```
+
+Re-run after a fresh clone or after pulling hook changes. The hook only
+runs `gofmt`; vet, staticcheck, build, and tests stay in CI to keep the
+hook fast.
+
 ## Not yet implemented (v0)
 
 See the design doc's "Open questions / future work" section. Notably:

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# install-hooks.sh — install local git hooks that mirror CI's formatting gate.
+#
+# CI (.github/workflows/ci.yml) fails on any file not gofmt-clean. This hook
+# runs `gofmt -w` on staged .go files and re-stages them, so a commit can
+# never introduce gofmt drift in the first place. `go vet`, `staticcheck`,
+# build, and tests stay server-side in CI — the hook stays fast.
+#
+# Usage:
+#   scripts/install-hooks.sh
+#
+# Re-run after cloning or after pulling hook changes. Removes any existing
+# pre-commit hook written by this script (identified by its sentinel).
+
+set -euo pipefail
+
+# Resolve repo root via git; falls back to script's parent dir for bare setups.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$(cd "$SCRIPT_DIR/.." && pwd)")"
+HOOK="$REPO/.git/hooks/pre-commit"
+SENTINEL="# omac-install-hooks: pre-commit"
+
+if [ ! -d "$REPO/.git" ]; then
+  echo "not at a git worktree root: $REPO" >&2
+  exit 1
+fi
+
+mkdir -p "$REPO/.git/hooks"
+
+# Replace a previous install; preserve anything else.
+if [ -f "$HOOK" ] && ! grep -q "^$SENTINEL" "$HOOK"; then
+  echo "existing pre-commit hook is not ours; refusing to overwrite:" >&2
+  echo "  $HOOK" >&2
+  echo "move it aside and re-run." >&2
+  exit 1
+fi
+
+cat >"$HOOK" <<'HOOK_EOF'
+#!/usr/bin/env bash
+# omac-install-hooks: pre-commit
+#
+# Auto-format staged .go files with gofmt and re-stage them, mirroring the
+# gofmt gate in .github/workflows/ci.yml. Fails the commit only if gofmt
+# itself errors. Does not run vet/staticcheck/test — those stay in CI to
+# keep the hook fast.
+set -euo pipefail
+
+staged=$(git diff --cached --name-only --diff-filter=ACM -- '*.go' || true)
+[ -z "$staged" ] && exit 0
+
+root=$(git rev-parse --show-toplevel)
+changed=0
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  before=$(gofmt -l "$f")
+  if [ -n "$before" ]; then
+    (cd "$root" && gofmt -w "$f")
+    git add -- "$f"
+    changed=1
+  fi
+done <<<"$staged"
+
+if [ "$changed" -eq 1 ]; then
+  echo "pre-commit: gofmt reformatted and re-staged Go files; review and re-edit commit message if needed."
+fi
+exit 0
+HOOK_EOF
+
+chmod +x "$HOOK"
+echo "installed pre-commit hook -> $HOOK"
+echo "to remove: rm $HOOK"


### PR DESCRIPTION
## What

Adds `scripts/install-hooks.sh` — installs a local `.git/hooks/pre-commit` that runs `gofmt -w` on staged `.go` files and re-stages them, so gofmt drift can never be committed in the first place.

Mirrors the formatting gate in `.github/workflows/ci.yml`. `go vet`, `staticcheck`, build, and tests stay in CI to keep the hook fast.

## Why

CI repeatedly fails on gofmt drift; catching it locally before commit prevents the round-trip.

## How to use

```sh
scripts/install-hooks.sh
```

Re-run after a fresh clone or after pulling hook changes. Refuses to clobber a non-omac pre-commit hook (detected via sentinel).

## Files

- `scripts/install-hooks.sh` — installer + hook content
- `README.md` — short Development section pointing at the installer

## Verification

- Repo tree confirmed gofmt-clean + `go vet ./...` clean on `main`.
- Hook tested end-to-end in an isolated repo: staged drift → hook reformats + re-stages → clean commit.
- Hook installed locally and used to commit this change.