### PR TITLE
feat(sandbox): protect workdir .env/.envrc by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ sandbox:
 | Bridge socket (`$TMPDIR/omac-<hash>/bridge.sock`) | read+write | `--allow-file` / `--read` flags |
 | Dynamic socket dir (e.g. Agent View `/tmp/cc-daemon-<uid>`) | read+write + AF_UNIX connect | `--allow-unix-dir` flag / `filesystem.allow_unix_dir` |
 | Paths in `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.kube`, … | **denied** | protected paths (override with `filesystem.override_deny`) |
-| Workdir `.env` and `.envrc` (incl. nested) | **denied** | baseline workdir-protected set (override with `filesystem.override_deny: [".env"]`) |
+| Workdir and granted-tree `.env` / `.envrc` (incl. nested) | **denied** | baseline workdir-protected set (override with `filesystem.override_deny: [".env"]`) |
 | Files matching `filesystem.deny` (e.g. `*.key`) inside granted trees | **denied** | user deny list (`filesystem.deny` / `--deny`) |
 
 ## Typical workflow

--- a/README.md
+++ b/README.md
@@ -402,7 +402,8 @@ sandbox:
 | Bridge socket (`$TMPDIR/omac-<hash>/bridge.sock`) | read+write | `--allow-file` / `--read` flags |
 | Dynamic socket dir (e.g. Agent View `/tmp/cc-daemon-<uid>`) | read+write + AF_UNIX connect | `--allow-unix-dir` flag / `filesystem.allow_unix_dir` |
 | Paths in `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.kube`, … | **denied** | protected paths (override with `filesystem.override_deny`) |
-| Files matching `filesystem.deny` (e.g. `.env`, `*.key`) inside granted trees | **denied** | user deny list (`filesystem.deny` / `--deny`) |
+| Workdir `.env` and `.envrc` (incl. nested) | **denied** | baseline workdir-protected set (override with `filesystem.override_deny: [".env"]`) |
+| Files matching `filesystem.deny` (e.g. `*.key`) inside granted trees | **denied** | user deny list (`filesystem.deny` / `--deny`) |
 
 ## Typical workflow
 

--- a/internal/sandboxprofile/baseline.go
+++ b/internal/sandboxprofile/baseline.go
@@ -17,6 +17,12 @@ type Baseline struct {
 	// ProtectedPaths are denied even when covered by a broader grant,
 	// unless listed in filesystem.override_deny.
 	ProtectedPaths []string
+	// WorkdirProtected are basenames (e.g. ".env") denied inside the
+	// workdir and any explicitly granted tree. Unlike ProtectedPaths,
+	// they are resolved at launch time against the actual workdir, so
+	// they catch workdir-relative files the static ProtectedPaths set
+	// cannot. override_deny holes punch through here too.
+	WorkdirProtected []string
 }
 
 // PlatformBaseline returns the baseline for the current GOOS.
@@ -72,6 +78,17 @@ func protectedCommon() []string {
 	}
 }
 
+// workdirProtectedCommon are basenames denied inside the workdir and
+// any explicitly granted tree. Resolved at launch time against the
+// actual workdir (see ResolveGrants), so workdir-relative files like
+// `<workdir>/.env` are blocked by default without a --deny flag.
+func workdirProtectedCommon() []string {
+	return []string{
+		".env",
+		".envrc",
+	}
+}
+
 func darwinBaseline() Baseline {
 	return Baseline{
 		Read: []string{
@@ -122,6 +139,7 @@ func darwinBaseline() Baseline {
 			"~/Library/Containers/com.apple.Safari",
 			"~/Library/Application Support/MobileSync",
 		),
+		WorkdirProtected: workdirProtectedCommon(),
 	}
 }
 
@@ -151,6 +169,7 @@ func linuxBaseline() Baseline {
 			"~/.config/microsoft-edge",
 			"~/.config/BraveSoftware",
 		),
+		WorkdirProtected: workdirProtectedCommon(),
 	}
 }
 

--- a/internal/sandboxprofile/baseline.go
+++ b/internal/sandboxprofile/baseline.go
@@ -177,14 +177,7 @@ func linuxBaseline() Baseline {
 // profile's override_deny holes. Comparison happens on the expanded
 // form of both lists; entries that fail to expand are kept verbatim.
 func EffectiveProtectedPaths(b Baseline, overrideDeny []string) []string {
-	overrides := make(map[string]bool, len(overrideDeny))
-	for _, o := range overrideDeny {
-		if exp, err := ExpandPath(o); err == nil {
-			overrides[exp] = true
-		} else {
-			overrides[o] = true
-		}
-	}
+	overrides := BuildOverrideLookup(overrideDeny)
 	var out []string
 	for _, p := range b.ProtectedPaths {
 		exp, err := ExpandPath(p)
@@ -198,4 +191,20 @@ func EffectiveProtectedPaths(b Baseline, overrideDeny []string) []string {
 		out = append(out, exp)
 	}
 	return out
+}
+
+// BuildOverrideLookup creates a set keyed by both the raw and expanded
+// form of each override_deny entry, so overrides work as bare basenames
+// (e.g. ".env") or absolute paths. Shared by EffectiveProtectedPaths
+// and the workdir-protected resolver to keep the override-keying policy
+// in one place.
+func BuildOverrideLookup(overrideDeny []string) map[string]bool {
+	overrides := make(map[string]bool, len(overrideDeny))
+	for _, o := range overrideDeny {
+		overrides[o] = true
+		if exp, err := ExpandPath(o); err == nil {
+			overrides[exp] = true
+		}
+	}
+	return overrides
 }

--- a/internal/sandboxprofile/baseline.go
+++ b/internal/sandboxprofile/baseline.go
@@ -21,7 +21,7 @@ type Baseline struct {
 	// workdir and any explicitly granted tree. Unlike ProtectedPaths,
 	// they are resolved at launch time against the actual workdir, so
 	// they catch workdir-relative files the static ProtectedPaths set
-	// cannot. override_deny holes punch through here too.
+	// cannot.
 	WorkdirProtected []string
 }
 

--- a/internal/sandboxrun/grants.go
+++ b/internal/sandboxrun/grants.go
@@ -115,6 +115,12 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 	// trees so the same deny covers the cwd and any explicit grant.
 	protected = append(protected, resolveUserDeny(p.Filesystem.Deny, dedupe(denyScan), notices)...)
 
+	// Baseline workdir-protected basenames (e.g. ".env") are resolved
+	// against the same scan roots as user deny globs, so workdir-relative
+	// secret files are blocked by default without a --deny flag. Holes
+	// can be punched via filesystem.override_deny (basename form).
+	protected = append(protected, resolveBaselineWorkdirDeny(base.WorkdirProtected, p.Filesystem.OverrideDeny, dedupe(denyScan), notices)...)
+
 	g := &Grants{
 		Workdir:         workdir,
 		ReadPaths:       dedupe(read),
@@ -175,6 +181,45 @@ func resolveUserDeny(deny, scanRoots []string, notices io.Writer) []string {
 	out := explicit
 	if len(globs) > 0 {
 		out = append(out, walkGlobMatches(scanRoots, globs, notices)...)
+	}
+	return out
+}
+
+// resolveBaselineWorkdirDeny resolves the baseline workdir-protected
+// basenames (e.g. ".env") against the granted scan roots, mirroring
+// resolveUserDeny's glob walk. override_deny entries that are bare
+// basenames (e.g. ".env") or absolute paths matching a found file
+// punch holes in the result, so a skill that legitimately needs to
+// read a workdir .env can opt out via filesystem.override_deny.
+func resolveBaselineWorkdirDeny(basenames, overrideDeny, scanRoots []string, notices io.Writer) []string {
+	if len(basenames) == 0 {
+		return nil
+	}
+	// Build an override lookup keyed by both basename and absolute path.
+	overrides := make(map[string]bool, len(overrideDeny))
+	for _, o := range overrideDeny {
+		overrides[o] = true
+		if exp, err := sandboxprofile.ExpandPath(o); err == nil {
+			overrides[exp] = true
+		}
+	}
+	// Filter the basenames before walking.
+	var active []string
+	for _, b := range basenames {
+		if !overrides[b] {
+			active = append(active, b)
+		}
+	}
+	if len(active) == 0 {
+		return nil
+	}
+	matches := walkGlobMatches(scanRoots, active, notices)
+	// Drop matches that are also covered by an absolute override_deny.
+	var out []string
+	for _, m := range matches {
+		if !overrides[m] {
+			out = append(out, m)
+		}
 	}
 	return out
 }

--- a/internal/sandboxrun/grants.go
+++ b/internal/sandboxrun/grants.go
@@ -109,14 +109,14 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 
 	protected := sandboxprofile.EffectiveProtectedPaths(base, p.Filesystem.OverrideDeny)
 
-	// User deny entries carve holes out of the granted trees. Path-form
-	// entries expand to an explicit path; basename globs (e.g. ".env")
-	// are matched against the files inside the granted (non-baseline)
-	// trees so the same deny covers the cwd and any explicit grant.
-	protected = append(protected, resolveUserDeny(p.Filesystem.Deny, dedupe(denyScan), notices)...)
-
-	// Baseline workdir-protected basenames resolved against the same scan roots.
-	protected = append(protected, resolveBaselineWorkdirDeny(base.WorkdirProtected, p.Filesystem.OverrideDeny, dedupe(denyScan), notices)...)
+	// User deny entries and baseline workdir-protected basenames share
+	// a single walk over the granted (non-baseline) scan roots. Path-form
+	// deny entries expand to explicit paths; basename globs and baseline
+	// basenames are matched together in one pass.
+	protected = append(protected, resolveDenyPaths(
+		p.Filesystem.Deny, base.WorkdirProtected, p.Filesystem.OverrideDeny,
+		dedupe(denyScan), notices,
+	)...)
 
 	g := &Grants{
 		Workdir:         workdir,
@@ -147,20 +147,19 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 // stops the walk for that root (already-found matches are still masked).
 const maxDenyScanEntries = 200000
 
-// resolveUserDeny turns filesystem.deny entries into concrete protected
-// paths. Path-form entries (with a separator, ~ or $VAR) expand to a
-// single explicit path. Basename globs (e.g. ".env", "*.key") are
-// matched against the files found by walking scanRoots — the explicit
-// (non-baseline) granted trees plus the workdir — so one deny covers
-// the cwd and every directory the user granted. Baseline system trees
-// (e.g. /usr) are never scanned because they are not in scanRoots.
-func resolveUserDeny(deny, scanRoots []string, notices io.Writer) []string {
-	if len(deny) == 0 {
+// resolveDenyPaths resolves user deny entries and baseline workdir-protected
+// basenames in a single filesystem walk. User deny path-form entries expand
+// to explicit protected paths; basename globs and baseline basenames are
+// matched together. override_deny holes (basename or absolute path) are
+// punched through baseline matches.
+func resolveDenyPaths(userDeny, baselineBasenames, overrideDeny, scanRoots []string, notices io.Writer) []string {
+	if len(userDeny) == 0 && len(baselineBasenames) == 0 {
 		return nil
 	}
+
 	var explicit []string
 	var globs []string
-	for _, d := range deny {
+	for _, d := range userDeny {
 		if sandboxprofile.IsBasenameGlob(d) {
 			globs = append(globs, d)
 			continue
@@ -175,47 +174,22 @@ func resolveUserDeny(deny, scanRoots []string, notices io.Writer) []string {
 		explicit = append(explicit, exp)
 	}
 
+	// Filter baseline basenames through overrides before walking.
+	overrides := sandboxprofile.BuildOverrideLookup(overrideDeny)
+	for _, b := range baselineBasenames {
+		if !overrides[b] {
+			globs = append(globs, b)
+		}
+	}
+
 	out := explicit
 	if len(globs) > 0 {
-		out = append(out, walkGlobMatches(scanRoots, globs, notices)...)
-	}
-	return out
-}
-
-// resolveBaselineWorkdirDeny resolves the baseline workdir-protected
-// basenames (e.g. ".env") against the granted scan roots, sharing the
-// walkGlobMatches walk with resolveUserDeny. override_deny entries that
-// are bare basenames (e.g. ".env") or absolute paths matching a found
-// file punch holes in the result, so a skill that legitimately needs to
-// read a workdir .env can opt out via filesystem.override_deny.
-func resolveBaselineWorkdirDeny(basenames, overrideDeny, scanRoots []string, notices io.Writer) []string {
-	if len(basenames) == 0 {
-		return nil
-	}
-	// Build an override lookup keyed by both basename and absolute path.
-	overrides := make(map[string]bool, len(overrideDeny))
-	for _, o := range overrideDeny {
-		overrides[o] = true
-		if exp, err := sandboxprofile.ExpandPath(o); err == nil {
-			overrides[exp] = true
-		}
-	}
-	// Filter the basenames before walking.
-	var active []string
-	for _, b := range basenames {
-		if !overrides[b] {
-			active = append(active, b)
-		}
-	}
-	if len(active) == 0 {
-		return nil
-	}
-	matches := walkGlobMatches(scanRoots, active, notices)
-	// Drop matches that are also covered by an absolute override_deny.
-	var out []string
-	for _, m := range matches {
-		if !overrides[m] {
-			out = append(out, m)
+		matches := walkGlobMatches(scanRoots, globs, notices)
+		// Drop baseline matches covered by an absolute-path override.
+		for _, m := range matches {
+			if !overrides[m] {
+				out = append(out, m)
+			}
 		}
 	}
 	return out

--- a/internal/sandboxrun/grants.go
+++ b/internal/sandboxrun/grants.go
@@ -115,10 +115,7 @@ func ResolveGrants(p *sandboxprofile.Profile, workdir string, notices io.Writer)
 	// trees so the same deny covers the cwd and any explicit grant.
 	protected = append(protected, resolveUserDeny(p.Filesystem.Deny, dedupe(denyScan), notices)...)
 
-	// Baseline workdir-protected basenames (e.g. ".env") are resolved
-	// against the same scan roots as user deny globs, so workdir-relative
-	// secret files are blocked by default without a --deny flag. Holes
-	// can be punched via filesystem.override_deny (basename form).
+	// Baseline workdir-protected basenames resolved against the same scan roots.
 	protected = append(protected, resolveBaselineWorkdirDeny(base.WorkdirProtected, p.Filesystem.OverrideDeny, dedupe(denyScan), notices)...)
 
 	g := &Grants{
@@ -186,10 +183,10 @@ func resolveUserDeny(deny, scanRoots []string, notices io.Writer) []string {
 }
 
 // resolveBaselineWorkdirDeny resolves the baseline workdir-protected
-// basenames (e.g. ".env") against the granted scan roots, mirroring
-// resolveUserDeny's glob walk. override_deny entries that are bare
-// basenames (e.g. ".env") or absolute paths matching a found file
-// punch holes in the result, so a skill that legitimately needs to
+// basenames (e.g. ".env") against the granted scan roots, sharing the
+// walkGlobMatches walk with resolveUserDeny. override_deny entries that
+// are bare basenames (e.g. ".env") or absolute paths matching a found
+// file punch holes in the result, so a skill that legitimately needs to
 // read a workdir .env can opt out via filesystem.override_deny.
 func resolveBaselineWorkdirDeny(basenames, overrideDeny, scanRoots []string, notices io.Writer) []string {
 	if len(basenames) == 0 {

--- a/internal/sandboxrun/grants_test.go
+++ b/internal/sandboxrun/grants_test.go
@@ -469,3 +469,71 @@ func TestResolveGrantsWorkdirEnvProtectedByDefault(t *testing.T) {
 		}
 	})
 }
+
+// TestResolveGrantsBaselineWorkdirDenyDoesNotScanBaseline mirrors
+// TestResolveGrantsDenyGlobDoesNotScanBaseline but for the baseline
+// WorkdirProtected walk (resolveBaselineWorkdirDeny). The invariant
+// holds today (shares denyScan), but a regression that accidentally
+// passed base.Read into the baseline resolver would go undetected
+// without this guard.
+func TestResolveGrantsBaselineWorkdirDenyDoesNotScanBaseline(t *testing.T) {
+	wd := t.TempDir()
+	env := filepath.Join(wd, ".env")
+	writeFile(t, env)
+
+	p := &sandboxprofile.Profile{
+		Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+	}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Baseline .env protection is active.
+	if !slices.Contains(g.ProtectedPaths, env) {
+		t.Errorf("workdir .env not protected by default: %v", g.ProtectedPaths)
+	}
+	// No baseline system tree was scanned.
+	for _, prot := range g.ProtectedPaths {
+		if strings.HasPrefix(prot, "/usr/") || strings.HasPrefix(prot, "/lib") {
+			t.Errorf("baseline tree was scanned for workdir deny: %s", prot)
+		}
+	}
+}
+
+// TestResolveGrantsUserDenyAndBaselineBothActive verifies that when
+// both user deny globs and baseline workdir-protected basenames are
+// active simultaneously, all matches are found and no duplicates appear.
+func TestResolveGrantsUserDenyAndBaselineBothActive(t *testing.T) {
+	wd := t.TempDir()
+	env := filepath.Join(wd, ".env")
+	writeFile(t, env)
+	keyFile := filepath.Join(wd, "secret.key")
+	writeFile(t, keyFile)
+	keep := filepath.Join(wd, "app.go")
+	writeFile(t, keep)
+
+	p := &sandboxprofile.Profile{
+		Workdir:    sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+		Filesystem: sandboxprofile.Filesystem{Deny: []string{"*.key"}},
+	}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(g.ProtectedPaths, env) {
+		t.Errorf(".env (baseline) not protected: %v", g.ProtectedPaths)
+	}
+	if !slices.Contains(g.ProtectedPaths, keyFile) {
+		t.Errorf("secret.key (user deny) not protected: %v", g.ProtectedPaths)
+	}
+	if slices.Contains(g.ProtectedPaths, keep) {
+		t.Error("app.go must not be protected")
+	}
+	seen := map[string]bool{}
+	for _, prot := range g.ProtectedPaths {
+		if seen[prot] {
+			t.Errorf("duplicate protected path: %s", prot)
+		}
+		seen[prot] = true
+	}
+}

--- a/internal/sandboxrun/grants_test.go
+++ b/internal/sandboxrun/grants_test.go
@@ -388,3 +388,84 @@ func TestResolveGrantsDenyGlobDoesNotScanBaseline(t *testing.T) {
 		}
 	}
 }
+
+// TestResolveGrantsWorkdirEnvProtectedByDefault verifies that a
+// workdir-local .env / .envrc is masked by the baseline
+// WorkdirProtected set without any --deny flag, and that
+// filesystem.override_deny can punch a hole through it.
+func TestResolveGrantsWorkdirEnvProtectedByDefault(t *testing.T) {
+	wd := t.TempDir()
+	env := filepath.Join(wd, ".env")
+	writeFile(t, env)
+	envrc := filepath.Join(wd, ".envrc")
+	writeFile(t, envrc)
+	nested := filepath.Join(wd, "config")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nestedEnv := filepath.Join(nested, ".env")
+	writeFile(t, nestedEnv)
+	keep := filepath.Join(wd, "main.go")
+	writeFile(t, keep)
+
+	t.Run("default protects .env and .envrc", func(t *testing.T) {
+		p := &sandboxprofile.Profile{
+			Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+		}
+		g, err := ResolveGrants(p, wd, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.Contains(g.ProtectedPaths, env) {
+			t.Errorf("workdir .env not protected by default: %v", g.ProtectedPaths)
+		}
+		if !slices.Contains(g.ProtectedPaths, envrc) {
+			t.Errorf("workdir .envrc not protected by default: %v", g.ProtectedPaths)
+		}
+		if !slices.Contains(g.ProtectedPaths, nestedEnv) {
+			t.Errorf("nested .env not protected by default: %v", g.ProtectedPaths)
+		}
+		if slices.Contains(g.ProtectedPaths, keep) {
+			t.Error("non-.env file must not be protected")
+		}
+	})
+
+	t.Run("override_deny basename punches hole", func(t *testing.T) {
+		p := &sandboxprofile.Profile{
+			Workdir:    sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+			Filesystem: sandboxprofile.Filesystem{OverrideDeny: []string{".env"}},
+		}
+		g, err := ResolveGrants(p, wd, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if slices.Contains(g.ProtectedPaths, env) {
+			t.Errorf(".env should be unprotected via override_deny: %v", g.ProtectedPaths)
+		}
+		if slices.Contains(g.ProtectedPaths, nestedEnv) {
+			t.Errorf("nested .env should be unprotected via override_deny: %v", g.ProtectedPaths)
+		}
+		// .envrc is not overridden and stays protected.
+		if !slices.Contains(g.ProtectedPaths, envrc) {
+			t.Errorf(".envrc should remain protected: %v", g.ProtectedPaths)
+		}
+	})
+
+	t.Run("override_deny absolute path punches hole", func(t *testing.T) {
+		p := &sandboxprofile.Profile{
+			Workdir:    sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+			Filesystem: sandboxprofile.Filesystem{OverrideDeny: []string{env}},
+		}
+		g, err := ResolveGrants(p, wd, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if slices.Contains(g.ProtectedPaths, env) {
+			t.Errorf("absolute override_deny should unprotect %s: %v", env, g.ProtectedPaths)
+		}
+		// Nested .env is a different absolute path and stays protected.
+		if !slices.Contains(g.ProtectedPaths, nestedEnv) {
+			t.Errorf("nested .env should remain protected: %v", g.ProtectedPaths)
+		}
+	})
+}


### PR DESCRIPTION
## What

Workspace-local `.env` and `.envrc` files are now denied by default inside the sandbox, without needing `--deny .env` or `filesystem.deny`.

## Why

The baseline protected-path set covered `~/.env` (home dir), but a workdir-local `.env` holding real secrets was readable by the sandboxed agent unless the user remembered to opt in via `--deny .env`. This is a common footgun — workspace `.env` is the most likely place for project secrets.

## How

- New `WorkdirProtected []string` field on `Baseline` (`internal/sandboxprofile/baseline.go`) — basenames resolved at launch time against the workdir + every explicitly granted tree.
- `resolveBaselineWorkdirDeny` in `internal/sandboxrun/grants.go` reuses the existing `walkGlobMatches` machinery (same as `filesystem.deny` globs), so baseline system trees (`/usr`, `/lib`) are never scanned — only the workdir and explicit user grants.
- `filesystem.override_deny` holes punch through in both basename (`.env`) and absolute-path forms, so a skill that legitimately needs to read a workdir `.env` can opt out.

## Files

- `internal/sandboxprofile/baseline.go` — `WorkdirProtected` field + `workdirProtectedCommon()` (.env, .envrc)
- `internal/sandboxrun/grants.go` — `resolveBaselineWorkdirDeny` + wiring in `ResolveGrants`
- `internal/sandboxrun/grants_test.go` — `TestResolveGrantsWorkdirEnvProtectedByDefault` (default protection + override_deny basename + override_deny absolute)
- `README.md` — table row for workdir `.env`/`.envrc`

## Verification

- `go test ./internal/sandboxrun/... ./internal/sandboxprofile/...` — pass
- `go vet ./...` — clean
- gofmt — clean
- Existing deny tests still pass (no regression in `filesystem.deny` / `--deny` behavior)
