### PR TITLE
fix(sandbox): grant read on shared .agents skills dirs in default profile

### DIFF
--- a/internal/sandboxprofile/profile_test.go
+++ b/internal/sandboxprofile/profile_test.go
@@ -225,6 +225,28 @@ func TestResolveFirstStartScaffoldsDefault(t *testing.T) {
 	}
 }
 
+func TestDefaultProfileGrantsSharedAgentsSkillsRead(t *testing.T) {
+	// The shared neutral skills base ("agents") is in scope for every
+	// harness, so its user-global roots must be readable inside the
+	// sandbox. Per-harness global skills dirs are granted RW via
+	// Harness.SandboxDirs; only the shared base needs an explicit read
+	// grant in the default profile.
+	p := DefaultProfile()
+	want := []string{"~/.config/agents/skills", "~/.agents/skills"}
+	for _, w := range want {
+		found := false
+		for _, r := range p.Filesystem.Read {
+			if r == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("DefaultProfile.Filesystem.Read missing %q (got %v)", w, p.Filesystem.Read)
+		}
+	}
+}
+
 func TestResolveExistingDefaultWins(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/sandboxprofile/resolve.go
+++ b/internal/sandboxprofile/resolve.go
@@ -38,6 +38,13 @@ func DefaultProfile() *Profile {
 				"~/.nvm",
 				"~/.bun/bin",
 				"~/.bun/install/global/node_modules/opencode-ai",
+				// Shared neutral skills base (agentskills.io). In scope for every
+				// harness via InScopeSkillsBases, so a guidance-only SKILL.md
+				// placed under the shared global root is readable inside the
+				// sandbox. Per-harness global skills dirs are granted RW via
+				// Harness.SandboxDirs at launch.
+				"~/.config/agents/skills",
+				"~/.agents/skills",
 			},
 		},
 		Network: Network{


### PR DESCRIPTION
Closes #47.

## Problem

The shared neutral skills base (`agents`) is in scope for every harness (`config.Harness.InScopeSkillsBases`), but neither the platform baseline nor the default sandbox profile granted read access to its user-global roots (`~/.config/agents/skills`, `~/.agents/skills`).

Per-harness global skills dirs are covered by `Harness.SandboxDirs` (RW via `--allow` at launch):
- opencode → `~/.config/opencode`
- claude → `~/.claude`
- codex → `~/.codex`
- copilot → `~/.copilot`

But the shared base was unreadable inside the sandbox, so a guidance-only SKILL.md placed under the shared global root was invisible to the inner harness.

## Fix

Add `~/.config/agents/skills` and `~/.agents/skills` to `DefaultProfile().Filesystem.Read`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] new test `TestDefaultProfileGrantsSharedAgentsSkillsRead` asserts the paths are present
- [x] existing `TestResolveFirstStartScaffoldsDefault` still green