### PR TITLE
fix(e2e): read audit-output.txt in TestE2EProvenance instead of chat text

### DIFF
--- a/internal/e2e/provenance_test.go
+++ b/internal/e2e/provenance_test.go
@@ -130,10 +130,25 @@ func TestE2EProvenance(t *testing.T) {
 	}
 
 	// --- Step 3: Behavior cross-check via the audit agent ---
+	// The audit script writes its probe output to this file (via
+	// OMAC_AUDIT_OUTPUT_FILE, set by runAuditAgent) instead of stdout — some
+	// harness TUIs collapse tool output, so the test reads the file directly
+	// rather than depending on the agent pasting it back verbatim in chat.
+	auditOutputFile := filepath.Join(workdir, "audit-output.txt")
+
 	prompt := "Run this command and print its full output verbatim:\n\n" +
 		`sh "$OMAC_HARNESS_SKILLS_DIR/self-audit/scripts/audit.sh"` + "\n\n" +
 		"Do not summarize. Print every line."
-	auditStdout := runAuditAgent(t, h, omacBin, home, workdir, prompt)
+	agentOutput := runAuditAgent(t, h, omacBin, home, workdir, prompt)
+
+	auditOutput, err := os.ReadFile(auditOutputFile)
+	if err != nil {
+		t.Logf("audit-output.txt not found (%v) — falling back to agent stdout+stderr", err)
+		auditOutput = []byte(agentOutput)
+	} else {
+		t.Logf("audit-output.txt read: %d bytes", len(auditOutput))
+	}
+	auditStdout := string(auditOutput) + "\n" + agentOutput
 
 	// 3a. Network denial: spec.NetDenyDomain should be denied by the sandbox.
 	// The provenance output doesn't list it as allow → audit shows denial.


### PR DESCRIPTION
## What
`TestE2EProvenance` now reads `audit-output.txt` from disk (with a fallback to agent stdout/stderr) instead of asserting solely on the agent's chat reply.

## Why
The latest scheduled E2E run on `main` ([run 29146467693](https://github.com/TNG/oh-my-agentic-coder/actions/runs/29146467693)) failed `TestE2EProvenance` on 2 of 7 matrix jobs (`opencode/macos-latest`, `copilot/ubuntu-latest`) with:

```
behavior mismatch: "blocked.example.com" not denied by sandbox (audit output lacks denial message)
behavior mismatch: no filesystem denial in audit output despite provenance listing protected paths as denied
```

Downloading the uploaded session artifacts showed the sandbox actually enforced everything correctly — `DENY blocked.example.com`, `Permission denied` on `/etc/shadow`, etc. all appear in `audit-output.txt` and the omac logs for the failing runs. The test was reading the wrong source: `self-audit/scripts/audit.sh` redirects all its output to a file via `exec > "$_audit_file" 2>&1` (some harness TUIs collapse tool output), and `TestE2EProvenance` asserted only on the agent's free-form chat reply, which only contains the denial markers when the model happens to `cat` the file back verbatim. `TestE2ESecurityAudit` already reads `audit-output.txt` directly for exactly this reason — `TestE2EProvenance` never got the same treatment.

## How
Mirrors the existing pattern in `e2e_test.go`'s `TestE2ESecurityAudit`: read `workdir/audit-output.txt` after `runAuditAgent`, combine with agent stdout, and fall back to agent-only output if the file is missing (e.g. the agent refused to run the script).

## Verification
- `go build ./...` and `go build -tags=e2e ./...` — clean
- `go vet -tags=e2e ./internal/e2e/...` — clean
- `gofmt -l` — clean
- `go test ./...` (non-e2e suite) — all pass
- Did not run the live `-tags=e2e` suite locally (requires bubblewrap, live harness installs, and CI secrets); the actual fix will be exercised by the next scheduled/dispatched E2E run in CI.