### PR TITLE
fix(ci): serialize GLM-backed E2E harnesses to reduce backend contention

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,8 +32,17 @@ jobs:
           - os: macos-latest
             harness: codex
     runs-on: ${{ matrix.os }}
+    # opencode/codex/copilot all share the SKAINET_TOKEN-backed GLM-5.2
+    # endpoint; claude-code talks to Anthropic directly via a separate
+    # proxy. Running all three GLM-backed harnesses concurrently has been
+    # observed to overload/stall that shared backend, causing the CLI to
+    # sit on an open connection well past its final response and blow the
+    # per-agent 5m timeout ("agent did not exit within 5m0s") across
+    # unrelated tests in the same job. Serialize the GLM-backed harnesses
+    # per OS (one at a time) while leaving claude-code free to run in
+    # parallel, since it doesn't contend for that backend.
     concurrency:
-      group: e2e-${{ matrix.os }}-${{ matrix.harness }}
+      group: e2e-${{ matrix.os }}-${{ contains(fromJSON('["opencode","codex","copilot"]'), matrix.harness) && 'skainet-shared' || matrix.harness }}
       cancel-in-progress: false
     env:
       SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}


### PR DESCRIPTION
## What
Serializes `opencode`/`codex`/`copilot` (one at a time, per OS) in the E2E workflow's concurrency group, while leaving `claude-code` free to run in parallel.

## Why
Triggering the E2E workflow on #60 ([run 29240222298](https://github.com/TNG/oh-my-agentic-coder/actions/runs/29240222298)) failed 6 of 7 matrix jobs with `agent did not exit within 5m0s`. Investigation (full notes below) shows:

- `omac`'s own instrumented paths (supervisor, sandbox launcher, netproxy filter — including the new audit-trail `Emit()` calls added in #38) return promptly in every local repro I tried, including one that drives real proxied network traffic (allow + deny) through the sandbox. No hang reproduces there.
- In the failing CI runs, `omac`'s own log shows the CLI's single `ALLOW external.model.tngtech.com:443` decision at session start and then **nothing else** until the 5-minute deadline fires — the harness process (`copilot`/`opencode`/`codex`) had already printed its final answer/summary and simply never returned control.
- The one job that passed cleanly every time (`claude-code`) is also the only harness that does **not** share the `SKAINET_TOKEN`-backed GLM-5.2 endpoint (`external.model.tngtech.com`) — `opencode`, `codex`, and `copilot` all hit that same backend, and the workflow runs them fully concurrently.
- This exact failure signature (`agent did not exit within 5m0s`, across the whole matrix) already occurred in a scheduled run on `main` on 2026-07-10 — three commits *before* the audit-trail commit (#38) ever merged. That rules out #38, and rules out anything in #60, as the cause.

Net: this looks like contention/stalling on the shared GLM-5.2 backend under concurrent load (Node-based CLIs sitting on an open connection rather than exiting), not a code defect in this repo.

## How
Change the job's `concurrency.group` so the three GLM-backed harnesses share a single group per OS (serialized, one at a time), while `claude-code` keeps its own independent group and still runs in parallel.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))"` — valid YAML
- Manually checked the `contains(fromJSON(...), matrix.harness)` expression against GitHub Actions' documented expression functions (both are valid in any expression context, including `concurrency.group`)
- **Not proven**: this is a mitigation for a suspected environmental/backend cause, not a confirmed fix — I could not reproduce the hang locally to verify the fix closes it, since it depends on live shared-backend load. Recommend watching the next few scheduled/dispatched E2E runs for whether the hang recurs.

Related: #60 (separate fix for the `TestE2EProvenance` flake surfaced by the same investigation).