### PR TITLE
feat(update): add omac update self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,28 @@ curl -L -O \
 sudo pacman -U oh-my-agentic-coder_*.pkg.tar.zst
 ```
 
+### Updating
+
+However you installed omac, `omac update` detects the right method for this
+host and does it for you:
+
+```sh
+omac update            # prompts for confirmation before installing
+omac update --yes      # skip the confirmation prompt (scripting/CI)
+```
+
+It checks GitHub's latest release, and:
+
+- on macOS with a Homebrew-managed install, runs `brew upgrade
+  oh-my-agentic-coder` (equivalent to the `brew upgrade` above);
+- on Linux, detects `dpkg`/`rpm`/`pacman`/`apk` (in that priority) and
+  installs the matching package with `sudo`, same as the manual commands
+  above, after verifying its SHA-256 against `checksums.txt`;
+- otherwise (macOS without brew, or a Linux host with none of the above),
+  downloads the tarball and replaces the running binary in place.
+
+Declining the confirmation prompt does nothing — that's the dry run.
+
 ### Verifying downloads
 
 Every release includes `checksums.txt`:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -19,6 +19,7 @@ const (
 	ExitSandboxAbnormal        = 7
 	ExitKeychainError          = 8
 	ExitSecretRefused          = 9
+	ExitChecksumMismatch       = 10
 )
 
 // Command is a runnable omac subcommand.
@@ -129,6 +130,7 @@ func commands() map[string]Command {
 		"plugin":     {Name: "plugin", Short: "Install client-side harness bridge plugins (e.g. opencode-desktop).", Run: runPlugin},
 		"sandbox":    {Name: "sandbox", Short: "Built-in kernel sandbox (run|stage2).", Run: runSandbox},
 		"doctor":     {Name: "doctor", Short: "Run sanity checks.", Run: runDoctor},
+		"update":     {Name: "update", Short: "Check GitHub for a newer release and install it.", Run: runUpdate},
 		"manifest":   {Name: "manifest", Short: "Render the skills manifest from activate-response JSON.", Run: runManifest},
 		"version":    {Name: "version", Short: "Print version.", Run: runVersion},
 	}
@@ -160,6 +162,7 @@ Subcommands:
   plugin       Install client-side bridge plugins (e.g. opencode-desktop).
   sandbox      Built-in kernel sandbox: omac sandbox run [flags] -- <cmd>.
   doctor       Run sanity checks.
+  update       Check GitHub for a newer release and install it.
   manifest    Render the skills manifest from activate-response JSON.
   version      Print version.
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -56,7 +56,11 @@ func runUpdateWithDeps(env *Env, yes bool, deps updater.Deps) int {
 	}
 
 	if plan.Method == updater.MethodUpToDate {
-		fmt.Fprintf(env.Stdout, "[ok] omac %s is already up to date\n", plan.CurrentVersion)
+		if plan.CurrentVersion != plan.LatestVersion {
+			fmt.Fprintf(env.Stdout, "[ok] omac %s is newer than the latest release %s; nothing to do\n", plan.CurrentVersion, plan.LatestVersion)
+		} else {
+			fmt.Fprintf(env.Stdout, "[ok] omac %s is already up to date\n", plan.CurrentVersion)
+		}
 		return ExitOK
 	}
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	iofs "io/fs"
+	"os"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/term"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/updater"
+)
+
+func runUpdate(args []string, env *Env) int {
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	var yes bool
+	fs.BoolVar(&yes, "yes", false, "Skip the confirmation prompt (for scripting/non-interactive use).")
+	fs.BoolVar(&yes, "y", false, "Shorthand for --yes.")
+	fs.Usage = func() {
+		fmt.Fprintln(env.Stderr, "Usage: omac update [--yes|-y]")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(reorderFlagsFirst(args)); err != nil {
+		return ExitMisuse
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return ExitMisuse
+	}
+	return runUpdateWithDeps(env, yes, updater.RealDeps(env.Stdin, env.Stdout, env.Stderr))
+}
+
+func runUpdateWithDeps(env *Env, yes bool, deps updater.Deps) int {
+	ctx := context.Background()
+	plan, err := updater.Check(ctx, updater.Options{CurrentVersion: env.Version}, deps)
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "omac update:", err)
+		switch {
+		case errors.Is(err, updater.ErrChecksumMismatch):
+			return ExitChecksumMismatch
+		case errors.Is(err, updater.ErrNoMatchingAsset):
+			return ExitPrerequisiteMissing
+		default:
+			return ExitIOError
+		}
+	}
+
+	if plan.LocalPath != "" {
+		defer os.Remove(plan.LocalPath)
+	}
+
+	if plan.Method == updater.MethodUpToDate {
+		fmt.Fprintf(env.Stdout, "[ok] omac %s is already up to date\n", plan.CurrentVersion)
+		return ExitOK
+	}
+
+	printUpdatePlan(env, plan)
+
+	if !yes {
+		proceed, askErr := confirmUpdate(env)
+		if askErr != nil {
+			fmt.Fprintln(env.Stdout, "[noop]", askErr)
+			return ExitOK
+		}
+		if !proceed {
+			fmt.Fprintln(env.Stdout, "[noop] update cancelled")
+			return ExitOK
+		}
+	}
+
+	if err := updater.Apply(ctx, plan, deps); err != nil {
+		fmt.Fprintln(env.Stderr, "omac update:", err)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return ExitGeneric
+		}
+		if errors.Is(err, iofs.ErrPermission) {
+			fmt.Fprintln(env.Stderr, "omac update: permission denied replacing the binary — re-run with sudo, or reinstall via your package manager")
+		}
+		return ExitIOError
+	}
+	fmt.Fprintf(env.Stdout, "[ok] updated omac %s -> %s\n", plan.CurrentVersion, plan.LatestVersion)
+	return ExitOK
+}
+
+func printUpdatePlan(env *Env, plan updater.Plan) {
+	fmt.Fprintf(env.Stdout, "omac %s -> %s\n", plan.CurrentVersion, plan.LatestVersion)
+	switch plan.Method {
+	case updater.MethodBrew:
+		fmt.Fprintln(env.Stdout, "method: brew upgrade oh-my-agentic-coder")
+	case updater.MethodLinuxPackage:
+		fmt.Fprintf(env.Stdout, "method: %s (%s), checksum verified: %v\n", plan.PackageManager, plan.Asset.Name, plan.ChecksumVerified)
+	case updater.MethodTarballSelfReplace:
+		fmt.Fprintf(env.Stdout, "method: replace running binary from %s, checksum verified: %v\n", plan.Asset.Name, plan.ChecksumVerified)
+	}
+}
+
+func confirmUpdate(env *Env) (bool, error) {
+	if !term.IsTerminal(int(env.Stdin.Fd())) {
+		return false, errors.New("stdin is not a terminal; declining automatic update (re-run with --yes/-y to update non-interactively)")
+	}
+	fmt.Fprint(env.Stdout, "Proceed with update? [y/N] ")
+	line, _ := bufio.NewReader(env.Stdin).ReadString('\n')
+	return parseYesNo(line), nil
+}
+
+func parseYesNo(line string) bool {
+	a := strings.ToLower(strings.TrimSpace(line))
+	return a == "y" || a == "yes"
+}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,0 +1,344 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/updater"
+)
+
+// --- fakes implementing updater's exported interfaces -----------------
+
+type fakeSource struct {
+	rel updater.Release
+	err error
+}
+
+func (f fakeSource) LatestRelease(ctx context.Context) (updater.Release, error) {
+	return f.rel, f.err
+}
+
+type fakeFetcher struct {
+	files map[string][]byte
+}
+
+func (f fakeFetcher) FetchAll(ctx context.Context, url string) ([]byte, error) {
+	body, ok := f.files[url]
+	if !ok {
+		return nil, fmt.Errorf("fakeFetcher: no fixture for %s", url)
+	}
+	return body, nil
+}
+
+func (f fakeFetcher) FetchToFile(ctx context.Context, url, dir, pattern string) (string, error) {
+	body, ok := f.files[url]
+	if !ok {
+		return "", fmt.Errorf("fakeFetcher: no fixture for %s", url)
+	}
+	tmp, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", err
+	}
+	defer tmp.Close()
+	if _, err := tmp.Write(body); err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+type fakeRunner struct{ err error }
+
+func (f fakeRunner) Run(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	return f.err
+}
+
+type fakeReplacer struct{ err error }
+
+func (f fakeReplacer) Replace(path string, r io.Reader, mode fs.FileMode) error {
+	if _, err := io.Copy(io.Discard, r); err != nil {
+		return err
+	}
+	return f.err
+}
+
+func checksumsFile(name string, content []byte) []byte {
+	sum := sha256.Sum256(content)
+	return []byte(fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), name))
+}
+
+func baseTestDeps(t *testing.T) updater.Deps {
+	t.Helper()
+	return updater.Deps{
+		Executable: func() (string, error) { return filepath.Join(t.TempDir(), "omac"), nil },
+		TempDir:    t.TempDir(),
+		GOOS:       "linux",
+		GOARCH:     "amd64",
+		Stdin:      bytes.NewReader(nil),
+		Stdout:     io.Discard,
+		Stderr:     io.Discard,
+	}
+}
+
+// --- runUpdateWithDeps tests --------------------------------------------
+
+func runUpdateCapture(t *testing.T, yes bool, deps updater.Deps, stdinContent string) (stdout, stderr string, code int) {
+	t.Helper()
+	dir := t.TempDir()
+	outF, err := os.Create(filepath.Join(dir, "out"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	errF, err := os.Create(filepath.Join(dir, "err"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	inPath := filepath.Join(dir, "in")
+	if err := os.WriteFile(inPath, []byte(stdinContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	inF, err := os.Open(inPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := &Env{Version: "1.0.0", Workdir: dir, Stdout: outF, Stderr: errF, Stdin: inF}
+
+	code = runUpdateWithDeps(env, yes, deps)
+
+	outF.Close()
+	errF.Close()
+	inF.Close()
+	o, _ := os.ReadFile(outF.Name())
+	e, _ := os.ReadFile(errF.Name())
+	return string(o), string(e), code
+}
+
+func TestRunUpdate_AlreadyUpToDate(t *testing.T) {
+	deps := baseTestDeps(t)
+	deps.Source = fakeSource{rel: updater.Release{TagName: "v1.0.0"}}
+	deps.Fetcher = fakeFetcher{files: map[string][]byte{}}
+
+	out, _, code := runUpdateCapture(t, false, deps, "")
+	if code != ExitOK {
+		t.Fatalf("code = %d, want ExitOK; out=%s", code, out)
+	}
+	if !strings.Contains(out, "already up to date") {
+		t.Fatalf("out = %q, want mention of already up to date", out)
+	}
+}
+
+func TestRunUpdate_NonInteractiveWithoutYesNoops(t *testing.T) {
+	debURL := "https://example.invalid/x.deb"
+	sumsURL := "https://example.invalid/checksums.txt"
+	deps := baseTestDeps(t)
+	deps.Source = fakeSource{rel: updater.Release{TagName: "v2.0.0", Assets: []updater.Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.deb", BrowserDownloadURL: debURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	body := []byte("deb-bytes")
+	deps.Fetcher = fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.deb", body),
+		debURL:  body,
+	}}
+	deps.PkgManagers = []updater.PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+	deps.Runner = fakeRunner{}
+
+	// Regular file stdin is never a terminal, so this exercises the
+	// non-interactive branch regardless of content.
+	out, _, code := runUpdateCapture(t, false, deps, "y\n")
+	if code != ExitOK {
+		t.Fatalf("code = %d, want ExitOK; out=%s", code, out)
+	}
+	if !strings.Contains(out, "[noop]") {
+		t.Fatalf("out = %q, want a [noop] hint", out)
+	}
+	if strings.Contains(out, "updated omac") {
+		t.Fatalf("out = %q, should not have applied the update", out)
+	}
+}
+
+func TestRunUpdate_YesSkipsPromptAndApplies(t *testing.T) {
+	debURL := "https://example.invalid/x.deb"
+	sumsURL := "https://example.invalid/checksums.txt"
+	deps := baseTestDeps(t)
+	deps.Source = fakeSource{rel: updater.Release{TagName: "v2.0.0", Assets: []updater.Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.deb", BrowserDownloadURL: debURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	body := []byte("deb-bytes")
+	deps.Fetcher = fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.deb", body),
+		debURL:  body,
+	}}
+	deps.PkgManagers = []updater.PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+	deps.Runner = fakeRunner{}
+
+	out, _, code := runUpdateCapture(t, true, deps, "")
+	if code != ExitOK {
+		t.Fatalf("code = %d, want ExitOK; out=%s", code, out)
+	}
+	if !strings.Contains(out, "updated omac 1.0.0 -> 2.0.0") {
+		t.Fatalf("out = %q, want update confirmation", out)
+	}
+}
+
+func TestRunUpdate_ChecksumMismatch(t *testing.T) {
+	debURL := "https://example.invalid/x.deb"
+	sumsURL := "https://example.invalid/checksums.txt"
+	deps := baseTestDeps(t)
+	deps.Source = fakeSource{rel: updater.Release{TagName: "v2.0.0", Assets: []updater.Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.deb", BrowserDownloadURL: debURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	deps.Fetcher = fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.deb", []byte("expected")),
+		debURL:  []byte("actually-different"),
+	}}
+	deps.PkgManagers = []updater.PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+
+	_, errOut, code := runUpdateCapture(t, true, deps, "")
+	if code != ExitChecksumMismatch {
+		t.Fatalf("code = %d, want ExitChecksumMismatch; stderr=%s", code, errOut)
+	}
+}
+
+func TestRunUpdate_NoMatchingAsset(t *testing.T) {
+	deps := baseTestDeps(t)
+	deps.Source = fakeSource{rel: updater.Release{TagName: "v2.0.0", Assets: []updater.Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_arm64.deb", BrowserDownloadURL: "https://example.invalid/x.deb"},
+	}}}
+	deps.Fetcher = fakeFetcher{files: map[string][]byte{}}
+	deps.PkgManagers = []updater.PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+
+	_, _, code := runUpdateCapture(t, true, deps, "")
+	if code != ExitPrerequisiteMissing {
+		t.Fatalf("code = %d, want ExitPrerequisiteMissing", code)
+	}
+}
+
+func TestRunUpdate_InstallCommandFailure(t *testing.T) {
+	debURL := "https://example.invalid/x.deb"
+	sumsURL := "https://example.invalid/checksums.txt"
+	deps := baseTestDeps(t)
+	deps.Source = fakeSource{rel: updater.Release{TagName: "v2.0.0", Assets: []updater.Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.deb", BrowserDownloadURL: debURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	body := []byte("deb-bytes")
+	deps.Fetcher = fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.deb", body),
+		debURL:  body,
+	}}
+	deps.PkgManagers = []updater.PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+	deps.Runner = fakeRunner{err: fakeExitError(t)}
+
+	_, errOut, code := runUpdateCapture(t, true, deps, "")
+	if code != ExitGeneric {
+		t.Fatalf("code = %d, want ExitGeneric; stderr=%s", code, errOut)
+	}
+}
+
+func TestRunUpdate_SelfReplacePermissionDenied(t *testing.T) {
+	dir := t.TempDir()
+	tgzPath := filepath.Join(dir, "asset.tar.gz")
+	writeTestTarGzForCLI(t, tgzPath, "omac", []byte("bytes"), 0o755)
+	tgzURL := "https://example.invalid/x.tar.gz"
+	sumsURL := "https://example.invalid/checksums.txt"
+
+	deps := baseTestDeps(t)
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+	deps.Source = fakeSource{rel: updater.Release{TagName: "v2.0.0", Assets: []updater.Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.tar.gz", BrowserDownloadURL: tgzURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	content, err := os.ReadFile(tgzPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deps.Fetcher = fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.tar.gz", content),
+		tgzURL:  content,
+	}}
+	deps.PkgManagers = nil
+	deps.Replacer = fakeReplacer{err: fmt.Errorf("wrap: %w", fs.ErrPermission)}
+
+	_, errOut, code := runUpdateCapture(t, true, deps, "")
+	if code != ExitIOError {
+		t.Fatalf("code = %d, want ExitIOError; stderr=%s", code, errOut)
+	}
+	if !strings.Contains(errOut, "permission denied") {
+		t.Fatalf("stderr = %q, want a permission-denied hint", errOut)
+	}
+}
+
+func fakeExitError(t *testing.T) *exec.ExitError {
+	t.Helper()
+	err := exec.Command("false").Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError from `false`, got %v", err)
+	}
+	return exitErr
+}
+
+func writeTestTarGzForCLI(t *testing.T, path, name string, content []byte, mode int64) {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: mode, Size: int64(len(content))}); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("write tar content: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write tar.gz file: %v", err)
+	}
+}
+
+// --- parseYesNo ------------------------------------------------------------
+
+func TestParseYesNo(t *testing.T) {
+	cases := map[string]bool{
+		"y\n":   true,
+		"yes\n": true,
+		"Y\n":   true,
+		"n\n":   false,
+		"":      false,
+		"nope":  false,
+	}
+	for input, want := range cases {
+		if got := parseYesNo(input); got != want {
+			t.Errorf("parseYesNo(%q) = %v, want %v", input, got, want)
+		}
+	}
+}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -139,6 +139,25 @@ func TestRunUpdate_AlreadyUpToDate(t *testing.T) {
 	}
 }
 
+func TestRunUpdate_CurrentNewerThanLatestNoDowngrade(t *testing.T) {
+	deps := baseTestDeps(t)
+	// runUpdateCapture pins env.Version to 1.0.0; the latest release is older.
+	deps.Source = fakeSource{rel: updater.Release{TagName: "v0.9.0"}}
+	deps.Fetcher = fakeFetcher{files: map[string][]byte{}}
+	deps.Runner = fakeRunner{}
+
+	out, _, code := runUpdateCapture(t, true, deps, "")
+	if code != ExitOK {
+		t.Fatalf("code = %d, want ExitOK; out=%s", code, out)
+	}
+	if !strings.Contains(out, "newer than the latest release") {
+		t.Fatalf("out = %q, want a 'newer than the latest release' notice", out)
+	}
+	if strings.Contains(out, "updated omac") {
+		t.Fatalf("out = %q, must not downgrade to an older release", out)
+	}
+}
+
 func TestRunUpdate_NonInteractiveWithoutYesNoops(t *testing.T) {
 	debURL := "https://example.invalid/x.deb"
 	sumsURL := "https://example.invalid/checksums.txt"

--- a/internal/updater/assets.go
+++ b/internal/updater/assets.go
@@ -1,0 +1,53 @@
+package updater
+
+import "strings"
+
+// matchAsset finds the release asset for goos/goarch whose name ends with
+// formatSuffix. It scans by substring/suffix rather than reconstructing the
+// goreleaser filename template, so it keeps working if that template changes.
+func matchAsset(assets []Asset, goos, goarch, formatSuffix string) (Asset, bool) {
+	osTokens := osTokensFor(goos)
+	archTokens := archTokensFor(goarch)
+	for _, a := range assets {
+		name := strings.ToLower(a.Name)
+		if !strings.HasSuffix(name, formatSuffix) {
+			continue
+		}
+		if !containsAny(name, osTokens) || !containsAny(name, archTokens) {
+			continue
+		}
+		return a, true
+	}
+	return Asset{}, false
+}
+
+func osTokensFor(goos string) []string {
+	switch goos {
+	case "darwin":
+		return []string{"macos", "darwin"}
+	case "linux":
+		return []string{"linux"}
+	default:
+		return []string{goos}
+	}
+}
+
+func archTokensFor(goarch string) []string {
+	switch goarch {
+	case "amd64":
+		return []string{"x86_64", "amd64"}
+	case "arm64":
+		return []string{"arm64", "aarch64"}
+	default:
+		return []string{goarch}
+	}
+}
+
+func containsAny(s string, tokens []string) bool {
+	for _, t := range tokens {
+		if strings.Contains(s, strings.ToLower(t)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/updater/brew.go
+++ b/internal/updater/brew.go
@@ -1,0 +1,26 @@
+package updater
+
+import (
+	"runtime"
+	"strings"
+)
+
+// DetectBrewInstalled reports whether the running omac binary is a
+// Homebrew-managed install. Being on PATH isn't sufficient (a user might
+// have brew for other tools but installed omac via `go install`), so this
+// checks the resolved binary path first (cheap, no subprocess), falling
+// back to `brew list --formula oh-my-agentic-coder` succeeding.
+func DetectBrewInstalled(executable func() (string, error), lookPath func(string) (string, error), run func(name string, args ...string) error) bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	if exe, err := executable(); err == nil {
+		if strings.Contains(exe, "/Cellar/") || strings.Contains(exe, "/opt/homebrew/") {
+			return true
+		}
+	}
+	if _, err := lookPath("brew"); err != nil {
+		return false
+	}
+	return run("brew", "list", "--formula", "oh-my-agentic-coder") == nil
+}

--- a/internal/updater/exec.go
+++ b/internal/updater/exec.go
@@ -1,0 +1,25 @@
+package updater
+
+import (
+	"context"
+	"io"
+	"os/exec"
+)
+
+// CommandRunner runs an external command. The real implementation wires
+// stdin/stdout/stderr straight through to the terminal, so an interactive
+// prompt (sudo's password prompt, brew's progress output) behaves exactly
+// as if the user had typed the command themselves.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}

--- a/internal/updater/fetch.go
+++ b/internal/updater/fetch.go
@@ -1,0 +1,74 @@
+package updater
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Fetcher downloads release assets over HTTP.
+type Fetcher interface {
+	// FetchAll downloads url fully into memory. Used for small files
+	// (checksums.txt).
+	FetchAll(ctx context.Context, url string) ([]byte, error)
+	// FetchToFile streams url's body into a new temp file under dir (using
+	// pattern as os.CreateTemp's pattern) and returns its path. Used for
+	// package/tarball assets, which may be several MB.
+	FetchToFile(ctx context.Context, url, dir, pattern string) (path string, err error)
+}
+
+type httpFetcher struct {
+	client *http.Client
+}
+
+// NewHTTPFetcher returns a Fetcher backed by the real network.
+func NewHTTPFetcher() Fetcher {
+	return httpFetcher{client: &http.Client{Timeout: 60 * time.Second}}
+}
+
+func (f httpFetcher) get(ctx context.Context, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	return resp.Body, nil
+}
+
+func (f httpFetcher) FetchAll(ctx context.Context, url string) ([]byte, error) {
+	body, err := f.get(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+	return io.ReadAll(body)
+}
+
+func (f httpFetcher) FetchToFile(ctx context.Context, url, dir, pattern string) (string, error) {
+	body, err := f.get(ctx, url)
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+
+	tmp, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", err
+	}
+	defer tmp.Close()
+	if _, err := io.Copy(tmp, body); err != nil {
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	return tmp.Name(), nil
+}

--- a/internal/updater/github.go
+++ b/internal/updater/github.go
@@ -1,0 +1,66 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// ReleaseSource fetches metadata about the latest published release.
+type ReleaseSource interface {
+	LatestRelease(ctx context.Context) (Release, error)
+}
+
+type githubReleaseSource struct {
+	client      *http.Client
+	baseURL     string // overridable for tests (httptest.Server)
+	owner, repo string
+}
+
+// NewGitHubReleaseSource returns a ReleaseSource backed by the real GitHub
+// API, targeting TNG/oh-my-agentic-coder's /releases/latest endpoint (which
+// already excludes prereleases).
+func NewGitHubReleaseSource() ReleaseSource {
+	return &githubReleaseSource{
+		client:  &http.Client{Timeout: 15 * time.Second},
+		baseURL: "https://api.github.com",
+		owner:   "TNG",
+		repo:    "oh-my-agentic-coder",
+	}
+}
+
+type githubReleaseJSON struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+func (s *githubReleaseSource) LatestRelease(ctx context.Context) (Release, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", s.baseURL, s.owner, s.repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return Release{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return Release{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return Release{}, fmt.Errorf("GitHub API returned %s", resp.Status)
+	}
+	var body githubReleaseJSON
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return Release{}, fmt.Errorf("decode release: %w", err)
+	}
+	rel := Release{TagName: body.TagName}
+	for _, a := range body.Assets {
+		rel.Assets = append(rel.Assets, Asset{Name: a.Name, BrowserDownloadURL: a.BrowserDownloadURL})
+	}
+	return rel, nil
+}

--- a/internal/updater/github_test.go
+++ b/internal/updater/github_test.go
@@ -1,0 +1,50 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGithubReleaseSource_LatestRelease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/TNG/oh-my-agentic-coder/releases/latest" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tag_name": "v1.2.3",
+			"assets": []map[string]any{
+				{"name": "oh-my-agentic-coder_1.2.3_linux_x86_64.deb", "browser_download_url": "https://example.invalid/a.deb"},
+				{"name": "checksums.txt", "browser_download_url": "https://example.invalid/checksums.txt"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	src := &githubReleaseSource{client: srv.Client(), baseURL: srv.URL, owner: "TNG", repo: "oh-my-agentic-coder"}
+	rel, err := src.LatestRelease(context.Background())
+	if err != nil {
+		t.Fatalf("LatestRelease: %v", err)
+	}
+	if rel.TagName != "v1.2.3" {
+		t.Fatalf("TagName = %q", rel.TagName)
+	}
+	if len(rel.Assets) != 2 || rel.Assets[0].Name != "oh-my-agentic-coder_1.2.3_linux_x86_64.deb" {
+		t.Fatalf("Assets = %+v", rel.Assets)
+	}
+}
+
+func TestGithubReleaseSource_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	src := &githubReleaseSource{client: srv.Client(), baseURL: srv.URL, owner: "TNG", repo: "oh-my-agentic-coder"}
+	if _, err := src.LatestRelease(context.Background()); err == nil {
+		t.Fatalf("expected error for non-200 response")
+	}
+}

--- a/internal/updater/pkgmanagers.go
+++ b/internal/updater/pkgmanagers.go
@@ -1,0 +1,45 @@
+package updater
+
+// DetectPackageManagers returns the Linux package managers present on this
+// host, in priority order (highest first). Detection is capability-based
+// (is the binary on PATH) rather than parsing /etc/os-release, since the
+// binary's presence is exactly the capability needed to run the install
+// command anyway.
+func DetectPackageManagers(lookPath func(string) (string, error)) []PackageManager {
+	candidates := []PackageManager{
+		{
+			Name:        "dpkg",
+			AssetSuffix: ".deb",
+			InstallArgs: func(p string) []string { return []string{"-i", p} },
+		},
+		{
+			Name:        "rpm",
+			AssetSuffix: ".rpm",
+			// -U (upgrade) rather than -i (install): -i refuses when a
+			// same-named package at a different version is already
+			// installed, which is exactly the state every update-after-the-
+			// first-install is in. -U installs-or-upgrades correctly either way.
+			InstallArgs: func(p string) []string { return []string{"-U", p} },
+		},
+		{
+			Name:        "pacman",
+			AssetSuffix: ".pkg.tar.zst",
+			// --noconfirm avoids a second, redundant "Proceed with
+			// installation? [Y/n]" prompt after omac's own confirmation.
+			InstallArgs: func(p string) []string { return []string{"-U", "--noconfirm", p} },
+		},
+		{
+			Name:        "apk",
+			AssetSuffix: ".apk",
+			InstallArgs: func(p string) []string { return []string{"add", "--allow-untrusted", p} },
+		},
+	}
+
+	var out []PackageManager
+	for _, c := range candidates {
+		if _, err := lookPath(c.Name); err == nil {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/internal/updater/selfreplace.go
+++ b/internal/updater/selfreplace.go
@@ -1,0 +1,44 @@
+package updater
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// SelfReplacer atomically swaps the file at path with the content read from
+// r, applying mode.
+type SelfReplacer interface {
+	Replace(path string, r io.Reader, mode fs.FileMode) error
+}
+
+type fsSelfReplacer struct{}
+
+// Replace writes r to a temp file in the same directory as path (so the
+// subsequent rename is atomic and never crosses a filesystem boundary), then
+// renames it over path. A permission error creating the temp file (e.g. path
+// lives in a root-owned directory) surfaces directly via errors.Is(err,
+// fs.ErrPermission).
+func (fsSelfReplacer) Replace(path string, r io.Reader, mode fs.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".omac-update-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // no-op once Rename below succeeds
+
+	if _, err := io.Copy(tmp, r); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/updater/selfreplace_test.go
+++ b/internal/updater/selfreplace_test.go
@@ -1,0 +1,62 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFsSelfReplacer_Replace(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "omac")
+	if err := os.WriteFile(target, []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	r := fsSelfReplacer{}
+	if err := r.Replace(target, strings.NewReader("new"), 0o755); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(data) != "new" {
+		t.Fatalf("content = %q, want new", data)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("mode = %v, want 0755", info.Mode().Perm())
+	}
+
+	// No leftover temp files.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly the target file, got %v", entries)
+	}
+}
+
+func TestFsSelfReplacer_PermissionDenied(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root, permission checks don't apply")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o700) })
+
+	r := fsSelfReplacer{}
+	err := r.Replace(filepath.Join(dir, "omac"), strings.NewReader("new"), 0o755)
+	if err == nil {
+		t.Fatalf("expected permission error")
+	}
+}

--- a/internal/updater/targz.go
+++ b/internal/updater/targz.go
@@ -1,0 +1,39 @@
+package updater
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+)
+
+// ExtractBinary reads a gzip-compressed tar stream and returns the content
+// and mode of the first regular file entry named wantName.
+func ExtractBinary(gz io.Reader, wantName string) ([]byte, fs.FileMode, error) {
+	zr, err := gzip.NewReader(gz)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer zr.Close()
+
+	tr := tar.NewReader(zr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, 0, fmt.Errorf("binary %q not found in archive", wantName)
+		}
+		if err != nil {
+			return nil, 0, err
+		}
+		if hdr.Typeflag != tar.TypeReg || filepath.Base(hdr.Name) != wantName {
+			continue
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, 0, err
+		}
+		return data, fs.FileMode(hdr.Mode).Perm(), nil
+	}
+}

--- a/internal/updater/targz_test.go
+++ b/internal/updater/targz_test.go
@@ -1,0 +1,76 @@
+package updater
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"testing"
+)
+
+// writeTestTarGz builds a gzip-compressed tar archive at path containing a
+// single regular file entry named name with the given content and mode.
+func writeTestTarGz(t *testing.T, path, name string, content []byte, mode int64) {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: mode,
+		Size: int64(len(content)),
+	}); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("write tar content: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write tar.gz file: %v", err)
+	}
+}
+
+func TestExtractBinary_Found(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/asset.tar.gz"
+	writeTestTarGz(t, path, "omac", []byte("binary-content"), 0o755)
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	data, mode, err := ExtractBinary(f, "omac")
+	if err != nil {
+		t.Fatalf("ExtractBinary: %v", err)
+	}
+	if string(data) != "binary-content" {
+		t.Fatalf("data = %q", data)
+	}
+	if mode != 0o755 {
+		t.Fatalf("mode = %v, want 0755", mode)
+	}
+}
+
+func TestExtractBinary_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/asset.tar.gz"
+	writeTestTarGz(t, path, "README.md", []byte("docs"), 0o644)
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	if _, _, err := ExtractBinary(f, "omac"); err == nil {
+		t.Fatalf("expected error for missing binary entry")
+	}
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,306 @@
+// Package updater implements `omac update`: checking GitHub for the latest
+// release, verifying its checksum, and installing it via the mechanism that
+// matches how this host actually runs omac (a Linux package manager, brew,
+// or a self-replace of the running binary).
+//
+// All real-world side effects (HTTP, subprocess exec, filesystem replace)
+// are wrapped in interfaces on Deps, so Plan/Apply are fully testable
+// without touching the network, sudo, or any real package manager.
+package updater
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Method identifies how Apply will install the update.
+type Method int
+
+const (
+	MethodUpToDate Method = iota
+	MethodBrew
+	MethodLinuxPackage
+	MethodTarballSelfReplace
+)
+
+// Asset is one file attached to a GitHub release.
+type Asset struct {
+	Name               string
+	BrowserDownloadURL string
+}
+
+// Release is the subset of a GitHub release we need.
+type Release struct {
+	TagName string
+	Assets  []Asset
+}
+
+// PackageManager describes one Linux package-manager installer.
+type PackageManager struct {
+	Name        string // "dpkg" | "rpm" | "pacman" | "apk"
+	AssetSuffix string // ".deb" | ".rpm" | ".pkg.tar.zst" | ".apk"
+	InstallArgs func(pkgPath string) []string
+}
+
+// Plan is the fully-resolved result of Plan(): what would happen, and (for
+// every method except MethodUpToDate/MethodBrew) a checksum-verified local
+// download ready for Apply to install.
+type Plan struct {
+	CurrentVersion   string
+	LatestVersion    string
+	Method           Method
+	PackageManager   string // set for MethodLinuxPackage
+	Asset            Asset
+	LocalPath        string
+	ChecksumVerified bool
+}
+
+// Options configures Plan.
+type Options struct {
+	// CurrentVersion is env.Version verbatim; Plan strips a leading "v"
+	// before comparing against the latest release tag.
+	CurrentVersion string
+}
+
+// Deps wraps every real-world side effect Plan/Apply need. RealDeps builds
+// production wiring; tests build a Deps literal of fakes.
+type Deps struct {
+	Source   ReleaseSource
+	Fetcher  Fetcher
+	Runner   CommandRunner
+	Replacer SelfReplacer
+
+	// BrewInstalled reports whether omac is a Homebrew-managed install.
+	// Only consulted when GOOS == "darwin".
+	BrewInstalled func() bool
+
+	// PkgManagers is the priority-ordered list of Linux package managers
+	// present on this host (highest priority first). Empty means none
+	// detected, so Plan falls back to MethodTarballSelfReplace.
+	PkgManagers []PackageManager
+
+	// Executable resolves the path of the running binary (for self-replace).
+	Executable func() (string, error)
+
+	GOOS, GOARCH string
+	TempDir      string
+
+	Stdin          io.Reader
+	Stdout, Stderr io.Writer
+}
+
+// RealDeps builds production Deps: real HTTP, real subprocess exec, real
+// filesystem replace, real host detection.
+func RealDeps(stdin io.Reader, stdout, stderr io.Writer) Deps {
+	return Deps{
+		Source:        NewGitHubReleaseSource(),
+		Fetcher:       NewHTTPFetcher(),
+		Runner:        execRunner{},
+		Replacer:      fsSelfReplacer{},
+		BrewInstalled: func() bool { return DetectBrewInstalled(os.Executable, exec.LookPath, runCommand) },
+		PkgManagers:   DetectPackageManagers(exec.LookPath),
+		Executable:    os.Executable,
+		GOOS:          runtime.GOOS,
+		GOARCH:        runtime.GOARCH,
+		TempDir:       os.TempDir(),
+		Stdin:         stdin,
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}
+}
+
+func runCommand(name string, args ...string) error {
+	return exec.Command(name, args...).Run()
+}
+
+var (
+	// ErrNoMatchingAsset means no release asset matches this host's OS,
+	// architecture, and available install method.
+	ErrNoMatchingAsset = errors.New("no release asset matches this OS/architecture")
+	// ErrChecksumMismatch means the downloaded asset's SHA-256 does not
+	// match the release's published checksums.txt.
+	ErrChecksumMismatch = errors.New("checksum verification failed")
+)
+
+// Check contacts GitHub for the latest release, decides the install method
+// for this host, and (unless already up to date, or installing via brew)
+// downloads and checksum-verifies the matching asset, returning a Plan. It
+// never installs anything — see Apply for that.
+func Check(ctx context.Context, opts Options, deps Deps) (Plan, error) {
+	rel, err := deps.Source.LatestRelease(ctx)
+	if err != nil {
+		return Plan{}, fmt.Errorf("fetch latest release: %w", err)
+	}
+	current := strings.TrimPrefix(opts.CurrentVersion, "v")
+	latest := strings.TrimPrefix(rel.TagName, "v")
+
+	p := Plan{CurrentVersion: current, LatestVersion: latest}
+	if current == latest {
+		p.Method = MethodUpToDate
+		return p, nil
+	}
+
+	if deps.GOOS == "darwin" && deps.BrewInstalled != nil && deps.BrewInstalled() {
+		p.Method = MethodBrew
+		return p, nil
+	}
+
+	if deps.GOOS == "linux" && len(deps.PkgManagers) > 0 {
+		pm := deps.PkgManagers[0]
+		asset, ok := matchAsset(rel.Assets, deps.GOOS, deps.GOARCH, pm.AssetSuffix)
+		if !ok {
+			return Plan{}, fmt.Errorf("%w: no %s asset for %s/%s", ErrNoMatchingAsset, pm.AssetSuffix, deps.GOOS, deps.GOARCH)
+		}
+		p.Method = MethodLinuxPackage
+		p.PackageManager = pm.Name
+		p.Asset = asset
+		if err := downloadAndVerify(ctx, &p, rel, deps); err != nil {
+			return Plan{}, err
+		}
+		return p, nil
+	}
+
+	// Fallback: tarball self-replace (macOS without brew, or Linux with no
+	// known package manager present).
+	asset, ok := matchAsset(rel.Assets, deps.GOOS, deps.GOARCH, ".tar.gz")
+	if !ok {
+		return Plan{}, fmt.Errorf("%w: no tarball for %s/%s", ErrNoMatchingAsset, deps.GOOS, deps.GOARCH)
+	}
+	p.Method = MethodTarballSelfReplace
+	p.Asset = asset
+	if err := downloadAndVerify(ctx, &p, rel, deps); err != nil {
+		return Plan{}, err
+	}
+	return p, nil
+}
+
+// downloadAndVerify fetches p.Asset into a temp file and checks its SHA-256
+// against the release's checksums.txt, setting p.LocalPath/ChecksumVerified.
+func downloadAndVerify(ctx context.Context, p *Plan, rel Release, deps Deps) error {
+	var sums Asset
+	var ok bool
+	for _, a := range rel.Assets {
+		if a.Name == "checksums.txt" {
+			sums, ok = a, true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("%w: release has no checksums.txt", ErrNoMatchingAsset)
+	}
+	sumsData, err := deps.Fetcher.FetchAll(ctx, sums.BrowserDownloadURL)
+	if err != nil {
+		return fmt.Errorf("fetch checksums.txt: %w", err)
+	}
+	wantSum, ok := parseChecksums(sumsData, p.Asset.Name)
+	if !ok {
+		return fmt.Errorf("%w: %s not listed in checksums.txt", ErrChecksumMismatch, p.Asset.Name)
+	}
+
+	path, err := deps.Fetcher.FetchToFile(ctx, p.Asset.BrowserDownloadURL, deps.TempDir, "omac-update-*-"+p.Asset.Name)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", p.Asset.Name, err)
+	}
+	gotSum, err := sha256File(path)
+	if err != nil {
+		return fmt.Errorf("checksum %s: %w", p.Asset.Name, err)
+	}
+	if !strings.EqualFold(gotSum, wantSum) {
+		return fmt.Errorf("%w: %s", ErrChecksumMismatch, p.Asset.Name)
+	}
+	p.LocalPath = path
+	p.ChecksumVerified = true
+	return nil
+}
+
+// parseChecksums looks up name in the standard `sha256sum`-style
+// "<hash>  <filename>" lines produced by checksums.txt.
+func parseChecksums(data []byte, name string) (sum string, ok bool) {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		if fields[1] == name || filepath.Base(fields[1]) == name {
+			return fields[0], true
+		}
+	}
+	return "", false
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// Apply installs the update described by plan.
+func Apply(ctx context.Context, plan Plan, deps Deps) error {
+	switch plan.Method {
+	case MethodUpToDate:
+		return nil
+	case MethodBrew:
+		return deps.Runner.Run(ctx, "brew", []string{"upgrade", "oh-my-agentic-coder"}, deps.Stdin, deps.Stdout, deps.Stderr)
+	case MethodLinuxPackage:
+		var pm PackageManager
+		for _, c := range deps.PkgManagers {
+			if c.Name == plan.PackageManager {
+				pm = c
+				break
+			}
+		}
+		if pm.Name == "" {
+			return fmt.Errorf("unknown package manager %q", plan.PackageManager)
+		}
+		args := append([]string{pm.Name}, pm.InstallArgs(plan.LocalPath)...)
+		return deps.Runner.Run(ctx, "sudo", args, deps.Stdin, deps.Stdout, deps.Stderr)
+	case MethodTarballSelfReplace:
+		return applySelfReplace(plan, deps)
+	default:
+		return fmt.Errorf("unknown update method %d", plan.Method)
+	}
+}
+
+func applySelfReplace(plan Plan, deps Deps) error {
+	f, err := os.Open(plan.LocalPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	data, mode, err := ExtractBinary(f, "omac")
+	if err != nil {
+		return fmt.Errorf("extract omac from %s: %w", plan.Asset.Name, err)
+	}
+
+	target, err := deps.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve running binary path: %w", err)
+	}
+	if real, err := filepath.EvalSymlinks(target); err == nil {
+		target = real
+	}
+
+	return deps.Replacer.Replace(target, bytes.NewReader(data), mode)
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -145,7 +145,12 @@ func Check(ctx context.Context, opts Options, deps Deps) (Plan, error) {
 	latest := strings.TrimPrefix(rel.TagName, "v")
 
 	p := Plan{CurrentVersion: current, LatestVersion: latest}
-	if current == latest {
+	// Install only when the latest release is strictly newer. If this build is
+	// the same as, or ahead of, the latest release (a dev or pre-release build
+	// built past the last tag), there is nothing newer to install — never
+	// downgrade. When the versions are not comparable as semver, fall back to
+	// the conservative string-equality check.
+	if cmp, ok := compareVersions(current, latest); current == latest || (ok && cmp >= 0) {
 		p.Method = MethodUpToDate
 		return p, nil
 	}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -211,6 +211,11 @@ func downloadAndVerify(ctx context.Context, p *Plan, rel Release, deps Deps) err
 	if err != nil {
 		return fmt.Errorf("download %s: %w", p.Asset.Name, err)
 	}
+	defer func() {
+		if p.LocalPath == "" {
+			os.Remove(path)
+		}
+	}()
 	gotSum, err := sha256File(path)
 	if err != nil {
 		return fmt.Errorf("checksum %s: %w", p.Asset.Name, err)

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,357 @@
+package updater
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeReleaseSource struct {
+	rel Release
+	err error
+}
+
+func (f fakeReleaseSource) LatestRelease(ctx context.Context) (Release, error) {
+	return f.rel, f.err
+}
+
+// fakeFetcher serves fixed content per URL and never touches the network.
+type fakeFetcher struct {
+	files map[string][]byte // url -> body
+	calls int
+}
+
+func (f *fakeFetcher) FetchAll(ctx context.Context, url string) ([]byte, error) {
+	f.calls++
+	body, ok := f.files[url]
+	if !ok {
+		return nil, fmt.Errorf("fakeFetcher: no fixture for %s", url)
+	}
+	return body, nil
+}
+
+func (f *fakeFetcher) FetchToFile(ctx context.Context, url, dir, pattern string) (string, error) {
+	f.calls++
+	body, ok := f.files[url]
+	if !ok {
+		return "", fmt.Errorf("fakeFetcher: no fixture for %s", url)
+	}
+	tmp, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", err
+	}
+	defer tmp.Close()
+	if _, err := tmp.Write(body); err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+type runCall struct {
+	name string
+	args []string
+}
+
+type fakeRunner struct {
+	calls []runCall
+	err   error
+}
+
+func (f *fakeRunner) Run(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	f.calls = append(f.calls, runCall{name: name, args: args})
+	return f.err
+}
+
+type fakeReplacer struct {
+	err  error
+	got  []byte
+	path string
+	mode fs.FileMode
+}
+
+func (f *fakeReplacer) Replace(path string, r io.Reader, mode fs.FileMode) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	f.path, f.got, f.mode = path, data, mode
+	if f.err != nil {
+		return f.err
+	}
+	return nil
+}
+
+func checksumsFile(name string, content []byte) []byte {
+	sum := sha256.Sum256(content)
+	return []byte(fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), name))
+}
+
+func baseDeps(t *testing.T) Deps {
+	t.Helper()
+	return Deps{
+		Executable: func() (string, error) { return filepath.Join(t.TempDir(), "omac"), nil },
+		TempDir:    t.TempDir(),
+		Stdin:      bytes.NewReader(nil),
+		Stdout:     io.Discard,
+		Stderr:     io.Discard,
+	}
+}
+
+// --- Check() tests ---------------------------------------------------------
+
+func TestCheck_AlreadyUpToDate(t *testing.T) {
+	deps := baseDeps(t)
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v1.2.3"}}
+	deps.Fetcher = &fakeFetcher{files: map[string][]byte{}}
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+
+	plan, err := Check(context.Background(), Options{CurrentVersion: "1.2.3"}, deps)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if plan.Method != MethodUpToDate {
+		t.Fatalf("Method = %v, want MethodUpToDate", plan.Method)
+	}
+}
+
+func TestCheck_DarwinBrewInstalled(t *testing.T) {
+	deps := baseDeps(t)
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v2.0.0"}}
+	fetch := &fakeFetcher{files: map[string][]byte{}}
+	deps.Fetcher = fetch
+	deps.GOOS, deps.GOARCH = "darwin", "arm64"
+	deps.BrewInstalled = func() bool { return true }
+
+	plan, err := Check(context.Background(), Options{CurrentVersion: "1.0.0"}, deps)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if plan.Method != MethodBrew {
+		t.Fatalf("Method = %v, want MethodBrew", plan.Method)
+	}
+	if fetch.calls != 0 {
+		t.Fatalf("expected zero downloads for brew method, got %d calls", fetch.calls)
+	}
+}
+
+func TestCheck_LinuxPackageManagerPriority(t *testing.T) {
+	debBody := []byte("deb-bytes")
+	sumsURL := "https://example.invalid/checksums.txt"
+	debURL := "https://example.invalid/oh-my-agentic-coder_2.0.0_linux_x86_64.deb"
+
+	deps := baseDeps(t)
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v2.0.0", Assets: []Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.deb", BrowserDownloadURL: debURL},
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.rpm", BrowserDownloadURL: "https://example.invalid/x.rpm"},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	deps.Fetcher = &fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.deb", debBody),
+		debURL:  debBody,
+	}}
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+	deps.PkgManagers = []PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+		{Name: "rpm", AssetSuffix: ".rpm", InstallArgs: func(p string) []string { return []string{"-U", p} }},
+	}
+
+	plan, err := Check(context.Background(), Options{CurrentVersion: "1.0.0"}, deps)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if plan.Method != MethodLinuxPackage || plan.PackageManager != "dpkg" {
+		t.Fatalf("plan = %+v, want MethodLinuxPackage/dpkg", plan)
+	}
+	if !plan.ChecksumVerified {
+		t.Fatalf("expected checksum verified")
+	}
+}
+
+func TestCheck_LinuxNoPackageManagerFallsBackToTarball(t *testing.T) {
+	tgzBody := []byte("fake-tar-gz-bytes")
+	sumsURL := "https://example.invalid/checksums.txt"
+	tgzURL := "https://example.invalid/oh-my-agentic-coder_2.0.0_linux_x86_64.tar.gz"
+
+	deps := baseDeps(t)
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v2.0.0", Assets: []Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.tar.gz", BrowserDownloadURL: tgzURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	deps.Fetcher = &fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.tar.gz", tgzBody),
+		tgzURL:  tgzBody,
+	}}
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+	deps.PkgManagers = nil
+
+	plan, err := Check(context.Background(), Options{CurrentVersion: "1.0.0"}, deps)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if plan.Method != MethodTarballSelfReplace {
+		t.Fatalf("Method = %v, want MethodTarballSelfReplace", plan.Method)
+	}
+}
+
+func TestCheck_ChecksumMismatch(t *testing.T) {
+	sumsURL := "https://example.invalid/checksums.txt"
+	debURL := "https://example.invalid/oh-my-agentic-coder_2.0.0_linux_x86_64.deb"
+
+	deps := baseDeps(t)
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v2.0.0", Assets: []Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.deb", BrowserDownloadURL: debURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	deps.Fetcher = &fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.deb", []byte("expected-bytes")),
+		debURL:  []byte("actually-different-bytes"),
+	}}
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+	deps.PkgManagers = []PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+
+	_, err := Check(context.Background(), Options{CurrentVersion: "1.0.0"}, deps)
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("err = %v, want ErrChecksumMismatch", err)
+	}
+}
+
+func TestCheck_NoMatchingAsset(t *testing.T) {
+	deps := baseDeps(t)
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v2.0.0", Assets: []Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_arm64.deb", BrowserDownloadURL: "https://example.invalid/x.deb"},
+	}}}
+	deps.Fetcher = &fakeFetcher{files: map[string][]byte{}}
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+	deps.PkgManagers = []PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+
+	_, err := Check(context.Background(), Options{CurrentVersion: "1.0.0"}, deps)
+	if !errors.Is(err, ErrNoMatchingAsset) {
+		t.Fatalf("err = %v, want ErrNoMatchingAsset", err)
+	}
+}
+
+// --- Apply() tests ---------------------------------------------------------
+
+func TestApply_LinuxPackage_RunsSudoWithPackageManager(t *testing.T) {
+	deps := baseDeps(t)
+	runner := &fakeRunner{}
+	deps.Runner = runner
+	deps.PkgManagers = []PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+	plan := Plan{Method: MethodLinuxPackage, PackageManager: "dpkg", LocalPath: "/tmp/x.deb"}
+
+	if err := Apply(context.Background(), plan, deps); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected 1 run call, got %d", len(runner.calls))
+	}
+	got := runner.calls[0]
+	if got.name != "sudo" {
+		t.Fatalf("name = %q, want sudo", got.name)
+	}
+	want := []string{"dpkg", "-i", "/tmp/x.deb"}
+	if len(got.args) != len(want) {
+		t.Fatalf("args = %v, want %v", got.args, want)
+	}
+	for i := range want {
+		if got.args[i] != want[i] {
+			t.Fatalf("args = %v, want %v", got.args, want)
+		}
+	}
+}
+
+func TestApply_Brew(t *testing.T) {
+	deps := baseDeps(t)
+	runner := &fakeRunner{}
+	deps.Runner = runner
+	plan := Plan{Method: MethodBrew}
+
+	if err := Apply(context.Background(), plan, deps); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(runner.calls) != 1 || runner.calls[0].name != "brew" {
+		t.Fatalf("calls = %+v, want one brew call", runner.calls)
+	}
+}
+
+func TestApply_InstallCommandFailure(t *testing.T) {
+	deps := baseDeps(t)
+	sentinel := errors.New("dpkg exited 1")
+	deps.Runner = &fakeRunner{err: sentinel}
+	deps.PkgManagers = []PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+	plan := Plan{Method: MethodLinuxPackage, PackageManager: "dpkg", LocalPath: "/tmp/x.deb"}
+
+	err := Apply(context.Background(), plan, deps)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel wrapped", err)
+	}
+}
+
+func TestApply_SelfReplace_ExtractsAndWritesBinary(t *testing.T) {
+	dir := t.TempDir()
+	tgzPath := filepath.Join(dir, "asset.tar.gz")
+	writeTestTarGz(t, tgzPath, "omac", []byte("new-binary-bytes"), 0o755)
+
+	deps := baseDeps(t)
+	replacer := &fakeReplacer{}
+	deps.Replacer = replacer
+	deps.Executable = func() (string, error) { return filepath.Join(dir, "omac"), nil }
+	plan := Plan{Method: MethodTarballSelfReplace, LocalPath: tgzPath}
+
+	if err := Apply(context.Background(), plan, deps); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if string(replacer.got) != "new-binary-bytes" {
+		t.Fatalf("replacer got %q", replacer.got)
+	}
+	if replacer.mode != 0o755 {
+		t.Fatalf("mode = %v, want 0755", replacer.mode)
+	}
+}
+
+func TestApply_SelfReplace_PermissionDenied(t *testing.T) {
+	dir := t.TempDir()
+	tgzPath := filepath.Join(dir, "asset.tar.gz")
+	writeTestTarGz(t, tgzPath, "omac", []byte("bytes"), 0o755)
+
+	deps := baseDeps(t)
+	deps.Replacer = &fakeReplacer{err: fmt.Errorf("wrap: %w", fs.ErrPermission)}
+	deps.Executable = func() (string, error) { return filepath.Join(dir, "omac"), nil }
+	plan := Plan{Method: MethodTarballSelfReplace, LocalPath: tgzPath}
+
+	err := Apply(context.Background(), plan, deps)
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Fatalf("err = %v, want fs.ErrPermission", err)
+	}
+}
+
+// --- parseYesNo-style pure helpers (parseChecksums) ------------------------
+
+func TestParseChecksums(t *testing.T) {
+	data := []byte("abc123  file-a.deb\ndeadbeef  file-b.tar.gz\n")
+	sum, ok := parseChecksums(data, "file-b.tar.gz")
+	if !ok || sum != "deadbeef" {
+		t.Fatalf("sum=%q ok=%v, want deadbeef/true", sum, ok)
+	}
+	if _, ok := parseChecksums(data, "missing.deb"); ok {
+		t.Fatalf("expected no match for missing file")
+	}
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -29,6 +29,7 @@ func (f fakeReleaseSource) LatestRelease(ctx context.Context) (Release, error) {
 type fakeFetcher struct {
 	files map[string][]byte // url -> body
 	calls int
+	paths []string // temp files created by FetchToFile
 }
 
 func (f *fakeFetcher) FetchAll(ctx context.Context, url string) ([]byte, error) {
@@ -54,6 +55,7 @@ func (f *fakeFetcher) FetchToFile(ctx context.Context, url, dir, pattern string)
 	if _, err := tmp.Write(body); err != nil {
 		return "", err
 	}
+	f.paths = append(f.paths, tmp.Name())
 	return tmp.Name(), nil
 }
 
@@ -224,6 +226,37 @@ func TestCheck_ChecksumMismatch(t *testing.T) {
 	_, err := Check(context.Background(), Options{CurrentVersion: "1.0.0"}, deps)
 	if !errors.Is(err, ErrChecksumMismatch) {
 		t.Fatalf("err = %v, want ErrChecksumMismatch", err)
+	}
+}
+
+func TestCheck_ChecksumMismatch_CleansTempFile(t *testing.T) {
+	sumsURL := "https://example.invalid/checksums.txt"
+	debURL := "https://example.invalid/oh-my-agentic-coder_2.0.0_linux_x86_64.deb"
+
+	deps := baseDeps(t)
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v2.0.0", Assets: []Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.deb", BrowserDownloadURL: debURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	fetcher := &fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.deb", []byte("expected-bytes")),
+		debURL:  []byte("actually-different-bytes"),
+	}}
+	deps.Fetcher = fetcher
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+	deps.PkgManagers = []PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+
+	_, err := Check(context.Background(), Options{CurrentVersion: "1.0.0"}, deps)
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("err = %v, want ErrChecksumMismatch", err)
+	}
+	if len(fetcher.paths) != 1 {
+		t.Fatalf("expected 1 temp file created, got %d", len(fetcher.paths))
+	}
+	if _, statErr := os.Stat(fetcher.paths[0]); !os.IsNotExist(statErr) {
+		t.Fatalf("temp file %q still exists after checksum mismatch: %v", fetcher.paths[0], statErr)
 	}
 }
 

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -126,6 +126,60 @@ func TestCheck_AlreadyUpToDate(t *testing.T) {
 	}
 }
 
+func TestCheck_CurrentNewerThanLatestIsUpToDate(t *testing.T) {
+	deps := baseDeps(t)
+	// A dev/hotfix build ahead of the latest published release: with a package
+	// manager present and matching assets available, the only thing stopping an
+	// install is the version guard — so this proves it never downgrades.
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v1.2.0", Assets: []Asset{
+		{Name: "oh-my-agentic-coder_1.2.0_linux_x86_64.deb", BrowserDownloadURL: "https://example.invalid/x.deb"},
+		{Name: "checksums.txt", BrowserDownloadURL: "https://example.invalid/checksums.txt"},
+	}}}
+	fetch := &fakeFetcher{files: map[string][]byte{}}
+	deps.Fetcher = fetch
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+	deps.PkgManagers = []PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+
+	plan, err := Check(context.Background(), Options{CurrentVersion: "1.3.0"}, deps)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if plan.Method != MethodUpToDate {
+		t.Fatalf("Method = %v, want MethodUpToDate (no downgrade)", plan.Method)
+	}
+	if fetch.calls != 0 {
+		t.Fatalf("expected zero downloads when already newer, got %d", fetch.calls)
+	}
+}
+
+func TestCheck_DevBuildUpdatesToRelease(t *testing.T) {
+	tgzBody := []byte("fake-tar-gz-bytes")
+	sumsURL := "https://example.invalid/checksums.txt"
+	tgzURL := "https://example.invalid/oh-my-agentic-coder_0.1.0_linux_x86_64.tar.gz"
+
+	deps := baseDeps(t)
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v0.1.0", Assets: []Asset{
+		{Name: "oh-my-agentic-coder_0.1.0_linux_x86_64.tar.gz", BrowserDownloadURL: tgzURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	deps.Fetcher = &fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_0.1.0_linux_x86_64.tar.gz", tgzBody),
+		tgzURL:  tgzBody,
+	}}
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+
+	// A pre-release build of the same core version installs the release.
+	plan, err := Check(context.Background(), Options{CurrentVersion: "0.1.0-dev"}, deps)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if plan.Method != MethodTarballSelfReplace {
+		t.Fatalf("Method = %v, want MethodTarballSelfReplace", plan.Method)
+	}
+}
+
 func TestCheck_DarwinBrewInstalled(t *testing.T) {
 	deps := baseDeps(t)
 	deps.Source = fakeReleaseSource{rel: Release{TagName: "v2.0.0"}}

--- a/internal/updater/version.go
+++ b/internal/updater/version.go
@@ -1,0 +1,116 @@
+package updater
+
+import (
+	"strconv"
+	"strings"
+)
+
+// compareVersions compares two semver version strings, returning -1, 0, or 1
+// as a is less than, equal to, or greater than b. A leading "v" and any
+// "+build" metadata are ignored, and a pre-release ranks below its associated
+// release (1.0.0-rc1 < 1.0.0), per semver precedence.
+//
+// ok is false when either version's core (MAJOR.MINOR.PATCH) is not three
+// integers; callers must treat an unparseable pair conservatively and never
+// downgrade on the strength of it.
+func compareVersions(a, b string) (cmp int, ok bool) {
+	aCore, aPre, aOK := splitVersion(a)
+	bCore, bPre, bOK := splitVersion(b)
+	if !aOK || !bOK {
+		return 0, false
+	}
+	if c := compareCore(aCore, bCore); c != 0 {
+		return c, true
+	}
+	return comparePrerelease(aPre, bPre), true
+}
+
+// splitVersion parses "MAJOR.MINOR.PATCH[-prerelease][+build]" into its three
+// numeric core fields and the raw pre-release string, dropping build metadata.
+func splitVersion(v string) (core [3]int, pre string, ok bool) {
+	v = strings.TrimPrefix(v, "v")
+	if i := strings.IndexByte(v, '+'); i >= 0 {
+		v = v[:i]
+	}
+	coreStr := v
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		coreStr, pre = v[:i], v[i+1:]
+	}
+	parts := strings.Split(coreStr, ".")
+	if len(parts) != 3 {
+		return core, "", false
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return core, "", false
+		}
+		core[i] = n
+	}
+	return core, pre, true
+}
+
+func compareCore(a, b [3]int) int {
+	for i := range a {
+		switch {
+		case a[i] < b[i]:
+			return -1
+		case a[i] > b[i]:
+			return 1
+		}
+	}
+	return 0
+}
+
+// comparePrerelease applies semver §11: a release (empty pre-release) outranks
+// any pre-release; otherwise dot-separated identifiers are compared left to
+// right, numeric identifiers below alphanumeric ones, and a longer set of
+// identifiers wins when the shared prefix is equal.
+func comparePrerelease(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "" {
+		return 1
+	}
+	if b == "" {
+		return -1
+	}
+	as, bs := strings.Split(a, "."), strings.Split(b, ".")
+	for i := 0; i < len(as) && i < len(bs); i++ {
+		if c := compareIdent(as[i], bs[i]); c != 0 {
+			return c
+		}
+	}
+	switch {
+	case len(as) < len(bs):
+		return -1
+	case len(as) > len(bs):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func compareIdent(a, b string) int {
+	an, aErr := strconv.Atoi(a)
+	bn, bErr := strconv.Atoi(b)
+	aNum, bNum := aErr == nil, bErr == nil
+	switch {
+	case aNum && bNum:
+		switch {
+		case an < bn:
+			return -1
+		case an > bn:
+			return 1
+		default:
+			return 0
+		}
+	case aNum: // numeric identifiers have lower precedence than alphanumeric
+		return -1
+	case bNum:
+		return 1
+	default:
+		return strings.Compare(a, b)
+	}
+}

--- a/internal/updater/version_test.go
+++ b/internal/updater/version_test.go
@@ -1,0 +1,38 @@
+package updater
+
+import "testing"
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		a, b    string
+		wantCmp int
+		wantOK  bool
+	}{
+		{"1.2.3", "1.2.3", 0, true},
+		{"1.2.3", "1.2.4", -1, true},
+		{"1.2.4", "1.2.3", 1, true},
+		{"1.3.0", "1.2.9", 1, true},
+		{"2.0.0", "1.9.9", 1, true},
+		{"v1.2.3", "1.2.3", 0, true},        // leading v ignored
+		{"1.2.3+build.5", "1.2.3", 0, true}, // build metadata ignored
+		{"1.2.3-rc1", "1.2.3", -1, true},    // pre-release below release
+		{"1.2.3", "1.2.3-rc1", 1, true},
+		{"1.2.3-rc1", "1.2.3-rc2", -1, true},
+		{"1.2.3-2", "1.2.3-10", -1, true},          // numeric identifiers compare numerically
+		{"1.2.3-rc2", "1.2.3-rc10", 1, true},       // alphanumeric identifiers compare lexically
+		{"1.2.3-alpha", "1.2.3-alpha.1", -1, true}, // fewer identifiers ranks lower
+		{"1.2.3-1", "1.2.3-alpha", -1, true},       // numeric below alphanumeric
+		{"0.1.0-dev", "0.1.0", -1, true},
+		{"1.3.0-dev", "1.2.9", 1, true}, // ahead by core even as a pre-release
+		{"garbage", "1.2.3", 0, false},
+		{"1.2", "1.2.0", 0, false}, // core must be three fields
+		{"1.2.x", "1.2.3", 0, false},
+	}
+	for _, tt := range tests {
+		gotCmp, gotOK := compareVersions(tt.a, tt.b)
+		if gotOK != tt.wantOK || (gotOK && gotCmp != tt.wantCmp) {
+			t.Errorf("compareVersions(%q, %q) = (%d, %v), want (%d, %v)",
+				tt.a, tt.b, gotCmp, gotOK, tt.wantCmp, tt.wantOK)
+		}
+	}
+}

--- a/oh-my-agentic-coder.md
+++ b/oh-my-agentic-coder.md
@@ -629,8 +629,10 @@ Runs sanity checks:
 ### 10.5a `omac update`
 
 Checks GitHub's `/releases/latest` endpoint (prereleases are excluded
-automatically) and, if a newer version is available, installs it using
-whichever method matches how this host runs omac:
+automatically) and, if the release is *strictly newer* than the running build
+(compared as semver, so a dev or pre-release build already ahead of the latest
+tag is left alone — it never downgrades), installs it using whichever method
+matches how this host runs omac:
 
 1. **macOS, Homebrew-installed** (detected via the resolved binary path or
    `brew list --formula oh-my-agentic-coder`) — runs `brew upgrade

--- a/oh-my-agentic-coder.md
+++ b/oh-my-agentic-coder.md
@@ -652,7 +652,7 @@ checksum status, then asks `Proceed with update? [y/N]`. Pass `--yes`/`-y`
 to skip the prompt for scripting. There is no separate `--check`/`--dry-run`
 flag — declining the prompt *is* the dry run. In a non-interactive session
 (no TTY) without `--yes`, it prints a hint and exits `0` without changing
-anything, rather than hanging or failing.
+anything, rather than hanging on a prompt.
 
 ### 10.6 Exit codes (global)
 

--- a/oh-my-agentic-coder.md
+++ b/oh-my-agentic-coder.md
@@ -626,6 +626,34 @@ Runs sanity checks:
 - Stale runtime directories for this workdir (offers `--fix` to remove them).
 - Configured sandbox binary resolvable on `$PATH`.
 
+### 10.5a `omac update`
+
+Checks GitHub's `/releases/latest` endpoint (prereleases are excluded
+automatically) and, if a newer version is available, installs it using
+whichever method matches how this host runs omac:
+
+1. **macOS, Homebrew-installed** (detected via the resolved binary path or
+   `brew list --formula oh-my-agentic-coder`) — runs `brew upgrade
+   oh-my-agentic-coder`.
+2. **Linux, a known package manager is on `$PATH`** — in priority order
+   `dpkg` > `rpm` > `pacman` > `apk`, downloads the matching release asset
+   (`.deb`/`.rpm`/`.pkg.tar.zst`/`.apk`) and runs `sudo <tool> <install-verb>
+   <path>`.
+3. **Otherwise** (macOS without brew, or Linux with none of the above) —
+   downloads the release tarball and atomically replaces the running binary
+   in place.
+
+Every downloaded asset (except brew's own bottle) is verified against the
+release's published `checksums.txt` (SHA-256) before anything is installed;
+a mismatch aborts with exit code `10` and installs nothing.
+
+Before installing, it prints the current → latest version, the method, and
+checksum status, then asks `Proceed with update? [y/N]`. Pass `--yes`/`-y`
+to skip the prompt for scripting. There is no separate `--check`/`--dry-run`
+flag — declining the prompt *is* the dry run. In a non-interactive session
+(no TTY) without `--yes`, it prints a hint and exits `0` without changing
+anything, rather than hanging or failing.
+
 ### 10.6 Exit codes (global)
 
 | Code | Meaning |
@@ -635,9 +663,12 @@ Runs sanity checks:
 | `2` | misuse / invalid arguments |
 | `3` | configuration or metadata invalid |
 | `4` | prerequisite missing (skill not installed, binary not built) |
-| `5` | I/O error (registry, socket, fs) |
+| `5` | I/O error (registry, socket, fs, network) |
 | `6` | sidecar failed health check before sandbox was launched |
 | `7` | sandbox process exited with a non-zero code (exit code is propagated into the low 8 bits where possible) |
+| `8` | OS keychain (Secret Service) operation failed |
+| `9` | user refused a secret prompt |
+| `10` | `omac update` checksum verification failed |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `omac update`, which checks GitHub's latest release and installs it via whichever method matches how this host runs omac: `brew upgrade` on Homebrew-managed macOS installs, the matching native package (`.deb`/`.rpm`/`.pkg.tar.zst`/`.apk`) via `sudo` on Linux (priority `dpkg` > `rpm` > `pacman` > `apk`), or an atomic self-replace of the running binary as a fallback (macOS without brew, or Linux with none of the above).
- Every downloaded asset is SHA-256 verified against the release's `checksums.txt` before anything is installed; a mismatch aborts with a new exit code (`10`) and installs nothing.
- Confirms current → latest version, method, and checksum status before acting; `--yes`/`-y` skips the prompt for scripting. Declining the prompt is the dry run — no separate `--check`/`--dry-run` flag. A non-interactive session without `--yes` no-ops with exit `0`.
- New `internal/updater` package wraps every real-world side effect (HTTP, subprocess exec, filesystem replace) behind small interfaces, matching the existing `internal/netproxy` interface+fake convention, so all tests run without touching the network, sudo, or any real package manager.

Closes #59.

## Why
omac ships via Homebrew, `.deb`/`.rpm`/`.pkg.tar.zst`/`.apk`, a raw tarball, and `go install`, but only the Homebrew path had a documented upgrade story (`brew upgrade`). Everyone else had to manually re-download and reinstall.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `go test ./...` — full suite passes, no regressions
- [x] Manual smoke test against the real GitHub API on this machine: correctly detected `rpm` on this Fedora host, downloaded and checksum-verified the latest release asset, and declined cleanly on non-interactive stdin without installing anything
- [x] Fixed a real bug found during the smoke test: the checksum-verified download wasn't cleaned up after a decline, leaking a temp file per run

🤖 Generated with [Claude Code](https://claude.com/claude-code)