### PR TITLE
fix(keychain): actionable WSL hint on Secret Service failure, doc callout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,54 @@ jobs:
       - name: Test
         run: go test -race -count=1 -timeout=5m ./...
 
+  wsl2-session:
+    # WSL2-style degraded session. WSL2 distros commonly run without systemd
+    # (needs systemd=true in wsl.conf), and even with it, `Linger=no` makes
+    # systemd tear down /run/user/<uid> — including the session-bus socket —
+    # when the login session ends, while DBUS_SESSION_BUS_ADDRESS still points
+    # at the now-dead socket. Real WSL2 isn't worth running on CI (hosted
+    # windows runners only give WSL1; WSL2 needs nested virtualization), but
+    # the failure mode reproduces deterministically here: point the bus address
+    # at a socket that doesn't exist and confirm omac's keychain/Secret Service
+    # reads degrade gracefully (keychain.IsUnavailable) instead of surfacing
+    # raw dial errors.
+    name: WSL2-style session (dead bus)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install bubblewrap
+        run: |
+          sudo apt-get update && sudo apt-get install -y bubblewrap
+          # This job degrades the session, not the sandbox, so bwrap still
+          # needs the unprivileged-userns permission AppArmor denies by default
+          # on Ubuntu 24.04 — otherwise the sandbox integration tests would
+          # skip rather than run under the degraded session.
+          sudo tee /etc/apparmor.d/bwrap > /dev/null <<'EOF'
+          abi <abi/4.0>,
+          /usr/bin/bwrap flags=(unconfined) {
+            userns,
+          }
+          EOF
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test under a torn-down session bus
+        env:
+          # A /run/user/<uid>/bus that systemd already removed: the address is
+          # still exported, but the socket is gone (Linger=no teardown).
+          DBUS_SESSION_BUS_ADDRESS: unix:path=${{ runner.temp }}/dead-user-bus
+          # The runtime dir was never created — mimics a session with no
+          # systemd --user instance to populate it.
+          XDG_RUNTIME_DIR: ${{ runner.temp }}/nonexistent-run-user
+        run: go test -race -count=1 -timeout=5m ./...
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -266,6 +266,19 @@ missing.
 | **Secret Service / D-Bus** | ships with GNOME/KDE; `apt install libsecret-1-0` | built-in (Keychain) | Stores skill secrets (API keys, tokens) in the OS keychain so they never touch disk. If no Secret Service is running, `omac secrets` operations will fail. |
 | **Python 3** (stdlib only) | pre-installed on most distros | pre-installed | Sidecar processes are written against the Python standard library only. No pip packages required. |
 
+> **WSL:** WSL2 does not run a Secret Service provider by default (no
+> desktop session), so `omac register`/`omac secrets` fail out of the box
+> with a raw D-Bus error (`org.freedesktop.secrets was not provided by any
+> .service files`). Install and start gnome-keyring once per session:
+> ```bash
+> sudo apt install gnome-keyring dbus-x11
+> eval "$(dbus-launch --sh-syntax)"
+> gnome-keyring-daemon --unlock --components=secrets
+> ```
+> `omac doctor` reports whether the keychain backend is reachable. There is
+> no file-based fallback yet (see design doc §16.2) — a running Secret
+> Service provider is required on Linux/WSL.
+
 #### Network prompt dialog (strongly recommended)
 
 When the default sandbox profile's `network.network_prompt` is enabled (it is

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -25,8 +25,19 @@ func runDoctor(args []string, env *Env) int {
 	}
 
 	fmt.Fprintf(env.Stdout, "omac %s\n", env.Version)
-	fmt.Fprintf(env.Stdout, "OS: %s\n", osinfo.Detect())
+	host := osinfo.Detect()
+	fmt.Fprintf(env.Stdout, "OS: %s\n", host)
 	fmt.Fprintf(env.Stdout, "workdir: %s\n", env.Workdir)
+
+	if err := keychain.Ping(); err != nil {
+		if keychain.IsUnavailable(err) {
+			fmt.Fprintf(env.Stdout, "[warn] keychain backend: unavailable — %s\n", keychainUnavailableHint(host))
+		} else {
+			fmt.Fprintln(env.Stdout, "[warn] keychain backend:", err)
+		}
+	} else {
+		fmt.Fprintln(env.Stdout, "[ok] keychain backend: reachable")
+	}
 
 	// Launcher config resolution.
 	_, cfgPath, err := config.LoadLauncher(env.Workdir)

--- a/internal/cli/keychain_hint.go
+++ b/internal/cli/keychain_hint.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/keychain"
+	"github.com/tngtech/oh-my-agentic-coder/internal/osinfo"
+)
+
+// keychainUnavailableHint returns an actionable, OS-specific tip for a
+// missing Secret Service backend, appended to the raw D-Bus/keyring error
+// so a user isn't left with just "org.freedesktop.secrets was not provided
+// by any .service files". See README.md#prerequisites.
+func keychainUnavailableHint(host osinfo.OS) string {
+	if host == osinfo.WSL {
+		return "no Secret Service provider found — WSL doesn't ship one by default; " +
+			"install and start gnome-keyring once per session: " +
+			`sudo apt install gnome-keyring dbus-x11 && eval "$(dbus-launch --sh-syntax)" && ` +
+			"gnome-keyring-daemon --unlock --components=secrets (see README.md#prerequisites)"
+	}
+	return "no Secret Service provider found — install and start one (e.g. gnome-keyring or kwalletd), " +
+		"or set DBUS_SESSION_BUS_ADDRESS if one is already running (see README.md#prerequisites)"
+}
+
+// wrapKeychainErr appends keychainUnavailableHint to errors caused by a
+// missing keychain backend (keychain.IsUnavailable), leaving per-secret
+// errors (deleted item, permission denied, etc.) untouched.
+func wrapKeychainErr(err error) error {
+	if err == nil || !keychain.IsUnavailable(err) {
+		return err
+	}
+	return fmt.Errorf("%w — %s", err, keychainUnavailableHint(osinfo.Detect()))
+}

--- a/internal/cli/keychain_hint_test.go
+++ b/internal/cli/keychain_hint_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/osinfo"
+)
+
+// TestWrapKeychainErrOnlyHintsBackendFailures ensures the hint is attached
+// only for missing-backend errors (keychain.IsUnavailable), not for
+// genuine per-secret failures — a wrong hint on the latter would mislead a
+// user whose Secret Service is actually running fine.
+func TestWrapKeychainErrOnlyHintsBackendFailures(t *testing.T) {
+	unavailable := errors.New(`keychain set omac/slack/TOKEN: The name org.freedesktop.secrets was not provided by any .service files`)
+	if got := wrapKeychainErr(unavailable); !strings.Contains(got.Error(), "Secret Service") {
+		t.Errorf("wrapKeychainErr(unavailable) = %q, want it to contain a hint", got)
+	}
+
+	genuine := errors.New("permission denied")
+	if got := wrapKeychainErr(genuine); got.Error() != genuine.Error() {
+		t.Errorf("wrapKeychainErr(genuine) = %q, want unchanged %q", got, genuine)
+	}
+
+	if got := wrapKeychainErr(nil); got != nil {
+		t.Errorf("wrapKeychainErr(nil) = %v, want nil", got)
+	}
+}
+
+// TestKeychainUnavailableHintMentionsWSLSetup checks the WSL hint actually
+// names the fix (gnome-keyring) rather than just restating the symptom.
+func TestKeychainUnavailableHintMentionsWSLSetup(t *testing.T) {
+	if got := keychainUnavailableHint(osinfo.WSL); !strings.Contains(got, "gnome-keyring") {
+		t.Errorf("WSL hint = %q, want it to mention gnome-keyring", got)
+	}
+	if got := keychainUnavailableHint(osinfo.Linux); strings.Contains(got, "WSL") {
+		t.Errorf("Linux hint = %q, should not claim to be WSL-specific", got)
+	}
+}

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -500,7 +500,7 @@ func handleOneSecret(env *Env, scope, skill string, spec config.SecretSpec, repr
 			if verr := validatePattern(spec, def.ExposeString()); verr == nil {
 				if serr := keychain.SetWithDefault(scope, skill, spec.Name, def); serr != nil {
 					def.Zero()
-					return false, fmt.Errorf("keychain: %w", serr)
+					return false, fmt.Errorf("keychain: %w", wrapKeychainErr(serr))
 				}
 				def.Zero()
 				st.status(env.Stderr, "stored", spec.Name+st.gray(" (from remembered default)"), ansiGreen)
@@ -518,7 +518,7 @@ func handleOneSecret(env *Env, scope, skill string, spec config.SecretSpec, repr
 		s := secrets.NewSecretString(v)
 		defer s.Zero()
 		if err := keychain.SetWithDefault(scope, skill, spec.Name, s); err != nil {
-			return false, fmt.Errorf("keychain: %w", err)
+			return false, fmt.Errorf("keychain: %w", wrapKeychainErr(err))
 		}
 		st.status(env.Stderr, "stored", spec.Name+st.gray(" (from file)"), ansiGreen)
 		return false, nil
@@ -532,7 +532,7 @@ func handleOneSecret(env *Env, scope, skill string, spec config.SecretSpec, repr
 		s := secrets.NewSecretString(v)
 		defer s.Zero()
 		if err := keychain.SetWithDefault(scope, skill, spec.Name, s); err != nil {
-			return false, fmt.Errorf("keychain: %w", err)
+			return false, fmt.Errorf("keychain: %w", wrapKeychainErr(err))
 		}
 		st.status(env.Stderr, "stored", spec.Name+st.gray(fmt.Sprintf(" (from OMAC_SECRET_%s)", spec.Name)), ansiGreen)
 		return false, nil
@@ -569,7 +569,7 @@ func handleOneSecret(env *Env, scope, skill string, spec config.SecretSpec, repr
 					s := secrets.NewSecretString(v)
 					if err := keychain.SetWithDefault(scope, skill, spec.Name, s); err != nil {
 						s.Zero()
-						return false, fmt.Errorf("keychain: %w", err)
+						return false, fmt.Errorf("keychain: %w", wrapKeychainErr(err))
 					}
 					s.Zero()
 					st.status(env.Stderr, "stored", spec.Name+st.gray(fmt.Sprintf(" (from $%s)", spec.DefaultFromEnv)), ansiGreen)
@@ -596,7 +596,7 @@ func handleOneSecret(env *Env, scope, skill string, spec config.SecretSpec, repr
 		}
 		if err := keychain.SetWithDefault(scope, skill, spec.Name, value); err != nil {
 			value.Zero()
-			return false, fmt.Errorf("keychain: %w", err)
+			return false, fmt.Errorf("keychain: %w", wrapKeychainErr(err))
 		}
 		value.Zero()
 		st.status(env.Stderr, "stored", spec.Name, ansiGreen)

--- a/internal/cli/secrets_cmd.go
+++ b/internal/cli/secrets_cmd.go
@@ -175,7 +175,7 @@ func runSecretsImport(args []string, env *Env) int {
 		s := secrets.NewSecretString(v)
 		if err := keychain.SetScoped(scope, skill, k, s); err != nil {
 			s.Zero()
-			fmt.Fprintln(env.Stderr, "omac secrets import: keychain:", err)
+			fmt.Fprintln(env.Stderr, "omac secrets import: keychain:", wrapKeychainErr(err))
 			return ExitKeychainError
 		}
 		s.Zero()

--- a/internal/keychain/degraded_session_test.go
+++ b/internal/keychain/degraded_session_test.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package keychain
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestReadsDegradeWhenSessionBusSocketIsDead reproduces the WSL2 /
+// `Linger=no` field failure end-to-end through go-keyring, not just the
+// IsUnavailable classifier: DBUS_SESSION_BUS_ADDRESS still names a
+// /run/user/<uid>/bus socket that systemd tore down when the login session
+// ended. Read paths (start/serve) must treat the resulting dial failure as
+// "backend unavailable" — ErrNotFound / false — so optional secrets and
+// env_passthrough fallbacks keep working, rather than surfacing a raw
+// "dial unix ...: connect: no such file or directory" hard error.
+func TestReadsDegradeWhenSessionBusSocketIsDead(t *testing.T) {
+	deadSocket := filepath.Join(t.TempDir(), "bus")
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path="+deadSocket)
+
+	if _, err := Get("wsl2-probe-skill", "token"); err != ErrNotFound {
+		t.Errorf("Get on dead session bus = %v, want ErrNotFound", err)
+	}
+
+	has, err := Has("wsl2-probe-skill", "token")
+	if err != nil {
+		t.Errorf("Has on dead session bus returned error %v, want nil", err)
+	}
+	if has {
+		t.Error("Has on dead session bus = true, want false")
+	}
+}

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -15,9 +15,11 @@
 // docs/MULTI_DIR_DESKTOP.md §4.3/§8.2.
 //
 // The backend (macOS Keychain, Secret Service, Windows Credential Manager)
-// is selected by go-keyring based on the host OS. A file-based fallback
-// for headless Linux is declared as future work in the design doc and is
-// not implemented in v0.
+// is selected by go-keyring based on the host OS. A file-based fallback for
+// headless Linux (age-encrypted secrets.age, oh-my-agentic-coder.md §16.2)
+// is not implemented; on WSL / headless Linux without a running Secret
+// Service provider, keychain operations fail — see IsUnavailable and
+// README.md#prerequisites for the actionable fix.
 package keychain
 
 import (
@@ -107,7 +109,7 @@ func GetScoped(scope, skillName, name string) (secrets.Secret, error) {
 	svc := ScopedService(scope, skillName)
 	v, err := keyring.Get(svc, name)
 	if err != nil {
-		if errors.Is(err, keyring.ErrNotFound) || isKeychainUnavailable(err) {
+		if errors.Is(err, keyring.ErrNotFound) || IsUnavailable(err) {
 			return secrets.Secret{}, ErrNotFound
 		}
 		return secrets.Secret{}, fmt.Errorf("keychain get %s/%s: %w", svc, name, err)
@@ -115,12 +117,14 @@ func GetScoped(scope, skillName, name string) (secrets.Secret, error) {
 	return secrets.NewSecretString(v), nil
 }
 
-// isKeychainUnavailable reports whether err indicates the OS keychain
-// backend is missing (no Secret Service daemon on headless Linux, no
-// keychain daemon on macOS, etc.). Such errors are not per-secret failures
-// but environment-level ones; mapping them to ErrNotFound lets optional
-// secrets and env_passthrough fallbacks work in CI.
-func isKeychainUnavailable(err error) bool {
+// IsUnavailable reports whether err indicates the OS keychain backend
+// itself is missing (no Secret Service daemon on headless Linux, no
+// keychain daemon on macOS, etc.), as opposed to a per-secret failure. Read
+// paths (GetScoped/HasScoped) map such errors to ErrNotFound so optional
+// secrets and env_passthrough fallbacks still work in CI; write-path
+// callers (register, secrets set) use it instead to attach an actionable,
+// OS-specific hint rather than surfacing the raw backend error verbatim.
+func IsUnavailable(err error) bool {
 	msg := err.Error()
 	// Linux: org.freedesktop.secrets not provided by any .service files
 	// (dbus.ServiceUnknown when no Secret Service implementation is running).
@@ -132,6 +136,19 @@ func isKeychainUnavailable(err error) bool {
 		return true
 	}
 	return false
+}
+
+// Ping probes whether the OS keychain backend itself is reachable, for
+// diagnostics (`omac doctor`). It looks up a secret that will never exist:
+// a not-found result means the backend answered (available), while a
+// backend-level error is returned as-is so callers can classify it with
+// IsUnavailable and attach a hint.
+func Ping() error {
+	_, err := keyring.Get("omac/__doctor_probe__", "probe")
+	if err == nil || errors.Is(err, keyring.ErrNotFound) {
+		return nil
+	}
+	return err
 }
 
 // GetWithFallback retrieves a secret under (scope, skill), falling back to
@@ -161,7 +178,7 @@ func HasScoped(scope, skillName, name string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if errors.Is(err, keyring.ErrNotFound) || isKeychainUnavailable(err) {
+	if errors.Is(err, keyring.ErrNotFound) || IsUnavailable(err) {
 		return false, nil
 	}
 	return false, fmt.Errorf("keychain probe %s/%s: %w", svc, name, err)

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -135,6 +135,19 @@ func IsUnavailable(err error) bool {
 	if strings.Contains(msg, "dbus") || strings.Contains(msg, "D-Bus") {
 		return true
 	}
+	// Linux: the session-bus socket named by DBUS_SESSION_BUS_ADDRESS has
+	// been torn down while the env var still points at it — the WSL2 /
+	// `Linger=no` case where systemd removes /run/user/<uid> when the login
+	// session ends. go-keyring surfaces the raw dial failure ("dial unix
+	// <path>: connect: no such file or directory" / "connection refused"),
+	// which carries no dbus marker but is an environment-level unavailability,
+	// not a per-secret error.
+	if strings.Contains(msg, "dial unix") &&
+		(strings.Contains(msg, "no such file or directory") ||
+			strings.Contains(msg, "connection refused") ||
+			strings.Contains(msg, "permission denied")) {
+		return true
+	}
 	return false
 }
 

--- a/internal/keychain/keychain_test.go
+++ b/internal/keychain/keychain_test.go
@@ -1,6 +1,9 @@
 package keychain
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 // TestScopedServiceNaming locks the keychain service-name scheme so the
 // write side (register/secrets set) and the read side (start/serve) can
@@ -34,5 +37,27 @@ func TestWorkdirIDDeterministicAndDistinct(t *testing.T) {
 	}
 	if a1 == "" {
 		t.Error("WorkdirID returned empty")
+	}
+}
+
+// TestIsUnavailable locks the classification used to attach a WSL/headless
+// hint on the write path (see cli.wrapKeychainErr) vs. leaving genuine
+// per-secret errors (permission denied, corrupt entry, ...) untouched.
+func TestIsUnavailable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"dbus service unknown", errors.New(`keychain set omac/slack/TOKEN: The name org.freedesktop.secrets was not provided by any .service files`), true},
+		{"no dbus session", errors.New("dbus: could not connect: no such file or directory"), true},
+		{"D-Bus capitalized", errors.New("D-Bus connection failed"), true},
+		{"unrelated error", errors.New("permission denied"), false},
+		{"not found", ErrNotFound, false},
+	}
+	for _, c := range cases {
+		if got := IsUnavailable(c.err); got != c.want {
+			t.Errorf("IsUnavailable(%q) = %v, want %v", c.err, got, c.want)
+		}
 	}
 }

--- a/internal/keychain/keychain_test.go
+++ b/internal/keychain/keychain_test.go
@@ -52,7 +52,14 @@ func TestIsUnavailable(t *testing.T) {
 		{"dbus service unknown", errors.New(`keychain set omac/slack/TOKEN: The name org.freedesktop.secrets was not provided by any .service files`), true},
 		{"no dbus session", errors.New("dbus: could not connect: no such file or directory"), true},
 		{"D-Bus capitalized", errors.New("D-Bus connection failed"), true},
+		// go-keyring's real error when DBUS_SESSION_BUS_ADDRESS names a
+		// torn-down socket (WSL2 / Linger=no): a bare dial failure with no
+		// dbus marker, so the checks above don't catch it.
+		{"dead bus socket removed", errors.New("keychain get omac/slack/TOKEN: dial unix /run/user/1000/bus: connect: no such file or directory"), true},
+		{"dead bus socket refused", errors.New("dial unix /run/user/1000/bus: connect: connection refused"), true},
 		{"unrelated error", errors.New("permission denied"), false},
+		// A generic "no such file" that is NOT a bus dial must not be masked.
+		{"unrelated missing file", errors.New("open /some/config: no such file or directory"), false},
 		{"not found", ErrNotFound, false},
 	}
 	for _, c := range cases {

--- a/oh-my-agentic-coder.md
+++ b/oh-my-agentic-coder.md
@@ -983,10 +983,10 @@ Rules:
 | --- | --- |
 | macOS | Keychain Services (`security` framework). |
 | Linux (GNOME/KDE) | Secret Service API (`libsecret`, D-Bus). |
-| WSL / headless Linux | Pass-through to the native backend if present; otherwise fallback to an age-encrypted file under `~/.local/share/omac/secrets.age` with the passphrase unlocked once per session via keyring if available. |
+| WSL / headless Linux | Pass-through to the native backend if present. A file-based fallback (age-encrypted file under `~/.local/share/omac/secrets.age`, passphrase unlocked once per session via keyring if available) was proposed here but is **not implemented in v0** — see `internal/keychain`. Without a running Secret Service provider, keychain operations fail; `omac doctor` reports backend reachability and README.md#prerequisites has the gnome-keyring setup snippet. |
 | Windows (native, future) | Windows Credential Manager. |
 
-The backend selection is logged once on first use (`omac doctor` shows the active backend). Users can pin a backend via `OMAC_KEYRING_BACKEND=secret-service|keychain|file`.
+`omac doctor` reports whether the keychain backend is reachable. `OMAC_KEYRING_BACKEND=secret-service|keychain|file` pinning described in earlier drafts of this doc is likewise **not implemented**.
 
 ### 16.3 Naming convention
 


### PR DESCRIPTION
## What
- Export `keychain.IsUnavailable` (was internal `isKeychainUnavailable`) and add `keychain.Ping` for a lightweight backend-reachability probe.
- Add `cli.wrapKeychainErr` / `keychainUnavailableHint`: append an OS-aware, actionable hint (WSL gets a gnome-keyring setup snippet) to write-path keychain errors, without touching read-path behavior (`env_passthrough`/optional-secret fallbacks still work).
- Wire the hint into `omac register`, `omac secrets set`, `omac secrets import`, and add an upfront `[ok]/[warn] keychain backend` line to `omac doctor`.
- README: WSL prerequisites callout with the gnome-keyring setup snippet.
- Design doc §16.2: mark the age-encrypted file fallback and `OMAC_KEYRING_BACKEND` as not implemented, so it stops overpromising.

## Why
On WSL/headless Linux without a running Secret Service provider, `omac register`/`omac secrets` surfaced the raw D-Bus error (`org.freedesktop.secrets was not provided by any .service files`) with no guidance, and `omac doctor` silently counted secrets as "missing" instead of explaining why. Fixes #63.

The design doc's file-based fallback (`secrets.age`, `OMAC_KEYRING_BACKEND`) was never implemented, so this PR scopes to docs + CLI hint (issue ask #3's "optional" scope) rather than building that out — it's a meaningfully larger feature (new crypto dependency, passphrase UX, second secret-storage code path) that deserves its own design/issue.

## How
- `keychain.IsUnavailable` classifies backend-level errors (missing Secret Service, no D-Bus session) as opposed to per-secret failures. It was already used on the read path (`GetScoped`/`HasScoped` map it to `ErrNotFound`); this PR reuses it on the write path to attach a hint instead of silently swallowing it.
- `wrapKeychainErr` only touches errors that classify as unavailable — genuine per-secret failures (permission denied, etc.) pass through unchanged.
- `keychain.Ping` performs a lookup for a secret that can never exist; a not-found result means the backend answered, any other error is the backend failure itself.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Added `TestIsUnavailable` (keychain), `TestWrapKeychainErrOnlyHintsBackendFailures` and `TestKeychainUnavailableHintMentionsWSLSetup` (cli).
- Manually ran `omac doctor` on this host (reports `[ok] keychain backend: reachable`) and with a broken `DBUS_SESSION_BUS_ADDRESS` (confirmed the `[warn]` path fires with the raw error surfaced, i.e. wiring executes correctly end to end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)