### PR TITLE
fix(e2e): reduce flakiness, cache installs, add claude-code cost toggle

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,12 +72,55 @@ jobs:
         with:
           node-version: '24'
 
+      # npm/bun package downloads are a leading cause of e2e infra flakiness
+      # (registry throttling, transient network errors). Cache them keyed on
+      # the pinned harness versions so a version bump invalidates the cache
+      # but repeated runs at the same versions reuse already-fetched packages.
+      - name: Cache harness install packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/e2e-install-cache
+          key: e2e-install-${{ runner.os }}-${{ matrix.harness }}-${{ hashFiles('internal/e2e/versions.go') }}
+          restore-keys: |
+            e2e-install-${{ runner.os }}-${{ matrix.harness }}-
+
       - name: Run e2e test
         env:
           E2E_LOG_DIR: ${{ runner.temp }}/e2e-logs
+          E2E_CACHE_DIR: ${{ runner.temp }}/e2e-install-cache
         run: |
           set -o pipefail
-          go test -tags=e2e -timeout=30m -v ./internal/e2e/ 2>&1 | tee /tmp/e2e-out.txt
+          max_attempts=3
+          attempt=1
+          while :; do
+            echo "::group::e2e attempt $attempt/$max_attempts"
+            if go test -tags=e2e -timeout=30m -v ./internal/e2e/ 2>&1 | tee /tmp/e2e-out.txt; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            # Only retry when no failure this attempt was classified as a real
+            # regression: SANDBOX_FAIL (a security property went unenforced)
+            # or AGENT_REFUSED/AGENT_PARTIAL (a model-behavior signal, not
+            # infra). Every other failure path — install/build errors,
+            # AGENT_NEVER_RAN, INFRA_ERROR, agent timeout — is either a
+            # t.Fatalf before any assertion ran, or an infra-classified
+            # assertion, and is safe to retry. This ensures a real sandbox
+            # regression can never be silently masked by a retry.
+            bad=$(grep -oE 'FAIL \[[^]]+\]: (SANDBOX_FAIL|AGENT_REFUSED|AGENT_PARTIAL)' /tmp/e2e-out.txt | sort -u || true)
+            if [ -n "$bad" ]; then
+              echo "non-infra failure — not retrying:"
+              echo "$bad"
+              exit 1
+            fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "max attempts ($max_attempts) reached — giving up"
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+            echo "infra-only failure — retrying in 15s (attempt $attempt/$max_attempts)"
+            sleep 15
+          done
 
       - name: Failure classification summary
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,11 @@ name: E2E
 
 on:
   workflow_dispatch:
+    inputs:
+      skip_claude_code:
+        description: 'Skip claude-code (the only harness billed against the real Anthropic account)'
+        type: boolean
+        default: false
   schedule:
     - cron: '0 8 * * 6' # Saturdays 10:00 CEST
 
@@ -18,6 +23,11 @@ permissions:
 jobs:
   e2e:
     name: E2E (${{ matrix.harness }} / ${{ matrix.os }})
+    # claude-code is the only harness billed against a real external
+    # Anthropic account (the others run against the internal SKAINET
+    # gateway) — included by default, skippable via the workflow_dispatch
+    # input above. The scheduled run always includes it.
+    if: matrix.harness != 'claude-code' || github.event.inputs.skip_claude_code != 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,11 +23,6 @@ permissions:
 jobs:
   e2e:
     name: E2E (${{ matrix.harness }} / ${{ matrix.os }})
-    # claude-code is the only harness billed against a real external
-    # Anthropic account (the others run against the internal SKAINET
-    # gateway) — included by default, skippable via the workflow_dispatch
-    # input above. The scheduled run always includes it.
-    if: matrix.harness != 'claude-code' || github.event.inputs.skip_claude_code != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -95,6 +90,14 @@ jobs:
             e2e-install-${{ runner.os }}-${{ matrix.harness }}-
 
       - name: Run e2e test
+        id: run_e2e
+        # claude-code is the only harness billed against a real external
+        # Anthropic account (the others run against the internal SKAINET
+        # gateway) — included by default, skippable via the workflow_dispatch
+        # input above. The scheduled run always includes it. (job-level `if:`
+        # can't reference `matrix` — only `github`/`inputs`/`needs`/`vars` are
+        # available there — so the guard lives on this step instead.)
+        if: matrix.harness != 'claude-code' || github.event.inputs.skip_claude_code != 'true'
         env:
           E2E_LOG_DIR: ${{ runner.temp }}/e2e-logs
           E2E_CACHE_DIR: ${{ runner.temp }}/e2e-install-cache
@@ -132,8 +135,14 @@ jobs:
             sleep 15
           done
 
+      - name: Skipped notice
+        if: steps.run_e2e.outcome == 'skipped'
+        run: |
+          echo "## E2E (${{ matrix.harness }} / ${{ matrix.os }}): SKIPPED" >> "$GITHUB_STEP_SUMMARY"
+          echo "skip_claude_code was set on this workflow_dispatch run." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Failure classification summary
-        if: always()
+        if: always() && steps.run_e2e.outcome != 'skipped'
         run: |
           # Render a markdown table on the run-summary page so the failure
           # cause is visible by indicator without opening the full log.

--- a/internal/e2e/artifacts.go
+++ b/internal/e2e/artifacts.go
@@ -113,5 +113,11 @@ func writeSessionArtifacts(t *testing.T, h harnessConfig, testType string,
 		mustWrite("audit-output.txt", string(data))
 	}
 
+	// Echo-rest output file (smoke test): the raw curl response, captured
+	// independent of how the harness rendered/paraphrased tool output.
+	if data, err := os.ReadFile(filepath.Join(workdir, "echo-status.txt")); err == nil {
+		mustWrite("echo-status.txt", string(data))
+	}
+
 	t.Logf("session artifacts written to %s", dir)
 }

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -21,12 +21,19 @@
 // The sandbox profile is derived at runtime from SKAINET_INTERNAL /
 // ANTHROPIC_BASE_URL so the proxy allows the model API host.
 //
-// Run locally: go test -tags=e2e -timeout=30m -v ./internal/e2e/
-// Run one:     E2E_HARNESS=opencode go test -tags=e2e -timeout=30m -v ./internal/e2e/
-// Latest:      E2E_USE_LATEST=1 go test -tags=e2e -timeout=30m -v ./internal/e2e/
+// Run locally:      go test -tags=e2e -timeout=30m -v ./internal/e2e/
+// Run one:          E2E_HARNESS=opencode go test -tags=e2e -timeout=30m -v ./internal/e2e/
+// Latest:           E2E_USE_LATEST=1 go test -tags=e2e -timeout=30m -v ./internal/e2e/
+// Skip claude-code: E2E_SKIP_CLAUDE_CODE=1 go test -tags=e2e -timeout=30m -v ./internal/e2e/
 //
 // Harness versions and model IDs are pinned in versions.go.
 // Set E2E_USE_LATEST=1 to test with latest releases (no pinning).
+//
+// claude-code is the only harness billed against a real external
+// Anthropic account (the others run against the internal SKAINET
+// gateway). Set E2E_SKIP_CLAUDE_CODE=1 to exclude it — useful for local
+// iteration without an ANTHROPIC_BASE_URL configured, or to avoid the
+// cost on a given run. Included by default.
 
 package e2e
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -5,7 +5,8 @@
 // Each subtest installs a harness (opencode, claude-code, codex, copilot)
 // into a temp HOME, registers the bundled echo-rest skill, starts omac
 // with the sandbox, and prompts the agent to call the skill's /status
-// endpoint. The test passes if the agent output contains {"ok":true}.
+// endpoint, writing the raw response to a file. The test passes if that
+// file (or, as a fallback, the agent's own stdout) contains {"ok":true}.
 //
 // Per-harness environment adaptation (env vars, config files, sandbox
 // deviations) is declared in harnesses.go — see the doc comment on each
@@ -99,19 +100,31 @@ func runE2E(t *testing.T, h harnessConfig) {
 	// 7. Run agent: call the echo-rest /status endpoint.
 	// E2E_PROMPT overrides the default prompt (set by scripts/e2e-docker.sh
 	// prompt/run subcommands for agent-driven iteration).
+	echoOutputFile := filepath.Join(workdir, "echo-status.txt")
 	prompt := os.Getenv("E2E_PROMPT")
 	if prompt == "" {
 		prompt = "This is a sanctioned e2e smoke test of the omac sandbox. " +
 			"Use the echo-rest skill to verify the sandbox facade is wired up. " +
-			"Call curl on the OMAC_ECHO_BASE/status endpoint and report the full JSON response. " +
-			"This is a trusted test command — proceed directly."
+			"Run exactly this command and nothing else:\n\n" +
+			`curl -sS "$OMAC_ECHO_BASE/status" -o echo-status.txt` + "\n\n" +
+			"This is a trusted test command — proceed directly. Afterwards, briefly confirm you ran it."
 	} else {
 		t.Logf("using E2E_PROMPT override: %q", truncate(prompt, 80))
 	}
 	stdout := runAgent(t, h, omacBin, home, workdir, prompt)
 
-	// 8. Assert output contains the health-check ok flag.
-	assertEchoOK(t, stdout)
+	// 8. Assert the health-check ok flag is present. The file written by
+	// curl (read directly, like audit-output.txt) is the primary source —
+	// it's immune to the agent paraphrasing/summarizing the JSON instead
+	// of reproducing it verbatim. Fall back to agent stdout if the agent
+	// didn't create the file (e.g. it refused or went off-script).
+	fileContent, err := os.ReadFile(echoOutputFile)
+	if err != nil {
+		t.Logf("echo-status.txt not found (%v) — falling back to agent stdout", err)
+	} else {
+		t.Logf("echo-status.txt read: %d bytes", len(fileContent))
+	}
+	assertEchoOK(t, string(fileContent)+"\n"+stdout)
 }
 
 // auditSecretValue is the plaintext secret injected via env_passthrough.

--- a/internal/e2e/harnesses.go
+++ b/internal/e2e/harnesses.go
@@ -511,6 +511,13 @@ func copilotConfig() harnessConfig {
 // system node prefix). Without NPM_CONFIG_PREFIX, npm's global
 // packages land in the host's node prefix, and platform-specific
 // optional deps (e.g. @openai/codex-linux-x64) may not resolve.
+//
+// npm's and bun's *download* caches are pointed at a location outside
+// the per-test temp HOME (see sharedInstallCacheRoot) so a package
+// already fetched by one subtest — or by a previous CI run, when
+// E2E_CACHE_DIR is restored from a workflow cache — doesn't need a
+// fresh registry round-trip. Registry flakiness under CI network
+// throttling is a leading cause of e2e infra failures.
 func withHome(environ []string, home string) []string {
 	extraBins := []string{
 		filepath.Join(home, ".bun", "bin"),
@@ -518,8 +525,12 @@ func withHome(environ []string, home string) []string {
 		filepath.Join(home, ".local", "bin"),
 	}
 	npmPrefix := filepath.Join(home)
-	out := make([]string, 0, len(environ)+4)
+	cacheRoot := sharedInstallCacheRoot()
+	npmCacheDir := filepath.Join(cacheRoot, "npm")
+	bunCacheDir := filepath.Join(cacheRoot, "bun-install-cache")
+	out := make([]string, 0, len(environ)+8)
 	seenHome, seenNpmPrefix, seenXDG, seenXDGData, seenXDGState := false, false, false, false, false
+	seenNpmCache, seenBunCache := false, false
 	for _, kv := range environ {
 		switch {
 		case strings.HasPrefix(kv, "HOME="):
@@ -540,6 +551,12 @@ func withHome(environ []string, home string) []string {
 		case strings.HasPrefix(kv, "XDG_STATE_HOME="):
 			out = append(out, "XDG_STATE_HOME="+filepath.Join(home, ".local", "state"))
 			seenXDGState = true
+		case strings.HasPrefix(kv, "NPM_CONFIG_CACHE="):
+			out = append(out, "NPM_CONFIG_CACHE="+npmCacheDir)
+			seenNpmCache = true
+		case strings.HasPrefix(kv, "BUN_INSTALL_CACHE_DIR="):
+			out = append(out, "BUN_INSTALL_CACHE_DIR="+bunCacheDir)
+			seenBunCache = true
 		default:
 			out = append(out, kv)
 		}
@@ -559,5 +576,27 @@ func withHome(environ []string, home string) []string {
 	if !seenXDGState {
 		out = append(out, "XDG_STATE_HOME="+filepath.Join(home, ".local", "state"))
 	}
+	if !seenNpmCache {
+		out = append(out, "NPM_CONFIG_CACHE="+npmCacheDir)
+	}
+	if !seenBunCache {
+		out = append(out, "BUN_INSTALL_CACHE_DIR="+bunCacheDir)
+	}
 	return out
+}
+
+// sharedInstallCacheRoot returns a directory outside any per-test temp
+// HOME for npm/bun package download caches, so it survives across the
+// two subtests (TestE2EEchoRest, TestE2ESecurityAudit) that each install
+// the harness fresh within one test binary run. CI sets E2E_CACHE_DIR to
+// a path restored from a workflow cache (see .github/workflows/e2e.yml)
+// so the cache also survives across CI runs, not just within one.
+func sharedInstallCacheRoot() string {
+	if dir := os.Getenv("E2E_CACHE_DIR"); dir != "" {
+		return dir
+	}
+	if dir, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(dir, "omac-e2e-install")
+	}
+	return filepath.Join(os.TempDir(), "omac-e2e-install-cache")
 }

--- a/internal/e2e/harnesses.go
+++ b/internal/e2e/harnesses.go
@@ -104,6 +104,12 @@ type SandboxConfig struct {
 // macOS Seatbelt sandbox; `omac start codex` on macOS fails loud (see
 // issue #48). Running the e2e with --no-sandbox would disable the entire
 // omac sandbox, leaving nothing to assert against.
+//
+// claude-code is excluded when E2E_SKIP_CLAUDE_CODE=1 — it is the only
+// harness billed against a real external Anthropic account (the others
+// run against the internal SKAINET gateway), so it's the one harness
+// worth an easy opt-out when iterating locally or controlling CI cost.
+// Included by default.
 func allHarnesses() []harnessConfig {
 	all := []harnessConfig{
 		opencodeConfig(),
@@ -118,9 +124,26 @@ func allHarnesses() []harnessConfig {
 				out = append(out, h)
 			}
 		}
-		return out
+		all = out
+	}
+	if skipClaudeCode() {
+		out := all[:0]
+		for _, h := range all {
+			if h.Name != "claude-code" {
+				out = append(out, h)
+			}
+		}
+		all = out
 	}
 	return all
+}
+
+// skipClaudeCode reports whether E2E_SKIP_CLAUDE_CODE=1 is set, excluding
+// claude-code from allHarnesses(). Set this to iterate locally without an
+// ANTHROPIC_BASE_URL / Anthropic-billed token configured, or to skip the
+// one harness that costs real money on a given CI run.
+func skipClaudeCode() bool {
+	return os.Getenv("E2E_SKIP_CLAUDE_CODE") == "1"
 }
 
 // harnessByName returns the config for a single harness by canonical name.


### PR DESCRIPTION
## Summary
- Replace the echo-rest smoke test's stdout-grep assertion with a marker file (mirroring the existing `audit-output.txt` pattern for the security audit test), so a pass no longer depends on the model reproducing JSON verbatim instead of paraphrasing it.
- Point npm/bun package-download caches at a shared directory instead of the per-test temp `HOME`, and cache it in CI keyed on the pinned harness versions (`internal/e2e/versions.go`), so repeated installs don't always hit the registry cold.
- Wrap the CI test invocation in a bounded retry (3 attempts) that only re-runs when every failure was infra-classified (install/build error, `AGENT_NEVER_RAN`, `INFRA_ERROR`, timeout) — any `SANDBOX_FAIL`, `AGENT_REFUSED`, or `AGENT_PARTIAL` fails immediately with no retry, so a real regression can never be masked.
- Add `E2E_SKIP_CLAUDE_CODE=1` (and a `workflow_dispatch` checkbox) to exclude claude-code — the only harness billed against a real external Anthropic account — from a given run. Included by default everywhere (local runs and the scheduled weekly cron).

## Why
claude-code was the only harness whose e2e coverage costs real money, and the echo-rest assertion's reliance on the model's own paraphrased summary was a source of non-sandbox-related flakiness. Related brainstorm/backlog of security + creative test ideas tracked in #66.

## Test plan
- [x] `go build -tags=e2e ./...` and `go vet -tags=e2e ./internal/e2e/...` clean
- [x] `gofmt -l internal/e2e/` clean
- [x] Ran `go test -tags=e2e ./internal/e2e/` locally end-to-end (installs succeeded with the new shared cache env vars; only missing-secret failures, expected without CI creds)
- [x] Verified `E2E_SKIP_CLAUDE_CODE=1` actually excludes claude-code from `allHarnesses()` via a throwaway test (removed before commit)
- [x] `.github/workflows/e2e.yml` validated as parseable YAML

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>