### PR TITLE
fix(serve): stop /__omac__/dirs from leaking other workdirs' tokens

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1468,7 +1468,7 @@ func (s *serveServer) handleDirs(w http.ResponseWriter, r *http.Request) {
 	dirs := make([]map[string]string, 0, len(s.dirs))
 	for _, d := range s.dirs {
 		d.mu.Lock()
-		dirs = append(dirs, map[string]string{"dir": d.Dir, "dir_token": d.Token, "state": d.State})
+		dirs = append(dirs, map[string]string{"dir": d.Dir, "state": d.State})
 		d.mu.Unlock()
 	}
 	s.mu.RUnlock()

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -259,6 +259,30 @@ func TestReloadGlobalEndpointExists(t *testing.T) {
 	}
 }
 
+func TestDirsEndpointDoesNotLeakTokens(t *testing.T) {
+	s := newServeServerForTest(t)
+	wdA := t.TempDir()
+	wdB := t.TempDir()
+	stageSkillWithSecret(t, wdA, "slack")
+	stageSkillWithSecret(t, wdB, "slack")
+	if _, err := s.activate(wdA); err != nil {
+		t.Fatalf("activate A: %v", err)
+	}
+	if _, err := s.activate(wdB); err != nil {
+		t.Fatalf("activate B: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/__omac__/dirs", nil)
+	rec := httptest.NewRecorder()
+	s.controlMux().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("dirs status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "dir_token") {
+		t.Errorf("/__omac__/dirs leaked dir_token: %s", rec.Body.String())
+	}
+}
+
 func TestRootsEmptyAllowsAny(t *testing.T) {
 	s := newServeServerForTest(t)
 	// No roots configured -> any directory allowed.


### PR DESCRIPTION
## What
`GET /__omac__/dirs` in `omac serve` mode returned every active directory's `dir_token`, not just the caller's own.

## Why
`dir_token` is the facade's namespace key for cross-workdir isolation (see the `SECURITY:` comment in `internal/facade/facade.go` on `writeStatus`, which deliberately avoids this same class of leak). Any caller of this unauthenticated endpoint — including the sandboxed inner process, since the control-plane port is whitelisted into the sandbox — could harvest another workdir's token and reach its skills through the facade.

## How
Drop `dir_token` from the `/__omac__/dirs` response in `internal/cli/serve.go`. Callers already receive their own token from `/__omac__/activate`; nothing legitimate needs to read another dir's token from this listing endpoint.

## Verification
- Added `TestDirsEndpointDoesNotLeakTokens`, asserting the `/dirs` response contains no `dir_token` after activating two directories.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

Happy to add more context on request/impact if useful for review.