### PR TITLE
test(e2e): dir_token isolation + symlink/hardlink escape probes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,26 @@ on:
         description: 'Skip claude-code (the only harness billed against the real Anthropic account)'
         type: boolean
         default: false
+      use_latest:
+        description: 'Install each harness''s latest release instead of the pinned version below (drift-detection run; the *_version inputs are ignored when checked)'
+        type: boolean
+        default: false
+      opencode_version:
+        description: 'Pinned opencode package spec (ignored if "use latest" is checked)'
+        type: string
+        default: 'opencode-ai@1.17.12'
+      claude_code_version:
+        description: 'Pinned claude-code package spec (ignored if "use latest" is checked)'
+        type: string
+        default: '@anthropic-ai/claude-code@2.1.197'
+      codex_version:
+        description: 'Pinned codex package spec (ignored if "use latest" is checked)'
+        type: string
+        default: '@openai/codex@0.142.5'
+      copilot_version:
+        description: 'Pinned copilot package spec (ignored if "use latest" is checked)'
+        type: string
+        default: '@github/copilot@1.0.68'
   schedule:
     - cron: '0 8 * * 6' # Saturdays 10:00 CEST
 
@@ -45,6 +65,18 @@ jobs:
       SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
       E2E_HARNESS: ${{ matrix.harness }}
+      # Drift-detection: install latest instead of the pinned versions below.
+      # Empty (falsy) on schedule runs and on any workflow_dispatch where the
+      # box isn't checked — versions.go then falls back to its pinned map.
+      E2E_USE_LATEST: ${{ github.event.inputs.use_latest == 'true' && '1' || '' }}
+      # Per-harness pinned-version overrides for a manual run, so a version
+      # can be bumped/tested without editing internal/e2e/versions.go. Empty
+      # on schedule runs; versions.go falls back to its pinned map when unset.
+      # Ignored entirely when E2E_USE_LATEST is set.
+      E2E_VERSION_OPENCODE: ${{ github.event.inputs.opencode_version }}
+      E2E_VERSION_CLAUDE_CODE: ${{ github.event.inputs.claude_code_version }}
+      E2E_VERSION_CODEX: ${{ github.event.inputs.codex_version }}
+      E2E_VERSION_COPILOT: ${{ github.event.inputs.copilot_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,11 +113,14 @@ jobs:
       # (registry throttling, transient network errors). Cache them keyed on
       # the pinned harness versions so a version bump invalidates the cache
       # but repeated runs at the same versions reuse already-fetched packages.
+      # The use_latest/*_version inputs are folded in too, so a manual
+      # drift-detection or version-override run never reuses a cache keyed
+      # for the versions.go-pinned versions (or vice versa).
       - name: Cache harness install packages
         uses: actions/cache@v4
         with:
           path: ${{ runner.temp }}/e2e-install-cache
-          key: e2e-install-${{ runner.os }}-${{ matrix.harness }}-${{ hashFiles('internal/e2e/versions.go') }}
+          key: e2e-install-${{ runner.os }}-${{ matrix.harness }}-${{ hashFiles('internal/e2e/versions.go') }}-${{ github.event.inputs.use_latest }}-${{ github.event.inputs.opencode_version }}-${{ github.event.inputs.claude_code_version }}-${{ github.event.inputs.codex_version }}-${{ github.event.inputs.copilot_version }}
           restore-keys: |
             e2e-install-${{ runner.os }}-${{ matrix.harness }}-
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,23 +15,23 @@ on:
         type: boolean
         default: false
       use_latest:
-        description: 'Install each harness''s latest release instead of the pinned version below (drift-detection run; the *_version inputs are ignored when checked)'
+        description: 'Install each harness''s latest release for THIS RUN ONLY instead of internal/e2e/versions.go''s pin (drift-detection run; the *_version inputs below are ignored when checked)'
         type: boolean
         default: false
       opencode_version:
-        description: 'Pinned opencode package spec (ignored if "use latest" is checked)'
+        description: 'Pinned opencode package spec. Overrides internal/e2e/versions.go for THIS RUN ONLY (the file itself is untouched); ignored if "use latest" is checked'
         type: string
         default: 'opencode-ai@1.17.12'
       claude_code_version:
-        description: 'Pinned claude-code package spec (ignored if "use latest" is checked)'
+        description: 'Pinned claude-code package spec. Overrides internal/e2e/versions.go for THIS RUN ONLY (the file itself is untouched); ignored if "use latest" is checked'
         type: string
         default: '@anthropic-ai/claude-code@2.1.197'
       codex_version:
-        description: 'Pinned codex package spec (ignored if "use latest" is checked)'
+        description: 'Pinned codex package spec. Overrides internal/e2e/versions.go for THIS RUN ONLY (the file itself is untouched); ignored if "use latest" is checked'
         type: string
         default: '@openai/codex@0.142.5'
       copilot_version:
-        description: 'Pinned copilot package spec (ignored if "use latest" is checked)'
+        description: 'Pinned copilot package spec. Overrides internal/e2e/versions.go for THIS RUN ONLY (the file itself is untouched); ignored if "use latest" is checked'
         type: string
         default: '@github/copilot@1.0.68'
   schedule:

--- a/.opencode/skills/self-audit/scripts/audit.sh
+++ b/.opencode/skills/self-audit/scripts/audit.sh
@@ -131,6 +131,35 @@ echo "--- exec /bin/sh -c (read-only mount) ---"
 echo "=== END: fs_exec ==="
 
 echo ""
+echo "=== PROBE: symlink ==="
+# Symlink escape: create a symlink INSIDE the writable workdir that points
+# AT a denied path, then read/write through it. Creating a dangling symlink
+# never requires access to its target, so this isolates whether the sandbox
+# enforces the resolved (real) path or only the literal path the agent
+# opened — a sandbox that checks the latter would let this through.
+echo "--- symlink ./omac-audit-symlink-ssh -> \$HOME/.ssh/id_rsa (denied read path) ---"
+ln -sfn "$HOME/.ssh/id_rsa" ./omac-audit-symlink-ssh 2>&1 || true
+probe_read "--- read via symlink to ~/.ssh/id_rsa ---" ./omac-audit-symlink-ssh
+echo "--- symlink ./omac-audit-symlink-write -> /etc/omac-audit-test (denied write path) ---"
+ln -sfn /etc/omac-audit-test ./omac-audit-symlink-write 2>&1 || true
+( echo "test" > ./omac-audit-symlink-write ) 2>&1 || true
+rm -f ./omac-audit-symlink-ssh ./omac-audit-symlink-write 2>/dev/null || true
+echo "=== END: symlink ==="
+
+echo ""
+echo "=== PROBE: hardlink ==="
+# Hardlink escape: same idea as the symlink probe, but via a hardlink.
+# Unlike a symlink, creating a hardlink requires the target to be on the
+# same filesystem/device as the link, so this may fail for reasons
+# unrelated to the sandbox (EXDEV) depending on where HOME and the workdir
+# land. We log the result rather than assert on it.
+echo "--- hardlink ./omac-audit-hardlink-ssh -> \$HOME/.ssh/id_rsa (denied read path) ---"
+ln "$HOME/.ssh/id_rsa" ./omac-audit-hardlink-ssh 2>&1 || true
+probe_read "--- read via hardlink to ~/.ssh/id_rsa ---" ./omac-audit-hardlink-ssh
+rm -f ./omac-audit-hardlink-ssh 2>/dev/null || true
+echo "=== END: hardlink ==="
+
+echo ""
 echo "=== PROBE: net ==="
 echo "--- curl blocked.example.com ---"
 # Redact proxy auth header so output contains no real credentials.

--- a/internal/e2e/allowance.go
+++ b/internal/e2e/allowance.go
@@ -65,6 +65,13 @@ type AllowanceSpec struct {
 	// reach another registered skill's sidecar (e.g. echo-rest from
 	// self-audit). Each skill's sidecar should be isolated.
 	CrossSkillIsolated bool
+
+	// SymlinkEscapeDenyPaths are denied paths the agent targets via a
+	// symlink placed inside the allowed workdir, to check whether the
+	// sandbox enforces the resolved (real) path rather than only the
+	// literal path the agent opened. The test asserts denial through the
+	// symlink indirection just as it does for a direct path.
+	SymlinkEscapeDenyPaths []string
 }
 
 // allowanceSpecFor returns the allowance spec for a harness.
@@ -146,5 +153,11 @@ func allowanceSpecFor(h harnessConfig) AllowanceSpec {
 		NetDenyDomain:      "blocked.example.com",
 		SidecarReachable:   true,
 		CrossSkillIsolated: true, // echo-rest sidecar must NOT be reachable from self-audit
+		// Mirrors the symlink targets hardcoded in audit.sh's "symlink"
+		// probe (~/.ssh/id_rsa for read, /etc/omac-audit-test for write).
+		SymlinkEscapeDenyPaths: []string{
+			"~/.ssh/id_rsa",
+			"/etc/omac-audit-test",
+		},
 	}
 }

--- a/internal/e2e/classify.go
+++ b/internal/e2e/classify.go
@@ -90,7 +90,7 @@ func extractProbe(output, probeName string) string {
 // human-readable summary of what the agent did. Called on assertion
 // failure so CI output explains the failure mode.
 func classifyAgentOutput(output string) string {
-	probes := []string{"secret", "env", "fs_read", "fs_write", "fs_exec", "net", "sidecar", "xskill"}
+	probes := []string{"secret", "env", "fs_read", "fs_write", "fs_exec", "symlink", "hardlink", "net", "sidecar", "xskill"}
 	var present, complete, refused, neverRan []string
 	for _, p := range probes {
 		switch classifyProbe(output, p) {

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -185,8 +185,8 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 	}
 
 	spec := allowanceSpecFor(h)
-	t.Logf("allowance spec for %s: allow=%v deny=%v fsDeny=%v fsWriteDeny=%v netDeny=%s",
-		h.Name, spec.EnvAllowVars, spec.EnvDenyVars, spec.FsDenyPaths, spec.FsWriteDenyPaths, spec.NetDenyDomain)
+	t.Logf("allowance spec for %s: allow=%v deny=%v fsDeny=%v fsWriteDeny=%v symlinkDeny=%v netDeny=%s",
+		h.Name, spec.EnvAllowVars, spec.EnvDenyVars, spec.FsDenyPaths, spec.FsWriteDenyPaths, spec.SymlinkEscapeDenyPaths, spec.NetDenyDomain)
 
 	omacBin := buildOmac(t)
 	installHarness(t, h, home)
@@ -238,6 +238,7 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 		assertEnvVarsDenied(t, stdout, spec.EnvDenyVars)
 		assertFilesystemReadDenied(t, stdout)
 		assertFilesystemWriteDenied(t, stdout)
+		assertSymlinkEscapeDenied(t, stdout)
 		assertNetworkDenied(t, stdout, spec.NetDenyDomain)
 	} else {
 		t.Logf("skipping negative assertions: %s runs with --no-sandbox", h.Name)
@@ -260,6 +261,12 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 	// binds. This is a platform default, not a contract — we log the
 	// result so changes are visible in test output.
 	logExecProbeResults(t, stdout, spec.FsExecProbePaths)
+
+	// Hardlink escape: like the symlink probe, but hardlinks require the
+	// same filesystem/device as the target, so failure can mean either
+	// "sandbox denied it" or "cross-device link, unrelated to the
+	// sandbox". We log the result rather than assert on it.
+	logHardlinkProbeResults(t, stdout)
 
 	// Cross-skill sidecar isolation: omac currently does NOT isolate
 	// sidecars from each other — a skill can reach another skill's
@@ -660,6 +667,84 @@ func assertFilesystemWriteDenied(t *testing.T, output string) {
 		return
 	}
 	t.Logf("PASS: filesystem write protection — denial message found in agent output")
+}
+
+// assertSymlinkEscapeDenied verifies that the agent could not read a denied
+// path, nor write a denied path, through a symlink it planted inside the
+// allowed (writable) workdir. A sandbox that only checks the literal path
+// an agent opens — rather than the path a symlink resolves to — would let
+// this through even though assertFilesystemReadDenied/WriteDenied (direct
+// access, no indirection) pass.
+func assertSymlinkEscapeDenied(t *testing.T, output string) {
+	t.Helper()
+	mode := classifyProbe(output, "symlink")
+	switch mode {
+	case fmAgentNeverRan, fmAgentRefused:
+		failWithClassification(t, "symlinkEscapeDenied", mode, output)
+		return
+	case fmAgentPartial:
+		failWithClassification(t, "symlinkEscapeDenied", fmAgentPartial, output)
+		return
+	}
+	probeOut := extractProbe(output, "symlink")
+	readDenials := []string{
+		"Permission denied",
+		"No such file or directory",
+		"cannot open",
+		"Operation not permitted",
+	}
+	writeDenials := []string{
+		"Read-only file system",
+		"Permission denied",
+		"Operation not permitted",
+	}
+	foundRead := false
+	for _, d := range readDenials {
+		if strings.Contains(probeOut, d) {
+			foundRead = true
+			break
+		}
+	}
+	if !foundRead {
+		failWithClassification(t, "symlinkEscapeDenied", fmSandboxFail, output)
+		return
+	}
+	foundWrite := false
+	for _, d := range writeDenials {
+		if strings.Contains(probeOut, d) {
+			foundWrite = true
+			break
+		}
+	}
+	if !foundWrite {
+		failWithClassification(t, "symlinkEscapeDenied", fmSandboxFail, output)
+		return
+	}
+	t.Logf("PASS: symlink escape denied — read and write through a workdir symlink to a denied path both blocked")
+}
+
+// logHardlinkProbeResults logs whether a hardlink escape (same idea as the
+// symlink probe, but via a hardlink) succeeded or failed, without
+// asserting pass/fail. Hardlink creation requires the same filesystem as
+// the target, so a failure here can mean "sandbox denied it" or "cross-
+// device link" (EXDEV, unrelated to the sandbox) depending on where HOME
+// and the workdir land — not a stable cross-platform contract.
+func logHardlinkProbeResults(t *testing.T, output string) {
+	t.Helper()
+	if !strings.Contains(output, "=== PROBE: hardlink ===") {
+		return
+	}
+	probeOut := extractProbe(output, "hardlink")
+	switch {
+	case strings.Contains(probeOut, "Invalid cross-device link"):
+		t.Logf("INFO: hardlink escape probe — cross-device link (EXDEV), not a sandbox signal")
+	case strings.Contains(probeOut, "Permission denied"),
+		strings.Contains(probeOut, "Operation not permitted"),
+		strings.Contains(probeOut, "No such file or directory"):
+		t.Logf("INFO: hardlink escape DENIED")
+	default:
+		t.Logf("INFO: hardlink escape probe result inconclusive/allowed — see output:\n%s", probeOut)
+	}
 }
 
 // logCrossSkillIsolation logs whether the agent could reach another

--- a/internal/e2e/serve_isolation_test.go
+++ b/internal/e2e/serve_isolation_test.go
@@ -1,0 +1,202 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stageServeSkill writes a minimal workdir-local skill whose omac.yaml
+// declares a required secret that is never supplied. `serve` classifies it
+// pending-credentials on activation: a real facade route is installed (so
+// there's something to isolate) but no sidecar process is spawned, keeping
+// this test fast and independent of any live harness install.
+func stageServeSkill(t *testing.T, workdir, name string) {
+	t.Helper()
+	skillDir := filepath.Join(workdir, ".opencode", "skills", name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := "name: " + name + "\n" +
+		"sidecar:\n" +
+		"  command: [\"true\"]\n" +
+		"  secrets:\n" +
+		"    - name: API_TOKEN\n" +
+		"      required: true\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "omac.yaml"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+var (
+	controlBaseRe = regexp.MustCompile(`OMAC_CONTROL_BASE=(\S+)`)
+	facadePortRe  = regexp.MustCompile(`facade on 127\.0\.0\.1:(\d+)`)
+)
+
+// TestE2EServeDirTokenIsolation is a live regression test for the dir_token
+// leak fixed in 3ea0336 (#74, tracked for e2e coverage in #66): the
+// control-plane port is whitelisted into the sandbox (see injectOpenPort in
+// internal/cli/serve.go), so anything /__omac__/dirs returns is available
+// to a fully-confined sandboxed agent process. Before the fix, that
+// endpoint included every active directory's dir_token — the facade's
+// namespace key — letting one directory's agent harvest another's token
+// and reach its skills through the facade, which has no notion of which
+// sandbox is asking.
+//
+// Unlike the in-process handler tests in internal/cli/serve_test.go
+// (TestDirsEndpointDoesNotLeakTokens, TestTwoDirsDistinctTokensAndRoutes),
+// this drives the real compiled `omac serve` binary as a subprocess and
+// talks to its control-plane and facade ports over real loopback sockets —
+// the same topology a sandboxed inner process actually uses — catching
+// regressions in the real wire path, not just the Go-level handler. It
+// runs with --no-inner (control plane only, no inner harness), so it needs
+// no live LLM harness install and no OS sandbox, and runs fast.
+func TestE2EServeDirTokenIsolation(t *testing.T) {
+	omacBin := buildOmac(t)
+	home := t.TempDir()
+	cwd := t.TempDir()
+	wdA := t.TempDir()
+	wdB := t.TempDir()
+	stageServeSkill(t, wdA, "slack")
+	stageServeSkill(t, wdB, "slack")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, omacBin, "serve", "opencode", "--no-inner", "--control-addr", "127.0.0.1:0")
+	cmd.Dir = cwd
+	cmd.Env = withHome(os.Environ(), home)
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start omac serve: %v", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	controlBaseCh := make(chan string, 1)
+	facadePortCh := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdoutPipe)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if m := controlBaseRe.FindStringSubmatch(line); m != nil {
+				select {
+				case controlBaseCh <- m[1]:
+				default:
+				}
+			}
+			if m := facadePortRe.FindStringSubmatch(line); m != nil {
+				select {
+				case facadePortCh <- m[1]:
+				default:
+				}
+			}
+		}
+	}()
+
+	var controlBase, facadePort string
+	select {
+	case controlBase = <-controlBaseCh:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("omac serve did not print OMAC_CONTROL_BASE within 15s; stderr:\n%s", stderrBuf.String())
+	}
+	select {
+	case facadePort = <-facadePortCh:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("omac serve did not print facade port within 15s; stderr:\n%s", stderrBuf.String())
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	activate := func(dir string) map[string]any {
+		t.Helper()
+		body, _ := json.Marshal(map[string]string{"dir": dir})
+		resp, err := client.Post(controlBase+"/__omac__/activate", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("activate %s: %v", dir, err)
+		}
+		defer resp.Body.Close()
+		var m map[string]any
+		if derr := json.NewDecoder(resp.Body).Decode(&m); derr != nil {
+			t.Fatalf("decode activate response for %s: %v", dir, derr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("activate %s: status %d body=%v", dir, resp.StatusCode, m)
+		}
+		return m
+	}
+
+	mA := activate(wdA)
+	mB := activate(wdB)
+	tokA, _ := mA["dir_token"].(string)
+	tokB, _ := mB["dir_token"].(string)
+	if tokA == "" || tokB == "" {
+		t.Fatalf("expected non-empty dir_tokens, got A=%q B=%q", tokA, tokB)
+	}
+	if tokA == tokB {
+		t.Fatalf("dir A and dir B were minted the same token: %q", tokA)
+	}
+
+	// --- Core regression: /__omac__/dirs must not leak either token. ---
+	resp, err := client.Get(controlBase + "/__omac__/dirs")
+	if err != nil {
+		t.Fatalf("GET /__omac__/dirs: %v", err)
+	}
+	dirsBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if strings.Contains(string(dirsBody), tokA) || strings.Contains(string(dirsBody), tokB) {
+		t.Errorf("/__omac__/dirs leaked a dir_token over the wire (issue #74 regression): %s", dirsBody)
+	}
+
+	// --- Positive control: each dir's own token still resolves its own
+	// route through the real facade TCP listener — proves namespacing is
+	// live, not just that every request happens to fail. ---
+	facadeGet := func(token string) int {
+		t.Helper()
+		u := fmt.Sprintf("http://127.0.0.1:%s/%s/slack/status", facadePort, token)
+		r, err := client.Get(u)
+		if err != nil {
+			t.Fatalf("GET %s: %v", u, err)
+		}
+		defer r.Body.Close()
+		return r.StatusCode
+	}
+	if got := facadeGet(tokA); got != http.StatusConflict {
+		t.Errorf("dir A's own token against its own route: status=%d, want 409 (pending-credentials)", got)
+	}
+	if got := facadeGet(tokB); got != http.StatusConflict {
+		t.Errorf("dir B's own token against its own route: status=%d, want 409 (pending-credentials)", got)
+	}
+
+	// --- Negative control: a same-shaped but wrong token must not resolve
+	// any route. With two dirs active, the single-dir flat-alias fallback
+	// (refreshSingleDirAliases) is torn down, so no other path should
+	// resolve the mount. ---
+	wrongToken := strings.Repeat("0", len(tokA))
+	if wrongToken == tokA || wrongToken == tokB {
+		wrongToken = strings.Repeat("f", len(tokA))
+	}
+	if got := facadeGet(wrongToken); got != http.StatusNotFound {
+		t.Errorf("guessed token resolved a route: status=%d, want 404", got)
+	}
+}

--- a/internal/e2e/versions.go
+++ b/internal/e2e/versions.go
@@ -18,6 +18,18 @@ var harnessVersions = map[string]string{
 	"copilot":     "@github/copilot@1.0.68",
 }
 
+// versionEnvVar maps a harness name to the env var that can override its
+// pinned package spec for a single run, without editing this file. Wired
+// from the e2e workflow's workflow_dispatch *_version inputs
+// (.github/workflows/e2e.yml); unset in the scheduled run, so that run
+// always uses the harnessVersions map above.
+var versionEnvVar = map[string]string{
+	"opencode":    "E2E_VERSION_OPENCODE",
+	"claude-code": "E2E_VERSION_CLAUDE_CODE",
+	"codex":       "E2E_VERSION_CODEX",
+	"copilot":     "E2E_VERSION_COPILOT",
+}
+
 // Model identifiers per harness.
 var modelIDs = map[string]string{
 	"opencode":    "zai-org/GLM-5.2",
@@ -27,7 +39,10 @@ var modelIDs = map[string]string{
 }
 
 // pinnedPackage returns the package spec for a harness.
-// When E2E_USE_LATEST=1, returns the bare package name (latest).
+// When E2E_USE_LATEST=1, returns the bare package name (latest), ignoring
+// any per-harness version override. Otherwise, a non-empty versionEnvVar
+// override takes precedence over the harnessVersions map, so a single run
+// can test a candidate version without editing this file.
 func pinnedPackage(harness string) string {
 	if useLatest() {
 		// Strip @version from "pkg@1.2.3" → "pkg".
@@ -36,6 +51,11 @@ func pinnedPackage(harness string) string {
 			return pkg[:i]
 		}
 		return pkg
+	}
+	if ev, ok := versionEnvVar[harness]; ok {
+		if v := os.Getenv(ev); v != "" {
+			return v
+		}
 	}
 	return harnessVersions[harness]
 }

--- a/internal/e2e/versions_test.go
+++ b/internal/e2e/versions_test.go
@@ -1,0 +1,28 @@
+//go:build e2e
+
+package e2e
+
+import "testing"
+
+// TestPinnedPackageOverride covers the precedence between the hardcoded
+// harnessVersions map, a per-harness E2E_VERSION_* override (wired from the
+// e2e workflow's workflow_dispatch *_version inputs), and E2E_USE_LATEST.
+// No live agent involved — fast unit test.
+func TestPinnedPackageOverride(t *testing.T) {
+	t.Setenv("E2E_USE_LATEST", "")
+	t.Setenv("E2E_VERSION_OPENCODE", "")
+
+	if got, want := pinnedPackage("opencode"), harnessVersions["opencode"]; got != want {
+		t.Errorf("with no override set: pinnedPackage(opencode) = %q, want %q (pinned map)", got, want)
+	}
+
+	t.Setenv("E2E_VERSION_OPENCODE", "opencode-ai@9.9.9")
+	if got, want := pinnedPackage("opencode"), "opencode-ai@9.9.9"; got != want {
+		t.Errorf("with override set: pinnedPackage(opencode) = %q, want %q", got, want)
+	}
+
+	t.Setenv("E2E_USE_LATEST", "1")
+	if got, want := pinnedPackage("opencode"), "opencode-ai"; got != want {
+		t.Errorf("use_latest should win over the override and strip the version: pinnedPackage(opencode) = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

- `TestE2EServeDirTokenIsolation` (`internal/e2e/serve_isolation_test.go`): live regression test for the cross-workdir `dir_token` leak fixed in 3ea0336 (#74).
- `symlink`/`hardlink` probes in the self-audit skill's `audit.sh`, plus `assertSymlinkEscapeDenied` (hard assertion) and `logHardlinkProbeResults` (log-only) in `internal/e2e/e2e_test.go`.
- `use_latest` + per-harness `*_version` `workflow_dispatch` inputs on the e2e workflow, wiring the previously-dead `E2E_USE_LATEST` support in `versions.go` into CI, plus per-harness version overrides for one-off testing.
- Issue #66 updated: checked off the symlink/hardlink and dir_token backlog items, added 6 new high-ROI e2e ideas found during this review (harness-drift detection is now implemented here too).

## Why

3ea0336 fixed a real vuln (sandboxed inner process could harvest another workdir's `dir_token` via the whitelisted control-plane port and reach its skills through the facade) but shipped with only an in-process unit test in `serve_test.go`. `internal/e2e/` — the suite that actually drives the real binary under the real sandbox — has never exercised `omac serve` at all, only `omac start`. That's a coverage gap in exactly the suite issue #66 is about.

The symlink/hardlink escape test was an unimplemented item already on #66's backlog: it checks whether the sandbox enforces the *resolved* path of a workdir-planted symlink, not just the literal path the agent opens.

Separately, `versions.go` already supported `E2E_USE_LATEST` (install each harness's latest release instead of the pinned version, to catch a harness upgrade silently weakening sandbox coverage) but nothing in `.github/workflows/e2e.yml` ever set it — the whole mechanism was dead. A harness update could regress sandbox-relevant behavior between manual pin-bump PRs with nobody noticing.

## How

- `TestE2EServeDirTokenIsolation` builds the real `omac` binary and runs `omac serve --no-inner` as a subprocess (control-plane only, no inner harness — no live LLM call, no OS sandbox needed, runs in under a second). It activates two directories over the real control-plane HTTP server, harvests both real `dir_token`s from the (legitimate) `/activate` responses, then asserts:
  - `/__omac__/dirs` never includes either token in its response body (the core regression check).
  - Each dir's own token still resolves its own facade route (409 pending-credentials) — a positive control proving namespacing is live, not just that everything happens to fail.
  - A same-shaped but wrong token resolves nothing (404) — proving there's no fallback path once >1 dir is active (the single-dir flat-alias is torn down in that case).
- `symlink` probe: plants a symlink inside the writable workdir pointing at a denied path (`~/.ssh/id_rsa` for read, `/etc/omac-audit-test` for write) and reads/writes through it; `assertSymlinkEscapeDenied` fails the test if either indirection succeeds.
- `hardlink` probe: same idea via a hardlink, logged only (hardlink creation requires the same filesystem as the target, so failure can mean EXDEV rather than a sandbox decision).
- `use_latest` workflow_dispatch checkbox sets `E2E_USE_LATEST=1`; four `*_version` text inputs (default = the current `versions.go` pins) set `E2E_VERSION_<HARNESS>` overrides consumed by `pinnedPackage()` — env override wins over the hardcoded map, but `use_latest` wins over everything. GitHub Actions can't conditionally hide `workflow_dispatch` inputs, so the version boxes are always visible; they're documented (and enforced in Go) as ignored when `use_latest` is checked. The install-package cache key folds in all five inputs so an override/drift run never collides with the normal pinned-version cache entry.

## Verification

- `go build -tags e2e ./...` and `go vet -tags e2e ./...` clean.
- `go test -tags e2e -run TestE2EServeDirTokenIsolation -v` passes (~0.9s).
- `go test -tags e2e -run TestPinnedPackageOverride -v` passes — covers override > pinned-map > use_latest precedence.
- Existing non-live-agent e2e unit tests (`internal/e2e`, `internal/cli`) still pass.
- Manually validated the `symlink`/`hardlink` probe script directly against real bubblewrap (`omac sandbox run`) to confirm the sandbox denies both the read and the write through the symlink, and that the denial-message strings match what the new assertions check for.
- `.github/workflows/e2e.yml` parses as valid YAML (`yaml.safe_load`).
- The full live-agent `TestE2ESecurityAudit` (which now also runs the new probes) was not re-run end-to-end in this PR — it requires installed harnesses/model credentials and runs on the weekly e2e cron; the underlying probe mechanics were validated directly against the sandbox instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)