### PR TITLE
ci: add scheduled + on-demand strix security scan workflow

### DIFF
--- a/.github/scripts/security_scan_triage.py
+++ b/.github/scripts/security_scan_triage.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Post-process a strix scan's vulnerabilities.json into two outputs:
+
+1. A full triage report (every finding, full detail) -- meant for the
+   private artifact repo, never printed to the (public) job log.
+2. A redacted summary (severity + dedupe counts only, no titles/detail)
+   -- meant for the public $GITHUB_STEP_SUMMARY.
+
+Dedupe against currently-open GitHub issues uses the same LLM this repo's
+CI already has credentials for (Skainet/GLM), asked to judge whether each
+finding is already covered by an existing open issue. This is a triage
+aid, not a guarantee -- a human still reviews before anything is filed
+publicly, so a false "new" or false "duplicate" here just costs a human a
+few extra seconds, not a security miss.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+
+LLM_API_BASE = os.environ.get("LLM_API_BASE", "https://chat.model.tngtech.com/v1")
+LLM_MODEL = os.environ.get("STRIX_LLM", "openai/zai-org/GLM-5.2").removeprefix("openai/")
+LLM_API_KEY = os.environ.get("LLM_API_KEY", "")
+
+
+def fetch_open_issues(repo):
+    out = subprocess.run(
+        ["gh", "issue", "list", "--repo", repo, "--state", "open",
+         "--json", "number,title,body", "--limit", "200"],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(out.stdout)
+
+
+def ask_llm_duplicate(finding, issues):
+    if not issues:
+        return {"duplicate_of": None, "confidence": "high", "reasoning": "no open issues to compare against"}
+    issue_list = "\n".join(
+        f"#{i['number']}: {i['title']}\n{(i['body'] or '')[:500]}"
+        for i in issues
+    )
+    prompt = (
+        "You are triaging a security scan finding against a repository's currently "
+        "open GitHub issues. Decide whether the finding is ALREADY covered by one of "
+        "these issues (same underlying bug/gap, even if worded very differently), or "
+        "whether it looks new.\n\n"
+        f"FINDING:\nTitle: {finding['title']}\nSeverity: {finding.get('severity')}\n"
+        f"Description: {finding.get('description', '')[:1500]}\n\n"
+        f"OPEN ISSUES:\n{issue_list}\n\n"
+        "Respond with ONLY a JSON object: "
+        '{"duplicate_of": <issue number or null>, "confidence": "high"|"medium"|"low", '
+        '"reasoning": "<one sentence>"}'
+    )
+    body = json.dumps({
+        "model": LLM_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+    }).encode()
+    req = urllib.request.Request(
+        f"{LLM_API_BASE}/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {LLM_API_KEY}"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            resp = json.loads(r.read())
+        content = resp["choices"][0]["message"]["content"].strip()
+        start, end = content.find("{"), content.rfind("}")
+        return json.loads(content[start:end + 1])
+    except Exception as e:  # noqa: BLE001 - triage aid, must not crash the job
+        return {"duplicate_of": None, "confidence": "low", "reasoning": f"LLM triage call failed: {e}"}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vulns", required=True)
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--triage-out", required=True, help="full detail, private repo only")
+    ap.add_argument("--summary-out", required=True, help="redacted, safe for public step summary")
+    args = ap.parse_args()
+
+    with open(args.vulns) as f:
+        findings = json.load(f)
+
+    issues = fetch_open_issues(args.repo)
+
+    triage_lines = ["# Security scan triage report\n"]
+    counts = {}
+    new_count = 0
+    dup_count = 0
+
+    for finding in findings:
+        sev = (finding.get("severity") or "unknown").lower()
+        counts[sev] = counts.get(sev, 0) + 1
+        verdict = ask_llm_duplicate(finding, issues)
+        is_dup = verdict.get("duplicate_of") is not None and verdict.get("confidence") != "low"
+        if is_dup:
+            dup_count += 1
+            status = f"LIKELY DUPLICATE of #{verdict['duplicate_of']} (confidence: {verdict.get('confidence')})"
+        else:
+            new_count += 1
+            status = "NEW (not matched to any open issue)"
+
+        triage_lines.append(f"## {finding.get('id', '?')}: {finding['title']}")
+        triage_lines.append(f"**Severity:** {finding.get('severity')}  ")
+        triage_lines.append(f"**Triage verdict:** {status}  ")
+        triage_lines.append(f"**Triage reasoning:** {verdict.get('reasoning', '')}\n")
+        triage_lines.append(f"**Description:** {finding.get('description', '')}\n")
+        triage_lines.append(f"**Impact:** {finding.get('impact', '')}\n")
+        triage_lines.append("---\n")
+
+    with open(args.triage_out, "w") as f:
+        f.write("\n".join(triage_lines))
+
+    summary_lines = ["**Severity counts:**"]
+    for sev in ("critical", "high", "medium", "low"):
+        if sev in counts:
+            summary_lines.append(f"- {sev.upper()}: {counts[sev]}")
+    summary_lines.append("")
+    summary_lines.append(f"**Triage:** {new_count} new, {dup_count} likely already tracked")
+    summary_lines.append("")
+    summary_lines.append(
+        "No titles or technical detail are shown here by design -- see the private "
+        "artifact repo for the full triage report before deciding what (if anything) "
+        "to file publicly."
+    )
+    with open(args.summary_out, "w") as f:
+        f.write("\n".join(summary_lines))
+
+    print(f"wrote {args.triage_out} ({len(findings)} findings) and {args.summary_out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -46,8 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     env:
-      STRIX_LLM: openai/zai-org/GLM-5.2
-      LLM_API_BASE: https://chat.model.tngtech.com/v1
+      # SKAINET_EXTERNAL is the same secret e2e.yml uses for the model
+      # provider base URL (named for "reachable from GitHub-hosted CI",
+      # as opposed to a TNG-internal-only address) -- reused here rather
+      # than duplicating the URL.
+      LLM_API_BASE: ${{ secrets.SKAINET_EXTERNAL }}
       LLM_API_KEY: ${{ secrets.SKAINET_TOKEN }}
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -64,8 +67,24 @@ jobs:
       - name: Install strix
         run: pip install --user strix-agent==1.0.4
 
+      - name: Resolve model from e2e config
+        id: model
+        run: |
+          # Single source of truth is internal/e2e/versions.go's modelIDs map
+          # (opencode's entry -- GLM-5.2-TEE, same as e2e.yml uses) rather
+          # than duplicating the model name here.
+          model=$(awk '/^var modelIDs = map\[string\]string\{/{flag=1; next} /^\}/{flag=0} flag' \
+            target/internal/e2e/versions.go | grep '"opencode"' | sed -E 's/.*:\s*"([^"]+)".*/\1/')
+          if [ -z "$model" ]; then
+            echo "::error::could not resolve model from internal/e2e/versions.go"
+            exit 1
+          fi
+          echo "strix_llm=openai/$model" >> "$GITHUB_OUTPUT"
+
       - name: Run strix scan
         id: scan
+        env:
+          STRIX_LLM: ${{ steps.model.outputs.strix_llm }}
         run: |
           set -o pipefail
           run_label="$(date -u +%Y%m%d-%H%M%S)"
@@ -85,6 +104,8 @@ jobs:
           echo "run_dir=$run_dir" >> "$GITHUB_OUTPUT"
 
       - name: Dedupe against open issues + build triage report
+        env:
+          STRIX_LLM: ${{ steps.model.outputs.strix_llm }}
         run: |
           python3 target/.github/scripts/security_scan_triage.py \
             --vulns "${{ steps.scan.outputs.run_dir }}/vulnerabilities.json" \

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,116 @@
+# Security scan: runs `strix` (an LLM-driven pentest agent) against this
+# repo. Scheduled weekly and available on demand (including as a manual
+# pre-release check before cutting a release tag).
+#
+# Disclosure model: this workflow's own job log and step summary NEVER
+# contain finding titles, descriptions, or PoCs -- strix's full output is
+# redirected straight to a file and never printed to the console, because
+# this is a public repo and both the job log and (if used) upload-artifact
+# would be publicly downloadable. Full reports are pushed to a private
+# companion repo instead, and only aggregate severity/dedupe counts reach
+# the public step summary. A human reviews the private repo and decides
+# what -- if anything -- becomes a public GitHub issue. See
+# nhuelstng/oh-my-agentic-coder-security for the artifact history.
+name: Security Scan
+
+on:
+  schedule:
+    - cron: '0 8 * * 6' # Saturdays 10:00 CEST (same slot as e2e.yml)
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why this run is happening (e.g. "pre-release v0.3.0", "manual check")'
+        type: string
+        default: 'manual'
+      scan_mode:
+        description: 'strix scan depth'
+        type: choice
+        options: [quick, standard, deep]
+        default: deep
+      max_budget_usd:
+        description: 'LLM cost cap in USD for this run'
+        type: string
+        default: '10'
+
+permissions:
+  contents: read
+  issues: read # for dedupe against currently-open issues
+
+concurrency:
+  group: security-scan
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: Strix security scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      STRIX_LLM: openai/zai-org/GLM-5.2
+      LLM_API_BASE: https://chat.model.tngtech.com/v1
+      LLM_API_KEY: ${{ secrets.SKAINET_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+        with:
+          path: target
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install strix
+        run: pip install --user strix-agent==1.0.4
+
+      - name: Run strix scan
+        id: scan
+        run: |
+          set -o pipefail
+          run_label="$(date -u +%Y%m%d-%H%M%S)"
+          echo "run_label=$run_label" >> "$GITHUB_OUTPUT"
+          # Redirected to a file, NEVER printed to this (public) job log --
+          # strix's console output includes full vulnerability detail and
+          # working PoCs once findings surface.
+          "$HOME/.local/bin/strix" -n --mount "$PWD/target" \
+            --scan-mode "${{ inputs.scan_mode || 'deep' }}" \
+            --max-budget-usd "${{ inputs.max_budget_usd || '10' }}" \
+            > strix_scan.log 2>&1 || true
+          run_dir=$(ls -td target/strix_runs/*/ 2>/dev/null | head -1)
+          if [ -z "$run_dir" ]; then
+            echo "::error::strix produced no run directory -- scan likely failed to start (see strix_scan.log via the private artifact push step)"
+            exit 1
+          fi
+          echo "run_dir=$run_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Dedupe against open issues + build triage report
+        run: |
+          python3 target/.github/scripts/security_scan_triage.py \
+            --vulns "${{ steps.scan.outputs.run_dir }}/vulnerabilities.json" \
+            --repo "${{ github.repository }}" \
+            --triage-out triage-report.md \
+            --summary-out step-summary.md
+
+      - name: Public summary (counts only, no exploit detail)
+        run: cat step-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Push full report to private artifact repo
+        env:
+          SECURITY_SCAN_PAT: ${{ secrets.SECURITY_SCAN_PAT }}
+        run: |
+          set -euo pipefail
+          dest=$(mktemp -d)
+          git clone --quiet --depth 1 \
+            "https://x-access-token:${SECURITY_SCAN_PAT}@github.com/nhuelstng/oh-my-agentic-coder-security.git" \
+            "$dest"
+          scan_dir="$dest/scans/${{ steps.scan.outputs.run_label }}-${{ inputs.reason || 'scheduled' }}"
+          mkdir -p "$scan_dir"
+          cp -r "${{ steps.scan.outputs.run_dir }}"/* "$scan_dir"/
+          cp triage-report.md strix_scan.log "$scan_dir"/
+          cd "$dest"
+          git config user.name "strix-ci-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add .
+          git commit --quiet -m "scan: ${{ inputs.reason || 'scheduled' }} ($(date -u +%F))"
+          git push --quiet


### PR DESCRIPTION
## What
Adds `.github/workflows/security-scan.yml`: runs `strix` (LLM-driven pentest agent, Skainet GLM-5.2) against this repo every Saturday 10:00 CET, plus on-demand via `workflow_dispatch` (also serves as the manual pre-release check before cutting a release tag).

## Why
We've been running strix manually against this repo (see #74, #79, #80, #81). Automating it on a schedule + before releases catches regressions without relying on someone remembering to run it by hand.

## How
- Installs `strix-agent==1.0.4` via pip (pinned, not `curl|bash`).
- Model ID is resolved from `internal/e2e/versions.go`'s `modelIDs` map at runtime rather than duplicated in the workflow, so bumping the e2e model keeps this scan in sync.
- `LLM_API_BASE` reuses the existing `SKAINET_EXTERNAL` secret (same one `e2e.yml` uses) rather than a new/hardcoded endpoint.
- `.github/scripts/security_scan_triage.py` dedupes findings against currently-open issues using the same LLM credentials, so already-tracked bugs don't need re-triage every run. Validated locally against real scan data — correctly matched 5/7 real findings to their issues and flagged the 2 genuinely new ones.
- Since this repo is public, neither the job log nor `upload-artifact` are private here. strix's full output (includes working PoCs once findings surface) is redirected straight to a file and never printed to the console. Only redacted severity/dedupe counts reach the public step summary. Full reports push to a private companion repo (`nhuelstng/oh-my-agentic-coder-security`) for human triage before anything becomes a public issue.

Requires repo secret `SECURITY_SCAN_PAT` (fine-grained PAT scoped to the private companion repo only, Contents: Read and write) — already set.

## Verification
- [x] `actionlint` clean on the workflow file
- [x] `security_scan_triage.py` dry-run validated against a real `vulnerabilities.json` + the repo's actual open issues
- [x] Model-resolution `awk`/`sed` extraction tested against the real `versions.go`
- [ ] Live end-to-end `workflow_dispatch` run — to be done after merge, on request, since `workflow_dispatch` can't be triggered via API for a workflow that doesn't exist on the default branch yet