### PR TITLE
fix(ci): correct strix invocation in security-scan.yml

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -113,12 +113,18 @@ jobs:
             --scan-mode "${{ inputs.scan_mode || 'deep' }}" \
             > strix_scan.log 2>&1 || true
 
+          # strix_runs/ lands relative to strix's OWN invocation cwd (this
+          # job's default workspace root), as a sibling of target/ -- NOT
+          # nested inside target/strix_runs/, regardless of --target vs.
+          # --mount. Confirmed against a real run's own reported Output
+          # path: .../oh-my-agentic-coder/strix_runs/target_<id>.
+          #
           # nullglob + array, not `ls glob | head`: under bash -e + pipefail
           # (this shell's default), a non-matching glob inside `$(...)`
           # aborts the script with ls's own exit code, skipping the
           # friendly ::error:: below entirely.
           shopt -s nullglob
-          run_dirs=(target/strix_runs/*/)
+          run_dirs=(strix_runs/*/)
           shopt -u nullglob
           if [ ${#run_dirs[@]} -eq 0 ]; then
             echo "::error::strix produced no run directory -- scan likely failed to start (strix_scan.log is pushed to the private artifact repo below regardless of outcome -- check there, never printed here since it can contain scan content)"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -65,7 +65,16 @@ jobs:
           # No --user: actions/setup-python's toolcached interpreter is
           # already user-writable and its bin/ is on PATH, so --user risks
           # installing the console script somewhere PATH doesn't cover.
-          pip install strix-agent==1.0.4
+          #
+          # openai==2.44.0 pinned deliberately: strix-agent==1.0.4's own
+          # constraints let pip resolve openai==2.45.0, which changes the
+          # response shape openai-agents==0.14.6 parses just enough that
+          # `Usage(input_tokens_details=...)` fails pydantic validation
+          # (missing `cache_write_tokens`) against Skainet/litellm's
+          # translated response -- confirmed by reproducing locally and
+          # bisecting to this one package. Revisit this pin whenever
+          # strix-agent/openai-agents get bumped upstream.
+          pip install strix-agent==1.0.4 openai==2.44.0
           # Safe to print -- version string only, no scan content.
           strix --version
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -111,12 +111,13 @@ jobs:
           run_dirs=(target/strix_runs/*/)
           shopt -u nullglob
           if [ ${#run_dirs[@]} -eq 0 ]; then
-            echo "::error::strix produced no run directory -- scan likely failed to start (see strix_scan.log via the private artifact push step)"
+            echo "::error::strix produced no run directory -- scan likely failed to start (strix_scan.log is pushed to the private artifact repo below regardless of outcome -- check there, never printed here since it can contain scan content)"
             exit 1
           fi
           echo "run_dir=${run_dirs[-1]}" >> "$GITHUB_OUTPUT"
 
       - name: Dedupe against open issues + build triage report
+        if: steps.scan.outcome == 'success'
         env:
           STRIX_LLM: ${{ steps.model.outputs.strix_llm }}
         run: |
@@ -127,9 +128,15 @@ jobs:
             --summary-out step-summary.md
 
       - name: Public summary (counts only, no exploit detail)
+        if: steps.scan.outcome == 'success'
         run: cat step-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Push full report to private artifact repo
+        # Runs even when the scan step failed: strix_scan.log is the only
+        # way to debug a startup failure, and it must never be printed to
+        # this (public) job log -- the private repo is the one place it's
+        # safe to look, whether or not the scan actually produced findings.
+        if: always()
         env:
           SECURITY_SCAN_PAT: ${{ secrets.SECURITY_SCAN_PAT }}
         run: |
@@ -138,13 +145,18 @@ jobs:
           git clone --quiet --depth 1 \
             "https://x-access-token:${SECURITY_SCAN_PAT}@github.com/nhuelstng/oh-my-agentic-coder-security.git" \
             "$dest"
-          scan_dir="$dest/scans/${{ steps.scan.outputs.run_label }}-${{ inputs.reason || 'scheduled' }}"
+          status="${{ steps.scan.outcome == 'success' && 'ok' || 'FAILED' }}"
+          scan_dir="$dest/scans/${{ steps.scan.outputs.run_label }}-${{ inputs.reason || 'scheduled' }}-${status}"
           mkdir -p "$scan_dir"
-          cp -r "${{ steps.scan.outputs.run_dir }}"/* "$scan_dir"/
-          cp triage-report.md strix_scan.log "$scan_dir"/
+          run_dir="${{ steps.scan.outputs.run_dir }}"
+          if [ -n "$run_dir" ] && [ -d "$run_dir" ]; then
+            cp -r "$run_dir"/* "$scan_dir"/
+          fi
+          [ -f triage-report.md ] && cp triage-report.md "$scan_dir"/
+          [ -f strix_scan.log ] && cp strix_scan.log "$scan_dir"/
           cd "$dest"
           git config user.name "strix-ci-bot"
           git config user.email "actions@users.noreply.github.com"
           git add .
-          git commit --quiet -m "scan: ${{ inputs.reason || 'scheduled' }} ($(date -u +%F))"
+          git commit --quiet -m "scan: ${{ inputs.reason || 'scheduled' }} [$status] ($(date -u +%F))"
           git push --quiet

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -65,7 +65,13 @@ jobs:
           python-version: '3.12'
 
       - name: Install strix
-        run: pip install --user strix-agent==1.0.4
+        run: |
+          # No --user: actions/setup-python's toolcached interpreter is
+          # already user-writable and its bin/ is on PATH, so --user risks
+          # installing the console script somewhere PATH doesn't cover.
+          pip install strix-agent==1.0.4
+          # Safe to print -- version string only, no scan content.
+          strix --version
 
       - name: Resolve model from e2e config
         id: model
@@ -92,16 +98,23 @@ jobs:
           # Redirected to a file, NEVER printed to this (public) job log --
           # strix's console output includes full vulnerability detail and
           # working PoCs once findings surface.
-          "$HOME/.local/bin/strix" -n --mount "$PWD/target" \
+          strix -n --mount "$PWD/target" \
             --scan-mode "${{ inputs.scan_mode || 'deep' }}" \
             --max-budget-usd "${{ inputs.max_budget_usd || '10' }}" \
             > strix_scan.log 2>&1 || true
-          run_dir=$(ls -td target/strix_runs/*/ 2>/dev/null | head -1)
-          if [ -z "$run_dir" ]; then
+
+          # nullglob + array, not `ls glob | head`: under bash -e + pipefail
+          # (this shell's default), a non-matching glob inside `$(...)`
+          # aborts the script with ls's own exit code, skipping the
+          # friendly ::error:: below entirely.
+          shopt -s nullglob
+          run_dirs=(target/strix_runs/*/)
+          shopt -u nullglob
+          if [ ${#run_dirs[@]} -eq 0 ]; then
             echo "::error::strix produced no run directory -- scan likely failed to start (see strix_scan.log via the private artifact push step)"
             exit 1
           fi
-          echo "run_dir=$run_dir" >> "$GITHUB_OUTPUT"
+          echo "run_dir=${run_dirs[-1]}" >> "$GITHUB_OUTPUT"
 
       - name: Dedupe against open issues + build triage report
         env:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -27,10 +27,6 @@ on:
         type: choice
         options: [quick, standard, deep]
         default: deep
-      max_budget_usd:
-        description: 'LLM cost cap in USD for this run'
-        type: string
-        default: '10'
 
 permissions:
   contents: read
@@ -95,12 +91,17 @@ jobs:
           set -o pipefail
           run_label="$(date -u +%Y%m%d-%H%M%S)"
           echo "run_label=$run_label" >> "$GITHUB_OUTPUT"
+          # --target, not --mount: the PyPI release (strix-agent, pinned
+          # below) doesn't have --mount or --max-budget-usd -- those only
+          # exist in unreleased commits ahead of the 1.0.4 tag. --target
+          # copies the checkout into the sandbox rather than a read-only
+          # bind-mount; no cost cap beyond this job's timeout-minutes.
+          #
           # Redirected to a file, NEVER printed to this (public) job log --
           # strix's console output includes full vulnerability detail and
           # working PoCs once findings surface.
-          strix -n --mount "$PWD/target" \
+          strix -n --target "$PWD/target" \
             --scan-mode "${{ inputs.scan_mode || 'deep' }}" \
-            --max-budget-usd "${{ inputs.max_budget_usd || '10' }}" \
             > strix_scan.log 2>&1 || true
 
           # nullglob + array, not `ls glob | head`: under bash -e + pipefail


### PR DESCRIPTION
## What
Fixes the first live `security-scan.yml` run, which failed in ~5s with exit code 2 and no useful log output: https://github.com/TNG/oh-my-agentic-coder/actions/runs/29332643460

## Why
Two compounding bugs, both invisible from the (deliberately redacted) public job log:

1. `pip install --user strix-agent` + hardcoding `$HOME/.local/bin/strix` — under `actions/setup-python`'s toolcached interpreter, `--user` isn't needed (it's already user-writable and on PATH) and the hardcoded path likely didn't exist, so the invocation itself failed.
2. `run_dir=$(ls -td target/strix_runs/*/ | head -1)`: since strix never ran, the glob didn't match and `ls` exited non-zero (GNU ls: 2). Under `bash -e` + `pipefail`, a failing command substitution on a bare assignment aborts the script immediately with that exit code — bypassing my intended friendly `::error::` message entirely. That's why the job's reported exit code was 2, not the script's own `exit 1`.

## How
- Drop `--user`, invoke bare `strix` (matches strix's own documented CI example in its README).
- Add `strix --version` right after install — safe to print (version string only, no scan content), gives an immediate non-sensitive signal if the binary isn't invokable next time.
- Replace the `ls | head` glob-in-a-substitution with `shopt -s nullglob` + an array, which doesn't trigger `errexit` on a non-match, so the real `if [ ${#run_dirs[@]} -eq 0 ]` check actually runs.

## Verification
- `actionlint` clean
- Locally verified the nullglob/array logic under `bash -euo pipefail` for both the empty-match and one-match cases
- [ ] Live `workflow_dispatch` re-run after merge to confirm the fix