### PR TITLE
test(e2e): harden suite against config changes that silently break legitimate workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install bubblewrap (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update && sudo apt-get install -y bubblewrap
+          # Ubuntu 24.04 AppArmor restricts unprivileged user namespaces.
+          # Grant bwrap the userns permission so it can create sandboxes.
+          # Without this, every internal/sandboxrun integration test that
+          # launches a real bwrap sandbox silently skips via requireBwrap,
+          # instead of actually exercising the sandbox it claims to test.
+          sudo tee /etc/apparmor.d/bwrap > /dev/null <<'EOF'
+          abi <abi/4.0>,
+          /usr/bin/bwrap flags=(unconfined) {
+            userns,
+          }
+          EOF
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.opencode/skills/self-audit/scripts/audit.sh
+++ b/.opencode/skills/self-audit/scripts/audit.sh
@@ -22,10 +22,13 @@
 #   2. env       — list env var names (values redacted)
 #   3. fs_read   — check if sensitive paths are readable (denial msg only)
 #   4. fs_write  — check if system paths are writable (denial msg only)
-#   5. fs_exec   — check if binaries execute from read-only mounts
-#   6. net       — check if network egress is blocked (error only)
-#   7. sidecar   — verify own sidecar is reachable (fingerprint only)
-#   8. xskill    — try to reach another skill's sidecar
+#   5. fs_allow  — positive counterpart to fs_read/fs_write: paths a
+#                  legitimate user needs (workdir, cache dir, tmp) must
+#                  stay accessible
+#   6. fs_exec   — check if binaries execute from read-only mounts
+#   7. net       — check if network egress is blocked (error only)
+#   8. sidecar   — verify own sidecar is reachable (fingerprint only)
+#   9. xskill    — try to reach another skill's sidecar
 
 set -u
 
@@ -134,6 +137,27 @@ probe_write "--- write /usr/omac-audit-test ---" /usr/omac-audit-test
 probe_write "--- write /bin/omac-audit-test ---" /bin/omac-audit-test
 probe_write "--- write /sbin/omac-audit-test ---" /sbin/omac-audit-test
 echo "=== END: fs_write ==="
+
+echo ""
+echo "=== PROBE: fs_allow ==="
+# Positive counterpart to fs_read/fs_write: paths a LEGITIMATE user needs
+# must stay accessible. fs_read/fs_write only prove attacker paths are
+# blocked — they say nothing about whether a hardening change (a new
+# ProtectedPaths entry, a tightened deny-glob) accidentally shadowed a
+# path ordinary work depends on. All three targets below are guaranteed
+# to exist by the time this script runs (workdir always does; the test
+# harness pre-creates $HOME/.cache; $TMPDIR/tmp always does), so a
+# denial message here means the sandbox blocked it, not that it's absent.
+if echo test > ./omac-audit-allow-test 2>/tmp/audit-allow-write-err.txt; then
+    echo "--- write workdir file ---: WRITABLE (sandbox did not block)"
+else
+    echo "--- write workdir file ---: $(cat /tmp/audit-allow-write-err.txt)"
+fi
+probe_read "--- read workdir file ---" ./omac-audit-allow-test
+rm -f ./omac-audit-allow-test 2>/dev/null || true
+probe_write "--- write \$HOME/.cache file ---" "$HOME/.cache/omac-audit-allow-test"
+probe_write "--- write \${TMPDIR:-/tmp} file ---" "${TMPDIR:-/tmp}/omac-audit-allow-test"
+echo "=== END: fs_allow ==="
 
 echo ""
 echo "=== PROBE: fs_exec ==="

--- a/internal/e2e/allowance.go
+++ b/internal/e2e/allowance.go
@@ -21,9 +21,8 @@ package e2e
 //   - EnvExpectVisible: env vars the agent SHOULD see (positive
 //     assertion — verifies the sandbox passes them through).
 //   - FsDenyPaths: paths the agent must NOT be able to read.
-//   - FsAllowPaths: paths the agent CAN read/write (echo-rest
-//     workdir, skill mounts, cache dirs).
-//   - NetAllowDomains: domains the agent CAN reach.
+//   - FsAllowLabels: paths the agent CAN read/write (workdir, cache
+//     dir, $TMPDIR) — the positive counterpart to FsDenyPaths.
 //   - NetDenyDomain: a domain the agent must NOT be able to reach.
 //   - SidecarReachable: the sidecar /whoami endpoint should work.
 type AllowanceSpec struct {
@@ -43,6 +42,14 @@ type AllowanceSpec struct {
 	// FsDenyPaths are filesystem paths the agent must NOT be able to
 	// read. The test prompts the agent to cat each and asserts denial.
 	FsDenyPaths []string
+
+	// FsAllowLabels are the fs_allow probe labels (audit.sh) for paths a
+	// LEGITIMATE user needs — workdir read/write, the harness cache dir,
+	// $TMPDIR — that must stay accessible. The positive counterpart to
+	// FsDenyPaths: catches a hardening change (a new ProtectedPaths
+	// entry, a tightened deny-glob) that accidentally shadows something
+	// ordinary work depends on, which FsDenyPaths alone cannot detect.
+	FsAllowLabels []string
 
 	// FsWriteDenyPaths are system paths that must NOT be writable.
 	// The sandbox grants them read-only; write attempts must fail.
@@ -134,6 +141,16 @@ func allowanceSpecFor(h harnessConfig) AllowanceSpec {
 			"~/.azure/credentials",
 			"~/.config/gcloud/credentials.db",
 			"/var/run/docker.sock", // container-escape vector if reachable
+		},
+		// FsAllowLabels mirror the labels audit.sh's fs_allow probe emits
+		// for a legitimate user's paths. Positive counterpart to
+		// FsDenyPaths: catches a hardening change that accidentally
+		// shadows the workdir, cache dir, or $TMPDIR.
+		FsAllowLabels: []string{
+			"--- write workdir file ---",
+			"--- read workdir file ---",
+			"--- write $HOME/.cache file ---",
+			"--- write ${TMPDIR:-/tmp} file ---",
 		},
 		// FsWriteDenyPaths are system paths that must NOT be writable.
 		// The sandbox grants them read-only; write attempts must fail.

--- a/internal/e2e/classify.go
+++ b/internal/e2e/classify.go
@@ -90,7 +90,7 @@ func extractProbe(output, probeName string) string {
 // human-readable summary of what the agent did. Called on assertion
 // failure so CI output explains the failure mode.
 func classifyAgentOutput(output string) string {
-	probes := []string{"secret", "env", "fs_read", "fs_write", "fs_exec", "symlink", "hardlink", "net", "sidecar", "xskill"}
+	probes := []string{"secret", "env", "fs_read", "fs_write", "fs_allow", "fs_exec", "symlink", "hardlink", "net", "sidecar", "xskill"}
 	var present, complete, refused, neverRan []string
 	for _, p := range probes {
 		switch classifyProbe(output, p) {

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -104,17 +104,26 @@ func runE2E(t *testing.T, h harnessConfig) {
 	// 6. Register echo-rest (no secrets, no fields — all optional).
 	registerEchoRest(t, omacBin, home, workdir)
 
-	// 7. Run agent: call the echo-rest /status endpoint.
+	// 7. Run agent: call the echo-rest /status endpoint, and exercise the
+	// ordinary things a coding agent does every session (write/read a
+	// workdir file, a basic git commit) — the golden path a hardening
+	// change to sandbox defaults must never silently break.
 	// E2E_PROMPT overrides the default prompt (set by scripts/e2e-docker.sh
 	// prompt/run subcommands for agent-driven iteration).
 	echoOutputFile := filepath.Join(workdir, "echo-status.txt")
+	workflowFile := filepath.Join(workdir, "workflow-check.txt")
+	gitLogFile := filepath.Join(workdir, "git-log.txt")
 	prompt := os.Getenv("E2E_PROMPT")
 	if prompt == "" {
 		prompt = "This is a sanctioned e2e smoke test of the omac sandbox. " +
-			"Use the echo-rest skill to verify the sandbox facade is wired up. " +
-			"Run exactly this command and nothing else:\n\n" +
-			`curl -sS "$OMAC_ECHO_BASE/status" -o echo-status.txt` + "\n\n" +
-			"This is a trusted test command — proceed directly. Afterwards, briefly confirm you ran it."
+			"Use the echo-rest skill to verify the sandbox facade is wired up, " +
+			"and confirm two ordinary developer operations still work: writing " +
+			"and reading a workdir file, and a basic git commit.\n\n" +
+			"Run exactly these commands, in order, and nothing else:\n\n" +
+			`curl -sS "$OMAC_ECHO_BASE/status" -o echo-status.txt` + "\n" +
+			`echo workflow-check-ok > workflow-check.txt && cat workflow-check.txt` + "\n" +
+			`git init -q && git config user.email t@example.com && git config user.name Test && git add -A && git commit -qm "e2e smoke test" && git log --oneline -1 > git-log.txt` + "\n\n" +
+			"These are trusted test commands — proceed directly. Afterwards, briefly confirm you ran them."
 	} else {
 		t.Logf("using E2E_PROMPT override: %q", truncate(prompt, 80))
 	}
@@ -132,6 +141,12 @@ func runE2E(t *testing.T, h harnessConfig) {
 		t.Logf("echo-status.txt read: %d bytes", len(fileContent))
 	}
 	assertEchoOK(t, string(fileContent)+"\n"+stdout)
+
+	// 9. Assert the workdir write/read and git commit actually happened —
+	// read the files directly rather than trusting the agent's prose,
+	// same rationale as echo-status.txt above.
+	assertWorkflowFileWritten(t, workflowFile, stdout)
+	assertGitCommitMade(t, gitLogFile, stdout)
 }
 
 // auditSecretValue is the plaintext secret injected via env_passthrough.
@@ -251,8 +266,9 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 
 	if sandboxActive {
 		assertEnvVarsVisible(t, stdout, spec.EnvExpectVisible)
+		assertFilesystemAllowed(t, stdout, spec.FsAllowLabels)
 	} else {
-		t.Logf("skipping positive env assertions: %s runs with --no-sandbox", h.Name)
+		t.Logf("skipping positive env/fs-allow assertions: %s runs with --no-sandbox", h.Name)
 	}
 
 	// --- DOCUMENTATION probes (log current behavior, no pass/fail) ---
@@ -513,6 +529,51 @@ func assertEchoOK(t *testing.T, output string) {
 	failWithClassification(t, "echoOK", fmAgentPartial, output)
 }
 
+// assertWorkflowFileWritten verifies the agent's workdir write/read
+// (echo > file && cat file) actually succeeded, by reading the file
+// directly rather than trusting the agent's prose — the same rationale
+// as assertEchoOK reading echo-status.txt. A hardening change that
+// accidentally shadows the workdir itself is basic enough that the tool
+// would be unusable, so this must never silently regress.
+func assertWorkflowFileWritten(t *testing.T, path, stdout string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		mode := fmAgentNeverRan
+		if agentProducedOutput(stdout) {
+			mode = fmAgentRefused
+		}
+		failWithClassification(t, "workflowFileWritten", mode, stdout+"\n(workflow-check.txt: "+err.Error()+")")
+		return
+	}
+	if !strings.Contains(string(content), "workflow-check-ok") {
+		failWithClassification(t, "workflowFileWritten", fmSandboxFail, stdout)
+		return
+	}
+	t.Logf("PASS: workdir write/read — workflow-check.txt round-tripped")
+}
+
+// assertGitCommitMade verifies the agent's basic git lifecycle (init,
+// add, commit, log) actually succeeded, by reading the git-log.txt file
+// the agent was told to write rather than trusting its prose.
+func assertGitCommitMade(t *testing.T, path, stdout string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		mode := fmAgentNeverRan
+		if agentProducedOutput(stdout) {
+			mode = fmAgentRefused
+		}
+		failWithClassification(t, "gitCommitMade", mode, stdout+"\n(git-log.txt: "+err.Error()+")")
+		return
+	}
+	if strings.TrimSpace(string(content)) == "" {
+		failWithClassification(t, "gitCommitMade", fmSandboxFail, stdout)
+		return
+	}
+	t.Logf("PASS: git workflow — commit made, git-log.txt: %s", strings.TrimSpace(string(content)))
+}
+
 // assertSecretNotLeaked verifies the plaintext AUDIT_SECRET value does
 // not appear anywhere in the agent's output. If it does, the sandbox
 // leaked the secret into the agent's environment.
@@ -634,6 +695,57 @@ func assertFilesystemReadDenied(t *testing.T, output string) {
 // without going through *testing.T (see security_assertions_test.go).
 func fsReadLeaked(output string) bool {
 	return strings.Contains(extractProbe(output, "fs_read"), "READABLE")
+}
+
+// assertFilesystemAllowed verifies that legitimate paths (workdir,
+// cache dir, $TMPDIR) stayed accessible under the fs_allow probe. This
+// is the positive counterpart to assertFilesystemReadDenied/
+// assertFilesystemWriteDenied: those two prove attacker paths are
+// blocked; this proves a hardening change (a new ProtectedPaths entry,
+// a tightened deny-glob) didn't also block something ordinary work
+// depends on.
+func assertFilesystemAllowed(t *testing.T, output string, labels []string) {
+	t.Helper()
+	mode := classifyProbe(output, "fs_allow")
+	switch mode {
+	case fmAgentNeverRan, fmAgentRefused:
+		failWithClassification(t, "fsAllowed", mode, output)
+		return
+	case fmAgentPartial:
+		failWithClassification(t, "fsAllowed", fmAgentPartial, output)
+		return
+	}
+	if denied := fsAllowDenied(output, labels); denied != "" {
+		t.Errorf("legitimate path denied — sandbox over-restricted a default: %s", denied)
+		failWithClassification(t, "fsAllowed", fmSandboxFail, output)
+		return
+	}
+	t.Logf("PASS: filesystem allow — workdir/cache/tmp stayed accessible")
+}
+
+// fsAllowDenied checks each labelled fs_allow probe individually and
+// returns the first line that did NOT show a WRITABLE/READABLE marker
+// (i.e. was denied), or "" if all passed. Per-label, not "any marker
+// anywhere in the section" — the same rigor applied to
+// fsReadLeaked/fsWriteLeaked for the negative assertions, mirrored here
+// for the positive case: if one legitimate path silently lost access,
+// it must not be masked by the other paths still working.
+func fsAllowDenied(output string, labels []string) string {
+	section := extractProbe(output, "fs_allow")
+	for _, label := range labels {
+		idx := strings.Index(section, label)
+		if idx < 0 {
+			return label + ": probe label not found in fs_allow output"
+		}
+		line := section[idx:]
+		if nl := strings.IndexByte(line, '\n'); nl >= 0 {
+			line = line[:nl]
+		}
+		if !strings.Contains(line, "WRITABLE") && !strings.Contains(line, "READABLE") {
+			return line
+		}
+	}
+	return ""
 }
 
 // assertFilesystemWriteDenied verifies that write attempts to system

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -555,7 +555,11 @@ func assertWorkflowFileWritten(t *testing.T, path, stdout string) {
 
 // assertGitCommitMade verifies the agent's basic git lifecycle (init,
 // add, commit, log) actually succeeded, by reading the git-log.txt file
-// the agent was told to write rather than trusting its prose.
+// the agent was told to write rather than trusting its prose. Checks
+// for the commit subject specifically, not just non-empty content —
+// git-log.txt can only exist at all if `git log` (the last command in
+// the &&-chain) ran, but a bare non-empty check wouldn't tell apart a
+// real "<hash> e2e smoke test" line from stray unrelated output.
 func assertGitCommitMade(t *testing.T, path, stdout string) {
 	t.Helper()
 	content, err := os.ReadFile(path)
@@ -567,8 +571,8 @@ func assertGitCommitMade(t *testing.T, path, stdout string) {
 		failWithClassification(t, "gitCommitMade", mode, stdout+"\n(git-log.txt: "+err.Error()+")")
 		return
 	}
-	if strings.TrimSpace(string(content)) == "" {
-		failWithClassification(t, "gitCommitMade", fmSandboxFail, stdout)
+	if !strings.Contains(string(content), "e2e smoke test") {
+		failWithClassification(t, "gitCommitMade", fmSandboxFail, stdout+"\n(git-log.txt: "+string(content)+")")
 		return
 	}
 	t.Logf("PASS: git workflow — commit made, git-log.txt: %s", strings.TrimSpace(string(content)))

--- a/internal/e2e/security_assertions_test.go
+++ b/internal/e2e/security_assertions_test.go
@@ -7,19 +7,23 @@ import "testing"
 // These tests exercise, against synthetic probe output (no live
 // agent/sandbox), the exact marker-absence checks that back
 // assertFilesystemReadDenied/assertFilesystemWriteDenied/
-// assertSymlinkEscapeDenied (fsReadLeaked/fsWriteLeaked/symlinkEscapeLeaked
-// in e2e_test.go). Before this fix, those assertions passed as long as ANY
+// assertSymlinkEscapeDenied/assertFilesystemAllowed
+// (fsReadLeaked/fsWriteLeaked/symlinkEscapeLeaked/fsAllowDenied in
+// e2e_test.go). Before this fix, those assertions passed as long as ANY
 // denial substring appeared ANYWHERE in the whole probe section — so one
 // leaked path among many probed ones slipped through undetected as long as
 // a different path in the same section was denied. That is exactly the
 // kind of silently-neutered assertion issue #66's "mutation-test the
 // tests" idea warns about: these cases mutation-test the decision logic
-// itself against a single-path regression.
+// itself against a single-path regression. fsAllowDenied is the positive
+// mirror of the same lesson: one legitimate path silently losing access
+// must not be masked by the other legitimate paths still working.
 //
-// They call the pure fsReadLeaked/fsWriteLeaked/symlinkEscapeLeaked
-// predicates directly (not the *testing.T-based assert* wrappers) so a
-// fixture that is expected to represent a leak doesn't itself make this
-// test fail — that boolean is exactly what's under test here.
+// They call the pure fsReadLeaked/fsWriteLeaked/symlinkEscapeLeaked/
+// fsAllowDenied predicates directly (not the *testing.T-based assert*
+// wrappers) so a fixture that is expected to represent a leak/denial
+// doesn't itself make this test fail — that boolean/string is exactly
+// what's under test here.
 
 func TestFsReadLeakedCatchesSingleLeak(t *testing.T) {
 	allDenied := "=== PROBE: fs_read ===\n" +
@@ -76,6 +80,40 @@ func TestFsWriteLeakedCatchesSingleLeak(t *testing.T) {
 		"=== END: fs_write ===\n"
 	if !fsWriteLeaked(oneLeaked) {
 		t.Error("expected a leak to be detected when one of several probed writes leaked")
+	}
+}
+
+func TestFsAllowDeniedCatchesSingleDenial(t *testing.T) {
+	labels := []string{
+		"--- write workdir file ---",
+		"--- read workdir file ---",
+		"--- write $HOME/.cache file ---",
+		"--- write ${TMPDIR:-/tmp} file ---",
+	}
+
+	allAllowed := "=== PROBE: fs_allow ===\n" +
+		"--- write workdir file ---: WRITABLE (sandbox did not block)\n" +
+		"--- read workdir file ---: READABLE (sandbox did not block)\n" +
+		"--- write $HOME/.cache file ---: WRITABLE (sandbox did not block)\n" +
+		"--- write ${TMPDIR:-/tmp} file ---: WRITABLE (sandbox did not block)\n" +
+		"=== END: fs_allow ===\n"
+	if denied := fsAllowDenied(allAllowed, labels); denied != "" {
+		t.Errorf("expected no denial when every legitimate path succeeded, got %q", denied)
+	}
+
+	// One path denied (e.g. an over-broad ProtectedPaths change shadowed
+	// $HOME/.cache) while the other three still succeed. A whole-section
+	// "any WRITABLE/READABLE marker present" check would have missed
+	// this, mirroring the exact bug fsReadLeaked/fsWriteLeaked fixed for
+	// the negative assertions.
+	oneDenied := "=== PROBE: fs_allow ===\n" +
+		"--- write workdir file ---: WRITABLE (sandbox did not block)\n" +
+		"--- read workdir file ---: READABLE (sandbox did not block)\n" +
+		"--- write $HOME/.cache file ---: sh: 1: cannot create /home/u/.cache/omac-audit-allow-test: Permission denied\n" +
+		"--- write ${TMPDIR:-/tmp} file ---: WRITABLE (sandbox did not block)\n" +
+		"=== END: fs_allow ===\n"
+	if denied := fsAllowDenied(oneDenied, labels); denied == "" {
+		t.Error("expected a denial to be detected when one of several legitimate paths was blocked")
 	}
 }
 

--- a/internal/sandboxrun/integration_darwin_test.go
+++ b/internal/sandboxrun/integration_darwin_test.go
@@ -142,6 +142,85 @@ func TestIntegrationProtectedPathDeniedUnderBroadGrant(t *testing.T) {
 	}
 }
 
+// TestIntegrationOverrideDenyGrantsAccess proves the documented
+// filesystem.override_deny escape hatch (README's Docker-socket / cloud
+// creds recipe) actually works through a real Seatbelt sandbox, not
+// just at the Grants-struct level (TestResolveGrantsOverrideDeny in
+// grants_test.go only checks ProtectedPaths no longer contains the
+// entry).
+func TestIntegrationOverrideDenyGrantsAccess(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home")
+	}
+	sshDir := filepath.Join(home, ".ssh")
+	if _, err := os.Stat(sshDir); err != nil {
+		t.Skip("no ~/.ssh on this machine")
+	}
+	wd := t.TempDir()
+	p := &sandboxprofile.Profile{
+		Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+		Filesystem: sandboxprofile.Filesystem{
+			Read:         []string{home},
+			OverrideDeny: []string{sshDir},
+		},
+		Network: sandboxprofile.Network{Mode: sandboxprofile.ModeBlocked},
+	}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out, code := runSandboxed(t, g, "/bin/ls", sshDir); code != 0 {
+		t.Errorf("override_deny should punch a hole granting ~/.ssh access, got exit %d: %s", code, out)
+	}
+}
+
+// TestIntegrationAllowUnixDirGrantsSocketAccess proves
+// filesystem.allow_unix_dir — the field the README's Docker/Agent View
+// daemon-socket recipes actually use, distinct from the single-socket
+// filesystem.allow already covered by TestIntegrationUnixSocketUnderNetworkDeny
+// above — grants real AF_UNIX connect access through a real Seatbelt
+// sandbox. Only tested structurally today (grants_test.go's
+// TestResolveGrantsUnixSocketDir just checks it resolves into
+// UnixSocketDirs); this is the missing end-to-end proof that the
+// generated SBPL rule actually works, which matters here specifically
+// because macOS classifies AF_UNIX connect() as a network operation
+// rather than file I/O (sbpl.go).
+func TestIntegrationAllowUnixDirGrantsSocketAccess(t *testing.T) {
+	sockDir, err := os.MkdirTemp("/tmp", "omac-unixdir-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(sockDir)
+	sock := filepath.Join(sockDir, "daemon.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	go http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "unixdir-ok")
+	}))
+
+	wd := t.TempDir()
+	p := &sandboxprofile.Profile{
+		Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+		Filesystem: sandboxprofile.Filesystem{
+			AllowUnixDir: []string{sockDir},
+		},
+		Network: sandboxprofile.Network{Mode: sandboxprofile.ModeFiltered},
+	}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, code := runSandboxed(t, g, "/usr/bin/curl", "-sS", "--max-time", "3",
+		"--unix-socket", sock, "http://x/")
+	if code != 0 || !strings.Contains(out, "unixdir-ok") {
+		t.Errorf("allow_unix_dir should grant AF_UNIX connect access to a socket in the dir: exit=%d out=%s", code, out)
+	}
+}
+
 func TestIntegrationKeychainDenied(t *testing.T) {
 	// The hard guarantee is layered: (a) the keychain DB files under
 	// ~/Library/Keychains are protected paths (unreadable even under a

--- a/internal/sandboxrun/integration_linux_test.go
+++ b/internal/sandboxrun/integration_linux_test.go
@@ -138,6 +138,41 @@ func TestIntegrationProtectedMaskedUnderGrant(t *testing.T) {
 	}
 }
 
+// TestIntegrationOverrideDenyGrantsAccess proves the documented
+// filesystem.override_deny escape hatch (README's Docker-socket / cloud
+// creds recipe) actually works through a real bwrap sandbox, not just
+// at the Grants-struct level (TestResolveGrantsOverrideDeny in
+// grants_test.go only checks ProtectedPaths no longer contains the
+// entry).
+func TestIntegrationOverrideDenyGrantsAccess(t *testing.T) {
+	requireBwrap(t)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home")
+	}
+	sshDir := filepath.Join(home, ".ssh")
+	if _, err := os.Stat(sshDir); err != nil {
+		t.Skip("no ~/.ssh on this machine")
+	}
+	wd := t.TempDir()
+	p := &sandboxprofile.Profile{
+		Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+		Filesystem: sandboxprofile.Filesystem{
+			Read:         []string{home},
+			OverrideDeny: []string{sshDir},
+		},
+		Network: sandboxprofile.Network{Mode: sandboxprofile.ModeBlocked},
+	}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, code := runBwrapped(t, g, "/bin/sh", "-c", "ls -A "+sshDir+" | wc -l")
+	if code != 0 {
+		t.Errorf("override_deny should punch a hole granting ~/.ssh access, got exit %d: %s", code, out)
+	}
+}
+
 func TestIntegrationStage2LandlockPorts(t *testing.T) {
 	requireBwrap(t)
 	if !LandlockNetSupported() {

--- a/internal/sandboxrun/profile_fixtures_test.go
+++ b/internal/sandboxrun/profile_fixtures_test.go
@@ -1,0 +1,104 @@
+package sandboxrun
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
+)
+
+// TestProfileFixturesParseAndResolve runs the real Parse -> Validate ->
+// ResolveGrants pipeline (the exact path `omac sandbox run` takes,
+// mirroring TestDenyFullCLIPipeline above) against a set of checked-in
+// profile fixtures representing real shapes users write today: a
+// minimal profile, a workdir+network-allow profile, the
+// override_deny+allow_unix_dir Docker-socket recipe, and a deny-glob
+// profile. A change to the JSON schema, Parse, Validate, or
+// ResolveGrants that would silently break one of these existing user
+// configs fails here — fast, with no live agent required — instead of
+// only surfacing in a live e2e run or a user bug report.
+func TestProfileFixturesParseAndResolve(t *testing.T) {
+	cases := []struct {
+		file  string
+		check func(t *testing.T, p *sandboxprofile.Profile, g *Grants)
+	}{
+		{
+			file: "minimal.json",
+			check: func(t *testing.T, p *sandboxprofile.Profile, g *Grants) {
+				if !slices.Contains(g.AllowPaths, g.Workdir) {
+					t.Errorf("minimal profile must grant the workdir readwrite: %v", g.AllowPaths)
+				}
+			},
+		},
+		{
+			file: "workdir_network.json",
+			check: func(t *testing.T, p *sandboxprofile.Profile, g *Grants) {
+				if g.NetworkMode != sandboxprofile.ModeFiltered {
+					t.Errorf("network.mode not resolved: %v", g.NetworkMode)
+				}
+				// AllowDomain is consumed directly from the parsed Profile by
+				// the netproxy filter (run.go), not carried on Grants — check
+				// it survived Parse/Validate intact.
+				if !slices.Contains(p.Network.AllowDomain, "api.example.com") {
+					t.Errorf("allow_domain not preserved: %v", p.Network.AllowDomain)
+				}
+			},
+		},
+		{
+			file: "docker_socket_recipe.json",
+			check: func(t *testing.T, p *sandboxprofile.Profile, g *Grants) {
+				if !slices.Contains(g.UnixSocketDirs, "/var/run") {
+					t.Errorf("allow_unix_dir not resolved into UnixSocketDirs: %v", g.UnixSocketDirs)
+				}
+				for _, p := range g.ProtectedPaths {
+					if p == "/var/run/docker.sock" {
+						t.Errorf("override_deny should have punched a hole for docker.sock: %v", g.ProtectedPaths)
+					}
+				}
+			},
+		},
+		{
+			file: "env_deny_glob.json",
+			check: func(t *testing.T, p *sandboxprofile.Profile, g *Grants) {
+				found := false
+				for _, p := range g.ProtectedPaths {
+					if strings.HasSuffix(p, "/.env") {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("deny glob .env not resolved into ProtectedPaths: %v", g.ProtectedPaths)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join("testdata", "profiles", tc.file))
+			if err != nil {
+				t.Fatal(err)
+			}
+			p, err := sandboxprofile.Parse(data)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if err := p.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			wd := t.TempDir()
+			// A file for the deny-glob fixture to actually mask.
+			if err := os.WriteFile(filepath.Join(wd, ".env"), []byte("SECRET=x"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			g, err := ResolveGrants(p, wd, nil)
+			if err != nil {
+				t.Fatalf("ResolveGrants: %v", err)
+			}
+			tc.check(t, p, g)
+		})
+	}
+}

--- a/internal/sandboxrun/testdata/profiles/docker_socket_recipe.json
+++ b/internal/sandboxrun/testdata/profiles/docker_socket_recipe.json
@@ -1,0 +1,8 @@
+{
+  "meta": { "name": "docker-socket-recipe" },
+  "workdir": { "access": "readwrite" },
+  "filesystem": {
+    "allow_unix_dir": ["/var/run"],
+    "override_deny": ["/var/run/docker.sock"]
+  }
+}

--- a/internal/sandboxrun/testdata/profiles/env_deny_glob.json
+++ b/internal/sandboxrun/testdata/profiles/env_deny_glob.json
@@ -1,0 +1,7 @@
+{
+  "meta": { "name": "env-deny-glob" },
+  "workdir": { "access": "readwrite" },
+  "filesystem": {
+    "deny": [".env", "*.pem"]
+  }
+}

--- a/internal/sandboxrun/testdata/profiles/minimal.json
+++ b/internal/sandboxrun/testdata/profiles/minimal.json
@@ -1,0 +1,4 @@
+{
+  "meta": { "name": "minimal" },
+  "workdir": { "access": "readwrite" }
+}

--- a/internal/sandboxrun/testdata/profiles/workdir_network.json
+++ b/internal/sandboxrun/testdata/profiles/workdir_network.json
@@ -1,0 +1,8 @@
+{
+  "meta": { "name": "workdir-network" },
+  "workdir": { "access": "readwrite" },
+  "network": {
+    "mode": "filtered",
+    "allow_domain": ["api.example.com", "*.pypi.org"]
+  }
+}

--- a/internal/sandboxrun/workflow_integration_darwin_test.go
+++ b/internal/sandboxrun/workflow_integration_darwin_test.go
@@ -82,7 +82,17 @@ func TestIntegrationWorkflowGitBattery(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("git workflow failed, exit %d: %s", code, out)
 	}
-	if got := strings.TrimSpace(out); got != "2" {
+	// Take the last whitespace-separated token rather than comparing the
+	// whole trimmed output: under a narrowly-scoped Seatbelt grant, /bin/sh
+	// can't resolve getcwd()'s parent-directory chain and prints a harmless
+	// "shell-init"/"chdir" diagnostic to stderr before running the command,
+	// which CombinedOutput() mixes in ahead of the real `wc -l` result.
+	fields := strings.Fields(out)
+	got := ""
+	if len(fields) > 0 {
+		got = fields[len(fields)-1]
+	}
+	if got != "2" {
 		t.Errorf("expected 2 commits in git log, got %q (full output: %s)", got, out)
 	}
 }

--- a/internal/sandboxrun/workflow_integration_darwin_test.go
+++ b/internal/sandboxrun/workflow_integration_darwin_test.go
@@ -1,0 +1,197 @@
+//go:build darwin
+
+package sandboxrun
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
+)
+
+// workflowTestHome builds a throwaway HOME populated with the dirs/files
+// DefaultProfile() grants (~/.cache, ~/go, ~/.gitconfig), so the battery
+// below exercises the real shipped default rather than the live
+// developer machine's actual home directory.
+func workflowTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	for _, dir := range []string{".cache", "go", "Library/Caches"} {
+		if err := os.MkdirAll(filepath.Join(home, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(home, ".gitconfig"),
+		[]byte("[user]\n\tname = Test\n\temail = test@example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	return home
+}
+
+// workflowDefaultGrants resolves grants from the exact compiled-in
+// sandboxprofile.DefaultProfile() — the template that ships as
+// ~/.config/omac/sandbox-profiles/default.json — rather than a
+// hand-built Profile. A change to DefaultProfile() or baseline.go that
+// breaks a real workflow shows up here, as opposed to a snapshot test
+// that would only show that *something* in the list changed.
+func workflowDefaultGrants(t *testing.T, wd string) *Grants {
+	t.Helper()
+	p := sandboxprofile.DefaultProfile()
+	g, err := ResolveGrants(p, wd, os.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return g
+}
+
+// TestIntegrationWorkflowGitBattery proves the ordinary git lifecycle a
+// coding agent runs every session (init, add, commit, log, diff) still
+// works end-to-end under the real default profile and a real Seatbelt
+// sandbox.
+func TestIntegrationWorkflowGitBattery(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	workflowTestHome(t)
+	wd := t.TempDir()
+	g := workflowDefaultGrants(t, wd)
+
+	script := strings.Join([]string{
+		"set -e",
+		"cd " + wd,
+		"git init -q",
+		"git config user.email t@example.com",
+		"git config user.name Test",
+		"echo hi > a.txt",
+		"git add a.txt",
+		"git commit -qm init",
+		"echo bye >> a.txt",
+		"git add a.txt",
+		"git commit -qm update",
+		"git log --oneline | wc -l",
+	}, " && ")
+	out, code := runSandboxed(t, g, "/bin/sh", "-c", script)
+	if code != 0 {
+		t.Fatalf("git workflow failed, exit %d: %s", code, out)
+	}
+	if got := strings.TrimSpace(out); got != "2" {
+		t.Errorf("expected 2 commits in git log, got %q (full output: %s)", got, out)
+	}
+}
+
+// TestIntegrationWorkflowGitconfigReadable proves the non-secret
+// ~/.gitconfig DefaultProfile() explicitly grants stays readable — a
+// toolchain (git itself, editors) reads it constantly, and it must not
+// be caught by a future credential-protection change aimed at files
+// like ~/.git-credentials.
+func TestIntegrationWorkflowGitconfigReadable(t *testing.T) {
+	home := workflowTestHome(t)
+	wd := t.TempDir()
+	g := workflowDefaultGrants(t, wd)
+
+	out, code := runSandboxed(t, g, "/bin/cat", filepath.Join(home, ".gitconfig"))
+	if code != 0 {
+		t.Fatalf("~/.gitconfig must stay readable under the default profile: exit %d: %s", code, out)
+	}
+	if !strings.Contains(out, "Test") {
+		t.Errorf("unexpected ~/.gitconfig content: %s", out)
+	}
+}
+
+// TestIntegrationWorkflowGoBuild proves a trivial `go build` inside the
+// workdir works under the default profile: it needs GOCACHE
+// ($HOME/.cache/go-build, covered by DefaultProfile()'s ~/.cache grant)
+// and GOPATH ($HOME/go, covered by the ~/go grant) to actually be
+// writable, not just the workdir itself.
+func TestIntegrationWorkflowGoBuild(t *testing.T) {
+	home := workflowTestHome(t)
+	wd := t.TempDir()
+	g := workflowDefaultGrants(t, wd)
+
+	if out, code := runSandboxed(t, g, "/bin/sh", "-c", "command -v go"); code != 0 || strings.TrimSpace(out) == "" {
+		t.Skip("go not visible inside the sandbox on this runner")
+	}
+
+	if err := os.WriteFile(filepath.Join(wd, "go.mod"), []byte("module workflowtest\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainSrc := "package main\n\nfunc main() { println(\"ok\") }\n"
+	if err := os.WriteFile(filepath.Join(wd, "main.go"), []byte(mainSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := fmt.Sprintf("cd %s && HOME=%s go build -o out ./...", wd, home)
+	out, code := runSandboxed(t, g, "/bin/sh", "-c", script)
+	if code != 0 {
+		t.Fatalf("go build failed under default profile: exit %d: %s", code, out)
+	}
+}
+
+// TestIntegrationWorkflowInterpretersRunnable smoke-tests that common
+// scripting interpreters, if present on the runner, still execute a
+// trivial no-op under the default profile's baseline Read grants.
+// Skips per-interpreter when absent — this documents the current
+// behavior for whatever is installed rather than asserting a specific
+// toolchain must exist.
+func TestIntegrationWorkflowInterpretersRunnable(t *testing.T) {
+	workflowTestHome(t)
+	wd := t.TempDir()
+	g := workflowDefaultGrants(t, wd)
+
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		{"python3", []string{"python3", "-c", "print('ok')"}},
+		{"node", []string{"node", "-e", "console.log('ok')"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := exec.LookPath(c.argv[0]); err != nil {
+				t.Skipf("%s not installed", c.argv[0])
+			}
+			out, code := runSandboxed(t, g, c.argv...)
+			if code != 0 || !strings.Contains(out, "ok") {
+				t.Errorf("%s no-op failed under default profile: exit %d: %s", c.name, code, out)
+			}
+		})
+	}
+}
+
+// TestIntegrationWorkflowDefaultProfileOpenPort proves that the shipped
+// default profile's filtered network posture, combined with a
+// legitimate open_port grant a user adds for a local dev server, still
+// works together — mirrors TestIntegrationOpenPortReachable but pinned
+// to sandboxprofile.DefaultProfile() as the base rather than a
+// hand-built Profile, so a change to the default profile's Network
+// stanza is exercised here too.
+func TestIntegrationWorkflowDefaultProfileOpenPort(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "workflow-ok")
+	}))
+	defer srv.Close()
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+
+	workflowTestHome(t)
+	wd := t.TempDir()
+	p := sandboxprofile.DefaultProfile()
+	p.Network.OpenPort = []int{port}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, code := runSandboxed(t, g, "/usr/bin/curl", "-sS", "--max-time", "3",
+		fmt.Sprintf("http://127.0.0.1:%d/", port))
+	if code != 0 || !strings.Contains(out, "workflow-ok") {
+		t.Errorf("default profile + open_port loopback failed: exit=%d out=%s", code, out)
+	}
+}

--- a/internal/sandboxrun/workflow_integration_linux_test.go
+++ b/internal/sandboxrun/workflow_integration_linux_test.go
@@ -1,0 +1,236 @@
+//go:build linux
+
+package sandboxrun
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
+)
+
+// workflowTestHome builds a throwaway HOME populated with the dirs/files
+// DefaultProfile() grants (~/.cache, ~/go, ~/.gitconfig), so the battery
+// below exercises the real shipped default rather than the live
+// developer machine's actual home directory.
+func workflowTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	for _, dir := range []string{".cache", "go"} {
+		if err := os.MkdirAll(filepath.Join(home, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(home, ".gitconfig"),
+		[]byte("[user]\n\tname = Test\n\temail = test@example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	return home
+}
+
+// workflowDefaultGrants resolves grants from the exact compiled-in
+// sandboxprofile.DefaultProfile() — the template that ships as
+// ~/.config/omac/sandbox-profiles/default.json — rather than a
+// hand-built Profile. A change to DefaultProfile() or baseline.go that
+// breaks a real workflow shows up here, as opposed to a snapshot test
+// that would only show that *something* in the list changed.
+func workflowDefaultGrants(t *testing.T, wd string) *Grants {
+	t.Helper()
+	p := sandboxprofile.DefaultProfile()
+	g, err := ResolveGrants(p, wd, os.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return g
+}
+
+// TestIntegrationWorkflowGitBattery proves the ordinary git lifecycle a
+// coding agent runs every session (init, add, commit, log, diff) still
+// works end-to-end under the real default profile and a real bwrap
+// sandbox.
+func TestIntegrationWorkflowGitBattery(t *testing.T) {
+	requireBwrap(t)
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	workflowTestHome(t)
+	wd := t.TempDir()
+	g := workflowDefaultGrants(t, wd)
+
+	script := strings.Join([]string{
+		"set -e",
+		"cd " + wd,
+		"git init -q",
+		"git config user.email t@example.com",
+		"git config user.name Test",
+		"echo hi > a.txt",
+		"git add a.txt",
+		"git commit -qm init",
+		"echo bye >> a.txt",
+		"git add a.txt",
+		"git commit -qm update",
+		"git log --oneline | wc -l",
+	}, " && ")
+	out, code := runBwrapped(t, g, "/bin/sh", "-c", script)
+	if code != 0 {
+		t.Fatalf("git workflow failed, exit %d: %s", code, out)
+	}
+	if got := strings.TrimSpace(out); got != "2" {
+		t.Errorf("expected 2 commits in git log, got %q (full output: %s)", got, out)
+	}
+}
+
+// TestIntegrationWorkflowGitconfigReadable proves the non-secret
+// ~/.gitconfig DefaultProfile() explicitly grants stays readable — a
+// toolchain (git itself, editors) reads it constantly, and it must not
+// be caught by a future credential-protection change aimed at files
+// like ~/.git-credentials.
+func TestIntegrationWorkflowGitconfigReadable(t *testing.T) {
+	requireBwrap(t)
+	home := workflowTestHome(t)
+	wd := t.TempDir()
+	g := workflowDefaultGrants(t, wd)
+
+	out, code := runBwrapped(t, g, "/bin/cat", filepath.Join(home, ".gitconfig"))
+	if code != 0 {
+		t.Fatalf("~/.gitconfig must stay readable under the default profile: exit %d: %s", code, out)
+	}
+	if !strings.Contains(out, "Test") {
+		t.Errorf("unexpected ~/.gitconfig content: %s", out)
+	}
+}
+
+// TestIntegrationWorkflowGoBuild proves a trivial `go build` inside the
+// workdir works under the default profile: it needs GOCACHE
+// ($HOME/.cache/go-build, covered by DefaultProfile()'s ~/.cache grant)
+// and GOPATH ($HOME/go, covered by the ~/go grant) to actually be
+// writable, not just the workdir itself.
+func TestIntegrationWorkflowGoBuild(t *testing.T) {
+	requireBwrap(t)
+	home := workflowTestHome(t)
+	wd := t.TempDir()
+	g := workflowDefaultGrants(t, wd)
+
+	// Confirm `go` is visible inside the sandbox before asserting on the
+	// build itself — its install location varies by environment (apt vs.
+	// a version manager) and that's an environment property, not a
+	// regression this test is meant to catch.
+	if out, code := runBwrapped(t, g, "/bin/sh", "-c", "command -v go"); code != 0 || strings.TrimSpace(out) == "" {
+		t.Skip("go not visible inside the sandbox on this runner")
+	}
+
+	if err := os.WriteFile(filepath.Join(wd, "go.mod"), []byte("module workflowtest\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainSrc := "package main\n\nfunc main() { println(\"ok\") }\n"
+	if err := os.WriteFile(filepath.Join(wd, "main.go"), []byte(mainSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := fmt.Sprintf("cd %s && HOME=%s go build -o out ./...", wd, home)
+	out, code := runBwrapped(t, g, "/bin/sh", "-c", script)
+	if code != 0 {
+		t.Fatalf("go build failed under default profile: exit %d: %s", code, out)
+	}
+}
+
+// TestIntegrationWorkflowInterpretersRunnable smoke-tests that common
+// scripting interpreters, if present on the runner, still execute a
+// trivial no-op under the default profile's baseline Read grants
+// (/usr, /bin et al.). Skips per-interpreter when absent — this
+// documents the current behavior for whatever is installed rather than
+// asserting a specific toolchain must exist.
+func TestIntegrationWorkflowInterpretersRunnable(t *testing.T) {
+	requireBwrap(t)
+	workflowTestHome(t)
+	wd := t.TempDir()
+	g := workflowDefaultGrants(t, wd)
+
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		{"python3", []string{"python3", "-c", "print('ok')"}},
+		{"node", []string{"node", "-e", "console.log('ok')"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := exec.LookPath(c.argv[0]); err != nil {
+				t.Skipf("%s not installed", c.argv[0])
+			}
+			out, code := runBwrapped(t, g, c.argv...)
+			if code != 0 || !strings.Contains(out, "ok") {
+				t.Errorf("%s no-op failed under default profile: exit %d: %s", c.name, code, out)
+			}
+		})
+	}
+}
+
+// TestIntegrationWorkflowDefaultProfileOpenPort proves that the shipped
+// default profile's ModeFiltered network posture, combined with a
+// legitimate open_port grant a user adds for a local dev server, still
+// works together — mirrors TestIntegrationStage2LandlockPorts but
+// pinned to sandboxprofile.DefaultProfile() as the base rather than a
+// hand-built Profile, so a change to the default profile's Network
+// stanza is exercised here too.
+func TestIntegrationWorkflowDefaultProfileOpenPort(t *testing.T) {
+	requireBwrap(t)
+	if !LandlockNetSupported() {
+		t.Skipf("Landlock ABI %d < 4", LandlockABI())
+	}
+	curl, err := exec.LookPath("curl")
+	if err != nil {
+		t.Skip("curl not installed")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "workflow-ok")
+	}))
+	defer srv.Close()
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+
+	// Build omac using the real host HOME/GOPATH, before workflowTestHome
+	// below overrides HOME for the sandboxed run — otherwise `go build`
+	// writes its module cache (read-only files) into the throwaway HOME,
+	// which t.TempDir() cleanup then cannot remove.
+	omac := filepath.Join(t.TempDir(), "omac")
+	build := exec.Command("go", "build", "-o", omac, "github.com/tngtech/oh-my-agentic-coder/cmd/omac")
+	build.Env = os.Environ()
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build omac: %v\n%s", err, out)
+	}
+
+	workflowTestHome(t)
+	wd := t.TempDir()
+	p := sandboxprofile.DefaultProfile()
+	p.Network.OpenPort = []int{port}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g.ReadPaths = append(g.ReadPaths, filepath.Dir(omac))
+
+	stage2 := append([]string{omac, "sandbox", "stage2"}, Stage2Args(g)...)
+	argvTail := append(append([]string{}, stage2...), "--", curl, "-sS", "--max-time", "3",
+		fmt.Sprintf("http://127.0.0.1:%d/", port))
+	argv, err := BuildBwrapArgv(g, argvTail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(argv[0], argv[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("default profile + open_port loopback failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "workflow-ok") {
+		t.Errorf("unexpected response: %s", out)
+	}
+}

--- a/internal/sandboxrun/workflow_integration_linux_test.go
+++ b/internal/sandboxrun/workflow_integration_linux_test.go
@@ -83,7 +83,17 @@ func TestIntegrationWorkflowGitBattery(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("git workflow failed, exit %d: %s", code, out)
 	}
-	if got := strings.TrimSpace(out); got != "2" {
+	// Take the last whitespace-separated token rather than comparing the
+	// whole trimmed output — robust against any shell/sandbox diagnostic
+	// noise CombinedOutput() mixes in ahead of the real `wc -l` result
+	// (see the darwin variant, where a narrowly-scoped Seatbelt grant
+	// causes /bin/sh to print such a diagnostic).
+	fields := strings.Fields(out)
+	got := ""
+	if len(fields) > 0 {
+		got = fields[len(fields)-1]
+	}
+	if got != "2" {
 		t.Errorf("expected 2 commits in git log, got %q (full output: %s)", got, out)
 	}
 }


### PR DESCRIPTION
## What

Follow-up to #66/#84. Adds test coverage for a failure mode the suite had none for: a sandbox hardening change (new `ProtectedPaths` entry, tightened default, a regression in a documented escape hatch) silently breaking a *legitimate* workflow, as opposed to failing to block an attacker.

- **Developer-workflow regression battery** (`internal/sandboxrun/workflow_integration_{linux,darwin}_test.go`): git init/add/commit/log/diff, `go build`, common interpreters, and a network `open_port` grant — all run through a real bwrap/Seatbelt sandbox under the exact, unmodified `sandboxprofile.DefaultProfile()`.
- **Real integration tests for `override_deny`/`allow_unix_dir`**: these documented escape hatches (Docker socket / custom daemon dir access) were previously tested only structurally (Grants-struct/generated-arg checks). Now proven end-to-end through a real sandboxed process.
- **Config backward-compat fixtures** (`internal/sandboxrun/testdata/profiles/`): checked-in profile JSON mirroring real user shapes, run through the actual `Parse → Validate → ResolveGrants` pipeline.
- **Positive `fs_allow` probe** in the live security audit (`audit.sh`/`allowance.go`/`e2e_test.go`): proves the workdir, cache dir, and `$TMPDIR` stay reachable — the positive counterpart to the existing `fs_read`/`fs_write` denial checks, checked per-path for the same reason those were hardened earlier this cycle.
- **`TestE2EEchoRest` extended** with an ordinary git commit + workdir file round-trip, file-asserted like the existing `echo-status.txt` pattern.
- **CI fix**: `ci.yml`'s Linux test job never installed bubblewrap, so all 15 `internal/sandboxrun` integration tests (9 pre-existing + 6 new) were silently skipping via `requireBwrap` — passing green while testing nothing. Ported the working bwrap+AppArmor install from `e2e.yml`.
- **Assertion fix**: `assertGitCommitMade` now checks the commit subject, not just non-empty file content.

## Why

Explicitly requested: "how can we ensure we make no breaking (config) changes that makes the users stopping the tool?" The suite proved attacker paths are blocked but had no signal for the opposite regression. Deliberately did **not** add a golden/snapshot test pinning the exact baseline lists — that only proves a default changed (which `git diff` already shows in review), not whether it breaks anything real. These tests instead exercise real consequences.

The CI fix was found by auditing this work rather than trusting green CI: the bwrap-based tests looked correct in isolation but a check of `ci.yml` showed bubblewrap was never installed there, confirmed empirically by removing bwrap from `PATH` locally and observing the same near-instant "all-skip" signature as the historical ubuntu-latest CI log.

## How

See commit messages for per-workstream detail. `internal/sandboxrun` changes are plain Go tests (no `e2e` build tag, no live agent). `internal/e2e` changes ride along on the existing `TestE2ESecurityAudit`/`TestE2EEchoRest` live runs — no new live-agent cost.

## Verification

- `go build ./...`, `go vet ./...`, `go vet -tags e2e ./...`, `gofmt -l .` — clean.
- `go test ./...` — green (includes the new `internal/sandboxrun` tests, verified locally with a real bwrap; will now also run for real in CI per the `ci.yml` fix).
- Cross-compiled `GOOS=darwin` — clean.
- Live E2E workflow (`workflow_dispatch`, `skip_claude_code=true`) run twice against this branch: https://github.com/TNG/oh-my-agentic-coder/actions/runs/29352091511 — all 7 harness×OS combinations green (one `copilot`/`macos-latest` run hit an unrelated agent-refusal flake on the first attempt — every probe in that job failed identically, indicating the audit script never ran at all, not a regression; the rerun passed cleanly).