### PR TITLE
fix(e2e): wire up pi version-pin override in workflow_dispatch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,10 @@ on:
         description: 'Pinned copilot package spec. Overrides internal/e2e/versions.go for THIS RUN ONLY (the file itself is untouched); ignored if "use latest" is checked'
         type: string
         default: '@github/copilot@1.0.68'
+      pi_version:
+        description: 'Pinned pi package spec. Overrides internal/e2e/versions.go for THIS RUN ONLY (the file itself is untouched); ignored if "use latest" is checked'
+        type: string
+        default: '@earendil-works/pi-coding-agent@0.80.6'
   schedule:
     - cron: '0 8 * * 6' # Saturdays 10:00 CEST
 
@@ -77,6 +81,7 @@ jobs:
       E2E_VERSION_CLAUDE_CODE: ${{ github.event.inputs.claude_code_version }}
       E2E_VERSION_CODEX: ${{ github.event.inputs.codex_version }}
       E2E_VERSION_COPILOT: ${{ github.event.inputs.copilot_version }}
+      E2E_VERSION_PI: ${{ github.event.inputs.pi_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -120,7 +125,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ runner.temp }}/e2e-install-cache
-          key: e2e-install-${{ runner.os }}-${{ matrix.harness }}-${{ hashFiles('internal/e2e/versions.go') }}-${{ github.event.inputs.use_latest }}-${{ github.event.inputs.opencode_version }}-${{ github.event.inputs.claude_code_version }}-${{ github.event.inputs.codex_version }}-${{ github.event.inputs.copilot_version }}
+          key: e2e-install-${{ runner.os }}-${{ matrix.harness }}-${{ hashFiles('internal/e2e/versions.go') }}-${{ github.event.inputs.use_latest }}-${{ github.event.inputs.opencode_version }}-${{ github.event.inputs.claude_code_version }}-${{ github.event.inputs.codex_version }}-${{ github.event.inputs.copilot_version }}-${{ github.event.inputs.pi_version }}
           restore-keys: |
             e2e-install-${{ runner.os }}-${{ matrix.harness }}-
 

--- a/internal/e2e/versions.go
+++ b/internal/e2e/versions.go
@@ -29,6 +29,7 @@ var versionEnvVar = map[string]string{
 	"claude-code": "E2E_VERSION_CLAUDE_CODE",
 	"codex":       "E2E_VERSION_CODEX",
 	"copilot":     "E2E_VERSION_COPILOT",
+	"pi":          "E2E_VERSION_PI",
 }
 
 // Model identifiers per harness.

--- a/internal/e2e/versions_test.go
+++ b/internal/e2e/versions_test.go
@@ -26,3 +26,19 @@ func TestPinnedPackageOverride(t *testing.T) {
 		t.Errorf("use_latest should win over the override and strip the version: pinnedPackage(opencode) = %q, want %q", got, want)
 	}
 }
+
+// TestVersionEnvVarCompleteness guards against a harness being registered
+// (allHarnesses(), harnessVersions) without also wiring its workflow_dispatch
+// override — the class of bug fixed for pi, which shipped with a pinned
+// version but no E2E_VERSION_PI entry, so its version couldn't be overridden
+// for a manual run the way every other harness's could.
+func TestVersionEnvVarCompleteness(t *testing.T) {
+	for _, h := range allHarnesses() {
+		if _, ok := harnessVersions[h.Name]; !ok {
+			t.Errorf("harness %q has no entry in harnessVersions", h.Name)
+		}
+		if _, ok := versionEnvVar[h.Name]; !ok {
+			t.Errorf("harness %q has no entry in versionEnvVar (add its *_version workflow_dispatch input in .github/workflows/e2e.yml too)", h.Name)
+		}
+	}
+}


### PR DESCRIPTION
## What
Adds the missing `pi_version` workflow_dispatch input, `E2E_VERSION_PI` env var, install-cache key entry, and `versionEnvVar["pi"]` mapping in `internal/e2e/versions.go`, plus a regression test.

## Why
#73/#78 registered `pi` in `matrix.harness` and `harnessVersions`, but didn't extend the version-override plumbing added for the other four harnesses (opencode/claude-code/codex/copilot). Result: pi's version, unlike every other harness, could not be overridden for a single manual e2e run — a manual test of a candidate pi release would have to edit `internal/e2e/versions.go` directly instead of using the workflow's `*_version` inputs like every other harness.

## How
- `.github/workflows/e2e.yml`: add `pi_version` input (default `@earendil-works/pi-coding-agent@0.80.6`, matching the current pin), `E2E_VERSION_PI` env var, fold the input into the harness-install cache key.
- `internal/e2e/versions.go`: add `"pi": "E2E_VERSION_PI"` to `versionEnvVar` so `pinnedPackage("pi")` honors the override.
- `internal/e2e/versions_test.go`: add `TestVersionEnvVarCompleteness`, which asserts every harness returned by `allHarnesses()` has both a `harnessVersions` and `versionEnvVar` entry — so a future harness addition can't silently ship without a working version override the way pi did.

## Verification
- `go build -tags=e2e ./...` and `go vet -tags=e2e ./internal/e2e/...` pass.
- `go test -tags=e2e ./internal/e2e/ -run 'TestPinnedPackageOverride|TestVersionEnvVarCompleteness' -v` — both pass.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))"` — valid YAML.
- Diff is scoped to the three files above; no other e2e behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)