### PR TITLE
test: fail capability-gated helpers in CI instead of silently skipping

### DIFF
--- a/internal/cli/controlinfo_test.go
+++ b/internal/cli/controlinfo_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -10,18 +11,31 @@ import (
 	"time"
 )
 
-// requireLoopbackDial skips when this environment forbids connecting to
-// 127.0.0.1 (some sandboxes deny loopback TCP connect).
+// skipOrFailCI skips locally but fails in CI (GITHUB_ACTIONS=true), so a
+// missing capability there reads as an infrastructure regression instead of
+// a silently green run with zero coverage from the gated tests.
+func skipOrFailCI(t *testing.T, format string, args ...any) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Fatal(msg)
+	}
+	t.Skip(msg)
+}
+
+// requireLoopbackDial skips locally when this environment forbids connecting
+// to 127.0.0.1 (some sandboxes deny loopback TCP connect); in CI it fails
+// the test instead.
 func requireLoopbackDial(t *testing.T) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Skip("loopback listen not permitted:", err)
+		skipOrFailCI(t, "loopback listen not permitted: %v", err)
 	}
 	defer ln.Close()
 	c, err := net.DialTimeout("tcp", ln.Addr().String(), time.Second)
 	if err != nil {
-		t.Skip("loopback dial not permitted in this environment:", err)
+		skipOrFailCI(t, "loopback dial not permitted in this environment: %v", err)
 	}
 	c.Close()
 }

--- a/internal/facade/facade_test.go
+++ b/internal/facade/facade_test.go
@@ -16,25 +16,37 @@ import (
 	"time"
 )
 
-// requireUnixSocket skips the test when AF_UNIX listen/dial is not permitted
+// skipOrFailCI skips locally but fails in CI (GITHUB_ACTIONS=true), so a
+// missing capability there reads as an infrastructure regression instead of
+// a silently green run with zero coverage from the gated tests.
+func skipOrFailCI(t *testing.T, format string, args ...any) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Fatal(msg)
+	}
+	t.Skip(msg)
+}
+
+// requireUnixSocket skips locally when AF_UNIX listen/dial is not permitted
 // in the current environment (e.g. some sandboxes), mirroring the inline
-// probe the older integration tests do.
+// probe the older integration tests do; in CI it fails the test instead.
 func requireUnixSocket(t *testing.T) {
 	t.Helper()
 	probeDir, err := os.MkdirTemp(".", "omac-probe-")
 	if err != nil {
-		t.Skip("mkdir temp:", err)
+		skipOrFailCI(t, "mkdir temp: %v", err)
 	}
 	defer os.RemoveAll(probeDir)
 	ps := filepath.Join(probeDir, "p.sock")
 	pl, err := net.Listen("unix", ps)
 	if err != nil {
-		t.Skip("unix listen not permitted:", err)
+		skipOrFailCI(t, "unix listen not permitted: %v", err)
 	}
 	c, err := net.Dial("unix", ps)
 	if err != nil {
 		pl.Close()
-		t.Skip("unix dial not permitted:", err)
+		skipOrFailCI(t, "unix dial not permitted: %v", err)
 	}
 	c.Close()
 	pl.Close()

--- a/internal/facade/route_mutation_test.go
+++ b/internal/facade/route_mutation_test.go
@@ -12,19 +12,19 @@ import (
 	"time"
 )
 
-// requireLoopback skips the test when this environment forbids dialing
-// 127.0.0.1 (some sandboxes deny loopback TCP connect). Mirrors the
-// unix-socket probe-and-skip in facade_test.go.
+// requireLoopback skips locally when this environment forbids dialing
+// 127.0.0.1 (some sandboxes deny loopback TCP connect); in CI it fails the
+// test instead. Mirrors the unix-socket probe in facade_test.go.
 func requireLoopback(t *testing.T) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Skip("loopback listen not permitted:", err)
+		skipOrFailCI(t, "loopback listen not permitted: %v", err)
 	}
 	defer ln.Close()
 	c, err := net.DialTimeout("tcp", ln.Addr().String(), time.Second)
 	if err != nil {
-		t.Skip("loopback dial not permitted in this environment:", err)
+		skipOrFailCI(t, "loopback dial not permitted in this environment: %v", err)
 	}
 	c.Close()
 }

--- a/internal/sandboxrun/integration_linux_test.go
+++ b/internal/sandboxrun/integration_linux_test.go
@@ -16,16 +16,28 @@ import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
 )
 
-// requireBwrap skips when bubblewrap is unavailable (CI containers
-// often lack the userns privileges too).
+// skipOrFailCI skips locally but fails in CI (GITHUB_ACTIONS=true), so a
+// missing capability there reads as an infrastructure regression instead of
+// a silently green run with zero coverage from the gated tests.
+func skipOrFailCI(t *testing.T, format string, args ...any) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Fatal(msg)
+	}
+	t.Skip(msg)
+}
+
+// requireBwrap skips locally when bubblewrap is unavailable (CI containers
+// often lack the userns privileges too); in CI it fails the test instead.
 func requireBwrap(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("bwrap"); err != nil {
-		t.Skip("bwrap not installed")
+		skipOrFailCI(t, "bwrap not installed: %v", err)
 	}
 	// Smoke-test: user namespaces may be disabled.
 	if err := exec.Command("bwrap", "--ro-bind", "/", "/", "true").Run(); err != nil {
-		t.Skipf("bwrap not functional here: %v", err)
+		skipOrFailCI(t, "bwrap not functional here: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

Four capability-gated test helpers `t.Skip()` unconditionally when a runtime dependency isn't available, instead of failing in CI:

- `requireBwrap` (`internal/sandboxrun/integration_linux_test.go`)
- `requireUnixSocket` (`internal/facade/facade_test.go`)
- `requireLoopback` (`internal/facade/route_mutation_test.go`)
- `requireLoopbackDial` (`internal/cli/controlinfo_test.go`)

Adds `skipOrFailCI(t, format, args...)` per package (mirroring the `os.Getenv("GITHUB_ACTIONS") == "true"` gating pattern already used in `internal/e2e/classify.go`): skip locally, `t.Fatal` in CI. All four helpers now call it instead of `t.Skip`/`t.Skipf`.

## Why

This already bit us: `internal/sandboxrun`'s 15 `requireBwrap`-gated integration tests silently skipped in `ci.yml` for an unknown period because bubblewrap wasn't installed there — caught only by chance, fixed in #87 by adding provisioning. That fix adds bwrap to CI but adds no tripwire, so the same failure mode (an image update, a renamed package, a new self-hosted runner) can silently zero out coverage again. The other three helpers gate loopback TCP and AF_UNIX for the facade/control-plane tests and have the identical shape — they just haven't bitten us yet because GitHub-hosted runners are unsandboxed VMs where those always work.

## How

- Added a `skipOrFailCI` helper next to each `require*` function (one in `sandboxrun`, one shared across both facade test files since they're in the same package, one in `cli`) that skips locally and `t.Fatal`s when `GITHUB_ACTIONS=true`.
- No change to local dev behavior — a machine without bwrap/network sandboxing still gets clean skips.

## Verification

- `go build ./...` and `go vet` clean.
- `go test ./internal/sandboxrun/... ./internal/facade/... ./internal/cli/...` passes (capabilities are available in this environment, so the gated tests execute for real, not skip).
- Added a scratch test (not committed) that set `PATH` to an empty dir to force `bwrap` unavailable:
  - With `GITHUB_ACTIONS` unset: `requireBwrap` skips as before.
  - With `GITHUB_ACTIONS=true`: `requireBwrap` now fails loudly (`t.Fatal`) instead of silently passing.

Fixes #91