### PR TITLE
test(e2e): add README-onboarding completeness test

### DIFF
--- a/.github/workflows/e2e-readme-onboarding.yml
+++ b/.github/workflows/e2e-readme-onboarding.yml
@@ -1,0 +1,81 @@
+# E2E: README onboarding completeness test.
+#
+# Independent of the E2E harness×skill matrix (e2e.yml), which hands each
+# harness a fixed script inside an already-configured omac sandbox. This
+# workflow hands a single opencode-driven agent NOTHING but the checked-out
+# README.md — no other repo file — and asks it to self-serve a normal omac
+# dev setup exactly as a brand-new developer would, then report back on
+# every gap, ambiguity, or wrong instruction it hit along the way.
+#
+# Manual trigger only — this is a documentation-completeness audit, not a
+# regression gate, and involves a longer, more open-ended agent session
+# (real package installs, retries) than the scripted matrix suite.
+name: E2E README Onboarding
+
+on:
+  workflow_dispatch:
+    inputs:
+      opencode_version:
+        description: 'Pinned opencode package spec for the driving agent. Overrides scripts/e2e-readme-onboarding.sh''s default for THIS RUN ONLY'
+        type: string
+        default: 'opencode-ai@1.17.12'
+      timeout:
+        description: 'Wall-clock timeout for the onboarding agent session (e.g. 20m, 30m)'
+        type: string
+        default: '20m'
+
+permissions:
+  contents: read
+
+jobs:
+  readme-onboarding:
+    name: README onboarding (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    concurrency:
+      group: e2e-readme-onboarding-${{ matrix.os }}
+      cancel-in-progress: false
+    env:
+      SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+      SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+      E2E_VERSION_OPENCODE: ${{ github.event.inputs.opencode_version }}
+      E2E_ONBOARDING_TIMEOUT: ${{ github.event.inputs.timeout }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Run README onboarding test
+        id: run_onboarding
+        env:
+          E2E_LOG_DIR: ${{ runner.temp }}/e2e-readme-logs
+        run: scripts/e2e-readme-onboarding.sh
+
+      - name: Report summary
+        if: always()
+        run: |
+          echo "## README onboarding (${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.run_onboarding.outcome }}" = "success" ]; then
+            echo "**Result:** README was sufficient — doctor healthy, report written." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Result:** gaps blocked a clean setup, or the agent didn't finish — see the report below." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```markdown' >> "$GITHUB_STEP_SUMMARY"
+          cat "${{ runner.temp }}/e2e-readme-logs/ONBOARDING_REPORT.md" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "(no report file produced)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload session artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-readme-onboarding-${{ matrix.os }}
+          path: ${{ runner.temp }}/e2e-readme-logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/scripts/e2e-readme-onboarding.sh
+++ b/scripts/e2e-readme-onboarding.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# e2e-readme-onboarding.sh — README-completeness e2e test.
+#
+# Independent of internal/e2e (the harness×skill matrix suite): that suite
+# hands each harness a fixed 3-command script inside an already-configured
+# omac sandbox. This test hands a single agent NOTHING but README.md — no
+# other file from this repository — and asks it to self-serve a normal
+# omac dev setup exactly as a brand-new developer would. It verifies the
+# README itself is complete, not that omac's plumbing works.
+#
+# The agent runs unsandboxed, directly on the (already-ephemeral) CI
+# runner — omac isn't installed yet, so there is nothing to sandbox it
+# with. It gets full shell + internet access, deliberately, since a real
+# new developer has both.
+#
+# Driver: opencode (headless `run`, non-interactive by design — no
+# permission-bypass flag needed) against the internal SKAINET gateway,
+# same GLM-5.2 model used by the rest of the harness matrix. Deliberately
+# NOT claude-code: this session is open-ended (real installs, retries) and
+# claude-code is the one harness billed against a real external Anthropic
+# account.
+#
+# Usage:
+#   scripts/e2e-readme-onboarding.sh
+#
+# Environment:
+#   SKAINET_TOKEN                 model API key (required)
+#   SKAINET_INTERNAL               model provider base URL (required)
+#   E2E_VERSION_OPENCODE           override the pinned opencode package spec
+#   E2E_ONBOARDING_MODEL           override the model id (default: zai-org/GLM-5.2)
+#   E2E_LOG_DIR                    artifact output dir (default: /tmp/e2e-readme-logs)
+#   E2E_README_REF                 git ref to extract README.md from (default: HEAD)
+#   E2E_ONBOARDING_TIMEOUT         agent wall-clock timeout, e.g. "20m" (default: 20m)
+#
+# Exit code 0 = README was sufficient (doctor healthy + report written).
+# Exit code 1 = gaps blocked a working setup, or the agent never produced
+#               a report. Either way, the report/log artifacts are what
+#               matters here, not the exit code alone — always inspect them.
+
+set -euo pipefail
+
+# Keep this in sync with internal/e2e/versions.go's "opencode" pin
+# (duplicated there too, per existing e2e.yml convention).
+DEFAULT_OPENCODE_VERSION="opencode-ai@1.17.12"
+DEFAULT_MODEL="zai-org/GLM-5.2"
+DEFAULT_TIMEOUT="20m"
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_DIR="${E2E_LOG_DIR:-/tmp/e2e-readme-logs}"
+README_REF="${E2E_README_REF:-HEAD}"
+OPENCODE_VERSION="${E2E_VERSION_OPENCODE:-$DEFAULT_OPENCODE_VERSION}"
+MODEL="${E2E_ONBOARDING_MODEL:-$DEFAULT_MODEL}"
+TIMEOUT="${E2E_ONBOARDING_TIMEOUT:-$DEFAULT_TIMEOUT}"
+
+: "${SKAINET_TOKEN:?SKAINET_TOKEN not set}"
+: "${SKAINET_INTERNAL:?SKAINET_INTERNAL not set}"
+
+mkdir -p "$LOG_DIR"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Fresh HOME for the driving opencode CLI — a real onboarding session
+# starts with no prior omac/opencode state, and this must never see the
+# rest of this checkout (no CLAUDE.md, no docs/, no .git).
+DRIVER_HOME="$WORK/driver-home"
+ONBOARD_DIR="$WORK/onboarding"
+REPORT_FILE="$ONBOARD_DIR/ONBOARDING_REPORT.md"
+TRANSCRIPT_FILE="$LOG_DIR/session-transcript.log"
+mkdir -p "$DRIVER_HOME" "$ONBOARD_DIR"
+
+# The one and only file the agent starts with.
+git -C "$REPO" show "${README_REF}:README.md" > "$ONBOARD_DIR/README.md"
+
+echo "== Installing opencode CLI ($OPENCODE_VERSION) =="
+bun install -g "$OPENCODE_VERSION"
+
+echo "== Writing opencode provider config (SKAINET / GLM-5.2) =="
+mkdir -p "$DRIVER_HOME/.local/share/opencode" "$DRIVER_HOME/.config/opencode"
+cat > "$DRIVER_HOME/.local/share/opencode/auth.json" <<EOF
+{"model": {"type": "api", "key": "$SKAINET_TOKEN"}}
+EOF
+chmod 600 "$DRIVER_HOME/.local/share/opencode/auth.json"
+cat > "$DRIVER_HOME/.config/opencode/opencode.json" <<EOF
+{
+  "share": "disabled",
+  "provider": {
+    "model": {
+      "name": "Model",
+      "npm": "@ai-sdk/openai-compatible",
+      "options": { "baseURL": "$SKAINET_INTERNAL" },
+      "models": {
+        "$MODEL": { "name": "GLM 5.2", "limit": { "context": 131072, "output": 32000 } }
+      }
+    }
+  }
+}
+EOF
+
+PROMPT=$(cat <<EOF
+You are a brand-new developer who just joined a project called "omac"
+(oh-my-agentic-coder). The ONLY thing you have been given is the
+README.md file in your current directory — nothing else from the
+project's repository. You do have normal internet access and a normal
+shell, exactly like a real new hire would on day one.
+
+Your task: follow the README to set up omac for NORMAL, EVERYDAY
+DEVELOPMENT on this machine, the way any of its instructions describe.
+Concretely, aim to reach all of the following, in order, using only what
+the README tells you (or what you discover from --help output, doctor
+output, error messages, or the README's own linked pages/URLs):
+
+1. Install every prerequisite the README says this OS needs.
+2. Install omac itself, by whichever documented method makes sense here.
+3. Run whatever the README says verifies the install, and get it healthy.
+4. Install at least one inner coding harness the README lists, and get
+   as far as the README's own instructions take you toward actually
+   launching omac with it.
+
+Rules:
+- Do not use prior/background knowledge about this specific project's
+  internals that isn't written in README.md or reachable by following a
+  URL the README itself gives you. If you get stuck, say so — don't
+  quietly paper over a gap using outside knowledge.
+- Do not invent commands or paths beyond what's documented; if the
+  README's instructions don't work as written, that IS the finding.
+- If a step is genuinely ambiguous, pick the most literal reading, note
+  the ambiguity, and continue.
+- You may install system packages, clone/download things the README
+  points you at, and run any commands needed — this is a real machine,
+  not a sandbox.
+
+When you are done (whether fully successful, partially blocked, or
+stuck), write your findings to exactly this path, in exactly this
+structure, and nothing else:
+
+$REPORT_FILE
+
+# Onboarding report
+
+## Outcome
+One of: SUCCESS / PARTIAL / BLOCKED, plus one sentence.
+
+## Steps taken
+Numbered list of the commands you ran, in order.
+
+## README gaps
+For each problem you hit — a missing step, wrong command, unstated
+assumption, contradiction, or missing prerequisite — one entry with:
+- Where: which README section/line
+- What's wrong
+- What you had to do instead (if anything)
+- Suggested README fix
+If there were none, write "None found."
+
+## Assumptions / outside knowledge used
+Anything you had to infer or look up beyond the README text itself.
+
+## Verification
+The exact command(s) and output that show how far you actually got
+(e.g. doctor output, version strings). Be literal — quote real output,
+don't summarize it as working if it didn't.
+
+This is a sanctioned, pre-authorized test session — proceed directly
+without asking for confirmation.
+EOF
+)
+
+echo "== Running onboarding agent (timeout $TIMEOUT) =="
+cd "$ONBOARD_DIR"
+set +e
+HOME="$DRIVER_HOME" \
+SKAINET_TOKEN="$SKAINET_TOKEN" \
+PATH="$PATH" \
+timeout --signal=TERM "$TIMEOUT" \
+  opencode run --print-logs -m "model/$MODEL" "$PROMPT" \
+  > "$TRANSCRIPT_FILE" 2>&1
+agent_status=$?
+set -e
+echo "agent exit status: $agent_status"
+
+# Independent, objective check — never trust the agent's prose alone.
+# The agent's own PATH/HOME additions (e.g. installing to
+# $DRIVER_HOME/go/bin, ~/.local/bin) are what "doctor healthy" must find,
+# since that's genuinely what the README told it to do.
+doctor_output="$LOG_DIR/doctor-output.txt"
+doctor_ok=0
+if command -v omac >/dev/null 2>&1 || [ -x "$DRIVER_HOME/go/bin/omac" ]; then
+  OMAC_BIN="$(command -v omac || echo "$DRIVER_HOME/go/bin/omac")"
+  if HOME="$DRIVER_HOME" "$OMAC_BIN" doctor > "$doctor_output" 2>&1; then
+    doctor_ok=1
+  fi
+else
+  echo "omac binary not found on PATH or in \$DRIVER_HOME/go/bin" > "$doctor_output"
+fi
+echo "omac doctor exit ok: $doctor_ok"
+
+cp "$TRANSCRIPT_FILE" "$LOG_DIR/" 2>/dev/null || true
+if [ -f "$REPORT_FILE" ]; then
+  cp "$REPORT_FILE" "$LOG_DIR/"
+  report_present=1
+else
+  echo "agent did not write a report to $REPORT_FILE" | tee "$LOG_DIR/ONBOARDING_REPORT.md"
+  report_present=0
+fi
+
+echo "== Onboarding report =="
+cat "$LOG_DIR/ONBOARDING_REPORT.md"
+
+if [ "$report_present" -eq 1 ] && [ "$doctor_ok" -eq 1 ]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary
- Adds a new, independent e2e test that verifies README.md is self-sufficient for a brand-new developer, separate from the existing harness×skill matrix suite (`internal/e2e`).
- A single opencode-driven agent (GLM-5.2 via the internal SKAINET gateway — no real Anthropic billing) is given **only** README.md — no other repo file — and must self-serve installing prerequisites, installing omac, verifying it, and setting up an inner harness, exactly as a new hire would.
- The agent writes a structured `ONBOARDING_REPORT.md` (Outcome / Steps taken / README gaps / Assumptions used / Verification); the script independently re-verifies `omac doctor` rather than trusting the agent's prose.
- New workflow `e2e-readme-onboarding.yml`: `workflow_dispatch`-only (no schedule — this is a documentation audit, not a regression gate), matrixed over `ubuntu-latest`/`macos-latest` since the README's install steps diverge by OS.

## Why
- The harness matrix suite tests omac's plumbing with a fixed 3-command script inside an already-configured sandbox. It never tests whether README.md alone gets a new developer to a working setup.
- Runs unsandboxed by design: omac isn't installed yet at the point this agent runs, so there's nothing to sandbox with. Contained by running only on an ephemeral GH-hosted runner and only ever on an explicit manual trigger.

## How
- `scripts/e2e-readme-onboarding.sh` extracts README.md via `git show <ref>:README.md` into an isolated dir with a fresh `$HOME`, drives `opencode run` non-interactively with an onboarding prompt, and cross-checks the objective `omac doctor` result against the agent's own report.
- `.github/workflows/e2e-readme-onboarding.yml` wires it up with `SKAINET_TOKEN`/`SKAINET_EXTERNAL` secrets (same as the existing e2e workflow), uploads the transcript + report as a 14-day artifact, and prints the report into the job summary regardless of pass/fail.

## Test plan
- [ ] Trigger the workflow manually on `ubuntu-latest` and `macos-latest` and confirm it produces a report artifact either way.
- [ ] Review a sample `ONBOARDING_REPORT.md` for real README gaps it surfaces (e.g. `omac register <skill>` assumes a skill directory already exists but the README never explains how a fresh project obtains one).
- [ ] Confirm `omac doctor` cross-check correctly reflects whether the agent's setup actually worked.