### PR TITLE
fix(e2e): fix README-onboarding script for macOS bash 3.2 and runner XDG dirs

### DIFF
--- a/scripts/e2e-readme-onboarding.sh
+++ b/scripts/e2e-readme-onboarding.sh
@@ -98,7 +98,8 @@ cat > "$DRIVER_HOME/.config/opencode/opencode.json" <<EOF
 }
 EOF
 
-PROMPT=$(cat <<EOF
+PROMPT_FILE="$WORK/prompt.md"
+cat > "$PROMPT_FILE" <<EOF
 You are a brand-new developer who just joined a project called "omac"
 (oh-my-agentic-coder). The ONLY thing you have been given is the
 README.md file in your current directory — nothing else from the
@@ -165,12 +166,27 @@ don't summarize it as working if it didn't.
 This is a sanctioned, pre-authorized test session — proceed directly
 without asking for confirmation.
 EOF
-)
+# Read back from a plain file rather than nesting the heredoc inside
+# $(...) directly: bash 3.2 (macOS's stock /bin/bash) misparses a
+# command-substitution-nested heredoc whose body contains an apostrophe
+# (e.g. "project's", "don't") — "unexpected EOF while looking for
+# matching `''" or a stray body line executed as a command. A plain file
+# read sidesteps the bug entirely, regardless of body content.
+PROMPT="$(cat "$PROMPT_FILE")"
 
 echo "== Running onboarding agent (timeout $TIMEOUT) =="
 cd "$ONBOARD_DIR"
 set +e
+# GH Actions runners preset XDG_CONFIG_HOME/XDG_DATA_HOME (pointing at the
+# real runner $HOME), and opencode resolves config from those before
+# falling back to $HOME — so HOME alone does not isolate it. Must
+# override all three to match where auth.json/opencode.json were
+# written above, or opencode silently reads the real machine's config
+# instead of ours. Same fix as withHome() in internal/e2e/harnesses.go.
 HOME="$DRIVER_HOME" \
+XDG_CONFIG_HOME="$DRIVER_HOME/.config" \
+XDG_DATA_HOME="$DRIVER_HOME/.local/share" \
+XDG_STATE_HOME="$DRIVER_HOME/.local/state" \
 SKAINET_TOKEN="$SKAINET_TOKEN" \
 PATH="$PATH" \
 timeout --signal=TERM "$TIMEOUT" \
@@ -188,7 +204,11 @@ doctor_output="$LOG_DIR/doctor-output.txt"
 doctor_ok=0
 if command -v omac >/dev/null 2>&1 || [ -x "$DRIVER_HOME/go/bin/omac" ]; then
   OMAC_BIN="$(command -v omac || echo "$DRIVER_HOME/go/bin/omac")"
-  if HOME="$DRIVER_HOME" "$OMAC_BIN" doctor > "$doctor_output" 2>&1; then
+  if HOME="$DRIVER_HOME" \
+     XDG_CONFIG_HOME="$DRIVER_HOME/.config" \
+     XDG_DATA_HOME="$DRIVER_HOME/.local/share" \
+     XDG_STATE_HOME="$DRIVER_HOME/.local/state" \
+     "$OMAC_BIN" doctor > "$doctor_output" 2>&1; then
     doctor_ok=1
   fi
 else


### PR DESCRIPTION
## Summary
Fixes both failures from the first manual run of `e2e-readme-onboarding.yml` (#95):

- **macOS**: bash 3.2 (the stock `/bin/bash`) misparses a heredoc nested inside `$(...)` whenever the body contains an apostrophe (e.g. "project's", "don't"). Reproduced directly against the real `bash:3.2` image — a body with even one unescaped `'` causes `unexpected EOF while looking for matching `''`` or a stray line getting executed as a command.
- **ubuntu-latest**: opencode never picked up the `auth.json`/`opencode.json` written under the isolated `$DRIVER_HOME`. GH-hosted runners preset `XDG_CONFIG_HOME`/`XDG_DATA_HOME` to the real runner `$HOME`, and opencode resolves config from those ahead of `$HOME` — so overriding `HOME` alone left it silently reading the real runner's config and failing with `Model not found: model/zai-org/GLM-5.2`.

## Why
- The apostrophe/heredoc bug is inherent to how the onboarding prompt was built (`PROMPT=$(cat <<EOF ... EOF)`), independent of specific wording — any future edit to the prompt text risks reintroducing it.
- The XDG issue is the exact same failure mode the harness×skill matrix suite (`internal/e2e`) already had to work around in `withHome()` (`internal/e2e/harnesses.go:641`) — this script just hadn't replicated that fix yet.

## How
- Prompt is now written to a plain file (`$WORK/prompt.md`) via a normal heredoc, then read back with `PROMPT="$(cat "$PROMPT_FILE")"` — no heredoc ever nests inside a command substitution, so the bash 3.2 bug can't trigger regardless of prompt content.
- Both the agent invocation and the `omac doctor` cross-check now also export `XDG_CONFIG_HOME`/`XDG_DATA_HOME`/`XDG_STATE_HOME` pointing into `$DRIVER_HOME`, matching where the config/auth files were written.

## Verification
- `shellcheck` clean.
- Reproduced the original macOS failure against the real `bash:3.2` Docker image using the exact prompt body from the script, confirmed the fix resolves it (with and without apostrophes).
- Ran the full config-writing + prompt-assembly path of the actual (patched) script inside `bash:3.2` end-to-end (bun/opencode calls stubbed, real repo/README mounted) — completes cleanly.
- [ ] Re-run the `E2E README Onboarding` workflow on `main` after merge to confirm both OS legs now get past agent startup and produce a real onboarding report.