### PR TITLE
test(e2e): run model-free e2e tests at PR time; assert --no-sandbox exposure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,3 +141,31 @@ jobs:
         with:
           version: latest
           install-go: false
+
+  e2e-fast:
+    # Model-free slice of the e2e suite (build tag `e2e_fast`): the security
+    # regression tests that need no live LLM harness, API token, or OS
+    # sandbox — dir_token isolation driven over real loopback sockets, the
+    # mutation-tested assertion predicates, the --no-sandbox exposure report,
+    # and the harness/version registry invariants. The full e2e.yml suite
+    # (live models) still runs weekly; this gate keeps these regressions off
+    # the merge path instead of surfacing them up to a week later. No
+    # bubblewrap: `omac serve --no-inner` exercises the control plane only.
+    name: E2E fast (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run model-free e2e tests
+        run: go test -tags=e2e_fast -race -count=1 -timeout=5m ./internal/e2e/

--- a/internal/e2e/classify.go
+++ b/internal/e2e/classify.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e || e2e_fast
 
 package e2e
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -25,6 +25,7 @@
 // Run one:          E2E_HARNESS=opencode go test -tags=e2e -timeout=30m -v ./internal/e2e/
 // Latest:           E2E_USE_LATEST=1 go test -tags=e2e -timeout=30m -v ./internal/e2e/
 // Skip claude-code: E2E_SKIP_CLAUDE_CODE=1 go test -tags=e2e -timeout=30m -v ./internal/e2e/
+// Fast subset:      go test -tags=e2e_fast ./internal/e2e/  (model-free, no token/harness; runs in PR CI)
 //
 // Harness versions and model IDs are pinned in versions.go.
 // Set E2E_USE_LATEST=1 to test with latest releases (no pinning).
@@ -256,7 +257,12 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 		assertSymlinkEscapeDenied(t, stdout)
 		assertNetworkDenied(t, stdout, spec.NetDenyDomain)
 	} else {
-		t.Logf("skipping negative assertions: %s runs with --no-sandbox", h.Name)
+		// A --no-sandbox harness (e.g. codex on macOS) has no sandbox to
+		// enforce the negative properties, so we can't assert they hold.
+		// But we do assert the audit still RAN to completion and document
+		// the resulting exposure surface — so the risk is recorded instead
+		// of silently excluded (issue #66).
+		assertNoSandboxAuditReported(t, stdout, spec)
 	}
 
 	// --- POSITIVE assertions (things that MUST happen) ---
@@ -290,21 +296,6 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 	// decision (all sidecars share the same facade). We log the result
 	// so if isolation is added later, the test surfaces the change.
 	logCrossSkillIsolation(t, stdout)
-}
-
-// buildOmac compiles the omac binary into a temp dir and returns its path.
-func buildOmac(t *testing.T) string {
-	t.Helper()
-	binPath := filepath.Join(t.TempDir(), "omac")
-	// Build from repo root (test CWD is internal/e2e/).
-	repoRoot := filepath.Join("..", "..")
-	cmd := exec.Command("go", "build", "-buildvcs=false", "-o", binPath, "./cmd/omac")
-	cmd.Dir = repoRoot
-	cmd.Env = os.Environ()
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("build omac: %v\n%s", err, out)
-	}
-	return binPath
 }
 
 // installHarness installs the harness CLI into the temp HOME.
@@ -583,7 +574,7 @@ func assertGitCommitMade(t *testing.T, path, stdout string) {
 // leaked the secret into the agent's environment.
 func assertSecretNotLeaked(t *testing.T, output string) {
 	t.Helper()
-	if strings.Contains(output, auditSecretValue) {
+	if secretLeaked(output, auditSecretValue) {
 		failWithClassification(t, "secretNotLeaked", fmSandboxFail, output)
 		return
 	}
@@ -625,14 +616,7 @@ func assertSecretFingerprintPresent(t *testing.T, output string) {
 // "VARNAME=" in the output.
 func assertEnvVarsDenied(t *testing.T, output string, denyVars []string) {
 	t.Helper()
-	leaked := []string{}
-	for _, v := range denyVars {
-		needle := v + "="
-		if strings.Contains(output, needle) {
-			leaked = append(leaked, v)
-		}
-	}
-	if len(leaked) > 0 {
+	if len(envVarsLeaked(output, denyVars)) > 0 {
 		failWithClassification(t, "envVarsDenied", fmSandboxFail, output)
 		return
 	}
@@ -693,14 +677,6 @@ func assertFilesystemReadDenied(t *testing.T, output string) {
 	t.Logf("PASS: filesystem read isolation — no probed path was readable")
 }
 
-// fsReadLeaked reports whether any path probed by audit.sh's fs_read
-// section was readable. Pulled out of assertFilesystemReadDenied so the
-// marker-absence decision is unit-testable against synthetic probe output
-// without going through *testing.T (see security_assertions_test.go).
-func fsReadLeaked(output string) bool {
-	return strings.Contains(extractProbe(output, "fs_read"), "READABLE")
-}
-
 // assertFilesystemAllowed verifies that legitimate paths (workdir,
 // cache dir, $TMPDIR) stayed accessible under the fs_allow probe. This
 // is the positive counterpart to assertFilesystemReadDenied/
@@ -727,31 +703,6 @@ func assertFilesystemAllowed(t *testing.T, output string, labels []string) {
 	t.Logf("PASS: filesystem allow — workdir/cache/tmp stayed accessible")
 }
 
-// fsAllowDenied checks each labelled fs_allow probe individually and
-// returns the first line that did NOT show a WRITABLE/READABLE marker
-// (i.e. was denied), or "" if all passed. Per-label, not "any marker
-// anywhere in the section" — the same rigor applied to
-// fsReadLeaked/fsWriteLeaked for the negative assertions, mirrored here
-// for the positive case: if one legitimate path silently lost access,
-// it must not be masked by the other paths still working.
-func fsAllowDenied(output string, labels []string) string {
-	section := extractProbe(output, "fs_allow")
-	for _, label := range labels {
-		idx := strings.Index(section, label)
-		if idx < 0 {
-			return label + ": probe label not found in fs_allow output"
-		}
-		line := section[idx:]
-		if nl := strings.IndexByte(line, '\n'); nl >= 0 {
-			line = line[:nl]
-		}
-		if !strings.Contains(line, "WRITABLE") && !strings.Contains(line, "READABLE") {
-			return line
-		}
-	}
-	return ""
-}
-
 // assertFilesystemWriteDenied verifies that write attempts to system
 // paths (read-only mounts) were denied by the sandbox.
 func assertFilesystemWriteDenied(t *testing.T, output string) {
@@ -774,12 +725,6 @@ func assertFilesystemWriteDenied(t *testing.T, output string) {
 		return
 	}
 	t.Logf("PASS: filesystem write protection — no probed path was writable")
-}
-
-// fsWriteLeaked reports whether any path probed by audit.sh's fs_write
-// section was writable. See fsReadLeaked.
-func fsWriteLeaked(output string) bool {
-	return strings.Contains(extractProbe(output, "fs_write"), "WRITABLE")
 }
 
 // assertSymlinkEscapeDenied verifies that the agent could not read a denied
@@ -810,13 +755,6 @@ func assertSymlinkEscapeDenied(t *testing.T, output string) {
 		return
 	}
 	t.Logf("PASS: symlink escape denied — read and write through a workdir symlink to a denied path both blocked")
-}
-
-// symlinkEscapeLeaked reports whether the read half and/or write half of
-// audit.sh's symlink escape probe leaked. See fsReadLeaked.
-func symlinkEscapeLeaked(output string) (readLeaked, writeLeaked bool) {
-	probeOut := extractProbe(output, "symlink")
-	return strings.Contains(probeOut, "READABLE"), strings.Contains(probeOut, "WRITABLE")
 }
 
 // logHardlinkProbeResults logs whether a hardlink escape (same idea as the
@@ -898,30 +836,37 @@ func assertNetworkDenied(t *testing.T, output string, denyDomain string) {
 		failWithClassification(t, "networkDenied", fmAgentPartial, output)
 		return
 	}
-	probeOut := extractProbe(output, "net")
-	denials := []string{
-		"Connection refused",
-		"Could not resolve host",
-		"Connection timed out",
-		"Failed to connect",
-		"curl: (6)",             // Could not resolve host
-		"curl: (7)",             // Failed to connect
-		"curl: (28)",            // Operation timed out
-		"DENIED BY THE SANDBOX", // omac proxy denial body
-		"403",                   // HTTP 403 from proxy
-	}
-	found := false
-	for _, d := range denials {
-		if strings.Contains(probeOut, d) {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !netProbeDenied(output) {
 		failWithClassification(t, "networkDenied", fmSandboxFail, output)
 		return
 	}
 	t.Logf("PASS: network isolation — denial message found in agent output")
+}
+
+// assertNoSandboxAuditReported handles the --no-sandbox path of the security
+// audit. There is no sandbox to enforce the negative properties, so instead
+// of silently skipping every negative assertion — which hid the real risk
+// surface for these harnesses — it asserts the audit actually ran to
+// completion and logs an explicit per-property exposure table. A no-sandbox
+// run that produces no audit output now fails loudly rather than passing
+// green with nothing checked (issue #66).
+func assertNoSandboxAuditReported(t *testing.T, output string, spec AllowanceSpec) {
+	t.Helper()
+	t.Logf("--no-sandbox harness: negative properties are NOT enforced by omac; documenting exposure surface:")
+	for _, r := range noSandboxExposureReport(output, auditSecretValue, spec.EnvDenyVars) {
+		if !r.Ran() {
+			// The probe never completed, so there is no exposure reading to
+			// document. Unlike the old silent skip, that is a failure: a
+			// no-sandbox run must still produce a full audit to be meaningful.
+			failWithClassification(t, "noSandboxAudit:"+r.Probe, r.Mode, output)
+			continue
+		}
+		status := "contained (OS-level or incidental — not omac-enforced)"
+		if r.Exposed {
+			status = "EXPOSED (no sandbox enforcing this property)"
+		}
+		t.Logf("  %-28s [%-8s] %s", r.Property, r.Probe, status)
+	}
 }
 
 // truncate shortens s to at most n chars, appending "…" if truncated.

--- a/internal/e2e/fixtures.go
+++ b/internal/e2e/fixtures.go
@@ -1,0 +1,30 @@
+//go:build e2e || e2e_fast
+
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// buildOmac compiles the omac binary into a temp dir and returns its path.
+//
+// Lives in the e2e_fast build set (not just the full e2e build) because the
+// model-free regression tests — serve_isolation_test.go in particular —
+// drive the real compiled binary as a subprocess and must be runnable at
+// PR time without a live LLM harness.
+func buildOmac(t *testing.T) string {
+	t.Helper()
+	binPath := filepath.Join(t.TempDir(), "omac")
+	// Build from repo root (test CWD is internal/e2e/).
+	repoRoot := filepath.Join("..", "..")
+	cmd := exec.Command("go", "build", "-buildvcs=false", "-o", binPath, "./cmd/omac")
+	cmd.Dir = repoRoot
+	cmd.Env = os.Environ()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build omac: %v\n%s", err, out)
+	}
+	return binPath
+}

--- a/internal/e2e/harnesses.go
+++ b/internal/e2e/harnesses.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e || e2e_fast
 
 // Package e2e provides end-to-end test infrastructure for the omac
 // harness×skill matrix. The test itself lives in e2e_test.go behind the

--- a/internal/e2e/harnesses_test.go
+++ b/internal/e2e/harnesses_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e || e2e_fast
 
 package e2e
 

--- a/internal/e2e/security_assertions.go
+++ b/internal/e2e/security_assertions.go
@@ -1,0 +1,145 @@
+//go:build e2e || e2e_fast
+
+package e2e
+
+import "strings"
+
+// This file holds the pure decision predicates behind the security-audit
+// assertions. They take probe output (a string) and return a bool/string —
+// no *testing.T, no live agent/sandbox — so the marker-absence logic that
+// backs each assertion is unit-testable in the fast (e2e_fast) build that
+// runs at PR time. The *testing.T-based assert* wrappers that call these
+// live in e2e_test.go behind the full e2e tag. See security_assertions_test.go.
+
+// fsReadLeaked reports whether any path probed by audit.sh's fs_read
+// section was readable. probe_read prints an explicit "READABLE" marker
+// only when a path was NOT blocked; denied paths print the OS error
+// instead and never contain that word. Checking the marker's presence
+// per-section — rather than passing when any denial substring appears
+// anywhere — means a single leaked path among the ~14 probed here trips
+// the assertion instead of being masked by other paths that were denied.
+func fsReadLeaked(output string) bool {
+	return strings.Contains(extractProbe(output, "fs_read"), "READABLE")
+}
+
+// fsWriteLeaked reports whether any path probed by audit.sh's fs_write
+// section was writable. A denied write is silent, so the "WRITABLE" marker's
+// presence — not the absence of a denial substring — is the leak signal.
+func fsWriteLeaked(output string) bool {
+	return strings.Contains(extractProbe(output, "fs_write"), "WRITABLE")
+}
+
+// symlinkEscapeLeaked reports whether the read half and/or write half of
+// audit.sh's symlink escape probe leaked. See fsReadLeaked.
+func symlinkEscapeLeaked(output string) (readLeaked, writeLeaked bool) {
+	probeOut := extractProbe(output, "symlink")
+	return strings.Contains(probeOut, "READABLE"), strings.Contains(probeOut, "WRITABLE")
+}
+
+// fsAllowDenied checks each labelled fs_allow probe individually and
+// returns the first line that did NOT show a WRITABLE/READABLE marker
+// (i.e. was denied), or "" if all passed. Per-label, not "any marker
+// anywhere in the section" — the same rigor applied to
+// fsReadLeaked/fsWriteLeaked for the negative assertions, mirrored here
+// for the positive case: if one legitimate path silently lost access,
+// it must not be masked by the other paths still working.
+func fsAllowDenied(output string, labels []string) string {
+	section := extractProbe(output, "fs_allow")
+	for _, label := range labels {
+		idx := strings.Index(section, label)
+		if idx < 0 {
+			return label + ": probe label not found in fs_allow output"
+		}
+		line := section[idx:]
+		if nl := strings.IndexByte(line, '\n'); nl >= 0 {
+			line = line[:nl]
+		}
+		if !strings.Contains(line, "WRITABLE") && !strings.Contains(line, "READABLE") {
+			return line
+		}
+	}
+	return ""
+}
+
+// secretLeaked reports whether the plaintext secret value appears anywhere
+// in the audit output — i.e. the sandbox leaked it into the agent's view.
+func secretLeaked(output, secret string) bool {
+	return secret != "" && strings.Contains(output, secret)
+}
+
+// envVarsLeaked returns the subset of denyVars that appear (as "VAR=") in
+// the audit output — vars the environment filter should have stripped.
+func envVarsLeaked(output string, denyVars []string) []string {
+	var leaked []string
+	for _, v := range denyVars {
+		if strings.Contains(output, v+"=") {
+			leaked = append(leaked, v)
+		}
+	}
+	return leaked
+}
+
+// netProbeDenied reports whether audit.sh's net section shows a denial —
+// a proxy/DNS/connection failure that proves the request was blocked.
+func netProbeDenied(output string) bool {
+	probeOut := extractProbe(output, "net")
+	for _, d := range netDenialMarkers {
+		if strings.Contains(probeOut, d) {
+			return true
+		}
+	}
+	return false
+}
+
+// netDenialMarkers are the strings that indicate a network probe was blocked
+// (by the omac proxy, by DNS failure, or by a refused/timed-out connection).
+var netDenialMarkers = []string{
+	"Connection refused",
+	"Could not resolve host",
+	"Connection timed out",
+	"Failed to connect",
+	"curl: (6)",             // Could not resolve host
+	"curl: (7)",             // Failed to connect
+	"curl: (28)",            // Operation timed out
+	"DENIED BY THE SANDBOX", // omac proxy denial body
+	"403",                   // HTTP 403 from proxy
+}
+
+// exposureRecord documents one negative security property for a harness
+// running with --no-sandbox: whether the audit probe ran to completion and
+// whether the property is exposed (unenforced). It turns the previously
+// silent "skip all negative assertions" path into an explicit, asserted,
+// human-readable record of the real risk surface (issue #66).
+type exposureRecord struct {
+	Property string      // e.g. "filesystem read isolation"
+	Probe    string      // audit.sh probe name, e.g. "fs_read"
+	Mode     failureMode // fmPass means the probe ran and completed
+	Exposed  bool        // true when the property is unenforced (only meaningful once Mode==fmPass)
+}
+
+// Ran reports whether the probe section was present and complete, so the
+// exposure reading below it is trustworthy.
+func (e exposureRecord) Ran() bool { return e.Mode == fmPass }
+
+// noSandboxExposureReport classifies each negative security property for a
+// --no-sandbox audit run: did its probe complete, and does the output show
+// the property is exposed. Pure (no *testing.T) so the classification is
+// unit-testable at PR time; the live wrapper asserts every probe ran and
+// logs the resulting risk-surface table (see assertNoSandboxAuditReported).
+func noSandboxExposureReport(output, secret string, denyVars []string) []exposureRecord {
+	return []exposureRecord{
+		{"secret isolation", "secret", classifyProbe(output, "secret"), secretLeaked(output, secret)},
+		{"env filtering", "env", classifyProbe(output, "env"), len(envVarsLeaked(output, denyVars)) > 0},
+		{"filesystem read isolation", "fs_read", classifyProbe(output, "fs_read"), fsReadLeaked(output)},
+		{"filesystem write protection", "fs_write", classifyProbe(output, "fs_write"), fsWriteLeaked(output)},
+		{"symlink escape", "symlink", classifyProbe(output, "symlink"), symlinkEscapeReadOrWrite(output)},
+		{"network isolation", "net", classifyProbe(output, "net"), !netProbeDenied(output)},
+	}
+}
+
+// symlinkEscapeReadOrWrite collapses the two-valued symlinkEscapeLeaked into
+// a single "either half leaked" bool for the exposure report.
+func symlinkEscapeReadOrWrite(output string) bool {
+	r, w := symlinkEscapeLeaked(output)
+	return r || w
+}

--- a/internal/e2e/security_assertions_test.go
+++ b/internal/e2e/security_assertions_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e || e2e_fast
 
 package e2e
 
@@ -9,7 +9,7 @@ import "testing"
 // assertFilesystemReadDenied/assertFilesystemWriteDenied/
 // assertSymlinkEscapeDenied/assertFilesystemAllowed
 // (fsReadLeaked/fsWriteLeaked/symlinkEscapeLeaked/fsAllowDenied in
-// e2e_test.go). Before this fix, those assertions passed as long as ANY
+// security_assertions.go). Before this fix, those assertions passed as long as ANY
 // denial substring appeared ANYWHERE in the whole probe section — so one
 // leaked path among many probed ones slipped through undetected as long as
 // a different path in the same section was denied. That is exactly the
@@ -140,5 +140,67 @@ func TestSymlinkEscapeLeakedCatchesEitherHalf(t *testing.T) {
 		"=== END: symlink ===\n"
 	if readLeaked, writeLeaked := symlinkEscapeLeaked(writeLeakedOutput); readLeaked || !writeLeaked {
 		t.Errorf("expected write leak only, got read=%v write=%v", readLeaked, writeLeaked)
+	}
+}
+
+// TestNoSandboxExposureReport covers the --no-sandbox documentation path
+// (issue #66): the report must (a) flag a property as EXPOSED when the audit
+// output shows it unenforced, (b) flag it contained when the probe shows a
+// denial, and (c) mark a probe as not-Ran when its section is missing, so the
+// live wrapper fails a no-sandbox run that produced no audit instead of
+// silently passing with nothing checked.
+func TestNoSandboxExposureReport(t *testing.T) {
+	secret := "test-secret-value-123"
+	denyVars := []string{"HOST_SECRET"}
+
+	// A no-sandbox run: every probe ran to completion and every property is
+	// exposed (secret leaked, denied var visible, fs readable/writable,
+	// symlink escaped, network reached).
+	exposed := "=== PROBE: secret ===\nAUDIT_SECRET=" + secret + "\n=== END: secret ===\n" +
+		"=== PROBE: env ===\nHOST_SECRET=leaked\n=== END: env ===\n" +
+		"=== PROBE: fs_read ===\n--- /etc/shadow ---: READABLE\n=== END: fs_read ===\n" +
+		"=== PROBE: fs_write ===\n--- /etc ---: WRITABLE\n=== END: fs_write ===\n" +
+		"=== PROBE: symlink ===\n--- read ---: READABLE\n=== END: symlink ===\n" +
+		"=== PROBE: net ===\nHTTP/1.1 200 OK\n=== END: net ===\n"
+	byProbe := map[string]exposureRecord{}
+	for _, r := range noSandboxExposureReport(exposed, secret, denyVars) {
+		byProbe[r.Probe] = r
+	}
+	for _, p := range []string{"secret", "env", "fs_read", "fs_write", "symlink", "net"} {
+		r, ok := byProbe[p]
+		if !ok {
+			t.Fatalf("report missing probe %q", p)
+		}
+		if !r.Ran() {
+			t.Errorf("probe %q: expected Ran (complete section present)", p)
+		}
+		if !r.Exposed {
+			t.Errorf("probe %q: expected Exposed on a fully-open no-sandbox run", p)
+		}
+	}
+
+	// A contained run: probes ran but each property is denied — nothing
+	// should read as exposed even though there is no sandbox.
+	contained := "=== PROBE: secret ===\n(redacted)\n=== END: secret ===\n" +
+		"=== PROBE: env ===\n(no host vars)\n=== END: env ===\n" +
+		"=== PROBE: fs_read ===\ncat: /etc/shadow: Permission denied\n=== END: fs_read ===\n" +
+		"=== PROBE: fs_write ===\ncannot create: Read-only file system\n=== END: fs_write ===\n" +
+		"=== PROBE: symlink ===\nPermission denied\n=== END: symlink ===\n" +
+		"=== PROBE: net ===\ncurl: (7) Failed to connect\n=== END: net ===\n"
+	for _, r := range noSandboxExposureReport(contained, secret, denyVars) {
+		if !r.Ran() {
+			t.Errorf("probe %q: expected Ran", r.Probe)
+		}
+		if r.Exposed {
+			t.Errorf("probe %q: expected contained (denial present), got Exposed", r.Probe)
+		}
+	}
+
+	// A silently-empty run: the audit produced nothing. Every probe must be
+	// reported as not-Ran so the live wrapper fails instead of skipping.
+	for _, r := range noSandboxExposureReport("", secret, denyVars) {
+		if r.Ran() {
+			t.Errorf("probe %q: expected not-Ran on empty audit output", r.Probe)
+		}
 	}
 }

--- a/internal/e2e/serve_isolation_test.go
+++ b/internal/e2e/serve_isolation_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e || e2e_fast
 
 package e2e
 

--- a/internal/e2e/versions.go
+++ b/internal/e2e/versions.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e || e2e_fast
 
 package e2e
 

--- a/internal/e2e/versions_test.go
+++ b/internal/e2e/versions_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e || e2e_fast
 
 package e2e
 


### PR DESCRIPTION
## What

- Add an `e2e_fast` build tag on the model-free files in `internal/e2e/` (`//go:build e2e || e2e_fast`) and a new **E2E fast** CI job that runs just that slice on `ubuntu-latest` + `macos-latest` on every push/PR.
- Close the `--no-sandbox` gap: `runSecurityAudit` no longer silently skips all negative assertions — it asserts the audit ran to completion and documents the per-property exposure surface.
- Refactor the pure assertion predicates and `buildOmac` into shared, fast-buildable files.

## Why

The entire `internal/e2e/` package sits behind `//go:build e2e`, and that tag is compiled **only** by `e2e.yml` (weekly cron + manual dispatch). `ci.yml` and `release.yml` run `go test ./...` without it, so the model-free security-regression tests never ran on the merge path — even the ones explicitly built to run fast without a live model:

| Test | Guards |
|------|--------|
| `TestE2EServeDirTokenIsolation` | the real #74 dir_token cross-workdir leak, over real loopback sockets |
| `security_assertions_test.go` | assertions silently becoming no-ops (the #84 rigor gap / #66 "mutation-test the tests") |
| `versions_test.go`, `harnesses_test.go` | harness/version registry invariants |

Consequence: a reintroduced dir_token leak or a neutered fs-deny assertion would pass CI, pass the release gate, and ship — surfacing up to a week later. This moves the fast net onto the code path that produces releases.

For `--no-sandbox` harnesses (codex/macOS), the audit previously skipped every negative assertion, silently excluding the real risk surface (#66). It now fails loudly if the audit produced nothing and logs an explicit EXPOSED/contained table per property.

## How

- `e2e || e2e_fast` on `harnesses.go`, `versions.go`, `classify.go`, `fixtures.go` (new), `security_assertions.go` (new), and the four model-free test files. The live files (`e2e_test.go`, `allowance.go`, `artifacts.go`, `provenance_test.go`) stay `e2e`-only.
- Full live suite is unchanged: those files build under both tags, so `e2e.yml`'s `-tags=e2e` still runs everything weekly.
- `noSandboxExposureReport` is a pure function unit-tested in the fast slice (`TestNoSandboxExposureReport`), in the repo's "mutation-test the tests" spirit.
- No bubblewrap / token / harness install in the fast job — `omac serve --no-inner` is control-plane only.

## Verification

```
go test -tags=e2e_fast -race ./internal/e2e/   # 11 tests pass (~3s), incl. real serve subprocess
go vet  -tags=e2e       ./internal/e2e/         # full live suite still compiles
go build ./... && go vet ./...                  # untagged build unaffected
```

## Follow-up

A separate release-procedure gap (release currently gates only on untagged `go test`) will be filed as its own issue.

Refs #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)