### PR TITLE
fix(security-scan): harden strix scan — compaction, model-variant probe, tool_choice-422 retry

### DIFF
--- a/.github/scripts/security_scan/context_compaction.py
+++ b/.github/scripts/security_scan/context_compaction.py
@@ -1,0 +1,191 @@
+"""In-flight context-window compaction for the strix scan's chat traffic.
+
+strix (via the openai-agents SDK) resends the *entire* conversation on every
+request and has no compaction of its own, so a long whole-repo scan grows past
+the gateway model's context window (GLM-5.2: 202752 tokens). Once it does, every
+subsequent request 422s with ``context_length_exceeded`` -- and the failure is
+unrecoverable by ``strix --resume``, which reloads the same over-length state
+and overflows again immediately. This module compacts the ``messages`` array of
+a chat-completions request before it is forwarded upstream: when the estimated
+token count crosses ``trigger``, the oldest complete exchanges are evicted and
+replaced by a single LLM-generated briefing (Tier 2), shrinking the request
+back under ``target`` while preserving
+
+* the leading ``system`` prefix (so the gateway's prompt cache still hits),
+* the most recent turns verbatim (recency matters most to the agent),
+* ``tool_calls`` -> ``tool`` message pairing (an orphaned ``tool`` message is a
+  hard 400 from the API), by only ever evicting whole turns at a boundary.
+
+The summariser is injected (``summarize`` callable) so this module stays pure
+and unit-testable; :mod:`skainet_proxy` supplies the real gateway-backed one. If
+the summariser raises or returns nothing, eviction still happens with a static
+placeholder, so a summariser outage degrades coverage rather than crashing the
+scan. As a last resort -- when even the minimum kept turns exceed the hard
+``limit`` -- oversized ``tool`` result bodies are elided in place (Tier 1).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable
+
+logger = logging.getLogger("skainet_proxy.compaction")
+
+Message = dict[str, Any]
+
+# Rough chars-per-token for the size estimate. Deliberately low so the estimate
+# runs slightly high and compaction triggers with headroom to spare rather than
+# one request too late. Override via STRIX_COMPACT_CHARS_PER_TOKEN.
+DEFAULT_CHARS_PER_TOKEN = 3.5
+_PER_MESSAGE_OVERHEAD_TOKENS = 4
+
+_SUMMARY_LABEL = (
+    "[Context compacted to fit the model window. Briefing of earlier "
+    "investigation steps that were summarised out of the transcript:]\n\n"
+)
+_SUMMARY_FALLBACK = (
+    "[Earlier investigation steps were compacted out to fit the model context "
+    "window; their raw transcript is unavailable. Continue from the most recent "
+    "steps below and re-gather any earlier detail you still need.]"
+)
+
+
+def estimate_tokens(messages: list[Message], *, chars_per_token: float = DEFAULT_CHARS_PER_TOKEN) -> int:
+    """Estimate the token footprint of a messages array.
+
+    A serialization-length heuristic rather than a real tokenizer: the gateway
+    owns the authoritative count, and compaction leaves tens of thousands of
+    tokens of headroom, so an approximate-but-cheap estimate is sufficient and
+    keeps this module dependency-free.
+    """
+    total = 0.0
+    for message in messages:
+        total += len(json.dumps(message, ensure_ascii=False, separators=(",", ":"))) / chars_per_token
+        total += _PER_MESSAGE_OVERHEAD_TOKENS
+    return int(total)
+
+
+def _split_prefix(messages: list[Message]) -> tuple[list[Message], list[Message]]:
+    """Peel the leading run of ``system`` messages off the front."""
+    index = 0
+    while index < len(messages) and messages[index].get("role") == "system":
+        index += 1
+    return messages[:index], messages[index:]
+
+
+def _group_turns(messages: list[Message]) -> list[list[Message]]:
+    """Group messages into turns so eviction never orphans a ``tool`` result.
+
+    A turn starts at any non-``tool`` message; ``tool`` messages attach to the
+    turn they answer. Evicting or keeping whole turns therefore keeps every
+    assistant ``tool_calls`` message together with its ``tool`` replies.
+    """
+    turns: list[list[Message]] = []
+    for message in messages:
+        if message.get("role") == "tool" and turns:
+            turns[-1].append(message)
+        else:
+            turns.append([message])
+    return turns
+
+
+def _drop_leading_orphan_tool_turns(turns: list[list[Message]]) -> list[list[Message]]:
+    """Discard leading turns that begin with a ``tool`` message.
+
+    Only possible on malformed input, but a kept window that opens on a ``tool``
+    message would be an orphaned result once the preceding turns are evicted --
+    a hard API error. Cheap to guard against unconditionally.
+    """
+    while turns and turns[0] and turns[0][0].get("role") == "tool":
+        turns = turns[1:]
+    return turns
+
+
+def _summarise_evicted(
+    evicted: list[Message],
+    summarize: Callable[[list[Message]], str],
+) -> str:
+    """Run the injected summariser, falling back to a static note on failure."""
+    if not evicted:
+        return _SUMMARY_FALLBACK
+    try:
+        text = summarize(evicted)
+    except Exception:  # noqa: BLE001 - a summariser outage must not fail the scan
+        logger.warning("summariser raised; degrading to placeholder", exc_info=True)
+        return _SUMMARY_FALLBACK
+    text = (text or "").strip()
+    return text or _SUMMARY_FALLBACK
+
+
+def _elide_tool_bodies(messages: list[Message], *, limit: int, chars_per_token: float) -> list[Message]:
+    """Tier-1 last resort: shrink oldest ``tool`` result bodies to a stub.
+
+    Used only when the kept turns alone still exceed the hard ``limit`` (e.g. a
+    single huge tool result). Preserves message identity and pairing -- only the
+    ``content`` string is replaced -- so the request stays valid.
+    """
+    for message in messages:
+        if estimate_tokens(messages, chars_per_token=chars_per_token) <= limit:
+            break
+        if message.get("role") != "tool":
+            continue
+        body = message.get("content")
+        if isinstance(body, str) and len(body) > 200:
+            message["content"] = f"[elided {len(body)} chars of an earlier tool result to fit context]"
+    return messages
+
+
+def compact_messages(
+    messages: list[Message],
+    *,
+    summarize: Callable[[list[Message]], str],
+    limit: int,
+    trigger: int,
+    target: int,
+    keep_recent_turns: int = 3,
+    chars_per_token: float = DEFAULT_CHARS_PER_TOKEN,
+) -> tuple[list[Message], dict[str, Any] | None]:
+    """Compact ``messages`` if it is over ``trigger``; otherwise return it as-is.
+
+    Returns ``(messages, stats)`` where ``stats`` is ``None`` when no compaction
+    was needed, else a small dict describing what happened (for logging).
+
+    ``trigger`` is when to act, ``target`` is what to shrink down to (the gap
+    between them is the runway before the next compaction), and ``limit`` is the
+    hard model window that the Tier-1 elision guarantees we stay under.
+    """
+    before = estimate_tokens(messages, chars_per_token=chars_per_token)
+    if before <= trigger:
+        return messages, None
+
+    prefix, rest = _split_prefix(messages)
+    turns = _group_turns(rest)
+
+    kept = list(turns)
+    evicted: list[list[Message]] = []
+    summary_reserve = [{"role": "assistant", "content": _SUMMARY_LABEL + "x" * 4000}]
+    while len(kept) > keep_recent_turns:
+        candidate = prefix + summary_reserve + [m for turn in kept for m in turn]
+        if estimate_tokens(candidate, chars_per_token=chars_per_token) <= target:
+            break
+        evicted.append(kept.pop(0))
+
+    kept = _drop_leading_orphan_tool_turns(kept)
+    evicted_messages = [m for turn in evicted for m in turn]
+    summary_text = _summarise_evicted(evicted_messages, summarize)
+    summary_message: Message = {"role": "assistant", "content": _SUMMARY_LABEL + summary_text}
+
+    new_messages = prefix + [summary_message] + [m for turn in kept for m in turn]
+    new_messages = _elide_tool_bodies(new_messages, limit=limit, chars_per_token=chars_per_token)
+
+    after = estimate_tokens(new_messages, chars_per_token=chars_per_token)
+    stats = {
+        "evicted_turns": len(evicted),
+        "evicted_messages": len(evicted_messages),
+        "kept_turns": len(kept),
+        "before_tokens": before,
+        "after_tokens": after,
+        "summarised": bool(evicted_messages) and summary_text != _SUMMARY_FALLBACK,
+    }
+    return new_messages, stats

--- a/.github/scripts/security_scan/skainet_proxy.py
+++ b/.github/scripts/security_scan/skainet_proxy.py
@@ -1,0 +1,219 @@
+"""Local reverse proxy that compacts the strix scan's context in flight.
+
+strix (via the openai-agents SDK) resends the entire conversation on every
+request and never compacts it, so a long whole-repo scan grows past the gateway
+model's context window (GLM-5.2: 202752 tokens) and then every request 422s with
+``context_length_exceeded`` -- silently truncating the scan (strix crashes but
+leaves a partial run dir, so the workflow can mistake it for a finished scan).
+
+strix is a third-party CLI we don't own the call site of, so this proxy fixes it
+at the HTTP layer: strix points ``LLM_API_BASE`` here, and every chat-completions
+request is compacted before being forwarded (see :mod:`context_compaction`) --
+oldest exchanges are summarised by the model itself and replaced with a briefing,
+keeping the request under the window while preserving the system prefix, recent
+turns, and tool-call pairing.
+
+Unlike the sibling asml proxy this one does no token minting: strix already
+sends a working bearer, so the proxy passes ``Authorization`` straight through
+and reuses that same bearer (and the request's own ``model``) for the summariser
+call it originates. Only the upstream host needs configuring (``SKAINET_UPSTREAM``).
+
+Dependency-free beyond what ``pip install strix-agent`` already pulls in (httpx,
+starlette, uvicorn all land transitively via openai-agents/mcp).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+import httpx
+import uvicorn
+from starlette.applications import Starlette
+from starlette.concurrency import run_in_threadpool
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.routing import Route
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from context_compaction import compact_messages  # noqa: E402
+
+logger = logging.getLogger("skainet_proxy")
+
+UPSTREAM_BASE = os.environ["SKAINET_UPSTREAM"]  # bare host, e.g. https://external.model.tngtech.com
+CHAT_PATH = os.environ.get("SKAINET_CHAT_PATH", "/v1/chat/completions")
+
+_HOP_BY_HOP = {"connection", "content-encoding", "content-length", "transfer-encoding", "host"}
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ[name])
+    except (KeyError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ[name])
+    except (KeyError, ValueError):
+        return default
+
+
+_COMPACT_ENABLED = os.environ.get("STRIX_COMPACT_ENABLED", "1") != "0"
+_MODEL_CONTEXT = _int_env("STRIX_MODEL_CONTEXT_TOKENS", 202752)
+_COMPACT_TRIGGER = _int_env("STRIX_COMPACT_TRIGGER_TOKENS", 180_000)
+_COMPACT_TARGET = _int_env("STRIX_COMPACT_TARGET_TOKENS", 150_000)
+_COMPACT_KEEP_RECENT = _int_env("STRIX_COMPACT_KEEP_RECENT_TURNS", 3)
+_COMPACT_CHARS_PER_TOKEN = _float_env("STRIX_COMPACT_CHARS_PER_TOKEN", 3.5)
+_SUMMARY_MAX_TOKENS = _int_env("STRIX_COMPACT_SUMMARY_MAX_TOKENS", 1200)
+
+_SUMMARY_SYSTEM_PROMPT = (
+    "You are compacting the transcript of an autonomous security-pentest agent "
+    "so it fits the model context window. Summarise the messages below into a "
+    "dense briefing that preserves everything needed to continue the scan: "
+    "files, endpoints, and components already examined; hypotheses raised; "
+    "vulnerabilities confirmed or ruled out; credentials, tokens, or IDs "
+    "discovered; and any pending next steps. Omit raw file dumps and verbose "
+    "command output, keep the security-relevant conclusions. Be terse and "
+    "factual; use short bullet points."
+)
+
+_client = httpx.AsyncClient(base_url=UPSTREAM_BASE, timeout=httpx.Timeout(300.0))
+_summary_client = httpx.Client(base_url=UPSTREAM_BASE, timeout=httpx.Timeout(120.0))
+
+
+def _render_for_summary(messages: list[dict[str, Any]], *, per_message_cap: int = 3000) -> str:
+    """Flatten evicted messages into bounded plain text for the summariser."""
+    lines: list[str] = []
+    for message in messages:
+        role = message.get("role", "?")
+        content = message.get("content")
+        if isinstance(content, str) and content:
+            text = content
+        elif message.get("tool_calls"):
+            calls = "; ".join(
+                f"{call.get('function', {}).get('name')}"
+                f"({str(call.get('function', {}).get('arguments', ''))[:200]})"
+                for call in message["tool_calls"]
+            )
+            text = f"[tool calls] {calls}"
+        else:
+            text = json.dumps(content, ensure_ascii=False) if content is not None else ""
+        lines.append(f"{role}: {text[:per_message_cap]}")
+    return "\n\n".join(lines)
+
+
+def _summarize_via_gateway(evicted: list[dict[str, Any]], *, model: str, authorization: str) -> str:
+    """Summarise evicted messages with one direct (non-proxied) gateway call,
+    reusing the bearer and model of the request being compacted."""
+    if not authorization:
+        raise RuntimeError("no Authorization header to reuse for summarisation")
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": _SUMMARY_SYSTEM_PROMPT},
+            {"role": "user", "content": _render_for_summary(evicted)},
+        ],
+        "temperature": 0,
+        "max_tokens": _SUMMARY_MAX_TOKENS,
+        "stream": False,
+    }
+    resp = _summary_client.post(CHAT_PATH, json=payload, headers={"authorization": authorization})
+    resp.raise_for_status()
+    return resp.json()["choices"][0]["message"]["content"] or ""
+
+
+def _summarizer_for(model: str, authorization: str) -> Callable[[list[dict[str, Any]]], str]:
+    def summarize(evicted: list[dict[str, Any]]) -> str:
+        return _summarize_via_gateway(evicted, model=model, authorization=authorization)
+
+    return summarize
+
+
+def _maybe_compact(body: bytes, path: str, authorization: str) -> bytes:
+    """Compact a chat-completions request body if it is over the window.
+
+    Any parsing/compaction failure returns the original body unchanged -- the
+    proxy must never turn a working request into a broken one.
+    """
+    if not (_COMPACT_ENABLED and path.endswith("/chat/completions")):
+        return body
+    try:
+        parsed = json.loads(body)
+    except (ValueError, TypeError):
+        return body
+    messages = parsed.get("messages")
+    if not isinstance(messages, list):
+        return body
+    try:
+        new_messages, stats = compact_messages(
+            messages,
+            summarize=_summarizer_for(parsed.get("model", ""), authorization),
+            limit=_MODEL_CONTEXT,
+            trigger=_COMPACT_TRIGGER,
+            target=_COMPACT_TARGET,
+            keep_recent_turns=_COMPACT_KEEP_RECENT,
+            chars_per_token=_COMPACT_CHARS_PER_TOKEN,
+        )
+    except Exception:  # noqa: BLE001 - degrade to the uncompacted request
+        logger.warning("compaction failed; forwarding request unchanged", exc_info=True)
+        return body
+    if stats is None:
+        return body
+    logger.info("compacted request: %s", stats)
+    parsed["messages"] = new_messages
+    return json.dumps(parsed).encode()
+
+
+async def healthz(request: Request) -> Response:
+    return JSONResponse({"ok": True})
+
+
+async def proxy(request: Request) -> Response:
+    headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+    body = await request.body()
+    body = await run_in_threadpool(
+        _maybe_compact, body, request.url.path, request.headers.get("authorization", "")
+    )
+
+    upstream_req = _client.build_request(
+        request.method,
+        request.url.path,
+        headers=headers,
+        params=request.query_params,
+        content=body,
+    )
+    upstream_resp = await _client.send(upstream_req, stream=True)
+
+    async def relay() -> object:
+        async for chunk in upstream_resp.aiter_raw():
+            yield chunk
+        await upstream_resp.aclose()
+
+    response_headers = {
+        k: v for k, v in upstream_resp.headers.items() if k.lower() not in _HOP_BY_HOP
+    }
+    return StreamingResponse(
+        relay(),
+        status_code=upstream_resp.status_code,
+        headers=response_headers,
+    )
+
+
+app = Starlette(
+    routes=[
+        Route("/healthz", healthz, methods=["GET"]),
+        Route("/{path:path}", proxy, methods=["GET", "POST"]),
+    ]
+)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    port = int(os.environ.get("SKAINET_PROXY_PORT", "8899"))
+    uvicorn.run(app, host="127.0.0.1", port=port, log_level="info")

--- a/.github/scripts/security_scan/skainet_proxy.py
+++ b/.github/scripts/security_scan/skainet_proxy.py
@@ -71,6 +71,7 @@ _COMPACT_TARGET = _int_env("STRIX_COMPACT_TARGET_TOKENS", 150_000)
 _COMPACT_KEEP_RECENT = _int_env("STRIX_COMPACT_KEEP_RECENT_TURNS", 3)
 _COMPACT_CHARS_PER_TOKEN = _float_env("STRIX_COMPACT_CHARS_PER_TOKEN", 3.5)
 _SUMMARY_MAX_TOKENS = _int_env("STRIX_COMPACT_SUMMARY_MAX_TOKENS", 1200)
+_TOOLCALL_422_RETRIES = _int_env("STRIX_TOOLCALL_422_RETRIES", 2)
 
 _SUMMARY_SYSTEM_PROMPT = (
     "You are compacting the transcript of an autonomous security-pentest agent "
@@ -170,6 +171,34 @@ def _maybe_compact(body: bytes, path: str, authorization: str) -> bytes:
     return json.dumps(parsed).encode()
 
 
+def _is_toolcall_parse_422(status_code: int, body: bytes) -> bool:
+    """Whether a 422 is the gateway's vLLM ``tool_choice=auto`` handler failing
+    to parse malformed tool-call JSON emitted by the model.
+
+    Distinct from ``context_length_exceeded`` (also a 422): that is a context
+    problem compaction handles and a retry can never fix, whereas a malformed
+    tool call is stochastic -- resampling usually yields valid JSON. The gateway
+    message carries ``tool_choice`` only for the former.
+    """
+    return status_code == 422 and b"tool_choice" in body
+
+
+def _bump_temperature(body: bytes, attempt: int) -> bytes:
+    """Raise sampling temperature for a retry so the model resamples a fresh
+    tool call instead of deterministically repeating the malformed one (greedy
+    decoding at temperature 0 reproduces it). Returns body unchanged if not JSON."""
+    try:
+        parsed = json.loads(body)
+    except (ValueError, TypeError):
+        return body
+    parsed["temperature"] = round(min(0.4 + 0.3 * attempt, 1.0), 2)
+    return json.dumps(parsed).encode()
+
+
+def _clean_response_headers(resp: httpx.Response) -> dict[str, str]:
+    return {k: v for k, v in resp.headers.items() if k.lower() not in _HOP_BY_HOP}
+
+
 async def healthz(request: Request) -> Response:
     return JSONResponse({"ok": True})
 
@@ -181,27 +210,48 @@ async def proxy(request: Request) -> Response:
         _maybe_compact, body, request.url.path, request.headers.get("authorization", "")
     )
 
-    upstream_req = _client.build_request(
-        request.method,
-        request.url.path,
-        headers=headers,
-        params=request.query_params,
-        content=body,
-    )
-    upstream_resp = await _client.send(upstream_req, stream=True)
+    attempt_body = body
+    for attempt in range(_TOOLCALL_422_RETRIES + 1):
+        upstream_resp = await _client.send(
+            _client.build_request(
+                request.method,
+                request.url.path,
+                headers=headers,
+                params=request.query_params,
+                content=attempt_body,
+            ),
+            stream=True,
+        )
+        if attempt < _TOOLCALL_422_RETRIES and upstream_resp.status_code == 422:
+            error_body = await upstream_resp.aread()
+            await upstream_resp.aclose()
+            if _is_toolcall_parse_422(422, error_body):
+                logger.warning(
+                    "gateway tool_choice 422 (malformed tool call); resampling at higher "
+                    "temperature (attempt %d/%d)",
+                    attempt + 1,
+                    _TOOLCALL_422_RETRIES,
+                )
+                attempt_body = _bump_temperature(attempt_body, attempt + 1)
+                continue
+            # A different 422 (e.g. context_length_exceeded) -- not resamplable;
+            # return it verbatim so strix sees the real error.
+            return Response(
+                content=error_body,
+                status_code=422,
+                headers=_clean_response_headers(upstream_resp),
+            )
+        break
 
     async def relay() -> object:
         async for chunk in upstream_resp.aiter_raw():
             yield chunk
         await upstream_resp.aclose()
 
-    response_headers = {
-        k: v for k, v in upstream_resp.headers.items() if k.lower() not in _HOP_BY_HOP
-    }
     return StreamingResponse(
         relay(),
         status_code=upstream_resp.status_code,
-        headers=response_headers,
+        headers=_clean_response_headers(upstream_resp),
     )
 
 

--- a/.github/scripts/security_scan/test_context_compaction.py
+++ b/.github/scripts/security_scan/test_context_compaction.py
@@ -1,0 +1,184 @@
+"""Tests for the in-flight context compaction used by the strix scan proxy.
+
+Runnable either under pytest or standalone (``python3 test_context_compaction.py``)
+so it needs no test harness beyond the standard library. The summariser is a
+stub -- the live gateway-backed one can only be exercised in CI, where the
+skainet M2M secret exists.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from context_compaction import (  # noqa: E402
+    _SUMMARY_FALLBACK,
+    compact_messages,
+    estimate_tokens,
+)
+
+# Small, explicit thresholds keep the synthetic payloads tiny and the intent
+# obvious; production defaults live in skainet_proxy.py.
+LIMIT = 12_000
+TRIGGER = 10_000
+TARGET = 6_000
+BIG = "A" * 3_500  # ~1000 estimated tokens per tool result
+
+
+def _stub_summary(_evicted: list[dict]) -> str:
+    return "- earlier steps summarised"
+
+
+def _system() -> dict:
+    return {"role": "system", "content": "You are a pentest agent. " * 50}
+
+
+def _turn(index: int, *, body: str = BIG) -> list[dict]:
+    call_id = f"call_{index}"
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": call_id, "type": "function", "function": {"name": "read", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": body},
+    ]
+
+
+def _conversation(n_turns: int) -> list[dict]:
+    messages = [_system(), {"role": "user", "content": "Scan the repo."}]
+    for i in range(n_turns):
+        messages += _turn(i)
+    return messages
+
+
+def _kwargs(**overrides) -> dict:
+    base = dict(
+        summarize=_stub_summary,
+        limit=LIMIT,
+        trigger=TRIGGER,
+        target=TARGET,
+        keep_recent_turns=3,
+    )
+    base.update(overrides)
+    return base
+
+
+def _assert_pairing(messages: list[dict]) -> None:
+    """Every tool message's id must belong to an assistant tool_call seen before it."""
+    seen_ids: set[str] = set()
+    for message in messages:
+        if message.get("role") == "assistant":
+            for call in message.get("tool_calls") or []:
+                seen_ids.add(call["id"])
+        elif message.get("role") == "tool":
+            tid = message.get("tool_call_id")
+            assert tid in seen_ids, f"orphaned tool message {tid!r} (no preceding tool_call)"
+
+
+def test_no_compaction_under_trigger() -> None:
+    messages = _conversation(3)
+    assert estimate_tokens(messages) <= TRIGGER
+    result, stats = compact_messages(messages, **_kwargs())
+    assert stats is None
+    assert result is messages
+
+
+def test_compaction_reduces_below_limit_and_target() -> None:
+    messages = _conversation(30)
+    before = estimate_tokens(messages)
+    assert before > TRIGGER
+    result, stats = compact_messages(messages, **_kwargs())
+    assert stats is not None
+    after = estimate_tokens(result)
+    assert after < before
+    assert after <= LIMIT
+    assert stats["before_tokens"] == before
+    assert stats["evicted_turns"] > 0
+    assert stats["summarised"] is True
+
+
+def test_pairing_preserved_after_compaction() -> None:
+    messages = _conversation(30)
+    result, _ = compact_messages(messages, **_kwargs())
+    _assert_pairing(result)
+
+
+def test_system_prefix_preserved() -> None:
+    messages = _conversation(30)
+    result, _ = compact_messages(messages, **_kwargs())
+    assert result[0] == messages[0]
+    assert result[0]["role"] == "system"
+
+
+def test_recent_turns_kept_verbatim() -> None:
+    messages = _conversation(30)
+    result, _ = compact_messages(messages, **_kwargs())
+    # The last kept turn (assistant tool_call + tool result) must survive intact.
+    assert messages[-2] in result  # assistant tool_call
+    assert messages[-1] in result  # its tool result
+
+
+def test_summary_message_inserted_after_prefix() -> None:
+    messages = _conversation(30)
+    result, _ = compact_messages(messages, **_kwargs())
+    summary = result[1]
+    assert summary["role"] == "assistant"
+    assert "compacted" in summary["content"].lower()
+
+
+def test_degrades_to_fallback_when_summariser_raises() -> None:
+    def boom(_evicted: list[dict]) -> str:
+        raise RuntimeError("gateway down")
+
+    messages = _conversation(30)
+    result, stats = compact_messages(messages, **_kwargs(summarize=boom))
+    assert stats is not None
+    assert stats["summarised"] is False
+    assert _SUMMARY_FALLBACK in result[1]["content"]
+    _assert_pairing(result)  # eviction still valid even without a summary
+    assert estimate_tokens(result) <= LIMIT
+
+
+def test_tier1_elision_when_recent_turn_exceeds_limit() -> None:
+    huge = "B" * (LIMIT * 4 * 4)  # one tool result far larger than the whole window
+    messages = [_system(), {"role": "user", "content": "go"}] + _turn(0, body=huge)
+    result, stats = compact_messages(messages, **_kwargs())
+    assert stats is not None
+    assert estimate_tokens(result) <= LIMIT
+    tool_bodies = [m["content"] for m in result if m.get("role") == "tool"]
+    assert any("elided" in body for body in tool_bodies)
+
+
+def test_no_orphan_tool_at_kept_boundary() -> None:
+    # Force keep_recent_turns=1 so the kept window is a single turn; it must
+    # still open on the assistant tool_call, never the bare tool result.
+    messages = _conversation(30)
+    result, _ = compact_messages(messages, **_kwargs(keep_recent_turns=1))
+    _assert_pairing(result)
+    first_non_prefix = next(m for m in result if m.get("role") != "system")
+    assert first_non_prefix["role"] != "tool"
+
+
+def _run_standalone() -> int:
+    tests = [obj for name, obj in sorted(globals().items()) if name.startswith("test_")]
+    failures = 0
+    for test in tests:
+        try:
+            test()
+            print(f"PASS {test.__name__}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL {test.__name__}: {exc}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"ERROR {test.__name__}: {exc!r}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_standalone())

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -118,19 +118,44 @@ jobs:
           fi
           echo "base=http://127.0.0.1:${SKAINET_PROXY_PORT}${suffix}" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve model from e2e config
+      - name: Resolve and verify model
         id: model
         run: |
-          # Single source of truth is internal/e2e/versions.go's modelIDs map
-          # (opencode's entry -- GLM-5.2-TEE, same as e2e.yml uses) rather
-          # than duplicating the model name here.
-          model=$(awk '/^var modelIDs = map\[string\]string\{/{flag=1; next} /^\}/{flag=0} flag' \
+          set -euo pipefail
+          # Base model name: single source of truth is internal/e2e/versions.go's
+          # modelIDs map (opencode's entry -- the plain GLM-5.2 name, which is
+          # what opencode's own resolution uses) rather than duplicating it here.
+          base=$(awk '/^var modelIDs = map\[string\]string\{/{flag=1; next} /^\}/{flag=0} flag' \
             target/internal/e2e/versions.go | grep '"opencode"' | sed -E 's/.*:\s*"([^"]+)".*/\1/')
-          if [ -z "$model" ]; then
+          if [ -z "$base" ]; then
             echo "::error::could not resolve model from internal/e2e/versions.go"
             exit 1
           fi
-          echo "strix_llm=openai/$model" >> "$GITHUB_OUTPUT"
+          # Harden against the gateway's raw /v1/chat/completions path only
+          # serving one model-name variant at a time: unlike opencode, strix
+          # calls that path directly, and it recently flipped from accepting the
+          # plain name to requiring the -TEE variant (422 model_unavailable).
+          # Probe the base name first, fall back to <base>-TEE, and use
+          # whichever the gateway currently accepts -- so a future flip in
+          # either direction self-heals. Model names aren't secret; the bearer
+          # in the header is and is never printed.
+          endpoint="${LLM_API_BASE%/}/chat/completions"
+          chosen=""
+          for candidate in "$base" "${base}-TEE"; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 \
+              -X POST "$endpoint" \
+              -H "authorization: Bearer ${LLM_API_KEY}" \
+              -H 'content-type: application/json' \
+              -d "{\"model\":\"${candidate}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":1}") || true
+            if [ "$code" = "200" ]; then chosen="$candidate"; break; fi
+            echo "model '${candidate}' not accepted (HTTP ${code}); trying next variant"
+          done
+          if [ -z "$chosen" ]; then
+            echo "::error::neither '${base}' nor '${base}-TEE' was accepted by the gateway -- check the model provider and SKAINET_TOKEN validity"
+            exit 1
+          fi
+          echo "selected model: ${chosen}"
+          echo "strix_llm=openai/${chosen}" >> "$GITHUB_OUTPUT"
 
       - name: Run strix scan
         id: scan

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -78,6 +78,46 @@ jobs:
           # Safe to print -- version string only, no scan content.
           strix --version
 
+      - name: Start context-compaction proxy
+        id: proxy
+        # strix resends the whole conversation on every request and has no
+        # context compaction, so a long scan overflows the model window
+        # (GLM-5.2: 202752 tokens) and every request then 422s with
+        # context_length_exceeded -- silently truncating results (a partial run
+        # dir survives, so the scan can look finished). This local proxy
+        # compacts requests in flight (summarising the oldest exchanges); strix
+        # is repointed at it below. See
+        # target/.github/scripts/security_scan/skainet_proxy.py.
+        env:
+          SKAINET_PROXY_PORT: '8899'
+        run: |
+          set -euo pipefail
+          # Split the gateway base into host + path suffix so the proxy forwards
+          # to the host and preserves whatever chat path strix used (with or
+          # without a /v1 prefix). LLM_API_BASE here is still the job-level
+          # gateway URL; the scan step below points strix at the proxy instead.
+          # Values are secret-derived -- never echoed.
+          host=$(printf '%s' "$LLM_API_BASE" | sed -E 's#(https?://[^/]+).*#\1#')
+          suffix=$(printf '%s' "$LLM_API_BASE" | sed -E 's#https?://[^/]+##; s#/$##')
+          nohup env \
+            SKAINET_UPSTREAM="$host" \
+            SKAINET_CHAT_PATH="${suffix}/chat/completions" \
+            SKAINET_PROXY_PORT="$SKAINET_PROXY_PORT" \
+            python target/.github/scripts/security_scan/skainet_proxy.py \
+            > proxy.log 2>&1 &
+          echo $! > proxy.pid
+          ok=0
+          for _ in $(seq 1 20); do
+            if curl -sf "http://127.0.0.1:${SKAINET_PROXY_PORT}/healthz" >/dev/null; then ok=1; break; fi
+            sleep 0.5
+          done
+          if [ "$ok" != "1" ]; then
+            echo "::error::compaction proxy did not become healthy"
+            cat proxy.log  # startup-only output (uvicorn lines) -- no scan content yet
+            exit 1
+          fi
+          echo "base=http://127.0.0.1:${SKAINET_PROXY_PORT}${suffix}" >> "$GITHUB_OUTPUT"
+
       - name: Resolve model from e2e config
         id: model
         run: |
@@ -96,6 +136,12 @@ jobs:
         id: scan
         env:
           STRIX_LLM: ${{ steps.model.outputs.strix_llm }}
+          # Route strix through the compaction proxy started above instead of
+          # straight at the gateway, so requests are compacted before they can
+          # overflow the model window. LLM_API_KEY (the bearer) is inherited and
+          # passed through by the proxy untouched; only triage below still talks
+          # to the gateway directly.
+          LLM_API_BASE: ${{ steps.proxy.outputs.base }}
         run: |
           set -o pipefail
           run_label="$(date -u +%Y%m%d-%H%M%S)"
@@ -132,6 +178,18 @@ jobs:
           fi
           echo "run_dir=${run_dirs[-1]}" >> "$GITHUB_OUTPUT"
 
+          # The proxy in front should keep every request under the model window.
+          # If it ever fails to, the scan overflows and every subsequent request
+          # 422s with context_length_exceeded -- but a partial run dir still
+          # exists, so WITHOUT this guard the truncated scan would be reported as
+          # successful and triaged as if complete. Fail loudly instead. grep -q:
+          # never print the log, it can contain scan content on this public
+          # runner (the full log is in the private artifact repo).
+          if grep -q "context_length_exceeded" strix_scan.log; then
+            echo "::error::strix hit context_length_exceeded -- scan truncated despite compaction; inspect proxy.log / strix_scan.log in the private artifact repo. Failing so a partial scan is not reported as complete."
+            exit 1
+          fi
+
       - name: Dedupe against open issues + build triage report
         if: steps.scan.outcome == 'success'
         env:
@@ -146,6 +204,10 @@ jobs:
       - name: Public summary (counts only, no exploit detail)
         if: steps.scan.outcome == 'success'
         run: cat step-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Stop context-compaction proxy
+        if: always()
+        run: kill "$(cat proxy.pid)" 2>/dev/null || true
 
       - name: Push full report to private artifact repo
         # Runs even when the scan step failed: strix_scan.log is the only
@@ -170,6 +232,11 @@ jobs:
           fi
           [ -f triage-report.md ] && cp triage-report.md "$scan_dir"/
           [ -f strix_scan.log ] && cp strix_scan.log "$scan_dir"/
+          # proxy.log holds the compaction telemetry (which requests were
+          # compacted, before/after token estimates) -- useful for debugging an
+          # overflow that slipped past compaction. Safe: it logs counts, not
+          # message content.
+          [ -f proxy.log ] && cp proxy.log "$scan_dir"/
           cd "$dest"
           git config user.name "strix-ci-bot"
           git config user.email "actions@users.noreply.github.com"


### PR DESCRIPTION
## What

Three reliability fixes to the weekly **strix security scan** (one branch, three commits):

1. **In-flight context compaction** via a new local proxy in front of strix.
2. **Model-variant probe/fallback** — auto-select the model name the gateway currently serves.
3. **Resample-retry of the gateway's `tool_choice=auto` 422** (malformed tool-call JSON).

## Why

- **Overflow:** strix resends the whole conversation each request and never compacts it, so a whole-repo scan overflows GLM-5.2's 202752-token window and every request then 422s with `context_length_exceeded` — and on that crash strix leaves a *partial* run dir, so a truncated scan was reported as complete and triaged as whole.
- **Model-variant flip:** the gateway's raw `/v1/chat/completions` path (which strix calls directly, unlike opencode's own resolution) serves only one model-name variant at a time and **flipped from `zai-org/GLM-5.2` to requiring `zai-org/GLM-5.2-TEE`** (422 `model_unavailable`), silently breaking every scan (strix never connects → no run dir). Confirmed from scan history: the last good run predates the flip.
- **Malformed tool calls:** the model intermittently emits tool-call JSON the gateway's vLLM `tool_choice=auto` handler can't parse (422); not context-length-driven, and `--resume` can't recover it (deterministic greedy decode).

## How

- New static-token compaction proxy (`.github/scripts/security_scan/`): passes the bearer through and reuses the request's own bearer + model for its summariser call, so no extra secrets. Compacts oldest turns → model-generated briefing, preserving system prefix, recent turns, and tool-call pairing. `STRIX_COMPACT_*` tunables.
- "Resolve and verify model" step probes the base name from `versions.go`, falls back to `<base>-TEE`, and uses whichever the gateway accepts — a future flip in either direction self-heals.
- Proxy retries the `tool_choice` 422 with raised temperature (resample); `context_length_exceeded` returned verbatim. `STRIX_TOOLCALL_422_RETRIES` (default 2).
- A `context_length_exceeded` guard fails the scan loudly instead of triaging a truncated run as complete; proxy log pushed to the private artifact repo. Respects the public-repo disclosure model (no scan content printed).

## Verification

- **Unit tests** (9) for compaction; **proxy integration** + **tool_choice-retry** tests against a mocked gateway — all pass. `actionlint` green.
- **Live run:** proxy start + healthcheck succeeded on the runner; the model probe selected `-TEE` and strix connected and scanned (previously failed instantly with `model_unavailable`).
