### PR TITLE
fix(sandbox): ship default env allowlist; strip ambient host env (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,10 +610,24 @@ sandbox:
 > explicit `environment.allow_vars` allowlist, so the sandbox no longer
 > inherits arbitrary ambient variables from the launching shell — only the
 > operational minimum plus the selected harness's provider-auth variables
-> pass through. **If you have an existing `~/.config/omac/sandbox-profiles/default.json`
-> with an empty `"environment": {}`**, it still inherits everything; run
-> `omac provenance --check` (it now flags the empty allowlist) and either
-> delete the file to let omac re-scaffold it, or add an `allow_vars` list.
+> pass through. Entries are exact names or trailing-`*` prefixes (e.g.
+> `OMAC_*`); `OMAC_*` is a **broad prefix**, so skill sidecars must not set
+> arbitrary `OMAC_*` variables in the host env expecting them to stay out of
+> the sandbox.
+>
+> **If you have an existing `~/.config/omac/sandbox-profiles/default.json`
+> with an empty `"environment": {}`**, it still inherits everything, and omac
+> does **not** auto-migrate it (`default.json` is only scaffolded on first
+> miss, never rewritten). Run `omac provenance --check` (it now flags the
+> empty allowlist as MEDIUM), then either:
+> - back up and delete the file to let omac re-scaffold it (hand edits are
+>   lost), or
+> - add an `allow_vars` list (see `DefaultAllowVars()` in
+>   `internal/sandboxprofile/env.go` for the operational minimum), or
+> - set `allow_vars: ["*"]` to restore the pre-#102 "inherit everything"
+>   behavior — the danger blocklist (`LD_*`, `NODE_OPTIONS`, 1Password
+>   tokens, …) still wins, so this is not the same as no filtering.
+>
 > Using a provider whose auth var isn't forwarded by default? Add its name
 > to `environment.allow_vars`.
 

--- a/README.md
+++ b/README.md
@@ -615,21 +615,45 @@ sandbox:
 > arbitrary `OMAC_*` variables in the host env expecting them to stay out of
 > the sandbox.
 >
-> **If you have an existing `~/.config/omac/sandbox-profiles/default.json`
-> with an empty `"environment": {}`**, it still inherits everything, and omac
-> does **not** auto-migrate it (`default.json` is only scaffolded on first
-> miss, never rewritten). Run `omac provenance --check` (it now flags the
-> empty allowlist as MEDIUM), then either:
-> - back up and delete the file to let omac re-scaffold it (hand edits are
->   lost), or
-> - add an `allow_vars` list (see `DefaultAllowVars()` in
->   `internal/sandboxprofile/env.go` for the operational minimum), or
-> - set `allow_vars: ["*"]` to restore the pre-#102 "inherit everything"
->   behavior — the danger blocklist (`LD_*`, `NODE_OPTIONS`, 1Password
->   tokens, …) still wins, so this is not the same as no filtering.
+> **Empty `allow_vars` — fail-closed at launch.** If a sandbox profile has an
+> empty `environment.allow_vars` (e.g. an existing `default.json` with
+> `"environment": {}`, or a hand-authored profile), `omac start` / `omac serve`
+> does **not** inherit every ambient var. It prints a warning, pauses briefly
+> so you can read it, then forwards **only the operational minimum** —
+> `sandboxprofile.DefaultAllowVars()`: `HOME`, `PATH`, `PWD`, `TMPDIR`, `LANG`,
+> `LC_*`, `TERM`, `SHELL`, `USER`, `LOGNAME`, `TZ`, `EDITOR`, `VISUAL`,
+> `XDG_*`, `NPM_CONFIG_PREFIX`, `OMAC_*`.
 >
-> Using a provider whose auth var isn't forwarded by default? Add its name
-> to `environment.allow_vars`.
+> Everything else is **stripped** — secrets, *and* provider-auth vars.
+> omac deliberately does **not** auto-forward the harness's auth variables for
+> an empty profile: an empty allowlist is a misconfiguration, and omac will not
+> silently push provider credentials into the sandbox to hide it. The harness
+> process starts (it has `HOME`/`PATH`), but it **cannot authenticate** until
+> you configure the profile. `omac doctor` and `omac provenance --check` both
+> flag an empty allowlist.
+>
+> To resolve an empty profile, either:
+> - add an explicit `allow_vars` list (start from `DefaultAllowVars()` in
+>   `internal/sandboxprofile/env.go`, then add the provider/token vars the
+>   harness reads — e.g. `ANTHROPIC_API_KEY`, or a custom `SKAINET_*`); back up
+>   + delete a scaffolded `default.json` to have omac re-scaffold the full list
+>   (it is not auto-migrated), or
+> - set `allow_vars: ["*"]` to forward **every** ambient var — the danger
+>   blocklist (`LD_*`, `NODE_OPTIONS`, 1Password tokens, …) still wins, so this
+>   is not the same as no filtering.
+>
+> Note: with a **non-empty** `allow_vars`, omac injects the selected harness's
+> documented auth vars (`harness.SandboxEnvAllow`) on top at launch — but only
+> for **single-provider** harnesses where the key is unambiguous (claude-code
+> → `ANTHROPIC_*`, codex → `OPENAI_*`, copilot → `GITHUB_TOKEN`). **Multi-provider
+> harnesses (opencode, pi) auto-forward nothing**: omac will not blindly push
+> every third-party provider key into the sandbox, so a user relying on an
+> env-based provider key lists it in `allow_vars` themselves (opencode's primary
+> `auth.json` login, in its granted dirs, is unaffected). Auto-forwarding is
+> skipped entirely for the empty (misconfigured) case. A direct
+> `omac sandbox run --profile X` invocation — not via `start`/`serve` — still
+> treats an empty `allow_vars` as inherit-all; the fail-closed seeding happens
+> in the `start`/`serve` launch path.
 
 For successfully inspectable built-in `{{self}} sandbox run` profiles,
 `omac doctor` warns when a profile re-introduces a broad read/write

--- a/README.md
+++ b/README.md
@@ -603,6 +603,19 @@ sandbox:
 | Paths in `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.kube`, … | **denied** | protected paths (override with `filesystem.override_deny`) |
 | Workdir and granted-tree `.env` / `.envrc` (incl. nested) | **denied** | baseline workdir-protected set (override with `filesystem.override_deny: [".env"]`) |
 | Files matching `filesystem.deny` (e.g. `*.key`) inside granted trees | **denied** | user deny list (`filesystem.deny` / `--deny`) |
+| Environment variables in `environment.allow_vars` (`OMAC_*`, `HOME`, `PATH`, `LANG`, `TERM`, … + the selected harness's auth vars) | passed through | default profile `environment.allow_vars` + `harness.SandboxEnvAllow` (injected at launch) |
+| Any other ambient env var (cloud/CI secrets, `DOCKER_HOST`, `SSH_AUTH_SOCK`, proxy config) | **stripped** | not on the allowlist |
+
+> **Environment allowlist (upgrade note).** The default profile ships an
+> explicit `environment.allow_vars` allowlist, so the sandbox no longer
+> inherits arbitrary ambient variables from the launching shell — only the
+> operational minimum plus the selected harness's provider-auth variables
+> pass through. **If you have an existing `~/.config/omac/sandbox-profiles/default.json`
+> with an empty `"environment": {}`**, it still inherits everything; run
+> `omac provenance --check` (it now flags the empty allowlist) and either
+> delete the file to let omac re-scaffold it, or add an `allow_vars` list.
+> Using a provider whose auth var isn't forwarded by default? Add its name
+> to `environment.allow_vars`.
 
 For successfully inspectable built-in `{{self}} sandbox run` profiles,
 `omac doctor` warns when a profile re-introduces a broad read/write

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -265,6 +265,17 @@ func doctorSandboxProfileWarnings(env *Env, lc config.LauncherConfig) {
 			fmt.Fprintf(env.Stdout, "  [warn] sandbox profile %q: %v\n", profName, err)
 			continue
 		}
+		if len(p.Environment.AllowVars) == 0 {
+			fmt.Fprintf(env.Stdout, "  [warn] sandbox profile %q has an empty environment.allow_vars\n", profName)
+			fmt.Fprintln(env.Stdout, "         impact:      at launch omac forwards only the operational minimum (HOME, PATH,")
+			fmt.Fprintln(env.Stdout, "                      TERM, locale, …); all other ambient env vars — including provider")
+			fmt.Fprintln(env.Stdout, "                      tokens and secrets — are NOT passed through, and omac does not")
+			fmt.Fprintln(env.Stdout, "                      auto-forward auth vars. This differs from the pre-#102 inherit-")
+			fmt.Fprintln(env.Stdout, "                      everything behavior; the harness starts but will not authenticate.")
+			fmt.Fprintln(env.Stdout, `         remediation: add the vars the harness needs to allow_vars (see`)
+			fmt.Fprintln(env.Stdout, `                      sandboxprofile.DefaultAllowVars), or set allow_vars: ["*"] to forward`)
+			fmt.Fprintln(env.Stdout, "                      every ambient var (minus the danger blocklist).")
+		}
 		warns := profileGrantWarnings(p)
 		// Cargo-specific presence warning (mode-000 sentinel files).
 		warns = append(warns, cargoSentinelWarnings()...)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -472,6 +472,74 @@ func TestDoctorOmittedProfileInspectsDefault(t *testing.T) {
 	}
 }
 
+// TestDoctorEmptyAllowVarsWarned asserts doctor flags a native sandbox
+// profile whose environment.allow_vars is empty: at launch the selected
+// harness's auth vars are injected as --allow-env, flipping the empty
+// (inherit-all) list into a restrictive allowlist that strips HOME/PATH and
+// provider tokens. Advisory only — exit stays ExitOK.
+func TestDoctorEmptyAllowVarsWarned(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	workdir := t.TempDir()
+
+	writeWorkdirConfig(t, workdir, "builtin", []string{
+		"{{self}}", "sandbox", "run",
+		"--profile", "default",
+		"--", "{{inner_cmd}}", "{{inner_args}}",
+	})
+
+	// No "environment" block → empty allow_vars (the legacy inherit-all shape).
+	stageProfile(t, home, `{
+	  "meta": {"name": "default"}
+	}`)
+
+	env, outBuf, _, drain := newPipeEnv(t, "")
+	env.Workdir = workdir
+	code := runDoctor([]string{}, env)
+	drain()
+	output := outBuf.String()
+
+	if code != ExitOK {
+		t.Errorf("doctor exit = %d, want ExitOK (advisory)", code)
+	}
+	if !strings.Contains(output, "allow_vars") {
+		t.Errorf("doctor output missing empty allow_vars warning; got:\n%s", output)
+	}
+	if !strings.Contains(strings.ToLower(output), "impact") ||
+		!strings.Contains(strings.ToLower(output), "remediation") {
+		t.Errorf("doctor output missing impact/remediation; got:\n%s", output)
+	}
+}
+
+// TestDoctorNonEmptyAllowVarsNotWarned asserts the empty-allow_vars warning
+// does NOT fire when the profile ships an explicit allowlist.
+func TestDoctorNonEmptyAllowVarsNotWarned(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	workdir := t.TempDir()
+
+	writeWorkdirConfig(t, workdir, "builtin", []string{
+		"{{self}}", "sandbox", "run",
+		"--profile", "default",
+		"--", "{{inner_cmd}}", "{{inner_args}}",
+	})
+
+	stageProfile(t, home, `{
+	  "meta": {"name": "default"},
+	  "environment": {"allow_vars": ["HOME", "PATH"]}
+	}`)
+
+	env, outBuf, _, drain := newPipeEnv(t, "")
+	env.Workdir = workdir
+	_ = runDoctor([]string{}, env)
+	drain()
+	output := outBuf.String()
+
+	if strings.Contains(output, "empty environment.allow_vars") {
+		t.Errorf("doctor warned on a profile with an explicit allowlist; got:\n%s", output)
+	}
+}
+
 func TestDoctorExplicitProfilePathInspected(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/provenance_test.go
+++ b/internal/cli/provenance_test.go
@@ -364,7 +364,7 @@ func TestRunProvenance_CheckDefaultProfileClean(t *testing.T) {
 	profDir := filepath.Join(wd, ".opencode")
 	os.MkdirAll(profDir, 0o755)
 	profPath := filepath.Join(profDir, "default.json")
-	os.WriteFile(profPath, []byte(`{"meta":{"name":"default"},"workdir":{"access":"readwrite"}}`), 0o644)
+	os.WriteFile(profPath, []byte(`{"meta":{"name":"default"},"workdir":{"access":"readwrite"},"environment":{"allow_vars":["HOME","PATH"]}}`), 0o644)
 
 	env, read := captureEnv(t, wd)
 	code := runProvenance([]string{"--profile", profPath, "--check"}, env)
@@ -384,7 +384,7 @@ func TestRunProvenance_CheckJSONEmptyArray(t *testing.T) {
 	profDir := filepath.Join(wd, ".opencode")
 	os.MkdirAll(profDir, 0o755)
 	profPath := filepath.Join(profDir, "default.json")
-	os.WriteFile(profPath, []byte(`{"meta":{"name":"default"},"workdir":{"access":"readwrite"}}`), 0o644)
+	os.WriteFile(profPath, []byte(`{"meta":{"name":"default"},"workdir":{"access":"readwrite"},"environment":{"allow_vars":["HOME","PATH"]}}`), 0o644)
 
 	env, read := captureEnv(t, wd)
 	code := runProvenance([]string{"--profile", profPath, "--check", "--json"}, env)

--- a/internal/cli/sandbox_cmd.go
+++ b/internal/cli/sandbox_cmd.go
@@ -42,7 +42,7 @@ func runSandboxRun(args []string, env *Env) int {
 	flags, err := sandboxprofile.ParseFlags(args)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac sandbox run:", err)
-		fmt.Fprintln(env.Stderr, "usage: omac sandbox run [--profile <ref>] [--allow <path>] [--read <path>] [--write <path>] [--deny <path|glob>] [--allow-file <path>] [--allow-unix-dir <dir>] [--open-port <port>] [--listen-port <port>] [--allow-tcp-connect <port>] [--allow-domain <d>] [--deny-domain <d>] [--block-net] [--workdir-access <level>] -- <cmd> [args...]")
+		fmt.Fprintln(env.Stderr, "usage: omac sandbox run [--profile <ref>] [--allow <path>] [--read <path>] [--write <path>] [--deny <path|glob>] [--allow-file <path>] [--allow-unix-dir <dir>] [--open-port <port>] [--listen-port <port>] [--allow-tcp-connect <port>] [--allow-domain <d>] [--deny-domain <d>] [--allow-env <name>] [--block-net] [--workdir-access <level>] -- <cmd> [args...]")
 		return ExitMisuse
 	}
 	return sandboxrun.Run(sandboxrun.Options{

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -398,6 +398,10 @@ func runServe(args []string, env *Env) int {
 		if cacheScope != nil {
 			argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)
 		}
+		// Forward the selected harness's auth env vars through the
+		// default profile's restrictive allow_vars filter. (Control-plane
+		// port and harness runtime dirs are granted inside sandboxServeArgv.)
+		argv = injectSandboxEnvAllow(argv, harness.SandboxEnvAllow)
 		// Pass the resolved audit path to `omac sandbox run` so its
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the
@@ -567,6 +571,41 @@ func injectSandboxDirs(argv []string, dirs []string) []string {
 		argv = injectSandboxFlag(argv, "--allow", d)
 	}
 	return argv
+}
+
+// injectSandboxEnvAllow splices --allow-env flags for each harness-declared
+// auth env var into the sandbox argv, so they survive the default profile's
+// restrictive allow_vars filter. Only the selected harness's vars are added.
+//
+// --allow-env is understood only by omac's native `sandbox run` backend
+// (where FilterEnv applies the allowlist); other backends (nono) do their
+// own env filtering via their own profile, so injecting the flag there
+// would be meaningless and could fail on an unknown flag. Guarded by
+// argvRunsNativeSandbox. Empty/nil is a no-op.
+func injectSandboxEnvAllow(argv []string, names []string) []string {
+	if !argvRunsNativeSandbox(argv) {
+		return argv
+	}
+	for _, n := range names {
+		if n == "" {
+			continue
+		}
+		argv = injectSandboxFlag(argv, "--allow-env", n)
+	}
+	return argv
+}
+
+// argvRunsNativeSandbox reports whether argv invokes omac's native
+// sandbox supervisor (`omac sandbox run …`), identified by consecutive
+// "sandbox" "run" tokens. This is the only backend that parses the
+// launch-injected sandbox flags omac itself defines (e.g. --allow-env).
+func argvRunsNativeSandbox(argv []string) bool {
+	for i := 0; i+1 < len(argv); i++ {
+		if argv[i] == "sandbox" && argv[i+1] == "run" {
+			return true
+		}
+	}
+	return false
 }
 
 // injectSandboxFlag splices a sandbox flag (with optional value; pass

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/opencodestate"
 	"github.com/tngtech/oh-my-agentic-coder/internal/registry"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandbox"
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
 	"github.com/tngtech/oh-my-agentic-coder/internal/secrets"
 	"github.com/tngtech/oh-my-agentic-coder/internal/skillconfig"
 	"github.com/tngtech/oh-my-agentic-coder/internal/skillsource"
@@ -398,10 +399,10 @@ func runServe(args []string, env *Env) int {
 		if cacheScope != nil {
 			argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)
 		}
-		// Forward the selected harness's auth env vars through the
-		// default profile's restrictive allow_vars filter. (Control-plane
-		// port and harness runtime dirs are granted inside sandboxServeArgv.)
-		argv = injectSandboxEnvAllow(argv, harness.SandboxEnvAllow, prof)
+		// Forward the selected harness's auth env vars through the default
+		// profile's restrictive allow_vars filter. (Control-plane port and
+		// harness runtime dirs are granted inside sandboxServeArgv.)
+		argv = forwardHarnessEnv(env, argv, harness, prof, profName)
 		// Pass the resolved audit path to `omac sandbox run` so its
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the
@@ -571,6 +572,53 @@ func injectSandboxDirs(argv []string, dirs []string) []string {
 		argv = injectSandboxFlag(argv, "--allow", d)
 	}
 	return argv
+}
+
+// emptyAllowVarsWarnDelay is how long omac pauses after warning about an
+// empty-allow_vars profile at launch, so the message is seen before the
+// harness UI takes over. Overridable in tests.
+var emptyAllowVarsWarnDelay = 2 * time.Second
+
+// forwardHarnessEnv forwards the selected harness's auth env vars into the
+// sandbox via --allow-env. If the resolved sandbox profile has an EMPTY
+// environment.allow_vars, leaving it empty would inherit every ambient host
+// var (the pre-#102 leak). Rather than either leak or break, omac fails
+// closed: it seeds ONLY the operational minimum (sandboxprofile.DefaultAllowVars)
+// so the empty inherit-all list becomes a restrictive allowlist — ambient
+// secrets are stripped while HOME/PATH/locale keep the harness runnable.
+// Provider-auth vars are deliberately NOT auto-forwarded here: an empty
+// profile is a misconfiguration, and omac does not silently push provider
+// credentials into the sandbox to paper over it. It warns that this differs
+// from the old inherit-everything behavior and pauses so the message is seen.
+func forwardHarnessEnv(env *Env, argv []string, harness config.Harness, prof config.SandboxProfile, profName string) []string {
+	if empty, ok := sandboxProfileAllowVarsEmpty(prof); ok && empty {
+		fmt.Fprintf(env.Stderr, "omac: sandbox profile %q has an empty environment.allow_vars.\n", profName)
+		fmt.Fprintln(env.Stderr, "      Forwarding only the operational minimum (HOME, PATH, TERM, locale, …).")
+		fmt.Fprintln(env.Stderr, "      No provider-auth or other ambient env vars are passed through (previously every")
+		fmt.Fprintln(env.Stderr, "      var was inherited). The harness starts but will not authenticate until you add")
+		fmt.Fprintln(env.Stderr, `      the vars it needs to allow_vars (see "omac doctor"), or set allow_vars: ["*"].`)
+		fmt.Fprintln(env.Stderr, "      Continuing shortly…")
+		time.Sleep(emptyAllowVarsWarnDelay)
+		// Seed only the operational minimum; do NOT auto-forward auth vars.
+		return injectSandboxEnvAllow(argv, sandboxprofile.DefaultAllowVars(), prof)
+	}
+	return injectSandboxEnvAllow(argv, harness.SandboxEnvAllow, prof)
+}
+
+// sandboxProfileAllowVarsEmpty reports whether the native sandbox profile
+// referenced by prof resolves to an empty environment.allow_vars. ok is false
+// when prof is not an inspectable native ({{self}} sandbox run) profile or the
+// referenced profile cannot be resolved read-only.
+func sandboxProfileAllowVarsEmpty(prof config.SandboxProfile) (empty bool, ok bool) {
+	ref, isNative := inspectBuiltinProfileRef(prof.Command)
+	if !isNative {
+		return false, false
+	}
+	sp, _, err := sandboxprofile.ResolveReadOnly(ref)
+	if err != nil {
+		return false, false
+	}
+	return len(sp.Environment.AllowVars) == 0, true
 }
 
 // injectSandboxEnvAllow splices --allow-env flags for each harness-declared

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -401,7 +401,7 @@ func runServe(args []string, env *Env) int {
 		// Forward the selected harness's auth env vars through the
 		// default profile's restrictive allow_vars filter. (Control-plane
 		// port and harness runtime dirs are granted inside sandboxServeArgv.)
-		argv = injectSandboxEnvAllow(argv, harness.SandboxEnvAllow)
+		argv = injectSandboxEnvAllow(argv, harness.SandboxEnvAllow, prof)
 		// Pass the resolved audit path to `omac sandbox run` so its
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the
@@ -581,9 +581,9 @@ func injectSandboxDirs(argv []string, dirs []string) []string {
 // (where FilterEnv applies the allowlist); other backends (nono) do their
 // own env filtering via their own profile, so injecting the flag there
 // would be meaningless and could fail on an unknown flag. Guarded by
-// argvRunsNativeSandbox. Empty/nil is a no-op.
-func injectSandboxEnvAllow(argv []string, names []string) []string {
-	if !argvRunsNativeSandbox(argv) {
+// profileRunsNativeSandbox. Empty/nil is a no-op.
+func injectSandboxEnvAllow(argv []string, names []string, prof config.SandboxProfile) []string {
+	if !profileRunsNativeSandbox(prof) {
 		return argv
 	}
 	for _, n := range names {
@@ -595,17 +595,16 @@ func injectSandboxEnvAllow(argv []string, names []string) []string {
 	return argv
 }
 
-// argvRunsNativeSandbox reports whether argv invokes omac's native
-// sandbox supervisor (`omac sandbox run …`), identified by consecutive
-// "sandbox" "run" tokens. This is the only backend that parses the
-// launch-injected sandbox flags omac itself defines (e.g. --allow-env).
-func argvRunsNativeSandbox(argv []string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == "sandbox" && argv[i+1] == "run" {
-			return true
-		}
-	}
-	return false
+// profileRunsNativeSandbox reports whether prof's command template invokes
+// omac's native sandbox supervisor ({{self}} sandbox run …) — the only
+// backend that parses the launch-injected sandbox flags omac defines (e.g.
+// --allow-env). Anchored on the leading template tokens rather than a bare
+// token scan of the expanded argv: {{self}} resolves to os.Executable() (an
+// absolute path, not "omac"), and a nono profile whose inner command merely
+// contains "sandbox"/"run" tokens must not be misclassified.
+func profileRunsNativeSandbox(prof config.SandboxProfile) bool {
+	c := prof.Command
+	return len(c) >= 3 && c[0] == "{{self}}" && c[1] == "sandbox" && c[2] == "run"
 }
 
 // injectSandboxFlag splices a sandbox flag (with optional value; pass

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -383,6 +383,66 @@ func TestInjectSandboxEnvAllow(t *testing.T) {
 	}
 }
 
+// TestForwardHarnessEnvEmptyProfileForwardsOperationalMinimum: with an
+// empty-allow_vars profile, omac fails closed — it seeds ONLY the operational
+// minimum (so HOME/PATH keep the harness runnable), does NOT auto-forward the
+// harness's provider-auth vars, strips everything else, and warns.
+func TestForwardHarnessEnvEmptyProfileForwardsOperationalMinimum(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stageProfile(t, home, `{"meta": {"name": "default"}}`)
+
+	old := emptyAllowVarsWarnDelay
+	emptyAllowVarsWarnDelay = 0
+	defer func() { emptyAllowVarsWarnDelay = old }()
+
+	env, _, errBuf, drain := newPipeEnv(t, "")
+	prof := config.SandboxProfile{Command: []string{"{{self}}", "sandbox", "run", "--profile", "default", "--", "x"}}
+	harness := config.Harness{Name: "test", SandboxEnvAllow: []string{"ANTHROPIC_API_KEY"}}
+	argv := []string{"/usr/bin/omac", "sandbox", "run", "--profile", "default", "--", "x"}
+
+	got := forwardHarnessEnv(env, argv, harness, prof, "default")
+	drain()
+
+	joined := strings.Join(got, " ")
+	// Operational minimum is forwarded so the harness runs.
+	for _, want := range []string{"--allow-env HOME", "--allow-env PATH"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("empty profile should forward %q; got %v", want, got)
+		}
+	}
+	// Provider-auth vars are NOT auto-forwarded on an empty profile.
+	if strings.Contains(joined, "ANTHROPIC_API_KEY") {
+		t.Errorf("empty profile must not auto-forward provider-auth vars; got %v", got)
+	}
+	if !strings.Contains(errBuf.String(), "allow_vars") {
+		t.Errorf("expected empty-allow_vars warning on stderr; got:\n%s", errBuf.String())
+	}
+}
+
+// TestForwardHarnessEnvNonEmptyProfileInjects: a profile with an explicit
+// allowlist still gets the harness auth vars injected as --allow-env.
+func TestForwardHarnessEnvNonEmptyProfileInjects(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stageProfile(t, home, `{"meta": {"name": "default"}, "environment": {"allow_vars": ["HOME"]}}`)
+
+	env, _, errBuf, drain := newPipeEnv(t, "")
+	prof := config.SandboxProfile{Command: []string{"{{self}}", "sandbox", "run", "--profile", "default", "--", "x"}}
+	harness := config.Harness{Name: "test", SandboxEnvAllow: []string{"ANTHROPIC_API_KEY"}}
+	argv := []string{"/usr/bin/omac", "sandbox", "run", "--profile", "default", "--", "x"}
+
+	got := forwardHarnessEnv(env, argv, harness, prof, "default")
+	drain()
+
+	if !strings.Contains(strings.Join(got, " "), "--allow-env ANTHROPIC_API_KEY") {
+		t.Errorf("non-empty profile: expected --allow-env injection; got %v", got)
+	}
+	if strings.Contains(errBuf.String(), "allow_vars") {
+		t.Errorf("non-empty profile must not warn; got:\n%s", errBuf.String())
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -318,6 +318,35 @@ func TestInjectOpenPort(t *testing.T) {
 	}
 }
 
+func TestInjectSandboxEnvAllow(t *testing.T) {
+	in := []string{"omac", "sandbox", "run", "--profile", "default", "--", "claude"}
+	got := injectSandboxEnvAllow(in, []string{"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"})
+	want := []string{
+		"omac", "sandbox", "run", "--profile", "default",
+		"--allow-env", "ANTHROPIC_API_KEY",
+		"--allow-env", "ANTHROPIC_BASE_URL",
+		"--", "claude",
+	}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// Empty names is a no-op; empty entries are skipped.
+	if got := injectSandboxEnvAllow(in, nil); !equalStrings(got, in) {
+		t.Errorf("nil names should be a no-op: %v", got)
+	}
+	if got := injectSandboxEnvAllow(in, []string{""}); !equalStrings(got, in) {
+		t.Errorf("empty entry should be skipped: %v", got)
+	}
+
+	// Non-native backend (nono) does not understand --allow-env: the argv
+	// must be left untouched (env filtering is nono's own concern).
+	nono := []string{"nono", "run", "--allow-cwd", "--profile", "tng-sandbox", "--", "opencode"}
+	if got := injectSandboxEnvAllow(nono, []string{"ANTHROPIC_API_KEY"}); !equalStrings(got, nono) {
+		t.Errorf("nono argv must be untouched: %v", got)
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -319,31 +319,67 @@ func TestInjectOpenPort(t *testing.T) {
 }
 
 func TestInjectSandboxEnvAllow(t *testing.T) {
-	in := []string{"omac", "sandbox", "run", "--profile", "default", "--", "claude"}
-	got := injectSandboxEnvAllow(in, []string{"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"})
-	want := []string{
-		"omac", "sandbox", "run", "--profile", "default",
-		"--allow-env", "ANTHROPIC_API_KEY",
-		"--allow-env", "ANTHROPIC_BASE_URL",
-		"--", "claude",
+	profiles := config.DefaultLauncherConfig().Sandbox.Profiles
+	expand := func(t *testing.T, prof config.SandboxProfile) []string {
+		t.Helper()
+		argv, err := sandbox.Expand(prof, sandbox.Inputs{
+			Workdir:  "/w",
+			Socket:   "/w/bridge.sock",
+			TCPPort:  6000,
+			InnerCmd: []string{"claude"},
+			TmpDir:   "/w/tmp",
+		})
+		if err != nil {
+			t.Fatalf("Expand: %v", err)
+		}
+		return argv
 	}
-	if !equalStrings(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+
+	// Native backend: use the real Expand output (argv[0] is os.Executable(),
+	// an absolute path — NOT the literal "omac"), so the detector cannot rely
+	// on argv[0] matching a hand-rolled name.
+	builtinProf := profiles["builtin"]
+	builtin := expand(t, builtinProf)
+	got := injectSandboxEnvAllow(builtin, []string{"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"}, builtinProf)
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "--allow-env ANTHROPIC_API_KEY") ||
+		!strings.Contains(joined, "--allow-env ANTHROPIC_BASE_URL") {
+		t.Errorf("native backend must gain --allow-env flags: %v", got)
 	}
 
 	// Empty names is a no-op; empty entries are skipped.
-	if got := injectSandboxEnvAllow(in, nil); !equalStrings(got, in) {
-		t.Errorf("nil names should be a no-op: %v", got)
+	if g := injectSandboxEnvAllow(builtin, nil, builtinProf); !equalStrings(g, builtin) {
+		t.Errorf("nil names should be a no-op: %v", g)
 	}
-	if got := injectSandboxEnvAllow(in, []string{""}); !equalStrings(got, in) {
-		t.Errorf("empty entry should be skipped: %v", got)
+	if g := injectSandboxEnvAllow(builtin, []string{""}, builtinProf); !equalStrings(g, builtin) {
+		t.Errorf("empty entry should be skipped: %v", g)
 	}
 
 	// Non-native backend (nono) does not understand --allow-env: the argv
 	// must be left untouched (env filtering is nono's own concern).
-	nono := []string{"nono", "run", "--allow-cwd", "--profile", "tng-sandbox", "--", "opencode"}
-	if got := injectSandboxEnvAllow(nono, []string{"ANTHROPIC_API_KEY"}); !equalStrings(got, nono) {
-		t.Errorf("nono argv must be untouched: %v", got)
+	nonoProf := profiles["nono"]
+	nono := expand(t, nonoProf)
+	if g := injectSandboxEnvAllow(nono, []string{"ANTHROPIC_API_KEY"}, nonoProf); !equalStrings(g, nono) {
+		t.Errorf("nono argv must be untouched: %v", g)
+	}
+
+	// Regression (issue #111 review): a nono profile whose inner command
+	// itself contains "sandbox" "run" tokens must NOT be misclassified as the
+	// native backend. Detection anchors on the profile template, not on a
+	// bare token scan of the expanded argv.
+	nonoInnerProf := nonoProf
+	nonoArgv, err := sandbox.Expand(nonoInnerProf, sandbox.Inputs{
+		Workdir:  "/w",
+		Socket:   "/w/bridge.sock",
+		TCPPort:  6000,
+		InnerCmd: []string{"sandbox", "run", "--weird"},
+		TmpDir:   "/w/tmp",
+	})
+	if err != nil {
+		t.Fatalf("Expand nono-inner: %v", err)
+	}
+	if g := injectSandboxEnvAllow(nonoArgv, []string{"ANTHROPIC_API_KEY"}, nonoInnerProf); !equalStrings(g, nonoArgv) {
+		t.Errorf("nono argv with inner sandbox/run tokens must be untouched: %v", g)
 	}
 }
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -808,7 +808,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 		// Forward the selected harness's auth env vars through the
 		// default profile's restrictive allow_vars filter — only for the
 		// selected harness.
-		argv = injectSandboxEnvAllow(argv, harness.SandboxEnvAllow)
+		argv = injectSandboxEnvAllow(argv, harness.SandboxEnvAllow, prof)
 		// Pass the resolved audit path down to `omac sandbox run` so the
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -805,6 +805,10 @@ func runLaunch(env *Env, opts launchOpts) int {
 		if cacheScope != nil {
 			argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)
 		}
+		// Forward the selected harness's auth env vars through the
+		// default profile's restrictive allow_vars filter — only for the
+		// selected harness.
+		argv = injectSandboxEnvAllow(argv, harness.SandboxEnvAllow)
 		// Pass the resolved audit path down to `omac sandbox run` so the
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -808,7 +808,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 		// Forward the selected harness's auth env vars through the
 		// default profile's restrictive allow_vars filter — only for the
 		// selected harness.
-		argv = injectSandboxEnvAllow(argv, harness.SandboxEnvAllow, prof)
+		argv = forwardHarnessEnv(env, argv, harness, prof, profName)
 		// Pass the resolved audit path down to `omac sandbox run` so the
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -114,14 +114,17 @@ type Harness struct {
 	// environment.allow_vars at launch (via --allow-env) so they survive
 	// the filter — for the selected harness only.
 	//
-	// The auth names are the provider-agnostic ones each CLI documents
-	// reading from the environment. Users on other providers add their own
-	// names to the user-editable default.json allow_vars. Entries are
-	// exact names or trailing-* prefixes (sandboxprofile.envVarAllowed).
+	// Only unambiguous, single-provider auth vars belong here (e.g.
+	// claude-code → ANTHROPIC_*, codex → OPENAI_*). Multi-provider harnesses
+	// (opencode, pi) leave this empty: omac must not blindly forward a
+	// grab-bag of third-party keys regardless of which provider is
+	// configured — the user declares the specific key their setup uses in the
+	// profile's environment.allow_vars. Entries are exact names or trailing-*
+	// prefixes (sandboxprofile.envVarAllowed).
 	//
 	// Harnesses that authenticate exclusively via on-disk config in their
-	// SandboxDirs (granted read+write) and inject no non-OMAC_* env need
-	// nothing here.
+	// SandboxDirs (granted read+write) and inject no non-OMAC_* env leave
+	// this empty.
 	SandboxEnvAllow []string
 }
 
@@ -233,17 +236,13 @@ func harnessRegistry() []Harness {
 				"~/.config/opencode",
 				"~/.opencode",
 			},
-			// OpenCode stores provider credentials in auth.json (in
-			// SandboxDirs) but also reads provider API keys from the
-			// environment. Forward the common provider keys so env-based
-			// auth works for the selected harness.
-			SandboxEnvAllow: []string{
-				"ANTHROPIC_API_KEY",
-				"OPENAI_API_KEY",
-				"OPENROUTER_API_KEY",
-				"GEMINI_API_KEY",
-				"GROQ_API_KEY",
-			},
+			// OpenCode authenticates primarily via auth.json (in SandboxDirs,
+			// granted read+write). It also supports several providers'
+			// env-var API keys, but omac does NOT auto-forward them: pushing
+			// every third-party key (Anthropic/OpenAI/OpenRouter/Gemini/Groq)
+			// into the sandbox regardless of which provider is configured is
+			// too broad. A user relying on env-based provider auth declares the
+			// specific key in the profile's environment.allow_vars.
 			NeedsPluginBootstrap: true,
 		},
 		{
@@ -378,13 +377,10 @@ func harnessRegistry() []Harness {
 			// ~/.pi/agent/ (git/npm package caches also nest under there —
 			// no separate ~/.cache/pi was observed in a live install).
 			SandboxDirs: []string{"~/.pi"},
-			// Pi resolves $ENV_VAR references in models.json; forward the
-			// common provider keys so those references resolve. Users with a
-			// differently-named key add it to the profile's allow_vars.
-			SandboxEnvAllow: []string{
-				"OPENAI_API_KEY",
-				"ANTHROPIC_API_KEY",
-			},
+			// Pi resolves $ENV_VAR references in models.json. It is
+			// multi-provider, so omac does NOT auto-forward a grab-bag of
+			// provider keys: the user declares the specific key their
+			// models.json references in the profile's environment.allow_vars.
 			Session: &HarnessSession{
 				ContinueArgs:   []string{"-c"},
 				ResumeByIDArgs: func(id string) []string { return []string{"--session", id} },

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -102,6 +102,27 @@ type Harness struct {
 	// Currently only OpenCode (whose briefing relay depends on the
 	// omac plugin in ~/.config/opencode/plugins).
 	NeedsPluginBootstrap bool
+
+	// SandboxEnvAllow lists the environment variables omac forwards into
+	// the sandbox for this harness: the vars it reads from the ambient
+	// environment to authenticate to its LLM provider (API keys, auth
+	// tokens, base-URL overrides), plus any omac-injected harness-config
+	// var whose name is not OMAC_*-prefixed (e.g. Copilot's briefing dir).
+	// The sandbox default profile ships a restrictive allowlist
+	// (sandboxprofile.DefaultAllowVars) that strips every other inherited
+	// variable; omac merges these names into the profile's
+	// environment.allow_vars at launch (via --allow-env) so they survive
+	// the filter — for the selected harness only.
+	//
+	// The auth names are the provider-agnostic ones each CLI documents
+	// reading from the environment. Users on other providers add their own
+	// names to the user-editable default.json allow_vars. Entries are
+	// exact names or trailing-* prefixes (sandboxprofile.envVarAllowed).
+	//
+	// Harnesses that authenticate exclusively via on-disk config in their
+	// SandboxDirs (granted read+write) and inject no non-OMAC_* env need
+	// nothing here.
+	SandboxEnvAllow []string
 }
 
 // SessionListKind selects how omac enumerates a harness's prior sessions for
@@ -212,6 +233,17 @@ func harnessRegistry() []Harness {
 				"~/.config/opencode",
 				"~/.opencode",
 			},
+			// OpenCode stores provider credentials in auth.json (in
+			// SandboxDirs) but also reads provider API keys from the
+			// environment. Forward the common provider keys so env-based
+			// auth works for the selected harness.
+			SandboxEnvAllow: []string{
+				"ANTHROPIC_API_KEY",
+				"OPENAI_API_KEY",
+				"OPENROUTER_API_KEY",
+				"GEMINI_API_KEY",
+				"GROQ_API_KEY",
+			},
 			NeedsPluginBootstrap: true,
 		},
 		{
@@ -231,6 +263,15 @@ func harnessRegistry() []Harness {
 			HomeEnv:        "CLAUDE_HOME",
 			// Claude stores configuration, authentication, and sessions in ~/.claude; runtime state is in ~/.local/share/claude.
 			SandboxDirs: []string{"~/.claude", "~/.local/share/claude"},
+			// Interactive login credentials live in ~/.claude (SandboxDirs);
+			// these are the documented env vars for API-key / custom-endpoint
+			// auth (Anthropic-compatible gateway).
+			SandboxEnvAllow: []string{
+				"ANTHROPIC_API_KEY",
+				"ANTHROPIC_AUTH_TOKEN",
+				"ANTHROPIC_BASE_URL",
+				"ANTHROPIC_MODEL",
+			},
 			Session: &HarnessSession{
 				ContinueArgs:   []string{"--continue"},
 				ResumeByIDArgs: func(id string) []string { return []string{"--resume", id} },
@@ -253,6 +294,12 @@ func harnessRegistry() []Harness {
 			HomeEnv:        "CODEX_HOME",
 			// Codex stores configuration, sessions, and authentication in ~/.codex.
 			SandboxDirs: []string{"~/.codex"},
+			// Codex reads the OpenAI API key (and optional base-URL override)
+			// from the environment; config.toml may also reference env vars.
+			SandboxEnvAllow: []string{
+				"OPENAI_API_KEY",
+				"OPENAI_BASE_URL",
+			},
 			Session: &HarnessSession{
 				ContinueArgs:   []string{"resume", "--last"},
 				ResumeByIDArgs: func(id string) []string { return []string{"resume", id} },
@@ -279,6 +326,15 @@ func harnessRegistry() []Harness {
 			HomeEnv:        "COPILOT_HOME",
 			// Copilot stores configuration, session state, and authentication in ~/.copilot.
 			SandboxDirs: []string{"~/.copilot"},
+			// Copilot authenticates with a GitHub token (both spellings are
+			// accepted by the GitHub toolchain). COPILOT_CUSTOM_INSTRUCTIONS_DIRS
+			// is set by omac's BriefingEnvFunc to point copilot at the
+			// per-launch briefing dir; it must survive the env filter.
+			SandboxEnvAllow: []string{
+				"GITHUB_TOKEN",
+				"GH_TOKEN",
+				"COPILOT_CUSTOM_INSTRUCTIONS_DIRS",
+			},
 			Session: &HarnessSession{
 				ContinueArgs:   []string{"--continue"},
 				ResumeByIDArgs: func(id string) []string { return []string{"--session-id", id} },
@@ -322,6 +378,13 @@ func harnessRegistry() []Harness {
 			// ~/.pi/agent/ (git/npm package caches also nest under there —
 			// no separate ~/.cache/pi was observed in a live install).
 			SandboxDirs: []string{"~/.pi"},
+			// Pi resolves $ENV_VAR references in models.json; forward the
+			// common provider keys so those references resolve. Users with a
+			// differently-named key add it to the profile's allow_vars.
+			SandboxEnvAllow: []string{
+				"OPENAI_API_KEY",
+				"ANTHROPIC_API_KEY",
+			},
 			Session: &HarnessSession{
 				ContinueArgs:   []string{"-c"},
 				ResumeByIDArgs: func(id string) []string { return []string{"--session", id} },

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
 )
 
 func TestLookupHarness(t *testing.T) {
@@ -186,6 +188,26 @@ func TestDefaultSandboxProfilesHaveEmptyInnerCmd(t *testing.T) {
 	// no-sandbox-debug is a debug shell, not an agent harness: it keeps bash.
 	if got := lc.Sandbox.Profiles["no-sandbox-debug"].InnerCmd; !reflect.DeepEqual(got, []string{"bash"}) {
 		t.Errorf("no-sandbox-debug inner_cmd = %v, want [bash]", got)
+	}
+}
+
+func TestHarnessSandboxEnvAllowIsSafe(t *testing.T) {
+	// Every harness must declare the auth env vars it needs (they would
+	// otherwise be stripped by the default profile's allowlist — issue
+	// #102), and none of those names may collide with the always-drop
+	// danger blocklist, which would make the forward a silent no-op.
+	for _, h := range AllHarnesses() {
+		if len(h.SandboxEnvAllow) == 0 {
+			t.Errorf("harness %q declares no SandboxEnvAllow", h.Name)
+		}
+		for _, name := range h.SandboxEnvAllow {
+			if strings.TrimSpace(name) == "" {
+				t.Errorf("harness %q has an empty SandboxEnvAllow entry", h.Name)
+			}
+			if sandboxprofile.IsDangerousEnvVar(name) {
+				t.Errorf("harness %q forwards blocklisted env var %q (would be stripped)", h.Name, name)
+			}
+		}
 	}
 }
 

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -192,14 +192,13 @@ func TestDefaultSandboxProfilesHaveEmptyInnerCmd(t *testing.T) {
 }
 
 func TestHarnessSandboxEnvAllowIsSafe(t *testing.T) {
-	// Every harness must declare the auth env vars it needs (they would
-	// otherwise be stripped by the default profile's allowlist — issue
-	// #102), and none of those names may collide with the always-drop
-	// danger blocklist, which would make the forward a silent no-op.
+	// A harness may auto-forward the provider-auth vars it unambiguously
+	// needs (injected via --allow-env for the selected harness); the list is
+	// allowed to be empty for multi-provider harnesses that must not blindly
+	// forward a grab-bag of third-party keys (declare them in allow_vars
+	// instead). Whatever IS declared must be a real, non-blocklisted name —
+	// a blank or always-drop entry would be a silent no-op.
 	for _, h := range AllHarnesses() {
-		if len(h.SandboxEnvAllow) == 0 {
-			t.Errorf("harness %q declares no SandboxEnvAllow", h.Name)
-		}
 		for _, name := range h.SandboxEnvAllow {
 			if strings.TrimSpace(name) == "" {
 				t.Errorf("harness %q has an empty SandboxEnvAllow entry", h.Name)
@@ -207,6 +206,44 @@ func TestHarnessSandboxEnvAllowIsSafe(t *testing.T) {
 			if sandboxprofile.IsDangerousEnvVar(name) {
 				t.Errorf("harness %q forwards blocklisted env var %q (would be stripped)", h.Name, name)
 			}
+		}
+	}
+}
+
+// TestHarnessAuthForwardPolicy pins the auto-forward policy: single-provider
+// harnesses inject their targeted auth vars; multi-provider harnesses
+// (opencode, pi) auto-forward NOTHING — a user relying on env-based provider
+// auth declares the specific key in the profile's allow_vars, so omac does not
+// blindly push every third-party key into the sandbox.
+func TestHarnessAuthForwardPolicy(t *testing.T) {
+	multiProvider := map[string]bool{"opencode": true, "pi": true}
+	for _, h := range AllHarnesses() {
+		if multiProvider[h.Name] {
+			if len(h.SandboxEnvAllow) != 0 {
+				t.Errorf("multi-provider harness %q must not auto-forward provider keys; got %v", h.Name, h.SandboxEnvAllow)
+			}
+			continue
+		}
+	}
+	// Single-provider harnesses keep their targeted forwarding.
+	for name, want := range map[string]string{
+		"claude-code": "ANTHROPIC_API_KEY",
+		"codex":       "OPENAI_API_KEY",
+		"copilot":     "GITHUB_TOKEN",
+	} {
+		h, ok := LookupHarness(name)
+		if !ok {
+			t.Errorf("harness %q not found", name)
+			continue
+		}
+		found := false
+		for _, v := range h.SandboxEnvAllow {
+			if v == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("single-provider harness %q should forward %q; got %v", name, want, h.SandboxEnvAllow)
 		}
 	}
 }

--- a/internal/e2e/cache_isolation_test.go
+++ b/internal/e2e/cache_isolation_test.go
@@ -219,6 +219,14 @@ func writeCacheTestProfile(t *testing.T, home string, extraRead, extraAllow []st
 		"network": map[string]any{
 			"mode": "blocked",
 		},
+		// This fixture exercises cache-dir isolation, not env allowlisting: the
+		// dev tools (go/node/npm/pip/cargo/rustc) need their ambient env
+		// (GOPATH, GOMODCACHE, node paths, …). "*" inherits every ambient var
+		// (still minus the danger blocklist) so an empty allow_vars is not
+		// fail-closed to the operational minimum at launch (see forwardHarnessEnv).
+		"environment": map[string]any{
+			"allow_vars": []string{"*"},
+		},
 	}
 	if extraOpenPort > 0 {
 		profile["network"] = map[string]any{

--- a/internal/profileaudit/check.go
+++ b/internal/profileaudit/check.go
@@ -21,8 +21,28 @@ func Check(profile *sandboxprofile.Profile) []Finding {
 	findings = append(findings, checkOverrideDeny(profile)...)
 	findings = append(findings, checkFSGrants(profile)...)
 	findings = append(findings, checkNetwork(profile)...)
+	findings = append(findings, checkEnvironment(profile)...)
 	sortFindings(findings)
 	return findings
+}
+
+// checkEnvironment flags an empty env allowlist. With no allow_vars the
+// sandbox inherits every ambient variable except the danger blocklist —
+// credentials, capability pointers, proxy settings — contradicting the
+// "no host env unless explicitly forwarded" trust model (issue #102).
+// MEDIUM: it is a real leak but affects only the launching shell's own
+// environment, not an on-disk secret.
+func checkEnvironment(profile *sandboxprofile.Profile) []Finding {
+	if len(profile.Environment.AllowVars) > 0 {
+		return nil
+	}
+	return []Finding{{
+		Severity: SeverityMedium,
+		Category: CatEnvironment,
+		Field:    "environment.allow_vars",
+		Value:    "(empty)",
+		Message:  "empty allowlist inherits all ambient env vars except the danger blocklist; add an explicit allow_vars list",
+	}}
 }
 
 // sortFindings orders findings by severity (high first), then category,

--- a/internal/profileaudit/check_test.go
+++ b/internal/profileaudit/check_test.go
@@ -44,6 +44,21 @@ func TestCheck_EmptyAllowVarsIsMedium(t *testing.T) {
 	}
 }
 
+// TestCheck_WildcardAllowVarsNoFinding documents allow_vars: ["*"] as the
+// explicit "inherit everything (except the danger blocklist)" escape hatch:
+// it is non-empty, so it suppresses the empty-allowlist finding, and it is
+// still safe because IsDangerousEnvVar wins over the allowlist in FilterEnv
+// (issue #111 review).
+func TestCheck_WildcardAllowVarsNoFinding(t *testing.T) {
+	p := cleanProfile()
+	p.Environment.AllowVars = []string{"*"}
+	for _, f := range Check(p) {
+		if f.Category == CatEnvironment && f.Field == "environment.allow_vars" {
+			t.Errorf(`allow_vars ["*"] must not produce an environment finding; got %+v`, f)
+		}
+	}
+}
+
 func TestCheck_OverrideDenyBaselinePathIsHigh(t *testing.T) {
 	// ~/.ssh is in the cross-platform protectedCommon set (baseline.go:35).
 	p := cleanProfile()

--- a/internal/profileaudit/check_test.go
+++ b/internal/profileaudit/check_test.go
@@ -8,11 +8,14 @@ import (
 )
 
 // cleanProfile returns a minimal profile with no grants, ready for tests
-// to populate specific fields.
+// to populate specific fields. It carries an explicit env allowlist so it
+// stays clean under checkEnvironment (an empty allow_vars is itself a
+// finding); tests exercising other categories start from a clean base.
 func cleanProfile() *sandboxprofile.Profile {
 	return &sandboxprofile.Profile{
-		Meta:    sandboxprofile.Meta{Name: "test"},
-		Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessNone},
+		Meta:        sandboxprofile.Meta{Name: "test"},
+		Workdir:     sandboxprofile.Workdir{Access: sandboxprofile.AccessNone},
+		Environment: sandboxprofile.Environment{AllowVars: []string{"HOME", "PATH"}},
 	}
 }
 
@@ -20,6 +23,24 @@ func TestCheck_EmptyProfileNoFindings(t *testing.T) {
 	findings := Check(cleanProfile())
 	if len(findings) != 0 {
 		t.Errorf("empty profile should produce no findings; got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestCheck_EmptyAllowVarsIsMedium(t *testing.T) {
+	p := cleanProfile()
+	p.Environment.AllowVars = nil
+	findings := Check(p)
+	var found bool
+	for _, f := range findings {
+		if f.Category == CatEnvironment && f.Field == "environment.allow_vars" {
+			found = true
+			if f.Severity != SeverityMedium {
+				t.Errorf("empty allow_vars severity = %q, want medium", f.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("empty allow_vars should produce an environment finding; got %+v", findings)
 	}
 }
 

--- a/internal/profileaudit/finding.go
+++ b/internal/profileaudit/finding.go
@@ -20,6 +20,7 @@ const (
 	CatFSGrant      Category = "filesystem"
 	CatNetwork      Category = "network"
 	CatOverrideDeny Category = "override_deny"
+	CatEnvironment  Category = "environment"
 )
 
 // Finding is one static-check result.

--- a/internal/sandboxprofile/env.go
+++ b/internal/sandboxprofile/env.go
@@ -41,6 +41,38 @@ var dangerousEnvPrefixes = []string{
 	"OP_SESSION_",
 }
 
+// DefaultAllowVars is the minimal set of environment variables the
+// sandboxed runtime needs to function. It is compiled into
+// DefaultProfile so the scaffolded default.json ships an explicit
+// allowlist rather than the implicit "inherit everything" behaviour of
+// an empty list. Harness-specific auth variables (e.g. the LLM provider
+// token) are NOT here — they are merged in per-harness at launch via
+// Harness.SandboxEnvAllow (mirroring how SandboxDirs are injected).
+//
+// Entries are exact names or trailing-* prefixes (see envVarAllowed).
+// Injected variables (HTTP(S)_PROXY, OMAC_* skill bases) bypass the
+// allowlist entirely via the injected overlay in FilterEnv, but OMAC_*
+// is listed too because omac sets several OMAC_* vars in its own process
+// environment before exec (see internal/cli/start.go), and those reach
+// the child through inheritance rather than the injected overlay.
+func DefaultAllowVars() []string {
+	return []string{
+		"OMAC_*",
+		"HOME",
+		"PATH",
+		"PWD",
+		"TMPDIR",
+		"LANG",
+		"LC_*",
+		"TERM",
+		"SHELL",
+		"XDG_CONFIG_HOME",
+		"XDG_DATA_HOME",
+		"XDG_STATE_HOME",
+		"NPM_CONFIG_PREFIX",
+	}
+}
+
 // IsDangerousEnvVar reports whether key is on the always-drop blocklist.
 func IsDangerousEnvVar(key string) bool {
 	if dangerousEnvExact[key] {

--- a/internal/sandboxprofile/env.go
+++ b/internal/sandboxprofile/env.go
@@ -55,6 +55,11 @@ var dangerousEnvPrefixes = []string{
 // is listed too because omac sets several OMAC_* vars in its own process
 // environment before exec (see internal/cli/start.go), and those reach
 // the child through inheritance rather than the injected overlay.
+//
+// USER/LOGNAME (default identity for git/npm/ssh — also forwarded to the
+// facade via FacadeConfig.BaseEnvPassthrough), TZ (date formatting), and
+// EDITOR/VISUAL (harnesses that shell out to an editor) round out the
+// operational minimum; all are non-secret.
 func DefaultAllowVars() []string {
 	return []string{
 		"OMAC_*",
@@ -66,6 +71,11 @@ func DefaultAllowVars() []string {
 		"LC_*",
 		"TERM",
 		"SHELL",
+		"USER",
+		"LOGNAME",
+		"TZ",
+		"EDITOR",
+		"VISUAL",
 		"XDG_CONFIG_HOME",
 		"XDG_DATA_HOME",
 		"XDG_STATE_HOME",

--- a/internal/sandboxprofile/flags.go
+++ b/internal/sandboxprofile/flags.go
@@ -22,6 +22,7 @@ type Flags struct {
 	AllowTCP      []int    // --allow-tcp-connect <port>
 	AllowDomain   []string // --allow-domain <domain>
 	DenyDomain    []string // --deny-domain <domain>
+	AllowEnv      []string // --allow-env <name>    additive env allow_vars entry
 	BlockNet      bool     // --block-net
 	Learn         bool     // --learn: unrestricted fs + folder recording
 	WorkdirAccess string   // --workdir-access <level>
@@ -162,6 +163,12 @@ func ParseFlags(args []string) (*Flags, error) {
 				return nil, err
 			}
 			f.DenyDomain = append(f.DenyDomain, v)
+		case "--allow-env":
+			v, err := val(a)
+			if err != nil {
+				return nil, err
+			}
+			f.AllowEnv = append(f.AllowEnv, v)
 		case "--block-net":
 			if hasInline {
 				return nil, fmt.Errorf("--block-net takes no value")
@@ -227,6 +234,8 @@ func Merge(p *Profile, f *Flags) (*Profile, []string) {
 	out.Network.AllowTCPConnect = appendIntCopy(p.Network.AllowTCPConnect, f.AllowTCP...)
 	out.Network.AllowDomain = appendCopy(p.Network.AllowDomain, f.AllowDomain...)
 	out.Network.DenyDomain = appendCopy(p.Network.DenyDomain, f.DenyDomain...)
+
+	out.Environment.AllowVars = appendCopy(p.Environment.AllowVars, f.AllowEnv...)
 
 	if f.WorkdirAccess != "" {
 		out.Workdir.Access = f.WorkdirAccess

--- a/internal/sandboxprofile/profile.go
+++ b/internal/sandboxprofile/profile.go
@@ -222,8 +222,14 @@ func (n *Network) EffectiveEnforcement() string {
 
 // Environment configures env-var filtering for the child.
 type Environment struct {
-	// AllowVars lists exact names or trailing-* prefixes. Empty/absent
-	// means every variable passes (minus the always-on blocklist).
+	// AllowVars lists env-var patterns to pass through. Each entry is
+	// either an exact name ("HOME") or a trailing-* prefix ("OMAC_*",
+	// matched from the key start — "FOO_OMAC_*" does not match). Only a
+	// trailing "*" is special; a bare "*" allows everything. An entry
+	// without a trailing "*" is an exact match, so a typo like "OMAC"
+	// (no "*") matches only the literal "OMAC", not "OMAC_BASE".
+	// Empty/absent means every variable passes (minus the always-on
+	// danger blocklist, which wins over any allow entry).
 	AllowVars []string `json:"allow_vars,omitempty"`
 }
 

--- a/internal/sandboxprofile/profile_test.go
+++ b/internal/sandboxprofile/profile_test.go
@@ -705,6 +705,92 @@ func TestDefaultProfileEnvAllowlist(t *testing.T) {
 	}
 }
 
+// TestFilterEnvMergedLaunchEnv exercises the full launch-time composition:
+// the default allowlist, PLUS a harness's SandboxEnvAllow (merged in at
+// launch via --allow-env), PLUS the injected HTTP(S)_PROXY/OMAC_* overlay.
+// It asserts the exact resulting child env — operational + auth vars pass,
+// the injected overlay wins over an inherited value, and an ambient secret
+// not on either list is stripped (issue #111 review: no default-CI coverage
+// of the merged env, only the e2e build tag).
+func TestFilterEnvMergedLaunchEnv(t *testing.T) {
+	environ := []string{
+		"HOME=/home/u",
+		"PATH=/usr/bin",
+		"USER=alice",
+		"TZ=Europe/Berlin",
+		"OMAC_BASE=http://127.0.0.1:1/x",
+		"ANTHROPIC_API_KEY=sk-secret", // harness auth var (merged allow)
+		"AWS_SECRET_ACCESS_KEY=oops",  // ambient secret, on neither list
+		"HTTP_PROXY=http://stale:1",   // overridden by the injected overlay
+	}
+	// DefaultAllowVars() + the selected harness's auth names, mirroring the
+	// launch-time --allow-env merge.
+	allow := append(DefaultAllowVars(), "ANTHROPIC_API_KEY")
+	injected := map[string]string{
+		"HTTP_PROXY": "http://omac:tok@127.0.0.1:9",
+		"OMAC_GATE":  "1",
+	}
+
+	got := envMap(FilterEnv(environ, allow, injected))
+	want := map[string]string{
+		"HOME":              "/home/u",
+		"PATH":              "/usr/bin",
+		"USER":              "alice",
+		"TZ":                "Europe/Berlin",
+		"OMAC_BASE":         "http://127.0.0.1:1/x",
+		"ANTHROPIC_API_KEY": "sk-secret",
+		"HTTP_PROXY":        "http://omac:tok@127.0.0.1:9", // injected wins
+		"OMAC_GATE":         "1",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("merged env has %d entries, want %d:\n got  %v\n want %v", len(got), len(want), got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s = %q, want %q", k, got[k], v)
+		}
+	}
+	if _, leaked := got["AWS_SECRET_ACCESS_KEY"]; leaked {
+		t.Error("ambient secret AWS_SECRET_ACCESS_KEY must be stripped")
+	}
+}
+
+// TestDefaultAllowVarsGoldenList pins the exact membership of
+// DefaultAllowVars so future drift (an accidental add or removal) is caught
+// by the test suite rather than silently changing the sandbox's operational
+// minimum (issue #111 review).
+func TestDefaultAllowVarsGoldenList(t *testing.T) {
+	want := []string{
+		"OMAC_*",
+		"HOME",
+		"PATH",
+		"PWD",
+		"TMPDIR",
+		"LANG",
+		"LC_*",
+		"TERM",
+		"SHELL",
+		"USER",
+		"LOGNAME",
+		"TZ",
+		"EDITOR",
+		"VISUAL",
+		"XDG_CONFIG_HOME",
+		"XDG_DATA_HOME",
+		"XDG_STATE_HOME",
+		"NPM_CONFIG_PREFIX",
+	}
+	got := DefaultAllowVars()
+	if len(got) != len(want) {
+		t.Fatalf("DefaultAllowVars() has %d entries, want %d:\n got  %v\n want %v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("DefaultAllowVars()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestDangerousEnvBlocklist(t *testing.T) {
 	exact, prefixes := DangerousEnvBlocklist()
 	if len(exact) == 0 {

--- a/internal/sandboxprofile/profile_test.go
+++ b/internal/sandboxprofile/profile_test.go
@@ -486,6 +486,29 @@ func TestParseFlagsInlineValues(t *testing.T) {
 	}
 }
 
+func TestParseAndMergeAllowEnvFlag(t *testing.T) {
+	f, err := ParseFlags([]string{"--allow-env", "ANTHROPIC_API_KEY", "--allow-env=OPENAI_API_KEY", "--", "true"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.AllowEnv) != 2 || f.AllowEnv[0] != "ANTHROPIC_API_KEY" || f.AllowEnv[1] != "OPENAI_API_KEY" {
+		t.Fatalf("allow-env flags = %v", f.AllowEnv)
+	}
+	p := &Profile{Environment: Environment{AllowVars: []string{"HOME", "PATH"}}}
+	merged, _ := Merge(p, f)
+	if len(merged.Environment.AllowVars) != 4 {
+		t.Errorf("merged allow_vars = %v, want 4 (profile + 2 flags)", merged.Environment.AllowVars)
+	}
+	// Merge must not mutate the input profile's slice.
+	if len(p.Environment.AllowVars) != 2 {
+		t.Errorf("Merge mutated input allow_vars: %v", p.Environment.AllowVars)
+	}
+	// The merged allowlist must actually admit the forwarded var.
+	if !envVarAllowed("ANTHROPIC_API_KEY", merged.Environment.AllowVars) {
+		t.Error("merged allow_vars should admit ANTHROPIC_API_KEY")
+	}
+}
+
 func TestParseAndMergeDenyFlag(t *testing.T) {
 	f, err := ParseFlags([]string{"--deny", ".env", "--deny=*.key", "--", "true"})
 	if err != nil {
@@ -640,6 +663,45 @@ func TestFilterEnv(t *testing.T) {
 	got = FilterEnv(environ, []string{"NODE_OPTIONS"}, nil)
 	if len(got) != 0 {
 		t.Errorf("blocklist must beat allowlist: %v", got)
+	}
+
+	// Inverse of the no-allowlist case: with the default allowlist an
+	// ambient secret that is neither injected nor listed must be stripped
+	// (issue #102 — ambient env leak). HOME/PATH still pass.
+	got = FilterEnv(environ, DefaultAllowVars(), nil)
+	gotMap = envMap(got)
+	if _, ok := gotMap["AWS_SECRET_ACCESS_KEY"]; ok {
+		t.Error("default allowlist: ambient secret AWS_SECRET_ACCESS_KEY must be stripped")
+	}
+	for _, k := range []string{"HOME", "PATH", "OMAC_BASE"} {
+		if _, ok := gotMap[k]; !ok {
+			t.Errorf("default allowlist: operational var %s should pass", k)
+		}
+	}
+}
+
+// TestDefaultProfileEnvAllowlist asserts the compiled-in (and therefore
+// scaffolded) default profile ships an explicit env allowlist, so the
+// sandbox does not inherit arbitrary ambient variables (issue #102).
+func TestDefaultProfileEnvAllowlist(t *testing.T) {
+	p := DefaultProfile()
+	if len(p.Environment.AllowVars) == 0 {
+		t.Fatal("DefaultProfile must ship a non-empty environment.allow_vars")
+	}
+	want := map[string]bool{"OMAC_*": false, "HOME": false, "PATH": false}
+	for _, v := range p.Environment.AllowVars {
+		if _, ok := want[v]; ok {
+			want[v] = true
+		}
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("default allowlist missing %q", k)
+		}
+	}
+	// A known ambient secret must NOT be allowed by the default list.
+	if envVarAllowed("AWS_SECRET_ACCESS_KEY", p.Environment.AllowVars) {
+		t.Error("default allowlist must not permit AWS_SECRET_ACCESS_KEY")
 	}
 }
 

--- a/internal/sandboxprofile/resolve.go
+++ b/internal/sandboxprofile/resolve.go
@@ -53,6 +53,11 @@ func DefaultProfile() *Profile {
 				OnUnavailable:     OnUnavailableDeny,
 			},
 		},
+		// Explicit allowlist: only the operational minimum passes through.
+		// An empty list would inherit every ambient variable (secrets,
+		// capability pointers) except the danger blocklist — the leak
+		// fixed here. Harness auth vars are merged at launch.
+		Environment: Environment{AllowVars: DefaultAllowVars()},
 	}
 }
 


### PR DESCRIPTION
## What

Harden the sandbox environment so it forwards only what is explicitly needed, and make a misconfigured (empty) allowlist fail **safe** rather than leak or break.

- **Hardened default profile.** `DefaultProfile()` (compiled-in → scaffolded `default.json`) ships an explicit `environment.allow_vars` — the operational minimum: `OMAC_*`, `HOME`, `PATH`, `PWD`, `TMPDIR`, `LANG`, `LC_*`, `TERM`, `SHELL`, `USER`, `LOGNAME`, `TZ`, `EDITOR`, `VISUAL`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `NPM_CONFIG_PREFIX`.
- **Targeted per-harness auth forwarding.** Each *single-provider* `Harness` declares the auth vars it unambiguously needs (claude-code → `ANTHROPIC_*`, codex → `OPENAI_*`, copilot → `GITHUB_TOKEN`/`GH_TOKEN` + `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`); omac injects them for the *selected* harness at launch via a new additive `--allow-env` flag on `omac sandbox run`. **Multi-provider harnesses (opencode, pi) forward nothing** — auto-pushing a grab-bag of unrelated third-party keys overshoots the trust model; those setups declare the specific key they use in `allow_vars`.
- **Empty allowlist fails closed, with a heads-up.** On `omac start`/`serve`, a profile with an empty `allow_vars` no longer inherits every ambient var. omac warns, pauses briefly (~2s), and forwards **only** the operational minimum (no auto-auth). The harness starts but authenticates only once the profile declares what it needs.
- **Two diagnostics.** `omac provenance --check` flags an empty `allow_vars` (MEDIUM); `omac doctor` warns for every native profile with an empty `allow_vars`, with impact + remediation.

## Why

Closes #102. An empty `allow_vars` made `FilterEnv` inherit **every** ambient parent-process variable except the small danger blocklist: cloud/CI secrets, capability pointers (`DOCKER_HOST`, `SSH_AUTH_SOCK`), proxy config, harness metadata. This contradicted the documented trust model — *"the sandbox never sees any host env var that isn't explicitly forwarded"* (`oh-my-agentic-coder.md` §16, README §What the sandbox can see).

Two follow-on risks surfaced during review and had to be handled for the model to stay coherent:
- The launch-time `--allow-env` injection, appended to an **empty** profile, would flip it from inherit-all into a restrictive list of just those names — silently stripping `HOME`/`PATH`/tokens and breaking the harness. Hence fail-closed-to-operational-minimum **plus a visible warning**, rather than a silent break.
- Blindly forwarding every provider key a multi-provider harness *could* read overshoots "forward only what's needed"; forwarding is now targeted, and custom/unknown provider tokens are declared per-profile.

## How

- `sandboxprofile.DefaultAllowVars()` defines the operational minimum; `DefaultProfile()` sets it, so both the compiled-in default and the scaffolded `default.json` carry an explicit allowlist.
- `--allow-env` is additive into `Environment.AllowVars` (`Merge`), injected per selected harness at launch (mirroring how `SandboxDirs` become `--allow` flags). Injection is gated on a **template-anchored** check (`profileRunsNativeSandbox`: the profile's command template begins with `{{self}} sandbox run`) rather than an unanchored token scan — so a `nono` profile whose inner command merely contains `sandbox`/`run` tokens is never misclassified, and `{{self}}` resolving to an absolute `os.Executable()` path is irrelevant.
- `forwardHarnessEnv` resolves the referenced profile read-only; on an empty `allow_vars` it warns, sleeps (`emptyAllowVarsWarnDelay`, 2s), and seeds **only** `DefaultAllowVars()` — deliberately *not* the harness auth vars (omac does not silently push provider credentials into a misconfigured sandbox). Non-empty profiles inject the harness's auth vars as before.
- Injected vars (`HTTP(S)_PROXY`, `OMAC_*`) still bypass the allowlist via the injected overlay — unchanged.
- Users on other/custom providers (e.g. a TNG-style `SKAINET_*`) add the var to the profile's `allow_vars`; documented in the README migration note, which also covers the `allow_vars: ["*"]` inherit-everything escape hatch.

## Verification

- `go test ./...` green; `go build -tags e2e ./...`, `gofmt`, `go vet` clean. Full CI green including the e2e **Cache integration** and **model-free** jobs.
- Tests:
  - `FilterEnv` strips an ambient secret under the default allowlist; default profile excludes `AWS_SECRET_ACCESS_KEY`; golden-list pins the exact `DefaultAllowVars()` membership.
  - `--allow-env` parse + additive merge (no input mutation); merged launch-env asserted end-to-end.
  - Template-anchored native detection exercised against real `Expand` output; a `nono` profile with inner `sandbox`/`run` tokens is left untouched.
  - Empty profile at launch forwards the operational minimum, does **not** auto-forward auth vars, and warns; a non-empty profile still injects.
  - `omac doctor` warns on empty `allow_vars` (impact/remediation) and is silent on an explicit list.
  - Empty `allow_vars` produces a MEDIUM audit finding; `allow_vars: ["*"]` suppresses it.
  - Auth-forward policy: opencode/pi forward nothing; claude-code/codex/copilot keep their targeted keys.
  - e2e cache-isolation fixture declares `allow_vars: ["*"]` (it exercises cache-dir isolation, not env allowlisting).

## Acceptance criteria

- [x] Default profile (compiled-in and scaffolded) contains an explicit `allow_vars` list.
- [x] Unlisted inherited variables are absent from the child env.
- [x] Regression test asserts an ambient secret not in the allowlist is stripped.
- [x] Migration note for users with existing scaffolded profiles.
- [x] An empty/misconfigured profile fails **closed** (operational minimum) with a launch warning — not a silent leak or a broken launch.
- [x] Auth forwarding is targeted per harness; multi-provider harnesses declare their key explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
