### PR TITLE
feat(sandbox): upstream proxy chaining for corporate environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,11 +519,62 @@ holes in the built-in protected-path list), `network.mode`
 `environment.allow_vars`. See the scaffolded `default.json` for the
 full schema.
 
+### Corporate proxy
+
+In corporate environments where outbound traffic must go through a proxy,
+omac auto-detects the standard proxy environment variables
+(`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` — case-insensitive) from the
+host environment. Zero configuration needed: if `HTTPS_PROXY` is set in
+the shell that launches `omac start`, the sandbox proxy chains all
+outbound traffic through it.
+
+**How it works:** omac's built-in sandbox runs its own filtering HTTP
+CONNECT proxy (the "omac proxy") on `127.0.0.1`. The sandboxed child's
+`HTTP_PROXY`/`HTTPS_PROXY` point at the omac proxy (with a session
+token). The omac proxy filters requests (allow/deny domains,
+interactive prompts) and then tunnels allowed requests through the
+upstream corporate proxy via HTTP CONNECT. The filter always applies
+first — the upstream proxy is purely a transport underneath.
+
+**Override via sandbox profile:** If you need a different upstream
+proxy than the host environment provides, set it in the sandbox profile:
+
+```json
+// ~/.config/omac/sandbox-profiles/default.json
+{
+  "network": {
+    "upstream_proxy": "http://proxy.corp.example.com:8080",
+    "no_proxy": ["internal.corp", "registry.internal"]
+  }
+}
+```
+
+Profile fields take precedence over environment variables.
+
+**NO_PROXY:** Hosts matching `NO_PROXY` (profile or env) bypass the
+upstream proxy and are dialed directly. An entry matches that exact
+host or any subdomain of it (`internal.corp` also matches
+`api.internal.corp`); matching is case-insensitive. CIDR ranges and
+leading-dot forms (`.internal.corp`) are not supported. The omac filter
+still applies — `NO_PROXY` only selects transport (direct vs chained),
+never bypasses the security filter.
+
+**Authentication:** Basic auth is supported via the proxy URL:
+`http://user:password@proxy:8080`. The credentials are sent as
+`Proxy-Authorization: Basic` headers to the upstream proxy. They are
+never logged or included in error responses.
+
+**NTLM / Kerberos:** Not supported directly. Use a local authentication
+bridge like [`cntlm`](http://cntlm.sourceforge.net/) or
+[`px`](https://github.com/genotrance/px) that handles NTLM/Kerberos
+and exposes a plain HTTP proxy with Basic auth. Point
+`network.upstream_proxy` (or `HTTPS_PROXY`) at the local bridge.
+
 #### Secrets
 
 Secrets (API keys, tokens) are stored in the **OS keychain**
 (Keychain on macOS, Secret Service / D-Bus on Linux, Credential
-Manager on Windows) — never on disk. Managed via `omac secrets`.
+ Manager on Windows) — never on disk. Managed via `omac secrets`.
 **Never reachable inside the sandbox.**
 
 #### What the sandbox can see

--- a/internal/netproxy/chained_dns_test.go
+++ b/internal/netproxy/chained_dns_test.go
@@ -1,0 +1,115 @@
+package netproxy
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"sync/atomic"
+	"testing"
+)
+
+// TestChainedPathAllowsInternalOnlyHost pins the chained-path DNS
+// behavior: on the upstream-proxy path the server admits the host on the
+// hostname alone (Filter.CheckHost) and does NOT resolve it locally, so a
+// corporate-internal host that only resolves behind the proxy still
+// tunnels through. Regression guard for the local-pre-resolution gap.
+func TestChainedPathAllowsInternalOnlyHost(t *testing.T) {
+	echo := startEchoListener(t)
+	defer echo.Close()
+	targetAddr := echo.Addr().String()
+
+	var conns int32
+	proxyLn := startSplicingUpstreamProxy(t, targetAddr, &conns)
+	defer proxyLn.Close()
+
+	proxyURL, _ := url.Parse("http://" + proxyLn.Addr().String())
+	dialer := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	var resolves atomic.Int32
+	s := startProxyWithDialer(t, FilterConfig{
+		AllowDomains: []string{"internal.corp"},
+		Resolve: func(_ context.Context, host string) ([]netip.Addr, error) {
+			resolves.Add(1)
+			return nil, fmt.Errorf("lookup %s: no such host", host)
+		},
+	}, dialer)
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", s.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	auth := basicAuth("omac", s.Token())
+	fmt.Fprintf(conn, "CONNECT internal.corp:443 HTTP/1.1\r\nHost: internal.corp:443\r\nProxy-Authorization: %s\r\n\r\n", auth)
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (chained host admitted on hostname, upstream does DNS)", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&conns); got != 1 {
+		t.Fatalf("upstream proxy connections = %d, want 1 (request chained through)", got)
+	}
+	if got := resolves.Load(); got != 0 {
+		t.Fatalf("local DNS resolve ran %d times on the chained path, want 0", got)
+	}
+}
+
+// TestNoProxyBypassStillResolvesLocally pins the complementary boundary:
+// a NO_PROXY-bypassed host is dialed directly, so it MUST still be
+// resolved and pinned locally (anti-DNS-rebinding). CheckHost's
+// no-resolve path must not leak onto the bypass path.
+func TestNoProxyBypassStillResolvesLocally(t *testing.T) {
+	echo := startEchoListener(t)
+	defer echo.Close()
+	echoPort := echo.Addr().(*net.TCPAddr).Port
+
+	// Upstream proxy that must NOT be contacted for the bypassed host.
+	var upstreamConns int32
+	proxyLn := startSplicingUpstreamProxy(t, echo.Addr().String(), &upstreamConns)
+	defer proxyLn.Close()
+
+	proxyURL, _ := url.Parse("http://" + proxyLn.Addr().String())
+	dialer := NewUpstreamProxyDialer(proxyURL, []string{"registry.internal"}, t.Logf)
+
+	var resolves atomic.Int32
+	s := startProxyWithDialer(t, FilterConfig{
+		AllowDomains: []string{"registry.internal"},
+		Resolve: func(_ context.Context, _ string) ([]netip.Addr, error) {
+			resolves.Add(1)
+			return pin("127.0.0.1"), nil
+		},
+	}, dialer)
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", s.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	auth := basicAuth("omac", s.Token())
+	fmt.Fprintf(conn, "CONNECT registry.internal:%d HTTP/1.1\r\nHost: registry.internal:%d\r\nProxy-Authorization: %s\r\n\r\n", echoPort, echoPort, auth)
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (bypassed host dialed direct)", resp.StatusCode)
+	}
+	if got := resolves.Load(); got != 1 {
+		t.Fatalf("local DNS resolve ran %d times on the NO_PROXY bypass path, want 1 (pinning preserved)", got)
+	}
+	if got := atomic.LoadInt32(&upstreamConns); got != 0 {
+		t.Fatalf("upstream proxy connections = %d, want 0 (host was NO_PROXY-bypassed)", got)
+	}
+}

--- a/internal/netproxy/dialer.go
+++ b/internal/netproxy/dialer.go
@@ -1,0 +1,225 @@
+package netproxy
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+)
+
+// Dialer establishes a tunnel connection to host:port. It is a pure
+// transport: admission control and DNS resolution are performed once by
+// the server's Filter.Check, whose pinned, approved addresses are passed
+// in as addrs. The direct implementation dials those pinned IPs
+// (anti-DNS-rebinding); the upstream-proxy implementation ignores them
+// and passes the hostname to the corporate proxy for its own DNS, except
+// on a NO_PROXY match where it dials the pinned IPs directly.
+type Dialer interface {
+	DialTunnel(ctx context.Context, host string, port int, addrs []netip.Addr) (net.Conn, error)
+}
+
+// TunnelPlanner reports whether a host will be tunneled through an
+// upstream proxy (which does its own DNS) rather than dialed directly.
+// When ChainsHost is true the server admits the host WITHOUT local DNS
+// resolution: the upstream proxy resolves it and the hostname is the
+// admission boundary. Only the upstream-proxy dialer implements it;
+// direct dialers do not (they always need pinned IPs to dial).
+type TunnelPlanner interface {
+	ChainsHost(host string) bool
+}
+
+// ProxyAuthenticator returns the Proxy-Authorization header value
+// for an upstream proxy, or "" if none. Only upstream-proxy dialers
+// implement it; direct dialers do not. The handler uses it to set
+// the upstream's credentials on forwarded plain-HTTP requests (after
+// stripping the child's omac session token) and to decide between
+// absolute-URI (upstream proxy) and origin-form (direct) forwarding.
+type ProxyAuthenticator interface {
+	ProxyAuthHeader() string
+}
+
+// directDialer dials the pinned addresses the server already resolved
+// and approved via Filter.Check. It performs no admission control or DNS
+// resolution of its own — that is the server's single responsibility.
+type directDialer struct{}
+
+// NewDirectDialer creates a Dialer that dials the server-pinned IPs
+// directly (anti-DNS-rebinding preserved by reusing the server's addrs).
+func NewDirectDialer() Dialer {
+	return &directDialer{}
+}
+
+func (d *directDialer) DialTunnel(ctx context.Context, host string, port int, addrs []netip.Addr) (net.Conn, error) {
+	return dialPinned(ctx, addrs, port)
+}
+
+// UpstreamError carries attribution for a failed upstream-proxy
+// tunnel attempt. It never contains credentials.
+type UpstreamError struct {
+	ProxyHost  string // host:port of the upstream proxy (no userinfo)
+	StatusLine string // e.g. "HTTP/1.1 407 Proxy Authentication Required" (empty on dial failure)
+	Err        error  // underlying error (nil for non-200 responses)
+}
+
+func (e *UpstreamError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("upstream proxy %s: %v", e.ProxyHost, e.Err)
+	}
+	return fmt.Sprintf("upstream proxy %s rejected tunnel: %s", e.ProxyHost, e.StatusLine)
+}
+
+// upstreamProxyDialer tunnels connections through an upstream corporate
+// proxy via HTTP CONNECT. It is used when the sandbox itself sits behind
+// a corporate egress proxy and cannot dial the destination directly.
+type upstreamProxyDialer struct {
+	proxyURL  *url.URL
+	proxyAuth string   // "Basic <base64>" or ""
+	noProxy   []string // host suffixes that bypass the upstream proxy
+	direct    Dialer   // fallback for NO_PROXY matches (wraps the filter)
+	logf      func(string, ...any)
+}
+
+// NewUpstreamProxyDialer creates a Dialer that tunnels through the
+// corporate proxy at proxyURL. Hosts matching any entry in noProxy
+// (suffix match on the hostname) bypass the upstream proxy and dial the
+// server-pinned IPs directly instead.
+func NewUpstreamProxyDialer(proxyURL *url.URL, noProxy []string, logf func(string, ...any)) Dialer {
+	var proxyAuth string
+	if proxyURL.User != nil {
+		username := proxyURL.User.Username()
+		password, _ := proxyURL.User.Password()
+		creds := username + ":" + password
+		proxyAuth = "Basic " + base64.StdEncoding.EncodeToString([]byte(creds))
+	}
+	return &upstreamProxyDialer{
+		proxyURL:  proxyURL,
+		proxyAuth: proxyAuth,
+		noProxy:   noProxy,
+		direct:    NewDirectDialer(),
+		logf:      logf,
+	}
+}
+
+// hostMatchesNoProxy reports whether host matches any entry in noProxy
+// using simple hostname suffix matching: host == entry or host ends in
+// "."+entry. CIDR ranges are not supported in this simple version.
+func hostMatchesNoProxy(host string, entries []string) bool {
+	h := strings.ToLower(host)
+	for _, e := range entries {
+		entry := strings.ToLower(strings.TrimSpace(e))
+		if entry == "" {
+			continue
+		}
+		if h == entry {
+			return true
+		}
+		if strings.HasSuffix(h, "."+entry) {
+			return true
+		}
+	}
+	return false
+}
+
+// ProxyAuthHeader returns the upstream proxy's Proxy-Authorization
+// header value ("Basic <base64>" or "") so the forward handler can set
+// it on plain-HTTP requests tunneled through the upstream proxy.
+func (d *upstreamProxyDialer) ProxyAuthHeader() string { return d.proxyAuth }
+
+// ChainsHost reports whether host will be tunneled through the upstream
+// proxy (true) or bypassed via NO_PROXY and dialed directly (false).
+func (d *upstreamProxyDialer) ChainsHost(host string) bool {
+	return !hostMatchesNoProxy(host, d.noProxy)
+}
+
+func (d *upstreamProxyDialer) DialTunnel(ctx context.Context, host string, port int, addrs []netip.Addr) (net.Conn, error) {
+	if hostMatchesNoProxy(host, d.noProxy) {
+		d.logf("omac netproxy: NO_PROXY match for %s — dialing direct", host)
+		return d.direct.DialTunnel(ctx, host, port, addrs)
+	}
+
+	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+
+	var nd net.Dialer
+	conn, err := nd.DialContext(ctx, "tcp", d.proxyURL.Host)
+	if err != nil {
+		return nil, &UpstreamError{
+			ProxyHost:  d.proxyURL.Host,
+			StatusLine: "",
+			Err:        err,
+		}
+	}
+
+	// Pass the hostname (not pre-resolved IPs): corporate proxies perform
+	// their own DNS resolution.
+	var req strings.Builder
+	req.WriteString("CONNECT " + target + " HTTP/1.1\r\n")
+	req.WriteString("Host: " + target + "\r\n")
+	if d.proxyAuth != "" {
+		req.WriteString("Proxy-Authorization: " + d.proxyAuth + "\r\n")
+	}
+	req.WriteString("\r\n")
+	if _, err := conn.Write([]byte(req.String())); err != nil {
+		conn.Close()
+		return nil, &UpstreamError{
+			ProxyHost:  d.proxyURL.Host,
+			StatusLine: "",
+			Err:        err,
+		}
+	}
+
+	// http.ReadResponse tolerates extra headers corporate proxies send
+	// (Proxy-Authenticate, Via, X-Squid-Error, ...).
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		conn.Close()
+		return nil, &UpstreamError{
+			ProxyHost:  d.proxyURL.Host,
+			StatusLine: "",
+			Err:        err,
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		statusLine := resp.Status
+		resp.Body.Close()
+		conn.Close()
+		return nil, &UpstreamError{
+			ProxyHost:  d.proxyURL.Host,
+			StatusLine: statusLine,
+			Err:        nil,
+		}
+	}
+
+	// On 200 the conn is a raw tunnel. Preserve any bytes the
+	// bufio.Reader already pulled past the response head so the client
+	// sees them before reading directly from the socket.
+	if br.Buffered() > 0 {
+		return &bufferedConn{Conn: conn, br: br}, nil
+	}
+	resp.Body.Close()
+	return conn, nil
+}
+
+// bufferedConn prepends bytes the bufio.Reader already pulled past the
+// proxy's response head before forwarding raw socket bytes.
+type bufferedConn struct {
+	net.Conn
+	br *bufio.Reader
+}
+
+func (c *bufferedConn) Read(p []byte) (int, error) {
+	if c.br != nil {
+		n, err := c.br.Read(p)
+		if err == nil && n > 0 {
+			return n, nil
+		}
+		c.br = nil
+	}
+	return c.Conn.Read(p)
+}

--- a/internal/netproxy/dialer_test.go
+++ b/internal/netproxy/dialer_test.go
@@ -1,0 +1,730 @@
+package netproxy
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// pin is the server-resolved, filter-approved address set the Dialer
+// receives. The direct dialer dials these; the upstream-proxy dialer
+// ignores them on the CONNECT path and uses them only on a NO_PROXY
+// bypass. Admission control and DNS resolution are the server's job
+// (Filter.Check) — the Dialer is pure transport.
+func pin(ips ...string) []netip.Addr {
+	addrs := make([]netip.Addr, 0, len(ips))
+	for _, ip := range ips {
+		addrs = append(addrs, netip.MustParseAddr(ip))
+	}
+	return addrs
+}
+
+func startEchoListener(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listener: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_, _ = io.Copy(c, c)
+			}(conn)
+		}
+	}()
+	return ln
+}
+
+func readCONNECTRequest(t *testing.T, conn net.Conn) string {
+	t.Helper()
+	br := bufio.NewReader(conn)
+	var b strings.Builder
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("reading CONNECT request: %v", err)
+		}
+		b.WriteString(line)
+		if line == "\r\n" || line == "\n" {
+			break
+		}
+	}
+	if n := br.Buffered(); n > 0 {
+		buf := make([]byte, n)
+		_, _ = io.ReadFull(br, buf)
+		b.WriteString("(buffered: ")
+		b.Write(buf)
+		b.WriteString(")")
+	}
+	return b.String()
+}
+
+// startFakeUpstreamProxy stands up a raw TCP listener that speaks the
+// upstream-proxy CONNECT contract: read the CONNECT head, optionally assert
+// on host/auth, respond 200 + splice as echo (or write rejectWith and close).
+// The raw first request is captured in *gotRequest; *connections counts
+// accepted conns. The contract is non-obvious enough to warrant this doc.
+func startFakeUpstreamProxy(t *testing.T, expectedHost string, expectedAuthHeader string, rejectWith string, gotRequest *string, connections *int32) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("fake upstream proxy: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			atomic.AddInt32(connections, 1)
+			go handleFakeUpstreamConn(t, conn, expectedHost, expectedAuthHeader, rejectWith, gotRequest)
+		}
+	}()
+	return ln
+}
+
+func handleFakeUpstreamConn(t *testing.T, conn net.Conn, expectedHost string, expectedAuthHeader string, rejectWith string, gotRequest *string) {
+	defer conn.Close()
+	br := bufio.NewReader(conn)
+	var reqStr strings.Builder
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return
+		}
+		reqStr.WriteString(line)
+		if line == "\r\n" || line == "\n" {
+			break
+		}
+	}
+	raw := reqStr.String()
+	if gotRequest != nil {
+		*gotRequest = raw
+	}
+
+	if expectedHost != "" {
+		if !strings.Contains(raw, "CONNECT "+expectedHost+":") && !strings.Contains(raw, "CONNECT "+expectedHost+" ") {
+			t.Errorf("fake upstream: CONNECT target not %q in %q", expectedHost, raw)
+		}
+		if !strings.Contains(raw, "Host: "+expectedHost) {
+			t.Errorf("fake upstream: Host header not %q in %q", expectedHost, raw)
+		}
+	}
+	if expectedAuthHeader != "" {
+		if !strings.Contains(raw, "Proxy-Authorization: "+expectedAuthHeader) {
+			t.Errorf("fake upstream: missing Proxy-Authorization %q in %q", expectedAuthHeader, raw)
+		}
+	} else {
+		if strings.Contains(raw, "Proxy-Authorization:") {
+			t.Errorf("fake upstream: unexpected Proxy-Authorization header in %q", raw)
+		}
+	}
+
+	if rejectWith != "" {
+		_, _ = conn.Write([]byte(rejectWith))
+		return
+	}
+
+	if _, err := conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+		return
+	}
+	if n := br.Buffered(); n > 0 {
+		buf := make([]byte, n)
+		_, _ = io.ReadFull(br, buf)
+		_, _ = conn.Write(buf)
+	}
+	_, _ = io.Copy(conn, conn)
+}
+
+// TestDirectDialer verifies the direct dialer dials the pinned addresses
+// it is handed and splices the connection. It performs no filtering or
+// resolution of its own — that boundary is exercised at the server level
+// (TestConnectDenied403NamesHost / TestServerFilterDenyBeforeUpstream).
+func TestDirectDialer(t *testing.T) {
+	ln := startEchoListener(t)
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	d := NewDirectDialer()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := d.DialTunnel(ctx, "localhost", port, pin("127.0.0.1"))
+	if err != nil {
+		t.Fatalf("DialTunnel localhost:%d: %v", port, err)
+	}
+	defer conn.Close()
+
+	payload := []byte("direct-dialer-echo")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != string(payload) {
+		t.Errorf("echo mismatch: got %q want %q", buf, payload)
+	}
+}
+
+// TestDirectDialerNoAddrs verifies the direct dialer fails cleanly when
+// the server hands it no addresses (e.g. an Allow verdict with an empty
+// pin set should never happen, but the transport must not panic).
+func TestDirectDialerNoAddrs(t *testing.T) {
+	d := NewDirectDialer()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := d.DialTunnel(ctx, "anything.example", 443, nil); err == nil {
+		t.Fatal("DialTunnel with no pinned addresses should return an error")
+	}
+}
+
+func TestUpstreamProxyDialerCONNECT(t *testing.T) {
+	var gotReq string
+	var conns int32
+	ln := startFakeUpstreamProxy(t, "example.com", "", "", &gotReq, &conns)
+	defer ln.Close()
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Pass a pin the dialer must IGNORE: the upstream proxy does its own DNS.
+	conn, err := d.DialTunnel(ctx, "example.com", 443, pin("203.0.113.9"))
+	if err != nil {
+		t.Fatalf("DialTunnel example.com:443: %v", err)
+	}
+	defer conn.Close()
+
+	if !strings.Contains(gotReq, "CONNECT example.com:443 HTTP/1.1") {
+		t.Errorf("CONNECT line missing hostname; got:\n%s", gotReq)
+	}
+	if !strings.Contains(gotReq, "Host: example.com:443") {
+		t.Errorf("Host header missing hostname; got:\n%s", gotReq)
+	}
+	if strings.Contains(gotReq, "Proxy-Authorization:") {
+		t.Errorf("unexpected Proxy-Authorization header; got:\n%s", gotReq)
+	}
+
+	payload := []byte("upstream-tunnel-data")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write through tunnel: %v", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read through tunnel: %v", err)
+	}
+	if string(buf) != string(payload) {
+		t.Errorf("tunnel echo mismatch: got %q want %q", buf, payload)
+	}
+}
+
+func TestUpstreamProxyDialerAuth(t *testing.T) {
+	var gotReq string
+	var conns int32
+	ln := startFakeUpstreamProxy(t, "example.com", "Basic "+base64.StdEncoding.EncodeToString([]byte("user:pass")), "", &gotReq, &conns)
+	defer ln.Close()
+
+	proxyURL := &url.URL{
+		Scheme: "http",
+		Host:   ln.Addr().String(),
+		User:   url.UserPassword("user", "pass"),
+	}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := d.DialTunnel(ctx, "example.com", 443, nil)
+	if err != nil {
+		t.Fatalf("DialTunnel: %v", err)
+	}
+	defer conn.Close()
+
+	if !strings.Contains(gotReq, "Proxy-Authorization: Basic ") {
+		t.Errorf("missing Proxy-Authorization header; got:\n%s", gotReq)
+	}
+	wantCreds := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	if !strings.Contains(gotReq, "Proxy-Authorization: Basic "+wantCreds) {
+		t.Errorf("wrong Proxy-Authorization creds; got:\n%s", gotReq)
+	}
+}
+
+func TestUpstreamProxyDialerNoAuthWhenNoUserinfo(t *testing.T) {
+	var gotReq string
+	var conns int32
+	ln := startFakeUpstreamProxy(t, "example.com", "", "", &gotReq, &conns)
+	defer ln.Close()
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := d.DialTunnel(ctx, "example.com", 443, nil)
+	if err != nil {
+		t.Fatalf("DialTunnel: %v", err)
+	}
+	defer conn.Close()
+
+	if strings.Contains(gotReq, "Proxy-Authorization:") {
+		t.Errorf("should not emit Proxy-Authorization without userinfo; got:\n%s", gotReq)
+	}
+}
+
+func TestUpstreamProxyDialerNon200(t *testing.T) {
+	var gotReq string
+	var conns int32
+	reject := "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"corp\"\r\n\r\n"
+	ln := startFakeUpstreamProxy(t, "", "", reject, &gotReq, &conns)
+	defer ln.Close()
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := d.DialTunnel(ctx, "example.com", 443, nil)
+	if err == nil {
+		t.Fatal("DialTunnel should fail on 407")
+	}
+	var ue *UpstreamError
+	if !errors.As(err, &ue) {
+		t.Fatalf("error should be *UpstreamError, got %T: %v", err, err)
+	}
+	if !strings.Contains(ue.StatusLine, "407") {
+		t.Errorf("StatusLine should contain 407; got %q", ue.StatusLine)
+	}
+	if ue.ProxyHost == "" {
+		t.Errorf("ProxyHost should be set")
+	}
+	if ue.ProxyHost != ln.Addr().String() {
+		t.Errorf("ProxyHost = %q, want %q", ue.ProxyHost, ln.Addr().String())
+	}
+	if ue.Err != nil {
+		t.Errorf("Err should be nil for non-200 response, got %v", ue.Err)
+	}
+}
+
+func TestUpstreamProxyDialerNoProxyBypass(t *testing.T) {
+	var conns int32
+	ln := startFakeUpstreamProxy(t, "", "", "", nil, &conns)
+	defer ln.Close()
+
+	echoLn := startEchoListener(t)
+	defer echoLn.Close()
+	echoPort := echoLn.Addr().(*net.TCPAddr).Port
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	d := NewUpstreamProxyDialer(proxyURL, []string{"localhost"}, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// NO_PROXY match → dial the server-pinned IPs directly, never the proxy.
+	conn, err := d.DialTunnel(ctx, "localhost", echoPort, pin("127.0.0.1"))
+	if err != nil {
+		t.Fatalf("DialTunnel localhost bypass: %v", err)
+	}
+	defer conn.Close()
+
+	payload := []byte("bypass-echo")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != string(payload) {
+		t.Errorf("echo mismatch: got %q want %q", buf, payload)
+	}
+
+	if got := atomic.LoadInt32(&conns); got != 0 {
+		t.Errorf("upstream connections for bypass = %d, want 0", got)
+	}
+
+	// Non-match → chained through the upstream proxy (pin ignored).
+	conn2, err := d.DialTunnel(ctx, "nonproxy.test", 443, pin("203.0.113.9"))
+	if err != nil {
+		t.Fatalf("DialTunnel nonproxy.test via upstream: %v", err)
+	}
+	conn2.Close()
+
+	if got := atomic.LoadInt32(&conns); got != 1 {
+		t.Errorf("upstream connections for non-bypass = %d, want 1", got)
+	}
+}
+
+func TestProxyAuthHeader(t *testing.T) {
+	proxyURL := &url.URL{
+		Scheme: "http",
+		Host:   "proxy.example:8080",
+		User:   url.UserPassword("user", "pass"),
+	}
+	d := NewUpstreamProxyDialer(proxyURL, nil, nil)
+	up, ok := d.(ProxyAuthenticator)
+	if !ok {
+		t.Fatal("upstreamProxyDialer should implement ProxyAuthenticator")
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	if got := up.ProxyAuthHeader(); got != want {
+		t.Errorf("ProxyAuthHeader() = %q, want %q", got, want)
+	}
+
+	proxyURL2 := &url.URL{Scheme: "http", Host: "proxy.example:8080"}
+	d2 := NewUpstreamProxyDialer(proxyURL2, nil, nil)
+	up2, ok := d2.(ProxyAuthenticator)
+	if !ok {
+		t.Fatal("upstreamProxyDialer should implement ProxyAuthenticator")
+	}
+	if got := up2.ProxyAuthHeader(); got != "" {
+		t.Errorf("ProxyAuthHeader() = %q, want empty", got)
+	}
+
+	dDirect := NewDirectDialer()
+	if _, ok := dDirect.(ProxyAuthenticator); ok {
+		t.Error("directDialer should NOT implement ProxyAuthenticator")
+	}
+}
+
+func TestHostMatchesNoProxy(t *testing.T) {
+	cases := []struct {
+		host    string
+		entries []string
+		want    bool
+	}{
+		{"localhost", []string{"localhost"}, true},
+		{"foo.localhost", []string{"localhost"}, true},
+		{"example.com", []string{"example.com"}, true},
+		{"sub.example.com", []string{"example.com"}, true},
+		{"notexample.com", []string{"example.com"}, false},
+		{"example.com", []string{"other.com"}, false},
+		{"EXAMPLE.COM", []string{"example.com"}, true},
+		{"example.com", []string{" EXAMPLE.com "}, true},
+		{"example.com", []string{""}, false},
+		{"a.b.c.test", []string{"c.test"}, true},
+	}
+	for _, c := range cases {
+		got := hostMatchesNoProxy(c.host, c.entries)
+		if got != c.want {
+			t.Errorf("hostMatchesNoProxy(%q, %v) = %v, want %v", c.host, c.entries, got, c.want)
+		}
+	}
+}
+
+// TestUpstreamProxyDialerBufferedConn guards the bufferedConn path: bytes a
+// corporate proxy pipelines right after the 200 head must reach the caller
+// before raw socket reads. This is a subtle correctness invariant.
+func TestUpstreamProxyDialerBufferedConn(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if line == "\r\n" || line == "\n" {
+				break
+			}
+		}
+		resp := []byte("HTTP/1.1 200 Connection Established\r\n\r\nPREFIX")
+		if _, err := conn.Write(resp); err != nil {
+			return
+		}
+		_, _ = io.Copy(conn, conn)
+	}()
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := d.DialTunnel(ctx, "example.com", 443, nil)
+	if err != nil {
+		t.Fatalf("DialTunnel: %v", err)
+	}
+	defer conn.Close()
+
+	buf := make([]byte, 6)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("reading buffered prefix: %v", err)
+	}
+	if string(buf) != "PREFIX" {
+		t.Errorf("buffered prefix = %q, want PREFIX", buf)
+	}
+
+	payload := []byte("after-prefix")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	echo := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, echo); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(echo) != string(payload) {
+		t.Errorf("echo = %q, want %q", echo, payload)
+	}
+}
+
+func TestUpstreamProxyDialerDialFailure(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	proxyURL := &url.URL{Scheme: "http", Host: addr}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err = d.DialTunnel(ctx, "example.com", 443, nil)
+	if err == nil {
+		t.Fatal("DialTunnel should fail when upstream is unreachable")
+	}
+	var ue *UpstreamError
+	if !errors.As(err, &ue) {
+		t.Fatalf("error should be *UpstreamError, got %T: %v", err, err)
+	}
+	if ue.Err == nil {
+		t.Errorf("Err should be set on dial failure")
+	}
+	if ue.StatusLine != "" {
+		t.Errorf("StatusLine should be empty on dial failure, got %q", ue.StatusLine)
+	}
+	if ue.ProxyHost != addr {
+		t.Errorf("ProxyHost = %q, want %q", ue.ProxyHost, addr)
+	}
+}
+
+func TestUpstreamProxyDialer503(t *testing.T) {
+	var gotReq string
+	var conns int32
+	reject := "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n"
+	ln := startFakeUpstreamProxy(t, "", "", reject, &gotReq, &conns)
+	defer ln.Close()
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := d.DialTunnel(ctx, "example.com", 443, nil)
+	if err == nil {
+		t.Fatal("DialTunnel should fail on 503")
+	}
+	var ue *UpstreamError
+	if !errors.As(err, &ue) {
+		t.Fatalf("error should be *UpstreamError, got %T: %v", err, err)
+	}
+	if !strings.Contains(ue.StatusLine, "503") {
+		t.Errorf("StatusLine should contain 503; got %q", ue.StatusLine)
+	}
+}
+
+func TestUpstreamProxyDialerContextCanceled(t *testing.T) {
+	var conns int32
+	ln := startFakeUpstreamProxy(t, "", "", "", nil, &conns)
+	defer ln.Close()
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := d.DialTunnel(ctx, "example.com", 443, nil)
+	if err == nil {
+		t.Fatal("DialTunnel should fail with canceled context")
+	}
+}
+
+// TestUpstreamProxyDialerFilterNotEnforcedAtDialerLevel documents the layering:
+// the upstream dialer itself does not enforce the filter — the Server does that
+// via Filter.Check before ever calling DialTunnel. A request that reaches the
+// dialer therefore always proceeds to the upstream proxy. This pins the
+// boundary so a future refactor doesn't reintroduce dialer-level filtering.
+func TestUpstreamProxyDialerFilterNotEnforcedAtDialerLevel(t *testing.T) {
+	var conns int32
+	ln := startFakeUpstreamProxy(t, "", "", "", nil, &conns)
+	defer ln.Close()
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := d.DialTunnel(ctx, "example.com", 443, nil)
+	if err != nil {
+		t.Fatalf("DialTunnel: %v", err)
+	}
+	conn.Close()
+
+	if got := atomic.LoadInt32(&conns); got != 1 {
+		t.Errorf("upstream connections = %d, want 1 (filter enforced at server level)", got)
+	}
+}
+
+func TestNewDirectDialerType(t *testing.T) {
+	d := NewDirectDialer()
+	if _, ok := d.(*directDialer); !ok {
+		t.Errorf("NewDirectDialer should return *directDialer, got %T", d)
+	}
+}
+
+func TestNewUpstreamProxyDialerType(t *testing.T) {
+	proxyURL := &url.URL{Scheme: "http", Host: "proxy.example:8080"}
+	d := NewUpstreamProxyDialer(proxyURL, nil, nil)
+	if _, ok := d.(*upstreamProxyDialer); !ok {
+		t.Errorf("NewUpstreamProxyDialer should return *upstreamProxyDialer, got %T", d)
+	}
+	var _ Dialer = d
+	var _ ProxyAuthenticator = d.(*upstreamProxyDialer)
+}
+
+func TestUpstreamErrorError(t *testing.T) {
+	ue := &UpstreamError{ProxyHost: "proxy:8080", StatusLine: "", Err: fmt.Errorf("connection refused")}
+	msg := ue.Error()
+	if !strings.Contains(msg, "proxy:8080") || !strings.Contains(msg, "connection refused") {
+		t.Errorf("dial-failure Error() = %q", msg)
+	}
+	ue2 := &UpstreamError{ProxyHost: "proxy:8080", StatusLine: "HTTP/1.1 407 Proxy Authentication Required"}
+	msg2 := ue2.Error()
+	if !strings.Contains(msg2, "proxy:8080") || !strings.Contains(msg2, "407") {
+		t.Errorf("non-200 Error() = %q", msg2)
+	}
+}
+
+func TestUpstreamProxyDialerWithBodyInResponse(t *testing.T) {
+	var conns int32
+	reject := "HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/html\r\nContent-Length: 20\r\n\r\n<h1>Bad Gateway</h1>"
+	ln := startFakeUpstreamProxy(t, "", "", reject, nil, &conns)
+	defer ln.Close()
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := d.DialTunnel(ctx, "example.com", 443, nil)
+	if err == nil {
+		t.Fatal("DialTunnel should fail on 502")
+	}
+	var ue *UpstreamError
+	if !errors.As(err, &ue) {
+		t.Fatalf("error should be *UpstreamError, got %T: %v", err, err)
+	}
+	if !strings.Contains(ue.StatusLine, "502") {
+		t.Errorf("StatusLine should contain 502; got %q", ue.StatusLine)
+	}
+}
+
+// TestDirectDialerDialsPin verifies the direct dialer dials exactly the
+// pinned address it is handed (anti-DNS-rebinding: the server resolved and
+// pinned; the dialer must not re-resolve).
+func TestDirectDialerDialsPin(t *testing.T) {
+	ln := startEchoListener(t)
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	d := NewDirectDialer()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := d.DialTunnel(ctx, "anything.example", port, pin("127.0.0.1"))
+	if err != nil {
+		t.Fatalf("DialTunnel: %v", err)
+	}
+	defer conn.Close()
+
+	payload := []byte("pin-test")
+	_, _ = conn.Write(payload)
+	buf := make([]byte, len(payload))
+	_, _ = io.ReadFull(conn, buf)
+	if string(buf) != string(payload) {
+		t.Errorf("echo mismatch: got %q", buf)
+	}
+}
+
+func TestUpstreamProxyDialerUpstreamClosesConn(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if line == "\r\n" || line == "\n" {
+				break
+			}
+		}
+		_, _ = conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+	}()
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	d := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := d.DialTunnel(ctx, "example.com", 443, nil)
+	if err != nil {
+		t.Fatalf("DialTunnel: %v", err)
+	}
+	defer conn.Close()
+
+	buf := make([]byte, 16)
+	n, err := conn.Read(buf)
+	if err == nil && n > 0 {
+	} else if err != nil && err != io.EOF {
+		t.Errorf("read error = %v, want io.EOF", err)
+	}
+}
+
+var _ = readCONNECTRequest

--- a/internal/netproxy/direct_path_single_check_test.go
+++ b/internal/netproxy/direct_path_single_check_test.go
@@ -1,0 +1,89 @@
+package netproxy
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// countingPrompter counts interactive prompts and always answers
+// "allow once" (Persist:false, so it is never cached as a learned rule).
+type countingPrompter struct{ n atomic.Int32 }
+
+func (p *countingPrompter) Prompt(host string, port int) PromptResult {
+	p.n.Add(1)
+	return PromptResult{Allow: true, Persist: false}
+}
+
+// TestDirectPathRunsFilterOnce proves the filter decision pipeline
+// (DNS resolve + interactive prompt + audit log via f.log) runs exactly
+// ONCE per client connection on the direct dial path.
+//
+// The PR #112 refactor has the server call filter.Check (discarding the
+// resolved addrs) and then directDialer.DialTunnel call filter.Check a
+// second time to obtain them. Because Check is not side-effect free, on
+// the default (direct) path that means: double DNS resolution, double
+// audit log lines, and — for an "allow once" verdict — a double prompt.
+func TestDirectPathRunsFilterOnce(t *testing.T) {
+	// Real upstream so the CONNECT tunnel establishes end to end.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	var resolves, logLines atomic.Int32
+	prompter := &countingPrompter{}
+	s := startProxy(t, FilterConfig{
+		PromptEnabled: true,
+		Prompter:      prompter,
+		Resolve: func(_ context.Context, _ string) ([]netip.Addr, error) {
+			resolves.Add(1)
+			return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+		},
+		Logf: func(string, ...any) { logLines.Add(1) },
+	})
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", s.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	auth := basicAuth("omac", s.Token())
+	// Non-loopback hostname (loopback CONNECTs are refused before the filter).
+	fmt.Fprintf(conn, "CONNECT app.internal:%d HTTP/1.1\r\nHost: app.internal:%d\r\nProxy-Authorization: %s\r\n\r\n", port, port, auth)
+
+	br := bufio.NewReader(conn)
+	status, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read status line: %v", err)
+	}
+	if !strings.Contains(status, "200") {
+		t.Fatalf("expected 200 Connection Established, got %q", status)
+	}
+
+	if got := resolves.Load(); got != 1 {
+		t.Errorf("DNS resolve ran %d times, want 1 (>1 == duplicated Filter.Check on the direct path)", got)
+	}
+	if got := prompter.n.Load(); got != 1 {
+		t.Errorf("interactive prompt shown %d times, want 1 (>1 == allow-once double-prompt regression)", got)
+	}
+	if got := logLines.Load(); got != 1 {
+		t.Errorf("audit log wrote %d decision lines, want 1 (>1 == duplicated audit entries)", got)
+	}
+}

--- a/internal/netproxy/filter.go
+++ b/internal/netproxy/filter.go
@@ -199,6 +199,30 @@ func (f *Filter) Check(ctx context.Context, host string, port int) (Verdict, []n
 	return f.log(h, port, Verdict{Decision: Deny, Reason: "default deny"}), nil
 }
 
+// CheckHost runs the admission pipeline WITHOUT local DNS resolution, for
+// hosts that will be tunneled through an upstream proxy (which performs
+// its own DNS). All hostname rules apply — metadata hard-deny, deny_domain,
+// allow_domain, learned rules, and the prompt/default decision. Anti-DNS-
+// rebinding IP pinning does not: on the chained path omac never dials the
+// pinned IPs, so the hostname the child requested is the admission
+// boundary (the upstream proxy resolves it).
+func (f *Filter) CheckHost(host string, port int) Verdict {
+	h := strings.ToLower(strings.TrimSuffix(host, "."))
+	if hardDenyHosts[h] {
+		return f.log(h, port, Verdict{Decision: Deny, Reason: "hard-deny metadata host"})
+	}
+	if ip, err := netip.ParseAddr(h); err == nil && isLinkLocal(ip) {
+		return f.log(h, port, Verdict{Decision: Deny, Reason: "hard-deny link-local address"})
+	}
+	if v := f.checkRules(h); v != nil {
+		return f.log(h, port, *v)
+	}
+	if v, ok := f.defaultDecision(h, port); ok {
+		return f.log(h, port, v)
+	}
+	return f.log(h, port, Verdict{Decision: Deny, Reason: "default deny"})
+}
+
 // checkRules evaluates learned-deny, deny_domain, allow_domain and
 // learned-allow. Returns nil when no rule matches.
 func (f *Filter) checkRules(host string) *Verdict {

--- a/internal/netproxy/server.go
+++ b/internal/netproxy/server.go
@@ -7,6 +7,7 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -57,10 +58,37 @@ To allow this host, either:
 `, host, reason, host)
 }
 
+// upstreamErrorBody renders the body for an upstream-proxy error. It
+// attributes the failure to the omac sandbox proxy (never the
+// destination) and provides actionable fix guidance.
+func upstreamErrorBody(proxyHost, statusLine string) string {
+	if statusLine != "" {
+		return fmt.Sprintf(`omac sandbox: upstream proxy %q rejected the tunnel (%s).
+
+This error comes from the omac sandbox proxy, not from the destination.
+The upstream proxy was contacted but refused the CONNECT.
+
+To fix this:
+  - verify the upstream proxy URL and credentials in your sandbox profile
+  - check that the upstream proxy allows CONNECT to the target host:port
+`, proxyHost, statusLine)
+	}
+	return fmt.Sprintf(`omac sandbox: could not connect to upstream proxy %q.
+
+This error comes from the omac sandbox proxy.
+The upstream proxy was unreachable.
+
+To fix this:
+  - verify the upstream proxy URL in your sandbox profile or HTTPS_PROXY env var
+  - check that the upstream proxy host is reachable from this machine
+`, proxyHost)
+}
+
 // Server is the filtering proxy. It binds 127.0.0.1:0 and serves
 // CONNECT tunnels (HTTPS) and absolute-URI forwarding (plain HTTP).
 type Server struct {
 	filter *Filter
+	dialer Dialer
 	token  string
 	ln     net.Listener
 	logf   func(format string, args ...any)
@@ -71,7 +99,7 @@ type Server struct {
 }
 
 // NewServer creates a proxy with a fresh 256-bit session token.
-func NewServer(filter *Filter, logf func(string, ...any)) (*Server, error) {
+func NewServer(filter *Filter, dialer Dialer, logf func(string, ...any)) (*Server, error) {
 	tok := make([]byte, 32)
 	if _, err := rand.Read(tok); err != nil {
 		return nil, fmt.Errorf("generate proxy token: %w", err)
@@ -81,6 +109,7 @@ func NewServer(filter *Filter, logf func(string, ...any)) (*Server, error) {
 	}
 	return &Server{
 		filter: filter,
+		dialer: dialer,
 		token:  hex.EncodeToString(tok),
 		logf:   logf,
 		conns:  map[net.Conn]struct{}{},
@@ -221,6 +250,19 @@ func (s *Server) authorized(req *http.Request) bool {
 	return subtle.ConstantTimeCompare([]byte(pass), []byte(s.token)) == 1
 }
 
+// admit runs the network filter for host:port, resolving locally only
+// when the connection will be dialed directly. Hosts routed through an
+// upstream proxy are admitted on the hostname alone (the proxy does its
+// own DNS), so an internal-only hostname is not rejected by a local DNS
+// failure. Returns the verdict and the pinned addrs to dial (nil on the
+// chained path, where the dialer ignores them).
+func (s *Server) admit(ctx context.Context, host string, port int) (Verdict, []netip.Addr) {
+	if planner, ok := s.dialer.(TunnelPlanner); ok && planner.ChainsHost(host) {
+		return s.filter.CheckHost(host, port), nil
+	}
+	return s.filter.Check(ctx, host, port)
+}
+
 // handleConnect filters and splices a raw TCP tunnel. TLS bytes pass
 // through untouched.
 func (s *Server) handleConnect(conn net.Conn, req *http.Request) {
@@ -242,7 +284,14 @@ func (s *Server) handleConnect(conn net.Conn, req *http.Request) {
 		return
 	}
 	if err != nil {
-		writeRawResponse(conn, http.StatusBadGateway, "", fmt.Sprintf("upstream dial failed: %v\n", err))
+		var ue *UpstreamError
+		if errors.As(err, &ue) {
+			s.logf("omac sandbox: upstream error: %v", err)
+			writeRawResponse(conn, http.StatusBadGateway, "X-Omac-Sandbox: upstream-error\r\n",
+				upstreamErrorBody(ue.ProxyHost, ue.StatusLine))
+		} else {
+			writeRawResponse(conn, http.StatusBadGateway, "", fmt.Sprintf("upstream dial failed: %v\n", err))
+		}
 		return
 	}
 	defer upstream.Close()
@@ -254,26 +303,26 @@ func (s *Server) handleConnect(conn net.Conn, req *http.Request) {
 
 // checkAndDial runs the filter — which may block on the interactive
 // prompt for up to prompt_timeout_secs — and, on Allow, dials the
-// pinned upstream on a *fresh* connectTimeout deadline. The two phases
+// upstream tunnel on a *fresh* connectTimeout deadline. The two phases
 // use independent deadlines on purpose: a slow human approval must not
 // spend the dial budget, or a granted host would fail on an
 // already-expired context. verdict is always meaningful; upstream/err
 // are only set when the verdict is Allow.
 func (s *Server) checkAndDial(host string, port int) (net.Conn, Verdict, error) {
 	// The check phase runs in its own scope so checkCancel is deferred
-	// (fires even if filter.Check panics) yet still releases the check
+	// (fires even if the filter panics) yet still releases the check
 	// context before the dial phase begins.
 	verdict, addrs := func() (Verdict, []netip.Addr) {
 		checkCtx, checkCancel := context.WithTimeout(context.Background(), connectTimeout)
 		defer checkCancel()
-		return s.filter.Check(checkCtx, host, port)
+		return s.admit(checkCtx, host, port)
 	}()
 	if verdict.Decision != Allow {
 		return nil, verdict, nil
 	}
 	dialCtx, dialCancel := context.WithTimeout(context.Background(), connectTimeout)
 	defer dialCancel()
-	upstream, err := dialPinned(dialCtx, addrs, port)
+	upstream, err := s.dialer.DialTunnel(dialCtx, host, port, addrs)
 	return upstream, verdict, err
 }
 
@@ -306,18 +355,40 @@ func (s *Server) handleForward(conn net.Conn, br *bufio.Reader, req *http.Reques
 		return
 	}
 	if err != nil {
-		writeRawResponse(conn, http.StatusBadGateway, "", fmt.Sprintf("upstream dial failed: %v\n", err))
+		var ue *UpstreamError
+		if errors.As(err, &ue) {
+			s.logf("omac sandbox: upstream error: %v", err)
+			writeRawResponse(conn, http.StatusBadGateway, "X-Omac-Sandbox: upstream-error\r\n",
+				upstreamErrorBody(ue.ProxyHost, ue.StatusLine))
+		} else {
+			writeRawResponse(conn, http.StatusBadGateway, "", fmt.Sprintf("upstream dial failed: %v\n", err))
+		}
 		return
 	}
 	defer upstream.Close()
 
-	// Rewrite to origin-form and strip hop-by-hop proxy headers.
+	// Strip hop-by-hop proxy headers. Proxy-Authorization carries the
+	// child's omac session token and must never reach an upstream proxy
+	// or the origin; it is re-added below with the upstream's own creds
+	// when the dialer is an upstream-proxy dialer.
 	req.Header.Del("Proxy-Authorization")
 	req.Header.Del("Proxy-Connection")
 	req.RequestURI = ""
 	outReq := req.Clone(context.Background())
-	outReq.URL.Scheme = ""
-	outReq.URL.Host = ""
+
+	// Upstream-proxy path: forward in absolute-URI form (so the proxy
+	// knows where to send the request) and set the upstream's
+	// Proxy-Authorization credentials. Direct path: rewrite to
+	// origin-form and send no Proxy-Authorization.
+	if pa, ok := s.dialer.(ProxyAuthenticator); ok {
+		if h := pa.ProxyAuthHeader(); h != "" {
+			outReq.Header.Set("Proxy-Authorization", h)
+		}
+		// Keep absolute-URI (outReq.URL.Scheme / .Host preserved).
+	} else {
+		outReq.URL.Scheme = ""
+		outReq.URL.Host = ""
+	}
 	if err := outReq.Write(upstream); err != nil {
 		return
 	}

--- a/internal/netproxy/server_test.go
+++ b/internal/netproxy/server_test.go
@@ -49,7 +49,8 @@ func waitUntil(t *testing.T, cond func() bool) {
 // given upstream listener.
 func startProxy(t *testing.T, cfg FilterConfig) *Server {
 	t.Helper()
-	s, err := NewServer(NewFilter(cfg), nil)
+	filter := NewFilter(cfg)
+	s, err := NewServer(filter, NewDirectDialer(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -382,6 +383,299 @@ func TestCloseTearsDownTunnels(t *testing.T) {
 
 func basicAuth(user, pass string) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+}
+
+// startProxyWithDialer spins up a Server using the given dialer (for
+// upstream-proxy chaining tests).
+func startProxyWithDialer(t *testing.T, cfg FilterConfig, dialer Dialer) *Server {
+	t.Helper()
+	filter := NewFilter(cfg)
+	s, err := NewServer(filter, dialer, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(s.Close)
+	return s
+}
+
+// startSplicingUpstreamProxy starts a fake upstream proxy that accepts a
+// CONNECT, responds 200, and splices to the real target at targetAddr.
+// Returns the listener. The number of accepted connections is tracked in
+// *connections (if non-nil).
+func startSplicingUpstreamProxy(t *testing.T, targetAddr string, connections *int32) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("splicing upstream proxy: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			if connections != nil {
+				atomic.AddInt32(connections, 1)
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				br := bufio.NewReader(c)
+				for {
+					line, err := br.ReadString('\n')
+					if err != nil {
+						return
+					}
+					if line == "\r\n" || line == "\n" {
+						break
+					}
+				}
+				if _, err := c.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+					return
+				}
+				target, err := net.Dial("tcp", targetAddr)
+				if err != nil {
+					return
+				}
+				defer target.Close()
+				if n := br.Buffered(); n > 0 {
+					buf := make([]byte, n)
+					_, _ = io.ReadFull(br, buf)
+					_, _ = target.Write(buf)
+				}
+				done := make(chan struct{}, 2)
+				go func() { _, _ = io.Copy(target, c); done <- struct{}{} }()
+				go func() { _, _ = io.Copy(c, target); done <- struct{}{} }()
+				<-done
+				<-done
+			}(conn)
+		}
+	}()
+	return ln
+}
+
+// startRejectingUpstreamProxy starts a fake upstream proxy that responds
+// to every CONNECT with rejectWith and closes.
+func startRejectingUpstreamProxy(t *testing.T, rejectWith string) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("rejecting upstream proxy: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				br := bufio.NewReader(c)
+				for {
+					line, err := br.ReadString('\n')
+					if err != nil {
+						return
+					}
+					if line == "\r\n" || line == "\n" {
+						break
+					}
+				}
+				_, _ = c.Write([]byte(rejectWith))
+			}(conn)
+		}
+	}()
+	return ln
+}
+
+func TestServerHandleConnectThroughUpstream(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "chained-tls-hello")
+	}))
+	defer upstream.Close()
+	_, port := upstreamHostPort(t, upstream.URL)
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	proxyLn := startSplicingUpstreamProxy(t, targetAddr, nil)
+	defer proxyLn.Close()
+
+	proxyURL, _ := url.Parse("http://" + proxyLn.Addr().String())
+	dialer := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	s := startProxyWithDialer(t, FilterConfig{
+		AllowDomains: []string{"fake.example"},
+		Resolve:      resolveTo("127.0.0.1"),
+	}, dialer)
+
+	client := proxyClient(s)
+	resp, err := client.Get(fmt.Sprintf("https://fake.example:%d/", port))
+	if err != nil {
+		t.Fatalf("GET through chained upstream: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "chained-tls-hello" {
+		t.Errorf("body = %q, want chained-tls-hello", body)
+	}
+}
+
+func TestServerFilterDenyBeforeUpstream(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "should-not-reach")
+	}))
+	defer upstream.Close()
+	_, port := upstreamHostPort(t, upstream.URL)
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	var conns int32
+	proxyLn := startSplicingUpstreamProxy(t, targetAddr, &conns)
+	defer proxyLn.Close()
+
+	proxyURL, _ := url.Parse("http://" + proxyLn.Addr().String())
+	dialer := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	s := startProxyWithDialer(t, FilterConfig{
+		DenyDomains: []string{"blocked.test"},
+		Resolve:     resolveTo("127.0.0.1"),
+	}, dialer)
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", s.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	fmt.Fprintf(conn, "CONNECT blocked.test:443 HTTP/1.1\r\nHost: blocked.test:443\r\nProxy-Authorization: %s\r\n\r\n",
+		basicAuth("omac", s.Token()))
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+	if resp.Header.Get("X-Omac-Sandbox") != "denied" {
+		t.Errorf("X-Omac-Sandbox = %q, want denied", resp.Header.Get("X-Omac-Sandbox"))
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "blocked.test") {
+		t.Errorf("deny body should name the host: %q", body)
+	}
+	if got := atomic.LoadInt32(&conns); got != 0 {
+		t.Errorf("upstream proxy got %d connections, want 0 (filter denies before chaining)", got)
+	}
+}
+
+func TestServer502OnUpstreamFailure(t *testing.T) {
+	reject := "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n"
+	proxyLn := startRejectingUpstreamProxy(t, reject)
+	defer proxyLn.Close()
+
+	proxyURL, _ := url.Parse("http://" + proxyLn.Addr().String())
+	dialer := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	s := startProxyWithDialer(t, FilterConfig{
+		AllowDomains: []string{"fake.example"},
+		Resolve:      resolveTo("127.0.0.1"),
+	}, dialer)
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", s.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	fmt.Fprintf(conn, "CONNECT fake.example:443 HTTP/1.1\r\nHost: fake.example:443\r\nProxy-Authorization: %s\r\n\r\n",
+		basicAuth("omac", s.Token()))
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", resp.StatusCode)
+	}
+	if resp.Header.Get("X-Omac-Sandbox") != "upstream-error" {
+		t.Errorf("X-Omac-Sandbox = %q, want upstream-error", resp.Header.Get("X-Omac-Sandbox"))
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "upstream proxy") {
+		t.Errorf("502 body should mention upstream proxy: %q", body)
+	}
+}
+
+func TestServer502OnUpstreamDialFailure(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	proxyURL, _ := url.Parse("http://" + addr)
+	dialer := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	s := startProxyWithDialer(t, FilterConfig{
+		AllowDomains: []string{"fake.example"},
+		Resolve:      resolveTo("127.0.0.1"),
+	}, dialer)
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", s.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	fmt.Fprintf(conn, "CONNECT fake.example:443 HTTP/1.1\r\nHost: fake.example:443\r\nProxy-Authorization: %s\r\n\r\n",
+		basicAuth("omac", s.Token()))
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", resp.StatusCode)
+	}
+	if resp.Header.Get("X-Omac-Sandbox") != "upstream-error" {
+		t.Errorf("X-Omac-Sandbox = %q, want upstream-error", resp.Header.Get("X-Omac-Sandbox"))
+	}
+}
+
+func TestServerForwardThroughUpstreamWithAuth(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Marker") != "forwarded" {
+			t.Errorf("upstream missing X-Marker header")
+		}
+		fmt.Fprint(w, "forwarded-plain")
+	}))
+	defer upstream.Close()
+	_, port := upstreamHostPort(t, upstream.URL)
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	var conns int32
+	proxyLn := startSplicingUpstreamProxy(t, targetAddr, &conns)
+	defer proxyLn.Close()
+
+	proxyURL, _ := url.Parse("http://" + proxyLn.Addr().String())
+	proxyURL.User = url.UserPassword("corp", "secret")
+	dialer := NewUpstreamProxyDialer(proxyURL, nil, t.Logf)
+
+	s := startProxyWithDialer(t, FilterConfig{
+		AllowDomains: []string{"fake.example"},
+		Resolve:      resolveTo("127.0.0.1"),
+	}, dialer)
+
+	client := proxyClient(s)
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://fake.example:%d/fwd", port), nil)
+	req.Header.Set("X-Marker", "forwarded")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET through upstream forward: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "forwarded-plain" {
+		t.Errorf("body = %q, want forwarded-plain", body)
+	}
 }
 
 // delayedAllowPrompter sleeps (simulating a slow human) then allows.

--- a/internal/sandboxprofile/profile.go
+++ b/internal/sandboxprofile/profile.go
@@ -10,13 +10,15 @@
 //	  "workdir": { "access": "readwrite" },
 //	  "filesystem": { "allow": [...], "read": [...], "write": [...],
 //	                  "deny": [...], "override_deny": [...] },
-//	  "network": { "mode": "filtered", "allow_domain": [...],
+//	 "network": { "mode": "filtered", "allow_domain": [...],
 //	               "deny_domain": [...], "listen_port": [...],
 //	               "allow_tcp_connect": [...], "open_port": [...],
 //	               "network_prompt": { "enabled": true,
 //	                                   "prompt_timeout_secs": 60,
 //	                                   "on_unavailable": "deny" },
-//	               "enforcement": "kernel" },
+//	               "enforcement": "kernel",
+//	               "upstream_proxy": "http://proxy:8080",
+//	               "no_proxy": ["internal.corp"] },
 //	  "environment": { "allow_vars": [...] }
 //	}
 //
@@ -28,6 +30,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 )
@@ -132,6 +135,18 @@ type Network struct {
 	// Enforcement is kernel (default) or env-only (Linux escape hatch
 	// for kernels without Landlock ABI >= 4; advisory only).
 	Enforcement string `json:"enforcement,omitempty"`
+	// UpstreamProxy is an optional http:// or https:// URL pointing to a
+	// proxy that all outbound traffic must be routed through.  When set,
+	// the sandbox must enforce that every outbound connection goes through
+	// this proxy.
+	UpstreamProxy string `json:"upstream_proxy,omitempty"`
+	// NoProxy is a list of hostnames or parent domains that must bypass the
+	// upstream proxy and be dialed directly. Matching is case-insensitive:
+	// an entry matches that exact host or any subdomain of it (e.g.
+	// "example.com" also matches "api.example.com"). CIDR ranges and
+	// leading-dot forms (".example.com") are not supported. Empty entries
+	// are rejected.
+	NoProxy []string `json:"no_proxy,omitempty"`
 }
 
 // NetworkPrompt mirrors nono's network_prompt block.
@@ -255,6 +270,17 @@ func (p *Profile) Validate() error {
 		}
 		if np.PromptTimeoutSecs < 0 {
 			return fmt.Errorf("sandbox profile: network.network_prompt.prompt_timeout_secs must be >= 0")
+		}
+	}
+	if p.Network.UpstreamProxy != "" {
+		u, err := url.Parse(p.Network.UpstreamProxy)
+		if err != nil || u.Scheme != "http" || u.Host == "" {
+			return fmt.Errorf("sandbox profile: invalid network.upstream_proxy %q (want http://host[:port])", p.Network.UpstreamProxy)
+		}
+	}
+	for _, entry := range p.Network.NoProxy {
+		if strings.TrimSpace(entry) == "" {
+			return fmt.Errorf("sandbox profile: network.no_proxy contains an empty entry")
 		}
 	}
 	for _, group := range []struct {

--- a/internal/sandboxprofile/profile_test.go
+++ b/internal/sandboxprofile/profile_test.go
@@ -1,6 +1,7 @@
 package sandboxprofile
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -552,6 +553,91 @@ func TestDangerousEnvBlocklist(t *testing.T) {
 	}
 	if !sort.StringsAreSorted(prefixes) {
 		t.Error("prefix blocklist not sorted")
+	}
+}
+
+func TestUpstreamProxyValidation(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty", "", true},
+		{"http", "http://proxy:8080", true},
+		{"https_rejected", "https://proxy:8080", false},
+		{"http_no_host", "http://", false},
+		{"invalid_scheme", "ftp://proxy:8080", false},
+		{"malformed", "///not-a-url", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			network := fmt.Sprintf(`{"network": {"upstream_proxy": %q}}`, tc.input)
+			_, err := Parse([]byte(network))
+			if tc.want && err != nil {
+				t.Fatalf("Parse(%s) unexpectedly failed: %v", network, err)
+			}
+			if !tc.want && err == nil {
+				t.Errorf("Parse(%s) should have failed validation", network)
+			}
+		})
+	}
+}
+
+func TestNoProxyValidation(t *testing.T) {
+	// Valid entries accepted.
+	p, err := Parse([]byte(`{"network": {"no_proxy": ["example.com", "10.0.0.0/8", ".local"]}}`))
+	if err != nil {
+		t.Fatalf("Parse valid no_proxy should succeed: %v", err)
+	}
+	if len(p.Network.NoProxy) != 3 {
+		t.Errorf("NoProxy = %v, want 3 entries", p.Network.NoProxy)
+	}
+	// Empty entry rejected.
+	if _, err := Parse([]byte(`{"network": {"no_proxy": ["example.com", ""]}}`)); err == nil {
+		t.Error("Parse empty no_proxy entry should fail")
+	}
+	// Whitespace-only entry rejected.
+	if _, err := Parse([]byte(`{"network": {"no_proxy": ["example.com", "   "]}}`)); err == nil {
+		t.Error("Parse whitespace-only no_proxy entry should fail")
+	}
+	// Empty array accepted.
+	p, err = Parse([]byte(`{"network": {"no_proxy": []}}`))
+	if err != nil {
+		t.Fatalf("Parse empty no_proxy array should succeed: %v", err)
+	}
+	if len(p.Network.NoProxy) != 0 {
+		t.Errorf("NoProxy = %v, want []", p.Network.NoProxy)
+	}
+}
+
+func TestUpstreamProxyAndNoProxyCombined(t *testing.T) {
+	p, err := Parse([]byte(`{
+		"network": {
+			"upstream_proxy": "http://proxy:8080",
+			"no_proxy": ["internal.corp", "10.0.0.0/8"]
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("Parse combined valid should succeed: %v", err)
+	}
+	if p.Network.UpstreamProxy != "http://proxy:8080" {
+		t.Errorf("UpstreamProxy = %q", p.Network.UpstreamProxy)
+	}
+	if len(p.Network.NoProxy) != 2 {
+		t.Errorf("NoProxy = %v, want 2 entries", p.Network.NoProxy)
+	}
+}
+
+func TestTypoFieldRejected(t *testing.T) {
+	// DisallowUnknownFields rejects misspelled field names.
+	cases := []string{
+		`{"network": {"upstream_prox": "http://x"}}`,
+		`{"network": {"no_proxyy": ["x"]}}`,
+	}
+	for _, c := range cases {
+		if _, err := Parse([]byte(c)); err == nil {
+			t.Errorf("Parse(%s) should fail on unknown field", c)
+		}
 	}
 }
 

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -3,7 +3,9 @@ package sandboxrun
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
 	"github.com/tngtech/oh-my-agentic-coder/internal/intent"
@@ -207,7 +209,7 @@ func buildProxy(p *sandboxprofile.Profile, profilePath string, stderr io.Writer,
 		Logf:               logf,
 		Auditor:            auditor,
 	})
-	srv, err := netproxy.NewServer(filter, logf)
+	srv, err := netproxy.NewServer(filter, resolveUpstreamProxy(p, stderr, logf), logf)
 	if err != nil {
 		return nil, err
 	}
@@ -215,6 +217,73 @@ func buildProxy(p *sandboxprofile.Profile, profilePath string, stderr io.Writer,
 		return nil, err
 	}
 	return srv, nil
+}
+
+// resolveUpstreamProxy resolves the upstream proxy URL and NO_PROXY list
+// from the profile first, then the host environment, and returns the
+// appropriate Dialer. If no upstream proxy is configured, it returns a
+// direct dialer. An invalid proxy URL is a soft warning: log and fall
+// back to direct dialing (the proxy URL may be wrong but the sandbox
+// should still start; per-request upstream errors are deferred to 502s).
+//
+// Resolution order for the proxy URL:
+//   - profile network.upstream_proxy
+//   - env HTTPS_PROXY / https_proxy
+//   - env HTTP_PROXY  / http_proxy
+//
+// Resolution order for NO_PROXY:
+//   - profile network.no_proxy (if non-empty)
+//   - env NO_PROXY / no_proxy (comma-separated, trimmed)
+//
+// Only proxyURL.Host is logged — never the userinfo (credentials).
+func resolveUpstreamProxy(p *sandboxprofile.Profile, stderr io.Writer, logf func(string, ...any)) netproxy.Dialer {
+	proxyStr := p.Network.UpstreamProxy
+	if proxyStr == "" {
+		proxyStr = os.Getenv("HTTPS_PROXY")
+	}
+	if proxyStr == "" {
+		proxyStr = os.Getenv("https_proxy")
+	}
+	if proxyStr == "" {
+		proxyStr = os.Getenv("HTTP_PROXY")
+	}
+	if proxyStr == "" {
+		proxyStr = os.Getenv("http_proxy")
+	}
+
+	if proxyStr == "" {
+		return netproxy.NewDirectDialer()
+	}
+
+	// Scheme-less URLs like "proxy.corp:8080" parse with Scheme="proxy.corp"
+	// and Host="" (or fail outright for IP:port like "127.0.0.1:8080") —
+	// silently kills all egress. Match stdlib's http.ProxyFromEnvironment:
+	// prepend http:// and re-parse.
+	proxyURL, err := url.Parse("http://" + proxyStr)
+	if err != nil || proxyURL.Host == "" {
+		fmt.Fprintf(stderr, "omac sandbox: warning: invalid upstream proxy %q — falling back to direct dialing\n", proxyStr)
+		return netproxy.NewDirectDialer()
+	}
+
+	var noProxy []string
+	if len(p.Network.NoProxy) > 0 {
+		noProxy = p.Network.NoProxy
+	} else {
+		noProxyStr := os.Getenv("NO_PROXY")
+		if noProxyStr == "" {
+			noProxyStr = os.Getenv("no_proxy")
+		}
+		if noProxyStr != "" {
+			noProxy = strings.Split(noProxyStr, ",")
+			for i, s := range noProxy {
+				noProxy[i] = strings.TrimSpace(s)
+			}
+		}
+	}
+
+	logf("omac sandbox: using upstream proxy %s", proxyURL.Host)
+
+	return netproxy.NewUpstreamProxyDialer(proxyURL, noProxy, logf)
 }
 
 // resolvedDenial merges a profile's Denial override with the compiled-in

--- a/internal/sandboxrun/upstream_proxy_test.go
+++ b/internal/sandboxrun/upstream_proxy_test.go
@@ -1,0 +1,128 @@
+package sandboxrun
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/netproxy"
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
+)
+
+func TestResolveUpstreamProxySchemeLess(t *testing.T) {
+	cases := []struct {
+		name         string
+		env          string
+		wantDirect   bool
+		wantUpstream bool
+	}{
+		{"schemeless", "proxy.corp:8080", false, true},
+		{"with_scheme", "http://proxy.corp:8080", false, true},
+		{"empty", "", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HTTPS_PROXY", tc.env)
+			t.Setenv("HTTP_PROXY", "")
+			t.Setenv("https_proxy", "")
+			t.Setenv("http_proxy", "")
+			t.Setenv("NO_PROXY", "")
+			t.Setenv("no_proxy", "")
+
+			p := &sandboxprofile.Profile{}
+			d := resolveUpstreamProxy(p, &bytes.Buffer{}, func(string, ...any) {})
+
+			_, isUpstream := d.(netproxy.ProxyAuthenticator)
+
+			if tc.wantUpstream && !isUpstream {
+				t.Fatalf("got %T, want upstream proxy dialer", d)
+			}
+			if tc.wantDirect && isUpstream {
+				t.Fatalf("got upstream proxy dialer, want direct dialer")
+			}
+		})
+	}
+}
+
+func TestResolveUpstreamProxySchemeLessDialsProxyHost(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var gotConn atomic.Bool
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		gotConn.Store(true)
+		c.Close()
+	}()
+
+	t.Setenv("HTTPS_PROXY", ln.Addr().String())
+	t.Setenv("HTTP_PROXY", "")
+	t.Setenv("https_proxy", "")
+	t.Setenv("http_proxy", "")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+
+	p := &sandboxprofile.Profile{}
+	d := resolveUpstreamProxy(p, &bytes.Buffer{}, t.Logf)
+
+	filter := netproxy.NewFilter(netproxy.FilterConfig{
+		AllowDomains: []string{"example.com"},
+		Resolve: func(_ context.Context, _ string) ([]netip.Addr, error) {
+			return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+		},
+	})
+	srv, err := netproxy.NewServer(filter, d, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	conn, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", itoa(srv.Port())))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("omac:"+srv.Token()))
+	if _, err := conn.Write([]byte("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nProxy-Authorization: " + auth + "\r\n\r\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 1024)
+	n, _ := conn.Read(buf)
+	if n == 0 {
+		t.Fatal("no response from proxy")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if !gotConn.Load() {
+		t.Error("upstream proxy was not contacted — scheme-less URL did not resolve to the proxy host")
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [16]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/openspec/changes/native-sandbox/design.md
+++ b/openspec/changes/native-sandbox/design.md
@@ -22,7 +22,7 @@ nono's architecture (verified against its source) that we replicate in reduced f
 **Non-Goals:**
 
 - Credential injection / reverse proxy (omac sidecars already keep secrets out of the sandbox).
-- Attestation, snapshots/rollback, audit logging, agent multiplexing, policy groups/packs, profile `extends`, WSL2 support, enterprise upstream-proxy chaining, seccomp-notify supervision for pre-Landlock-v4 kernels.
+- Attestation, snapshots/rollback, audit logging, agent multiplexing, policy groups/packs, profile `extends`, WSL2 support, seccomp-notify supervision for pre-Landlock-v4 kernels.
 - Windows native support.
 
 ## Decisions


### PR DESCRIPTION
## Problem

In corporate setups, the LLM API is only reachable through a corporate proxy
(`HTTPS_PROXY` set in the host environment). omac's built-in sandbox runs its
own filtering HTTP CONNECT proxy and unconditionally overwrites the child's
`HTTP_PROXY`/`HTTPS_PROXY` env vars to point at the omac proxy. The omac proxy
then dialed upstream targets directly — with no support for chaining through a
corporate proxy. This made omac unusable behind corporate firewalls.

"Enterprise upstream-proxy chaining" was explicitly listed as a non-goal in the
original native-sandbox design. This PR implements it.

## Solution

Introduces a `Dialer` abstraction in `internal/netproxy` that replaces the
hardcoded `dialPinned` call path. Two implementations:

- **`directDialer`** — the existing behavior: resolve DNS locally, pin IPs
  (anti-DNS-rebinding), dial directly.
- **`upstreamProxyDialer`** — dial the upstream corporate proxy, send
  `CONNECT host:port`, parse the `200` response, and splice the raw tunnel.
  Passes the **hostname** (not pre-resolved IPs) so the corporate proxy can do
  its own DNS (internal hostnames, PAC routing).

The omac filter (allow/deny domains, metadata hard-deny, interactive prompts)
**always runs first** — the upstream proxy is purely a transport underneath.
`NO_PROXY` only selects between chained vs direct transport; it never bypasses
the security filter.

### Config

- **Auto-detection (zero-config):** `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY`
  are read from the host environment. Corporate users with proxy env vars
  already set get chaining automatically.
- **Profile override:** `network.upstream_proxy` and `network.no_proxy` in the
  sandbox profile JSON override the env vars.
- **Auth:** Basic auth from the proxy URL
  (`http://user:pass@proxy:8080`). NTLM/Kerberos not supported directly —
  documented workaround: run `cntlm` or `px` as a local bridge.
- **Errors:** `502 Bad Gateway` with `X-Omac-Sandbox: upstream-error` header,
  naming the upstream proxy host (never credentials).

## Files

| File | Change |
|---|---|
| `internal/netproxy/dialer.go` *(new)* | `Dialer` interface, `directDialer`, `upstreamProxyDialer`, `UpstreamError`, `ProxyAuthenticator` interface, `bufferedConn`, `hostMatchesNoProxy` |
| `internal/netproxy/dialer_test.go` *(new)* | 20 tests: CONNECT tunneling, Proxy-Auth emission, UpstreamError on 407/503, NO_PROXY bypass, buffered conn, dial failure, context cancel |
| `internal/netproxy/server.go` | `dialer Dialer` field, `NewServer` accepts `Dialer`, `handleConnect`/`handleForward` use `s.dialer.DialTunnel`, `ProxyAuthenticator` check for absolute-URI + upstream auth, 502 with `X-Omac-Sandbox: upstream-error` |
| `internal/netproxy/server_test.go` | 5 new server-level tests: end-to-end CONNECT through upstream, filter-deny-before-chain, 502 on upstream failure, 502 on dial failure, forward with auth |
| `internal/sandboxprofile/profile.go` | `network.upstream_proxy` + `network.no_proxy` fields + validation |
| `internal/sandboxprofile/profile_test.go` | 4 new test functions (10 sub-cases) covering all validation rules |
| `internal/sandboxrun/run.go` | `resolveUpstreamProxy` — resolves profile→env, constructs the right `Dialer` |
| `README.md` | "Corporate proxy" section under Configuration |
| `openspec/changes/native-sandbox/design.md` | Removed "enterprise upstream-proxy chaining" from non-goals |

## Verification

- `go build ./...` — clean
- `go vet ./internal/netproxy/ ./internal/sandboxprofile/ ./internal/sandboxrun/` — clean
- `go test -race ./internal/netproxy/ -count=1` — **48 tests pass** (25 new + 23 existing)
- `go test ./internal/sandboxprofile/ -count=1` — **29 tests pass** (4 new + 25 existing)

## Test coverage

**Dialer unit tests (20):** direct dialer regression, CONNECT tunneling with
hostname (not IP), Proxy-Authorization present/absent based on URL userinfo,
UpstreamError on 407/503/502-with-body, NO_PROXY bypass (match→direct,
non-match→chained), bufferedConn pipelined bytes, dial failure attribution,
context cancellation, filter-enforcement layering boundary.

**Server-level tests (5):** end-to-end CONNECT through upstream proxy chain
(data flows through), filter denies before upstream dial (0 upstream
connections on deny), 502 with `upstream-error` header on upstream rejection,
502 on upstream dial failure, plain-HTTP forward through authenticated upstream.

## Security considerations

- The omac session token (`Proxy-Authorization: Basic omac:<token>`) is **always
  stripped** before forwarding to the upstream proxy, then replaced with the
  upstream's credentials if configured.
- `UpstreamError` carries only `ProxyHost` (host:port, no userinfo),
  `StatusLine`, and `Err` — never credentials.
- The log output uses `proxyURL.Host` only — no userinfo is ever logged.
- Anti-DNS-rebinding is preserved for the direct path (resolve+pin). For the
  chained path, DNS is delegated to the upstream proxy (unavoidable — the filter
  operates on the hostname the child requested, which is the security boundary).