### PR TITLE
test(e2e-drift): add serve-mode (Desktop) launch probe

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -7,6 +7,11 @@
 #              registry still exists in the harness's --help.
 #   launch   — model-free: `omac start <harness>` reaches the real binary
 #              through the sandbox.
+#   serve    — model-free: `omac serve <harness>` (Desktop mode) launches the
+#              real inner server daemon under the sandbox and its control plane
+#              drives an activate/deactivate cycle. Only harnesses with a
+#              server-launch convention (opencode → OpenCode Desktop) run it;
+#              others record ➖.
 #   llm      — a SINGLE lightweight agent turn (echo-rest) against the model
 #              provider, verifying the auth/proxy path and sidecar facade. Run
 #              for every harness, claude-code included. The heavy multi-probe
@@ -140,14 +145,14 @@ jobs:
             echo "version=main@$(git describe --tags --always --dirty)" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Model-free smoke (contract + launch)
+      - name: Model-free smoke (contract + launch + serve)
         id: modelfree
         env:
           E2E_CACHE_DIR: ${{ runner.temp }}/e2e-install-cache
         run: |
           set -o pipefail
-          go test -tags=e2e -timeout=15m -v \
-            -run 'TestHarnessCLIContract|TestHarnessLaunchProbe' \
+          go test -tags=e2e -timeout=20m -v \
+            -run 'TestHarnessCLIContract|TestHarnessLaunchProbe|TestHarnessServeProbe' \
             ./internal/e2e/ 2>&1 | tee modelfree.log || true
 
       - name: LLM turn
@@ -180,14 +185,18 @@ jobs:
         if: always()
         run: |
           # Read a stage's PASS/FAIL out of the OMAC_COMPAT lines the Go tests
-          # print; absent line ⇒ the test crashed before emitting ⇒ ❌.
+          # print. result=SKIP ⇒ ➖ (stage not applicable to this harness). The
+          # second arg is the mark for an ABSENT line: ❌ for stages that always
+          # run (a missing line ⇒ crash-before-emit), ➖ for serve (only server-
+          # mode harnesses emit it, so absence is "not applicable", not failure).
           stage_mark() {
-            local stage="$1"
+            local stage="$1" absent="${2:-❌}"
             local line
             line=$(grep -oE "OMAC_COMPAT .*stage=$stage .*result=[A-Z]+" modelfree.log 2>/dev/null | head -1 || true)
             case "$line" in
               *result=PASS) echo '✅' ;;
-              '') echo '❌' ;;
+              *result=SKIP) echo '➖' ;;
+              '') echo "$absent" ;;
               *) echo '❌' ;;
             esac
           }
@@ -196,13 +205,14 @@ jobs:
           [ -z "$version" ] && version="unknown"
           contract=$(stage_mark contract)
           launch=$(stage_mark launch)
+          serve=$(stage_mark serve ➖)
           case "${{ steps.llm.outcome }}" in
             success) llm='✅' ;;
             failure) llm='❌' ;;
             *)       llm='➖' ;;  # not run (e.g. leg crashed earlier)
           esac
           date_utc=$(date -u +%Y-%m-%d)
-          row="| $date_utc | ${{ steps.omac.outputs.version }} | ${{ matrix.os }} | ${{ matrix.harness }} | $version | $contract | $launch | $llm |"
+          row="| $date_utc | ${{ steps.omac.outputs.version }} | ${{ matrix.os }} | ${{ matrix.harness }} | $version | $contract | $launch | $serve | $llm |"
           mkdir -p compat
           slug="${{ matrix.os }}-${{ matrix.harness }}-${{ matrix.omac }}"
           printf '%s\n' "$row" > "compat/$slug.row"
@@ -215,10 +225,11 @@ jobs:
             stages=""
             [ "$contract" = "❌" ] && stages="$stages contract"
             [ "$launch" = "❌" ] && stages="$stages launch"
+            [ "$serve" = "❌" ] && stages="$stages serve"
             [ "$llm" = "❌" ] && stages="$stages llm"
             {
               echo "=== ${{ matrix.harness }} / ${{ matrix.os }} / omac@${{ matrix.omac }} — failing stage(s):$stages ==="
-              grep -hE 'CLI contract drift|no longer exposes|--- FAIL|omac start .* failed|FAIL \[|Error|panic:' \
+              grep -hE 'CLI contract drift|no longer exposes|--- FAIL|omac start .* failed|serve probe failed|omac serve exited|FAIL \[|Error|panic:' \
                 modelfree.log llm.log 2>/dev/null | head -40 || true
               tail -n 30 llm.log 2>/dev/null || true
               echo
@@ -227,8 +238,8 @@ jobs:
           {
             echo "### ${{ matrix.harness }} / ${{ matrix.os }} / omac@${{ matrix.omac }}"
             echo ""
-            echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | llm |"
-            echo "|---|---|---|---|---|:-:|:-:|:-:|"
+            echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm |"
+            echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|"
             echo "$row"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -409,8 +420,8 @@ jobs:
                 sed 's/^/> /' failure-summary.txt
                 echo ""
               fi
-              echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | llm |"
-              echo "|---|---|---|---|---|:-:|:-:|:-:|"
+              echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm |"
+              echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|"
               cat failing.rows
               echo ""
               # Footer hint depends on the failing stage: the contract-drift
@@ -418,14 +429,14 @@ jobs:
               if awk -F'|' '{gsub(/ /,"",$7)} $7 ~ /❌/{f=1} END{exit f?0:1}' failing.rows; then
                 echo "A ❌ in **contract** means the installed release renamed/removed a flag omac depends on — fix \`internal/config/harness.go\` and/or \`internal/e2e/harnesses.go\`. See docs/HARNESS_COMPAT.md."
               else
-                echo "See the summary above and the [run log]($RUN_URL) for the failing stage; a **launch**/**llm** ❌ is a sandbox-launch or model/agent-turn failure, not a CLI-contract break."
+                echo "See the summary above and the [run log]($RUN_URL) for the failing stage; a **launch**/**serve**/**llm** ❌ is a sandbox-launch, Desktop serve-mode, or model/agent-turn failure, not a CLI-contract break."
               fi
             fi
             echo ""
             echo "## History (rolling 30 days)"
             echo ""
-            echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | llm |"
-            echo "|---|---|---|---|---|:-:|:-:|:-:|"
+            echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm |"
+            echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|"
             printf '%s\n' "$all"
           } > dashboard.md
           if [ -n "$num" ]; then
@@ -460,8 +471,8 @@ jobs:
               echo ""
               echo "Appended by omac's e2e-smoke workflow. Do not edit by hand."
               echo ""
-              echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | llm |"
-              echo "|---|---|---|---|---|:-:|:-:|:-:|"
+              echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm |"
+              echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|"
               echo "<!-- COMPAT_TABLE_END -->"
             } > "$file"
           fi
@@ -504,7 +515,8 @@ jobs:
                 s="";
                 if ($7=="❌") s=s" contract";
                 if ($8=="❌") s=s" launch";
-                if ($9=="❌") s=s" llm";
+                if ($9=="❌") s=s" serve";
+                if ($10=="❌") s=s" llm";
                 printf "- %s/%s:%s\n", $5, $4, s
               }' failing.rows)
             fi

--- a/docs/HARNESS_COMPAT.md
+++ b/docs/HARNESS_COMPAT.md
@@ -5,16 +5,17 @@ A harness release can silently break omac by renaming a CLI flag, moving a
 subcommand, or changing a config schema. The weekly
 [`E2E: drift` workflow](../.github/workflows/e2e-smoke.yml) (also manually
 dispatchable) is the tripwire: it installs every harness's **latest** release and
-records three stages per harness, against **two omac versions** — `main` (built
+records four stages per harness, against **two omac versions** — `main` (built
 from source) and `release` (the latest published binary, i.e. what users run):
 
 | Stage | What it proves | Model call? |
 |-------|----------------|-------------|
 | `contract` | Every CLI flag/subcommand omac derives from its registry still exists in the harness's `--help` (see `internal/e2e/contract.go`). | no |
 | `launch` | `omac start <harness>` reaches the real binary through the sandbox (PATH, config-home, sandbox admission). | no |
+| `serve` | `omac serve <harness>` (Desktop mode) launches the real inner **server daemon** under the sandbox, and its host-side control plane drives an activate → manifest → deactivate cycle (see `internal/e2e/smoke_test.go`). Only run for harnesses with a server-launch convention — today **opencode** (`opencode serve`, backing OpenCode Desktop); the rest run their inner command as-is under serve and record `➖`. Eligibility is derived from the registry (`config.Harness.ServerLaunch`), not hardcoded. | no |
 | `llm` | A **single lightweight** agent turn (echo-rest) — confirms the model auth/proxy path and sidecar facade. Run for every harness, claude-code included. The heavy multi-probe security-audit stays in the pinned weekly `E2E: full`. | yes |
 
-`✅` pass · `❌` fail · `➖` not run. The matrix is
+`✅` pass · `❌` fail · `➖` not run / not applicable. The matrix is
 `harness × os × omac{main,release}` (codex/macOS excluded), and rows are sorted
 newest-first, then grouped by omac version, OS, and harness.
 
@@ -57,12 +58,17 @@ SKAINET summary of what broke) — plus links to the dashboard issue and the run
 
 ## Running the model-free checks
 
-The `contract` and `launch` stages need no token or model call. They run weekly as
-part of `E2E: drift` (never as a separate per-PR job). On every PR, `CI` →
+The `contract`, `launch`, and `serve` stages need no token or model call. They run
+weekly as part of `E2E: drift` (never as a separate per-PR job). On every PR, `CI` →
 `E2E: model-free` also runs the pure-Go derivation unit tests (`contract_test.go`),
-which verify the checked flags stay wired to the registry — without installing any
-harness. Run the full model-free tier locally:
+which verify the checked flags stay wired to the registry (and that serve eligibility
+tracks `ServerLaunch`) — without installing any harness. Run the full model-free tier
+locally:
 
 ```sh
-go test -tags=e2e -run 'TestHarnessCLIContract|TestHarnessLaunchProbe' -v ./internal/e2e/
+go test -tags=e2e -run 'TestHarnessCLIContract|TestHarnessLaunchProbe|TestHarnessServeProbe' -v ./internal/e2e/
 ```
+
+The `serve` probe launches the real `opencode serve` daemon under the sandbox, so it
+needs `opencode` installable via `bun` and a working sandbox backend (bubblewrap on
+Linux, Seatbelt on macOS); it is model-free and needs no provider token.

--- a/internal/e2e/contract.go
+++ b/internal/e2e/contract.go
@@ -164,6 +164,22 @@ func parseVersion(raw string) string {
 	return strings.TrimSpace(raw)
 }
 
+// harnessHasServerMode reports whether the harness declares a server-launch
+// convention in the registry (config.Harness.ServerLaunch) — i.e. whether
+// `omac serve <harness>` turns its inner command into a long-lived daemon.
+// Only such harnesses have a meaningful Desktop/serve mode to probe (today
+// opencode → `opencode serve`, for OpenCode Desktop); the rest run the inner
+// command as-is under serve, so the serve probe skips them. Deriving this from
+// the live registry keeps the probe in lockstep with harness.go rather than a
+// hardcoded name list. Returns false for an unknown harness name.
+func harnessHasServerMode(name string) bool {
+	reg, ok := config.LookupHarness(name)
+	if !ok {
+		return false
+	}
+	return reg.ServerLaunch != nil && reg.ServerLaunch.Subcommand != ""
+}
+
 // compatLine renders the stable machine-readable line the smoke test prints so
 // the workflow can parse it into the compatibility matrix without re-deriving
 // anything. The date and omac version are stamped by the workflow (they are not

--- a/internal/e2e/contract_test.go
+++ b/internal/e2e/contract_test.go
@@ -138,6 +138,25 @@ func TestCompatLine(t *testing.T) {
 	}
 }
 
+func TestHarnessHasServerMode(t *testing.T) {
+	// Derived from the live registry: only opencode ships a server-launch
+	// convention today. This test locks the serve-probe eligibility to that
+	// fact so adding/removing a harness's ServerLaunch is a conscious change.
+	cases := map[string]bool{
+		"opencode":    true,
+		"claude-code": false,
+		"codex":       false,
+		"copilot":     false,
+		"pi":          false,
+		"nonexistent": false,
+	}
+	for name, want := range cases {
+		if got := harnessHasServerMode(name); got != want {
+			t.Errorf("harnessHasServerMode(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
 func TestParseVersion(t *testing.T) {
 	cases := []struct{ raw, want string }{
 		{"opencode 1.17.12", "1.17.12"},

--- a/internal/e2e/smoke_test.go
+++ b/internal/e2e/smoke_test.go
@@ -15,10 +15,17 @@
 //   - TestHarnessLaunchProbe drives `omac start <harness> -- --version` through
 //     the real sandbox, exercising omac's launch/PATH/config-home/sandbox-
 //     admission wiring end-to-end (everything except the model call).
+//   - TestHarnessServeProbe launches `omac serve <harness>` with the REAL inner
+//     server daemon under the sandbox and drives the host-side control plane
+//     over HTTP (activate a directory, read its manifest, list dirs,
+//     deactivate) — the Desktop-mode analog of the launch probe. It runs only
+//     for harnesses with a server-launch convention (opencode, for OpenCode
+//     Desktop); the rest run their inner command as-is under serve and emit a
+//     SKIP row.
 //
-// Both are selectable without secrets (no SKAINET/Anthropic token needed):
+// All three are selectable without secrets (no SKAINET/Anthropic token needed):
 //
-//	go test -tags=e2e -run 'TestHarnessCLIContract|TestHarnessLaunchProbe' ./internal/e2e/
+//	go test -tags=e2e -run 'TestHarnessCLIContract|TestHarnessLaunchProbe|TestHarnessServeProbe' ./internal/e2e/
 //
 // The weekly "E2E: drift" workflow runs them with E2E_USE_LATEST=1 across every
 // harness and OS (alongside the llm stage), never as a separate per-PR job.
@@ -32,12 +39,17 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -48,6 +60,18 @@ const smokeCmdTimeout = 60 * time.Second
 // launchProbeTimeout bounds the `omac start ... -- --version` launch probe.
 // Generous vs. a bare --version because it spins up the sandbox first.
 const launchProbeTimeout = 2 * time.Minute
+
+// serveProbeTimeout bounds the whole `omac serve` probe: sandbox spin-up, inner
+// daemon launch, and the control-plane activate/dirs/deactivate round-trip.
+const serveProbeTimeout = 3 * time.Minute
+
+// serveReadyTimeout bounds how long the probe waits for the control plane to
+// announce itself on stdout after `omac serve` starts.
+const serveReadyTimeout = 90 * time.Second
+
+// serveControlBaseRe extracts the control-plane base URL from the line
+// `omac serve` prints on startup: "control plane on http://127.0.0.1:PORT; ...".
+var serveControlBaseRe = regexp.MustCompile(`control plane on (http://[0-9.]+:[0-9]+)`)
 
 // smokeHarnesses returns the harnesses to exercise, honoring E2E_HARNESS
 // (single-harness CI matrix leg) exactly like TestE2EEchoRest.
@@ -179,6 +203,276 @@ func TestHarnessLaunchProbe(t *testing.T) {
 			t.Logf("%s launch probe ok (%d bytes of --version output)", h.Name, len(strings.TrimSpace(combined)))
 		})
 	}
+}
+
+// TestHarnessServeProbe verifies omac's Desktop/serve mode end-to-end without a
+// model call: it launches `omac serve <harness>` with the REAL inner server
+// daemon under the sandbox, then drives the host-side control plane over HTTP
+// (activate a directory → read its manifest → list dirs → deactivate) and
+// confirms the inner daemon was admitted through the sandbox and stays alive.
+//
+// Only harnesses with a server-launch convention are exercised (opencode, whose
+// `opencode serve` daemon backs OpenCode Desktop). The rest run their inner
+// command as-is under serve — there is no daemon to probe — so they emit a SKIP
+// row and are skipped. Model-free and secret-free: `opencode serve` boots an
+// HTTP server without provider auth, and the probe never issues a model call.
+func TestHarnessServeProbe(t *testing.T) {
+	for _, h := range smokeHarnesses(t) {
+		t.Run(h.Name, func(t *testing.T) {
+			if !harnessHasServerMode(h.Name) {
+				emitCompat(compatLine(h.Name, "n/a", runtime.GOOS, "serve", "SKIP"))
+				t.Skipf("%s has no server-launch convention; serve/Desktop mode not applicable", h.Name)
+			}
+
+			home := t.TempDir()
+			workdir := t.TempDir()
+			cwd := t.TempDir()
+
+			// Runtime dirs the harness expects; the sandbox skips nonexistent
+			// allow paths, so create them before launch (mirrors the launch probe).
+			for _, dir := range []string{".cache", ".cache/opencode", ".local/share/opencode", ".local/state/opencode/locks"} {
+				if err := os.MkdirAll(filepath.Join(home, dir), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			omacBin := buildOmac(t)
+			installHarness(t, h, home)
+			version := harnessVersion(t, h, home)
+			writeSandboxProfile(t, home, h, nil)
+
+			err := runServeProbe(t, h, omacBin, home, workdir, cwd)
+
+			result := "PASS"
+			if err != nil {
+				result = "FAIL"
+			}
+			// Emit before asserting so the matrix records the outcome even when
+			// the assertion fails (same discipline as the other probes).
+			emitCompat(compatLine(h.Name, version, runtime.GOOS, "serve", result))
+
+			if err != nil {
+				t.Fatalf("serve probe failed: %v", err)
+			}
+			t.Logf("%s serve probe ok (control plane + inner daemon + activate/deactivate)", h.Name)
+		})
+	}
+}
+
+// runServeProbe launches `omac serve <harness>` as a subprocess with the real
+// inner daemon under the sandbox, waits for the control plane, drives one
+// activate → dirs → deactivate cycle, and verifies the daemon was admitted and
+// the process is still alive. It returns a descriptive error on the first
+// failure (with captured output), or nil on success. The subprocess is always
+// torn down via t.Cleanup.
+func runServeProbe(t *testing.T, h harnessConfig, omacBin, home, workdir, cwd string) error {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), serveProbeTimeout)
+	defer cancel()
+
+	args := []string{"serve", h.Name, "--control-addr", "127.0.0.1:0", "--verbose"}
+	if h.Sandbox.NoSandbox {
+		args = append(args, "--no-sandbox")
+	}
+
+	cmd := exec.CommandContext(ctx, omacBin, args...)
+	cmd.Dir = cwd
+	// A serve launch probe needs no provider creds (opencode serve boots an
+	// HTTP server without auth), so use a bare HOME env — NOT buildAgentEnv,
+	// whose per-harness EnvVars t.Fatal when SKAINET_TOKEN is unset. This keeps
+	// the probe genuinely model-free and secret-free.
+	cmd.Env = append(withHome(os.Environ(), home), "PWD="+cwd)
+	cmd.Stdin = strings.NewReader("")
+
+	// Capture stdout/stderr into goroutine-safe buffers rather than an
+	// os/exec pipe: the probe polls stdout for the control-plane line while a
+	// background goroutine calls cmd.Wait(), and reading a StdoutPipe
+	// concurrently with Wait is a documented footgun. Buffers we own sidestep
+	// it entirely.
+	var stdout, stderr syncBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	t.Logf("serve probe: omac %s", strings.Join(args, " "))
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start omac serve: %w", err)
+	}
+
+	// Wait for the subprocess in the background so we can distinguish "still
+	// running" (healthy daemon) from "exited early" (inner launch failed).
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-waitCh:
+		case <-time.After(10 * time.Second):
+			_ = cmd.Process.Kill()
+			<-waitCh
+		}
+	})
+
+	// Poll stdout for the control-plane URL the server prints on startup,
+	// bailing early if the process exits before announcing it.
+	controlBase, err := waitForControlBase(&stdout, waitCh, serveReadyTimeout)
+	if err != nil {
+		return fmt.Errorf("%w\nSTDERR:\n%s", err, tailLines(stderr.String(), 60))
+	}
+
+	// The inner daemon must be admitted through the sandbox. The control plane
+	// is announced BEFORE the child launches, so wait for the onReady marker
+	// (`--verbose`) rather than checking once — otherwise a slow runner could
+	// finish the API round-trip before the child has even spawned.
+	if err := waitForStderr(&stderr, "inner command started", waitCh, serveReadyTimeout); err != nil {
+		return fmt.Errorf("inner daemon never started under the sandbox: %w\nSTDERR:\n%s",
+			err, tailLines(stderr.String(), 60))
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+
+	// Activate the workdir and assert the manifest carries a namespacing token.
+	manifest, err := serveControlPost(client, controlBase+"/__omac__/activate", workdir)
+	if err != nil {
+		return fmt.Errorf("activate %s: %w\nSTDERR:\n%s", workdir, err, tailLines(stderr.String(), 60))
+	}
+	token, _ := manifest["dir_token"].(string)
+	if token == "" {
+		return fmt.Errorf("activate returned no dir_token: %v", manifest)
+	}
+	if state, _ := manifest["state"].(string); state == "" {
+		return fmt.Errorf("activate returned no state: %v", manifest)
+	}
+
+	// The dir must now show up as active over the control plane.
+	dirsBody, err := serveControlGet(client, controlBase+"/__omac__/dirs")
+	if err != nil {
+		return fmt.Errorf("GET /__omac__/dirs: %w", err)
+	}
+	if !strings.Contains(dirsBody, workdir) {
+		return fmt.Errorf("/__omac__/dirs did not list the activated dir %q: %s", workdir, dirsBody)
+	}
+
+	// Deactivate cleanly.
+	if _, err := serveControlPost(client, controlBase+"/__omac__/deactivate", workdir); err != nil {
+		return fmt.Errorf("deactivate %s: %w", workdir, err)
+	}
+
+	// The daemon must still be alive after the whole round-trip — an early exit
+	// means the sandboxed `<harness> serve` crashed rather than served.
+	select {
+	case werr := <-waitCh:
+		return fmt.Errorf("omac serve exited while the probe was driving it (inner daemon likely crashed): %v\nSTDERR:\n%s",
+			werr, tailLines(stderr.String(), 60))
+	default:
+	}
+	return nil
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer. The serve probe reads captured
+// stderr for diagnostics while the subprocess may still be writing to it (the
+// daemon runs until teardown), so plain bytes.Buffer would race.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// waitForControlBase polls the captured stdout for the control-plane URL
+// `omac serve` prints on startup, returning it once seen. It fails fast if the
+// process exits first (waitCh fires) or the timeout elapses.
+func waitForControlBase(stdout *syncBuffer, waitCh <-chan error, timeout time.Duration) (string, error) {
+	deadline := time.After(timeout)
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if m := serveControlBaseRe.FindStringSubmatch(stdout.String()); m != nil {
+			return m[1], nil
+		}
+		select {
+		case werr := <-waitCh:
+			// Drain-check one last time: the line may have been flushed just
+			// before exit.
+			if m := serveControlBaseRe.FindStringSubmatch(stdout.String()); m != nil {
+				return m[1], nil
+			}
+			return "", fmt.Errorf("omac serve exited before announcing the control plane: %v", werr)
+		case <-deadline:
+			return "", fmt.Errorf("omac serve did not announce a control plane within %v", timeout)
+		case <-tick.C:
+		}
+	}
+}
+
+// waitForStderr polls the captured stderr until it contains substr, returning
+// nil once seen. It fails fast if the process exits first or the timeout
+// elapses (the final drain-check covers a marker flushed just before exit).
+func waitForStderr(stderr *syncBuffer, substr string, waitCh <-chan error, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if strings.Contains(stderr.String(), substr) {
+			return nil
+		}
+		select {
+		case werr := <-waitCh:
+			if strings.Contains(stderr.String(), substr) {
+				return nil
+			}
+			return fmt.Errorf("process exited before %q appeared: %v", substr, werr)
+		case <-deadline:
+			return fmt.Errorf("%q did not appear within %v", substr, timeout)
+		case <-tick.C:
+		}
+	}
+}
+
+// serveControlPost POSTs {"dir": dir} to a control-plane endpoint and returns
+// the decoded JSON response, erroring on any non-200 status.
+func serveControlPost(client *http.Client, url, dir string) (map[string]any, error) {
+	body, _ := json.Marshal(map[string]string{"dir": dir})
+	resp, err := client.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var m map[string]any
+	if derr := json.NewDecoder(resp.Body).Decode(&m); derr != nil {
+		return nil, fmt.Errorf("decode response: %w", derr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d body=%v", resp.StatusCode, m)
+	}
+	return m, nil
+}
+
+// serveControlGet GETs a control-plane endpoint and returns the raw body.
+func serveControlGet(client *http.Client, url string) (string, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("status %d body=%s", resp.StatusCode, b)
+	}
+	return string(b), nil
 }
 
 // harnessVersion runs `<bin> --version` in the temp HOME and returns the


### PR DESCRIPTION
## What

Adds a fourth model-free stage — **`serve`** — to the weekly `E2E: drift` matrix.

`TestHarnessServeProbe` launches `omac serve <harness>` with the **real inner server daemon** under the sandbox, then drives the host-side control plane over HTTP: `activate → manifest → /dirs → deactivate`. It asserts the daemon is admitted through the sandbox (the `--verbose` onReady marker) and stays alive through the round-trip. The outcome is recorded as a new `serve` column in the compatibility matrix (dashboard, archive, Slack, step summary).

`✅` pass · `❌` fail · `➖` not run / not applicable.

## Why

serve/Desktop mode was covered only at the Go engine level (`serve_test.go`) and with `--no-inner` (`serve_isolation_test.go`) — nothing exercised the real inner daemon coming up under the sandbox. A harness release that broke `opencode serve` (the subcommand omac injects for **OpenCode Desktop**) would go undetected until a user hit it. This is the Desktop-mode analog of the existing `launch` stage.

**Only opencode is probed today, and that's by design, not a shortcut.** Eligibility is derived from the registry (`config.Harness.ServerLaunch`) via `harnessHasServerMode`: only opencode declares a server-launch convention (`opencode serve`). The other harnesses have `ServerLaunch: nil` and run their inner command as-is under `omac serve` (an interactive REPL, no daemon) — per `docs/MULTI_DIR_DESKTOP.md`, `omac start` is their primary mode. They emit `SKIP` → rendered `➖`. `TestHarnessHasServerMode` locks the mapping so gaining/losing a server mode is a conscious change; the day another harness ships a daemon, the probe picks it up with no workflow edit.

The probe is **model-free and secret-free**: `opencode serve` boots its HTTP server without provider auth (verified against opencode 1.17.12), and no model call is made.

## How

- `internal/e2e/smoke_test.go`: `TestHarnessServeProbe` + `runServeProbe` (subprocess launch, stdout poll for the control-plane URL, bounded wait for sandbox admission, control-plane activate/deactivate, liveness check). Goroutine-safe `syncBuffer` for concurrent stderr/stdout capture; avoids the `StdoutPipe`+concurrent-`Wait` footgun.
- `internal/e2e/contract.go`: `harnessHasServerMode` (registry-derived eligibility).
- `.github/workflows/e2e-smoke.yml`: run the probe in the model-free step; add the `serve` column to every table (step summary, dashboard "Currently failing" + "History", private archive) and to the Slack + `.ctx` failure paths; `stage_mark` maps `SKIP → ➖` and treats an absent `serve` line as not-applicable rather than a failure.
- `docs/HARNESS_COMPAT.md`: document the new stage.

## Verification

- `E2E_HARNESS=opencode go test -tags=e2e -race -run TestHarnessServeProbe` passes end-to-end under the real bwrap sandbox (control plane + inner daemon + activate/deactivate), ~4s, no data races.
- SKIP path confirmed for `claude-code` and `pi` (skips before any install).
- `go vet`, `gofmt`, `e2e_fast` unit tests (incl. `TestHarnessHasServerMode`), and full `go build ./...` all clean.
- Workflow `stage_mark` / row-building / Slack + footer awk logic simulated against sample `OMAC_COMPAT` output; YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
