### PR TITLE
fix(serve): allowlist the inner server's listen port in the sandbox (#115)

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -405,6 +406,13 @@ func runServe(args []string, env *Env) int {
 		if cp := controlPortOf(cln); cp != "" {
 			argv = injectOpenPort(argv, cp)
 		}
+		// Allowlist the inner server daemon's own listen port so its bind()
+		// is permitted inside the sandbox. The profile's `--open-port
+		// {{tcp_port}}` covers only the facade; the harness's server (e.g.
+		// `opencode serve` on 4096) binds a distinct port that no other
+		// grant covers, so a restrictive profile (network_prompt: deny)
+		// denies the bind and the daemon crashes on startup (issue #115).
+		argv = injectServerListenPort(argv, harness)
 		// Grant the selected harness's runtime dirs (config, state,
 		// sessions) read+write — only for the selected harness.
 		argv = injectSandboxDirs(argv, harness.SandboxDirs)
@@ -495,6 +503,18 @@ func controlPortOf(ln net.Listener) string {
 		return ""
 	}
 	return port
+}
+
+// injectServerListenPort splices `--listen-port <port>` into a sandbox argv
+// for a harness whose server daemon binds a fixed loopback port (declared on
+// its ServerLaunch descriptor). Without this the daemon's bind() is denied
+// under a restrictive sandbox profile and it crashes on startup (issue #115).
+// Harnesses with no server mode, or none declaring a port, are a no-op.
+func injectServerListenPort(argv []string, h config.Harness) []string {
+	if h.ServerLaunch == nil || h.ServerLaunch.ListenPort <= 0 {
+		return argv
+	}
+	return injectSandboxFlag(argv, "--listen-port", strconv.Itoa(h.ServerLaunch.ListenPort))
 }
 
 // injectOpenPort splices `--open-port <port>` into a sandbox argv so the

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -458,6 +458,12 @@ func runServe(args []string, env *Env) int {
 		fmt.Fprintf(env.Stderr, "[verbose] inner argv: %v\n", argv)
 	}
 
+	// Caution when the harness server will expose an unauthenticated loopback
+	// port (fires whether sandboxed or not — the server listens either way).
+	if w := serverExposureWarning(harness, os.Getenv); w != "" {
+		fmt.Fprintln(env.Stderr, w)
+	}
+
 	// Run the inner command (opencode serve) in the sandbox, with the
 	// control plane already serving. ExecWithReady blocks until the child
 	// exits; the deferred facade/supervisor/control teardown then runs
@@ -515,6 +521,24 @@ func injectServerListenPort(argv []string, h config.Harness) []string {
 		return argv
 	}
 	return injectSandboxFlag(argv, "--listen-port", strconv.Itoa(h.ServerLaunch.ListenPort))
+}
+
+// serverExposureWarning returns a one-line caution when a harness's server
+// daemon will bind a loopback port that is NOT protected by its auth env var
+// — that port is reachable by any local process, so an unauthenticated server
+// lets local callers drive the agent (bounded by the sandbox, but still). It
+// returns "" when there is no server port or the auth env var is set. getenv
+// is injected for testability.
+func serverExposureWarning(h config.Harness, getenv func(string) string) string {
+	sl := h.ServerLaunch
+	if sl == nil || sl.ListenPort <= 0 || sl.AuthEnvVar == "" {
+		return ""
+	}
+	if getenv(sl.AuthEnvVar) != "" {
+		return ""
+	}
+	return fmt.Sprintf("omac serve: %s server will listen on 127.0.0.1:%d, reachable by any local "+
+		"process; set %s to require authentication.", h.Name, sl.ListenPort, sl.AuthEnvVar)
 }
 
 // injectOpenPort splices `--open-port <port>` into a sandbox argv so the

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -383,14 +383,14 @@ func runServe(args []string, env *Env) int {
 	if *noSandbox {
 		argv = inner
 	} else {
-		argv, err = sandbox.Expand(prof, sandbox.Inputs{
+		argv, err = sandboxServeArgv(prof, sandbox.Inputs{
 			Workdir:  env.Workdir,
 			Socket:   socketPath,
 			TCPPort:  srv.tcpPort,
 			Mounts:   srv.facadeMounts(),
 			InnerCmd: inner,
 			TmpDir:   srv.sandboxTmp,
-		})
+		}, controlPortOf(cln), harness)
 		if err != nil {
 			fmt.Fprintln(env.Stderr, "omac serve: sandbox argv:", err)
 			return ExitConfigInvalid
@@ -398,24 +398,6 @@ func runServe(args []string, env *Env) int {
 		if cacheScope != nil {
 			argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)
 		}
-		// The control-plane port is distinct from the facade TCP port and
-		// is NOT whitelisted by the profile's `--open-port {{tcp_port}}`.
-		// Without opening it, the sandboxed `opencode serve` (and the plugin
-		// inside it) cannot reach OMAC_CONTROL_BASE — nono denies the
-		// loopback connect (FailedToOpenSocket). Whitelist it too.
-		if cp := controlPortOf(cln); cp != "" {
-			argv = injectOpenPort(argv, cp)
-		}
-		// Allowlist the inner server daemon's own listen port so its bind()
-		// is permitted inside the sandbox. The profile's `--open-port
-		// {{tcp_port}}` covers only the facade; the harness's server (e.g.
-		// `opencode serve` on 4096) binds a distinct port that no other
-		// grant covers, so a restrictive profile (network_prompt: deny)
-		// denies the bind and the daemon crashes on startup (issue #115).
-		argv = injectServerListenPort(argv, harness)
-		// Grant the selected harness's runtime dirs (config, state,
-		// sessions) read+write — only for the selected harness.
-		argv = injectSandboxDirs(argv, harness.SandboxDirs)
 		// Pass the resolved audit path to `omac sandbox run` so its
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the
@@ -509,6 +491,33 @@ func controlPortOf(ln net.Listener) string {
 		return ""
 	}
 	return port
+}
+
+// sandboxServeArgv expands the sandbox profile into an inner argv and applies
+// the serve-mode grants the profile template can't express on its own:
+//
+//   - the control-plane port — distinct from the facade `--open-port
+//     {{tcp_port}}`; without it the sandboxed inner (and its plugin) can't
+//     reach OMAC_CONTROL_BASE and the loopback connect is denied. Skipped
+//     when controlPort is "".
+//   - the harness server daemon's own listen port, so its bind() is permitted
+//     (issue #115 — otherwise a restrictive profile denies the bind and the
+//     daemon crashes on startup).
+//   - the selected harness's runtime dirs (config/state/sessions) read+write.
+//
+// Kept as one pure function so the grant sequence stays unit-testable without
+// launching the control plane.
+func sandboxServeArgv(prof config.SandboxProfile, in sandbox.Inputs, controlPort string, h config.Harness) ([]string, error) {
+	argv, err := sandbox.Expand(prof, in)
+	if err != nil {
+		return nil, err
+	}
+	if controlPort != "" {
+		argv = injectOpenPort(argv, controlPort)
+	}
+	argv = injectServerListenPort(argv, h)
+	argv = injectSandboxDirs(argv, h.SandboxDirs)
+	return argv, nil
 }
 
 // injectServerListenPort splices `--listen-port <port>` into a sandbox argv

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -201,6 +201,25 @@ func TestRootsPolicy(t *testing.T) {
 	}
 }
 
+func TestInjectServerListenPort(t *testing.T) {
+	oc, _ := config.LookupHarness("opencode")
+	cc, _ := config.LookupHarness("claude-code")
+
+	// A server harness gets its listen port allowlisted, spliced before `--`.
+	in := []string{"omac", "sandbox", "run", "--profile", "tng-default", "--open-port", "5000", "--", "opencode", "serve"}
+	got := injectServerListenPort(in, oc)
+	want := []string{"omac", "sandbox", "run", "--profile", "tng-default", "--open-port", "5000", "--listen-port", "4096", "--", "opencode", "serve"}
+	if !equalStrings(got, want) {
+		t.Errorf("opencode: got %v, want %v", got, want)
+	}
+
+	// A harness with no server mode is a no-op (nothing to allowlist).
+	in2 := []string{"nono", "run", "--", "claude"}
+	if got2 := injectServerListenPort(in2, cc); !equalStrings(got2, in2) {
+		t.Errorf("claude-code should be a no-op: got %v, want %v", got2, in2)
+	}
+}
+
 func TestInjectOpenPort(t *testing.T) {
 	// With a `--` separator, the flag goes right before it.
 	in := []string{"nono", "run", "--open-port", "5000", "--", "opencode", "serve"}

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -220,6 +220,34 @@ func TestInjectServerListenPort(t *testing.T) {
 	}
 }
 
+func TestServerExposureWarning(t *testing.T) {
+	oc, _ := config.LookupHarness("opencode")
+	cc, _ := config.LookupHarness("claude-code")
+
+	// opencode server + auth env UNSET -> warn (names the port + the env var).
+	unset := func(string) string { return "" }
+	w := serverExposureWarning(oc, unset)
+	if w == "" || !strings.Contains(w, "4096") || !strings.Contains(w, "OPENCODE_SERVER_PASSWORD") {
+		t.Errorf("expected warning naming :4096 and OPENCODE_SERVER_PASSWORD, got %q", w)
+	}
+
+	// Auth env SET -> no warning (the exposed port is protected).
+	set := func(k string) string {
+		if k == "OPENCODE_SERVER_PASSWORD" {
+			return "secret"
+		}
+		return ""
+	}
+	if w := serverExposureWarning(oc, set); w != "" {
+		t.Errorf("auth set should suppress the warning, got %q", w)
+	}
+
+	// Harness with no server mode -> nothing to warn about.
+	if w := serverExposureWarning(cc, unset); w != "" {
+		t.Errorf("non-server harness should not warn, got %q", w)
+	}
+}
+
 func TestInjectOpenPort(t *testing.T) {
 	// With a `--` separator, the flag goes right before it.
 	in := []string{"nono", "run", "--open-port", "5000", "--", "opencode", "serve"}

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/facade"
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandbox"
 	"github.com/tngtech/oh-my-agentic-coder/internal/toolcache"
 )
 
@@ -217,6 +218,52 @@ func TestInjectServerListenPort(t *testing.T) {
 	in2 := []string{"nono", "run", "--", "claude"}
 	if got2 := injectServerListenPort(in2, cc); !equalStrings(got2, in2) {
 		t.Errorf("claude-code should be a no-op: got %v, want %v", got2, in2)
+	}
+}
+
+// TestSandboxServeArgvInjectsListenPort exercises the serve argv assembly
+// end-to-end (the pipeline runServe actually calls), not just the
+// injectServerListenPort helper in isolation. It guards against the #115 bind
+// grant being dropped from the pipeline during a refactor.
+func TestSandboxServeArgvInjectsListenPort(t *testing.T) {
+	oc, _ := config.LookupHarness("opencode")
+	prof := config.SandboxProfile{
+		Command:  []string{"omac", "sandbox", "run", "--", "{{inner_cmd}}", "{{inner_args}}"},
+		InnerCmd: []string{"opencode"},
+	}
+	in := sandbox.Inputs{Workdir: "/w", InnerCmd: []string{"opencode", "serve"}}
+
+	argv, err := sandboxServeArgv(prof, in, "51234", oc)
+	if err != nil {
+		t.Fatalf("sandboxServeArgv: %v", err)
+	}
+	joined := strings.Join(argv, " ")
+
+	// The opencode server binds 4096; the pipeline must allowlist it for bind.
+	if !contains(joined, "--listen-port 4096") {
+		t.Errorf("serve argv missing --listen-port 4096: %s", joined)
+	}
+	// The control-plane port is opened for connect too.
+	if !contains(joined, "--open-port 51234") {
+		t.Errorf("serve argv missing --open-port 51234: %s", joined)
+	}
+	// Grants splice before the `--` separator, not after it.
+	if lp, sep := strings.Index(joined, "--listen-port"), strings.Index(joined, " -- "); lp < 0 || sep < 0 || lp > sep {
+		t.Errorf("--listen-port must appear before `--`: %s", joined)
+	}
+
+	// Empty control port skips only the control-plane grant; the #115 bind
+	// grant still applies.
+	noCP, err := sandboxServeArgv(prof, in, "", oc)
+	if err != nil {
+		t.Fatalf("sandboxServeArgv (no control port): %v", err)
+	}
+	nj := strings.Join(noCP, " ")
+	if contains(nj, "--open-port") {
+		t.Errorf("empty control port should add no --open-port: %s", nj)
+	}
+	if !contains(nj, "--listen-port 4096") {
+		t.Errorf("listen-port grant must still apply without a control port: %s", nj)
 	}
 }
 

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -173,6 +173,13 @@ type ServerLaunch struct {
 	// startup (issue #115). Zero means the harness declares no fixed port and
 	// omac injects no listen-port grant.
 	ListenPort int
+
+	// AuthEnvVar names the environment variable the harness's server reads to
+	// require authentication on its exposed loopback port (OpenCode uses
+	// OPENCODE_SERVER_PASSWORD). `omac serve` warns when a listen port is
+	// exposed while this var is unset — the port is reachable by any local
+	// process otherwise. Empty means the harness declares no auth control.
+	AuthEnvVar string
 }
 
 // defaultHarnessName is the harness used when `omac start`/`omac serve` is
@@ -189,7 +196,7 @@ func harnessRegistry() []Harness {
 			Name:         "opencode",
 			Aliases:      []string{"oc"},
 			InnerCmd:     []string{"opencode"},
-			ServerLaunch: &ServerLaunch{Subcommand: "serve", ListenPort: 4096},
+			ServerLaunch: &ServerLaunch{Subcommand: "serve", ListenPort: 4096, AuthEnvVar: "OPENCODE_SERVER_PASSWORD"},
 			BridgeDir:    filepath.Join(".opencode", "plugins"),
 			SkillsBase:   "opencode",
 			HomeEnv:      "OPENCODE_HOME",

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -165,6 +165,14 @@ type ServerLaunch struct {
 	// already begin with a subcommand (a non-flag positional). For OpenCode
 	// this is "serve".
 	Subcommand string
+
+	// ListenPort is the TCP port the harness's server daemon binds on
+	// loopback by default (OpenCode's `serve` listens on 4096). `omac serve`
+	// must allowlist this port for binding in the sandbox — otherwise the
+	// daemon's bind() is denied under a restrictive profile and it crashes on
+	// startup (issue #115). Zero means the harness declares no fixed port and
+	// omac injects no listen-port grant.
+	ListenPort int
 }
 
 // defaultHarnessName is the harness used when `omac start`/`omac serve` is
@@ -181,7 +189,7 @@ func harnessRegistry() []Harness {
 			Name:         "opencode",
 			Aliases:      []string{"oc"},
 			InnerCmd:     []string{"opencode"},
-			ServerLaunch: &ServerLaunch{Subcommand: "serve"},
+			ServerLaunch: &ServerLaunch{Subcommand: "serve", ListenPort: 4096},
 			BridgeDir:    filepath.Join(".opencode", "plugins"),
 			SkillsBase:   "opencode",
 			HomeEnv:      "OPENCODE_HOME",

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -128,6 +128,11 @@ func TestServerLaunchListenPort(t *testing.T) {
 	if oc.ServerLaunch.ListenPort != 4096 {
 		t.Errorf("opencode ServerLaunch.ListenPort = %d, want 4096", oc.ServerLaunch.ListenPort)
 	}
+	// opencode's server is unauthenticated unless OPENCODE_SERVER_PASSWORD is
+	// set; declaring it lets omac warn when the exposed loopback port is open.
+	if oc.ServerLaunch.AuthEnvVar != "OPENCODE_SERVER_PASSWORD" {
+		t.Errorf("opencode ServerLaunch.AuthEnvVar = %q, want OPENCODE_SERVER_PASSWORD", oc.ServerLaunch.AuthEnvVar)
+	}
 	for _, name := range []string{"claude-code", "codex", "copilot", "pi"} {
 		h, _ := LookupHarness(name)
 		if h.ServerLaunch != nil {

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -116,6 +116,26 @@ func TestApplyServerLaunch(t *testing.T) {
 	}
 }
 
+// TestServerLaunchListenPort locks the per-harness server listen port that
+// omac serve must allowlist in the sandbox. opencode's `serve` daemon binds
+// 4096 by default; without this the bind is denied under a restrictive
+// profile (issue #115). Harnesses with no server mode declare no port.
+func TestServerLaunchListenPort(t *testing.T) {
+	oc, ok := LookupHarness("opencode")
+	if !ok || oc.ServerLaunch == nil {
+		t.Fatal("opencode must have a ServerLaunch")
+	}
+	if oc.ServerLaunch.ListenPort != 4096 {
+		t.Errorf("opencode ServerLaunch.ListenPort = %d, want 4096", oc.ServerLaunch.ListenPort)
+	}
+	for _, name := range []string{"claude-code", "codex", "copilot", "pi"} {
+		h, _ := LookupHarness(name)
+		if h.ServerLaunch != nil {
+			t.Errorf("%s unexpectedly declares a ServerLaunch (%+v)", name, h.ServerLaunch)
+		}
+	}
+}
+
 func TestResolveInnerCmd(t *testing.T) {
 	oc, _ := LookupHarness("opencode")
 	cc, _ := LookupHarness("claude-code")


### PR DESCRIPTION
Fixes #115.

## What

`omac serve <harness>` now allowlists the **inner server daemon's own listen port** in the sandbox, so its `bind()` is permitted. The port is declared per-harness on `config.ServerLaunch.ListenPort` (opencode's `serve` → `4096`); `serve.go` injects `--listen-port <port>` into the sandbox argv, mirroring the existing `--open-port` injection for the facade/control ports. A second commit adds a launch-time caution when that exposed port is unauthenticated.

## Why

`omac serve` opened `--open-port` only for the **facade** and **control-plane** ports (so the sandboxed process can *connect to* omac). The harness's server binds a **separate** listen socket that no grant covered. Under a restrictive profile — notably the default `tng-default` (permits listening only on `4097`, `network_prompt.on_unavailable: deny`) — the bind was denied non-interactively and `opencode serve` crashed on startup with an opaque `ServeError`, making Desktop mode unusable.

Root cause proven with `strace -f` of the sandboxed daemon:

```
bind(17, {AF_INET, sin_port=htons(4096), 127.0.0.1}) = -1 EACCES (Permission denied)
bind(17, {AF_INET, sin_port=htons(0),    127.0.0.1}) = -1 EACCES (Permission denied)
```

`--no-sandbox` worked; the crash reproduced with an empty opencode config, so it was neither the user's config/plugins/MCP nor an omac version regression.

## How

- `config.ServerLaunch` gains `ListenPort int` (`0` = none) and `AuthEnvVar string`. opencode declares `{ ListenPort: 4096, AuthEnvVar: "OPENCODE_SERVER_PASSWORD" }`; harnesses with no server mode declare nothing → no-op.
- `injectServerListenPort(argv, harness)` splices `--listen-port <port>` before the `--` separator, right after the control-port `--open-port` injection in `runServe`.
- `serverExposureWarning(harness, getenv)` emits a one-line caution before exec when the listen port is exposed and `AuthEnvVar` is unset.

## Security implications

The grant is deliberately minimal and does **not** weaken the sandbox:

- **Bind-only, loopback-only.** In `bwrap.go`, `ListenPort` maps to `--bind-tcp <port>` **only** — inbound bind permission for one loopback port. It grants **no** outbound connect (that's `--connect-tcp`, used by `OpenPort`), so it's *narrower* than the existing facade/control-port grants.
- **Core protections untouched.** Outbound domain filtering (the loopback proxy / `allow_domain`), filesystem confinement (bwrap binds + Landlock + protected paths), and secret isolation are all unchanged. Deny-by-default is preserved for every other bind/connect (`network_prompt` still denies them).
- **The one exposure:** opencode's server becomes reachable on `127.0.0.1:4096` (loopback only — **not** the LAN). It's unauthenticated unless `OPENCODE_SERVER_PASSWORD` is set, so a local process could drive the agent — but that agent is **still fully sandboxed** (fs + egress), so the blast radius is bounded, unlike `--no-sandbox`. This exposure is inherent to `opencode serve` (present whenever serve mode runs, with or without omac); the second commit surfaces it at launch and points at the mitigation.
- **Net:** strictly safer than the `--no-sandbox` workaround it replaces, which removes all isolation.

## Verification

- **TDD (red → green):** `TestServerLaunchListenPort` + `TestInjectServerListenPort` + `TestServerExposureWarning` written failing-first, then green. Full `internal/config` + `internal/cli` suites pass; `go vet` and `go build ./...` clean.
- **End-to-end:** a build from this branch runs `omac serve opencode` under the **real `tng-default`** profile without crashing (was `ServeError`); inner argv now carries `--listen-port 4096`; the exposure warning prints when `OPENCODE_SERVER_PASSWORD` is unset and is silent when set. Root cause and fix confirmed with `strace`.

## Notes / follow-ups

- Scope is intentionally minimal: it allowlists the harness's declared default port. A harness server on a non-default/random port would need that port to flow into the grant — out of scope here.
- The weekly drift `serve` probe (separate PR) uses a permissive profile, so it doesn't reproduce this — correct for a *harness-drift* probe; this is a product bug with its own unit coverage here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
