### PR TITLE
fix(netprompt): give network-access dialogs a readable size on all platforms

### DIFF
--- a/cmd/netprompt-demo/main.go
+++ b/cmd/netprompt-demo/main.go
@@ -1,0 +1,48 @@
+// Command netprompt-demo pops up the real omac network-access dialog so its
+// appearance can be inspected on the current platform (zenity/kdialog on
+// Linux, osascript on macOS).
+//
+// It drives the same netprompt.Prompter used in production, so any change to
+// the dialog code — window size, option labels, prompt text — is reflected
+// here automatically; there is no separate demo layout to keep in sync.
+//
+// Usage:
+//
+//	go run ./cmd/netprompt-demo [-host H] [-port P] [-intent TEXT]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt"
+)
+
+func main() {
+	host := flag.String("host", "api.github.com", "destination host shown in the dialog")
+	port := flag.Int("port", 443, "destination port shown in the dialog")
+	intent := flag.String("intent", "clone the target repository", "agent-declared intent line (empty shows \"not declared\")")
+	flag.Parse()
+
+	// Force the real GUI backend even if a stub decision source is configured
+	// in the environment (e.g. from an e2e shell).
+	os.Unsetenv("OMAC_PROMPT_STUB")
+
+	var lookupIntent func(string) (string, bool)
+	if *intent != "" {
+		lookupIntent = func(string) (string, bool) { return *intent, true }
+	}
+
+	logf := func(format string, a ...any) { fmt.Fprintf(os.Stderr, format+"\n", a...) }
+	p, ok := netprompt.NewPrompter(120, logf, lookupIntent, nil)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "no dialog backend available (install zenity or kdialog on Linux, osascript ships with macOS)")
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stderr, "showing network-access dialog for %s:%d ...\n", *host, *port)
+	res := p.Prompt(*host, *port)
+	fmt.Printf("decision: allow=%v persist=%v scope=%q suffix=%q needs_intent=%v\n",
+		res.Allow, res.Persist, res.Scope, res.Suffix, res.NeedsIntent)
+}

--- a/internal/netprompt/prompt.go
+++ b/internal/netprompt/prompt.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,6 +23,17 @@ const (
 	tokenDenyPermanentHost    = "deny_permanent_host"
 	tokenDenyPermanentSuffix  = "deny_permanent_suffix"
 	tokenNeedsIntent          = "needs_intent"
+)
+
+// Dialog dimensions in pixels. The default GTK/Qt auto-size makes the popup
+// unreadable on Ubuntu: too narrow to show the longest option label ("Allow
+// permanently (this host)") and too short to show all seven options — the
+// multi-line prompt text consumes the height and the radiolist collapses to a
+// two-row scroll box. The width fits the labels; the height fits the prompt
+// text plus all seven rows plus the buttons without scrolling.
+const (
+	dialogWidth  = 520
+	dialogHeight = 560
 )
 
 // optionLabels are the exact seven dialog choices (nono parity, product
@@ -304,13 +316,17 @@ func (zenityBackend) available() bool {
 	return err == nil
 }
 
-func (zenityBackend) show(ctx context.Context, host string, port int, suffix, intent string) (string, error) {
+// zenityArgs builds the full zenity radiolist argv, including the explicit
+// window size. Extracted so the sizing can be asserted without launching a
+// dialog.
+func zenityArgs(host string, port int, suffix, intent string) []string {
 	args := []string{
 		"--list", "--radiolist",
 		"--title", "omac: network access",
 		"--text", promptText(host, port, intent),
 		"--column", "", "--column", "Decision",
-		"--height", "320",
+		"--width", strconv.Itoa(dialogWidth),
+		"--height", strconv.Itoa(dialogHeight),
 	}
 	for _, o := range optionLabels(suffix) {
 		sel := "FALSE"
@@ -319,7 +335,11 @@ func (zenityBackend) show(ctx context.Context, host string, port int, suffix, in
 		}
 		args = append(args, sel, o)
 	}
-	out, err := exec.CommandContext(ctx, "zenity", args...).Output()
+	return args
+}
+
+func (zenityBackend) show(ctx context.Context, host string, port int, suffix, intent string) (string, error) {
+	out, err := exec.CommandContext(ctx, "zenity", zenityArgs(host, port, suffix, intent)...).Output()
 	if err != nil {
 		// zenity exits 1 on Cancel; treat as cancel unless ctx expired.
 		if ctx.Err() != nil {
@@ -339,9 +359,13 @@ func (kdialogBackend) available() bool {
 	return err == nil
 }
 
-func (kdialogBackend) show(ctx context.Context, host string, port int, suffix, intent string) (string, error) {
+// kdialogArgs builds the full kdialog radiolist argv, including the explicit
+// --geometry window size. Extracted so the sizing can be asserted without
+// launching a dialog.
+func kdialogArgs(host string, port int, suffix, intent string) []string {
 	opts := optionLabels(suffix)
 	args := []string{
+		"--geometry", fmt.Sprintf("%dx%d", dialogWidth, dialogHeight),
 		"--title", "omac: network access",
 		"--radiolist", promptText(host, port, intent),
 	}
@@ -350,9 +374,14 @@ func (kdialogBackend) show(ctx context.Context, host string, port int, suffix, i
 		if o == "Deny once" {
 			state = "on"
 		}
-		args = append(args, fmt.Sprintf("%d", i), o, state)
+		args = append(args, strconv.Itoa(i), o, state)
 	}
-	out, err := exec.CommandContext(ctx, "kdialog", args...).Output()
+	return args
+}
+
+func (kdialogBackend) show(ctx context.Context, host string, port int, suffix, intent string) (string, error) {
+	opts := optionLabels(suffix)
+	out, err := exec.CommandContext(ctx, "kdialog", kdialogArgs(host, port, suffix, intent)...).Output()
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", ctx.Err()

--- a/internal/netprompt/prompt.go
+++ b/internal/netprompt/prompt.go
@@ -25,16 +25,35 @@ const (
 	tokenNeedsIntent          = "needs_intent"
 )
 
-// Dialog dimensions in pixels. The default GTK/Qt auto-size makes the popup
+// Default dialog dimensions in pixels. The GTK/Qt auto-size makes the popup
 // unreadable on Ubuntu: too narrow to show the longest option label ("Allow
 // permanently (this host)") and too short to show all seven options — the
 // multi-line prompt text consumes the height and the radiolist collapses to a
 // two-row scroll box. The width fits the labels; the height fits the prompt
 // text plus all seven rows plus the buttons without scrolling.
+//
+// These are defaults: OMAC_PROMPT_WIDTH / OMAC_PROMPT_HEIGHT override them for
+// users on unusual displays (small/720p laptops where 560 px crowds the
+// viewport, tiling WMs, HiDPI) — see dialogDimensions.
 const (
 	dialogWidth  = 520
 	dialogHeight = 560
 )
+
+// dialogDimensions returns the popup width and height in pixels, honouring the
+// OMAC_PROMPT_WIDTH / OMAC_PROMPT_HEIGHT overrides. A missing, non-numeric, or
+// non-positive value falls back to the default constant.
+func dialogDimensions() (int, int) {
+	return envDimension("OMAC_PROMPT_WIDTH", dialogWidth),
+		envDimension("OMAC_PROMPT_HEIGHT", dialogHeight)
+}
+
+func envDimension(key string, def int) int {
+	if n, err := strconv.Atoi(strings.TrimSpace(os.Getenv(key))); err == nil && n > 0 {
+		return n
+	}
+	return def
+}
 
 // optionLabels are the exact seven dialog choices (nono parity, product
 // name swapped). Order matters: Deny once is the default.
@@ -320,13 +339,14 @@ func (zenityBackend) available() bool {
 // window size. Extracted so the sizing can be asserted without launching a
 // dialog.
 func zenityArgs(host string, port int, suffix, intent string) []string {
+	width, height := dialogDimensions()
 	args := []string{
 		"--list", "--radiolist",
 		"--title", "omac: network access",
 		"--text", promptText(host, port, intent),
 		"--column", "", "--column", "Decision",
-		"--width", strconv.Itoa(dialogWidth),
-		"--height", strconv.Itoa(dialogHeight),
+		"--width", strconv.Itoa(width),
+		"--height", strconv.Itoa(height),
 	}
 	for _, o := range optionLabels(suffix) {
 		sel := "FALSE"
@@ -362,10 +382,19 @@ func (kdialogBackend) available() bool {
 // kdialogArgs builds the full kdialog radiolist argv, including the explicit
 // --geometry window size. Extracted so the sizing can be asserted without
 // launching a dialog.
+//
+// --geometry is a global option (registered by kdialog against
+// QCommandLineParser, KF6) whose value accepts the X11 "WxH" form; the parser
+// is position-independent for options, so it may precede --radiolist. The
+// dialog-type flag --radiolist takes its prompt text as the immediate
+// positional argument, before the option triples. Verified against
+// KDE/kdialog master; geometry is applied under X11/XWayland (on a pure
+// Wayland build kdialog accepts but may ignore it — never errors).
 func kdialogArgs(host string, port int, suffix, intent string) []string {
 	opts := optionLabels(suffix)
+	width, height := dialogDimensions()
 	args := []string{
-		"--geometry", fmt.Sprintf("%dx%d", dialogWidth, dialogHeight),
+		"--geometry", fmt.Sprintf("%dx%d", width, height),
 		"--title", "omac: network access",
 		"--radiolist", promptText(host, port, intent),
 	}

--- a/internal/netprompt/prompt_size_test.go
+++ b/internal/netprompt/prompt_size_test.go
@@ -1,0 +1,51 @@
+package netprompt
+
+import (
+	"strconv"
+	"testing"
+)
+
+// Below these the GTK/Qt auto-size collapses the radiolist and truncates the
+// longest option label ("Allow permanently (this host)"). This is the
+// regression guard for the "popups too small on Ubuntu" fix.
+const (
+	minReadableWidth  = 480
+	minReadableHeight = 300
+)
+
+func TestDialogDimensionsAreReadable(t *testing.T) {
+	if dialogWidth < minReadableWidth {
+		t.Errorf("dialogWidth = %d, want >= %d", dialogWidth, minReadableWidth)
+	}
+	if dialogHeight < minReadableHeight {
+		t.Errorf("dialogHeight = %d, want >= %d", dialogHeight, minReadableHeight)
+	}
+}
+
+func TestZenityArgsCarrySize(t *testing.T) {
+	args := zenityArgs("api.github.com", 443, "github.com", "")
+	if got := flagValue(args, "--width"); got != strconv.Itoa(dialogWidth) {
+		t.Errorf("zenity --width = %q, want %d", got, dialogWidth)
+	}
+	if got := flagValue(args, "--height"); got != strconv.Itoa(dialogHeight) {
+		t.Errorf("zenity --height = %q, want %d", got, dialogHeight)
+	}
+}
+
+func TestKdialogArgsCarrySize(t *testing.T) {
+	args := kdialogArgs("api.github.com", 443, "github.com", "")
+	want := strconv.Itoa(dialogWidth) + "x" + strconv.Itoa(dialogHeight)
+	if got := flagValue(args, "--geometry"); got != want {
+		t.Errorf("kdialog --geometry = %q, want %q", got, want)
+	}
+}
+
+// flagValue returns the argument following flag in args, or "".
+func flagValue(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}

--- a/internal/netprompt/prompt_size_test.go
+++ b/internal/netprompt/prompt_size_test.go
@@ -1,24 +1,68 @@
 package netprompt
 
 import (
+	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 )
 
-// Below these the GTK/Qt auto-size collapses the radiolist and truncates the
-// longest option label ("Allow permanently (this host)"). This is the
-// regression guard for the "popups too small on Ubuntu" fix.
+// Rendered-size estimates for the default GTK/Qt dialog font. Deliberately
+// conservative (see the reviewer's ~8 px/char heuristic). The floors below are
+// derived from the *actual* content (optionLabels/promptText), not pinned to
+// magic numbers, so if a label or the prompt grows the required size grows with
+// it and the guard fails unless dialogWidth/dialogHeight grow too.
 const (
-	minReadableWidth  = 480
-	minReadableHeight = 300
+	perCharPx    = 8   // per-char advance in the default UI font
+	widthChrome  = 120 // radio column + margins + scrollbar gutter
+	perRowPx     = 28  // one radiolist row
+	perLinePx    = 22  // one prompt-text line
+	heightChrome = 130 // title bar + button row + margins
+
+	// The pre-fix dialog used height 320; the PR's own rationale is that
+	// 320/360 collapse the radiolist to a two-row scroll box on Ubuntu. Any
+	// derived floor must stay strictly above this, or a drift back into the
+	// buggy range would pass silently.
+	knownBadHeight = 320
 )
 
-func TestDialogDimensionsAreReadable(t *testing.T) {
-	if dialogWidth < minReadableWidth {
-		t.Errorf("dialogWidth = %d, want >= %d", dialogWidth, minReadableWidth)
+// longestLabel returns the widest label by character count.
+func longestLabel(labels []string) string {
+	longest := ""
+	for _, l := range labels {
+		if len(l) > len(longest) {
+			longest = l
+		}
 	}
-	if dialogHeight < minReadableHeight {
-		t.Errorf("dialogHeight = %d, want >= %d", dialogHeight, minReadableHeight)
+	return longest
+}
+
+// TestDialogWidthFitsLongestLabel is the T2 guard: the bug being fixed is
+// "too narrow to show the longest option label", so the property under test is
+// "dialogWidth renders the longest label", not "dialogWidth >= some number".
+func TestDialogWidthFitsLongestLabel(t *testing.T) {
+	longest := longestLabel(optionLabels("example.com"))
+	need := len(longest)*perCharPx + widthChrome
+	if dialogWidth < need {
+		t.Errorf("dialogWidth = %d, but longest label %q needs >= %d px (%d chars * %d + %d chrome)",
+			dialogWidth, longest, need, len(longest), perCharPx, widthChrome)
+	}
+}
+
+// TestDialogHeightFitsAllRowsAndPrompt is the T1 guard: the floor is derived
+// from the seven option rows plus the wrapped prompt lines plus chrome, and is
+// asserted to sit above the known-bad 320 so the regression cannot creep back.
+func TestDialogHeightFitsAllRowsAndPrompt(t *testing.T) {
+	opts := optionLabels("example.com")
+	lines := strings.Count(promptText("api.github.com", 443, ""), "\n") + 1
+	need := len(opts)*perRowPx + lines*perLinePx + heightChrome
+	if need <= knownBadHeight {
+		t.Fatalf("derived height floor %d <= known-bad %d; estimates too low to guard the regression",
+			need, knownBadHeight)
+	}
+	if dialogHeight < need {
+		t.Errorf("dialogHeight = %d, but %d options + %d prompt lines need >= %d px",
+			dialogHeight, len(opts), lines, need)
 	}
 }
 
@@ -32,11 +76,57 @@ func TestZenityArgsCarrySize(t *testing.T) {
 	}
 }
 
-func TestKdialogArgsCarrySize(t *testing.T) {
+// TestKdialogGeometryFormatAndOrdering pins the two kdialog properties the
+// reviewer flagged as unverified. Verified against KDE/kdialog master (KF6):
+// --geometry is a registered QCommandLineOption whose value accepts the X11
+// "WxH" form, and QCommandLineParser treats it as an option regardless of
+// position, so placing it before --radiolist is safe. --radiolist takes its
+// prompt text as the immediate positional argument, ahead of the option
+// triples.
+func TestKdialogGeometryFormatAndOrdering(t *testing.T) {
 	args := kdialogArgs("api.github.com", 443, "github.com", "")
-	want := strconv.Itoa(dialogWidth) + "x" + strconv.Itoa(dialogHeight)
-	if got := flagValue(args, "--geometry"); got != want {
-		t.Errorf("kdialog --geometry = %q, want %q", got, want)
+
+	geo := flagValue(args, "--geometry")
+	if !regexp.MustCompile(`^\d+x\d+$`).MatchString(geo) {
+		t.Errorf("kdialog --geometry = %q, want WxH (e.g. 520x560)", geo)
+	}
+	if want := strconv.Itoa(dialogWidth) + "x" + strconv.Itoa(dialogHeight); geo != want {
+		t.Errorf("kdialog --geometry = %q, want %q", geo, want)
+	}
+
+	gi, ri := indexOf(args, "--geometry"), indexOf(args, "--radiolist")
+	if gi < 0 || ri < 0 || gi > ri {
+		t.Fatalf("--geometry (idx %d) must appear before --radiolist (idx %d)", gi, ri)
+	}
+	if got := args[ri+1]; got != promptText("api.github.com", 443, "") {
+		t.Errorf("arg after --radiolist = %q, want the prompt text", got)
+	}
+}
+
+func TestDialogDimensionsEnvOverride(t *testing.T) {
+	t.Setenv("OMAC_PROMPT_WIDTH", "800")
+	t.Setenv("OMAC_PROMPT_HEIGHT", "900")
+
+	w, h := dialogDimensions()
+	if w != 800 || h != 900 {
+		t.Fatalf("dialogDimensions() = %dx%d, want 800x900", w, h)
+	}
+	if got := flagValue(zenityArgs("h", 1, "s", ""), "--width"); got != "800" {
+		t.Errorf("zenity --width = %q, want 800", got)
+	}
+	if got := flagValue(kdialogArgs("h", 1, "s", ""), "--geometry"); got != "800x900" {
+		t.Errorf("kdialog --geometry = %q, want 800x900", got)
+	}
+}
+
+func TestDialogDimensionsEnvInvalidFallsBack(t *testing.T) {
+	t.Setenv("OMAC_PROMPT_WIDTH", "not-a-number")
+	t.Setenv("OMAC_PROMPT_HEIGHT", "-5")
+
+	w, h := dialogDimensions()
+	if w != dialogWidth || h != dialogHeight {
+		t.Errorf("dialogDimensions() = %dx%d with invalid env, want defaults %dx%d",
+			w, h, dialogWidth, dialogHeight)
 	}
 }
 
@@ -48,4 +138,14 @@ func flagValue(args []string, flag string) string {
 		}
 	}
 	return ""
+}
+
+// indexOf returns the index of target in args, or -1.
+func indexOf(args []string, target string) int {
+	for i, a := range args {
+		if a == target {
+			return i
+		}
+	}
+	return -1
 }

--- a/scripts/netprompt-popup-demo.sh
+++ b/scripts/netprompt-popup-demo.sh
@@ -7,6 +7,9 @@
 # Usage:
 #   scripts/netprompt-popup-demo.sh [-host H] [-port P] [-intent TEXT]
 #
+# Window size defaults to 520x560; override with OMAC_PROMPT_WIDTH /
+# OMAC_PROMPT_HEIGHT (e.g. on a small/720p screen or a tiling WM).
+#
 # Requires a dialog backend: zenity or kdialog on Linux, osascript on macOS.
 set -euo pipefail
 cd "$(dirname "$0")/.."

--- a/scripts/netprompt-popup-demo.sh
+++ b/scripts/netprompt-popup-demo.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Pop up the real omac network-access dialog to inspect its appearance on this
+# platform. Drives the production netprompt code path (cmd/netprompt-demo), so
+# changes to the dialog code — window size, labels, prompt text — show up here
+# automatically.
+#
+# Usage:
+#   scripts/netprompt-popup-demo.sh [-host H] [-port P] [-intent TEXT]
+#
+# Requires a dialog backend: zenity or kdialog on Linux, osascript on macOS.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec go run ./cmd/netprompt-demo "$@"


### PR DESCRIPTION
## What
Give the native network-access decision dialogs (`internal/netprompt/prompt.go`) a consistent, readable window size across platforms.

## Why
The zenity backend set only `--height 320` with **no `--width`**, so GTK auto-sized the window to its content and collapsed the radiolist below the width of its longest option (e.g. `Allow permanently (this host)`), truncating the choices — this is the "popups are too small on Ubuntu" symptom. The kdialog backend set **no size at all**.

## How
- Added shared `dialogWidth = 520` / `dialogHeight = 560` constants.
- zenity: added `--width` and drove `--height` from the constants.
- kdialog: added `--geometry 520x560`.
- macOS `choose from list` has no size API and already auto-sizes correctly, so it is left unchanged.

## Verification
- `go build ./...`
- `go vet ./internal/netprompt/`
- `go test ./internal/netprompt/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
