### PR TITLE
fix(release): install bubblewrap so pre-release tests pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install bubblewrap (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update && sudo apt-get install -y bubblewrap
+          # Ubuntu 24.04 AppArmor restricts unprivileged user namespaces.
+          # Grant bwrap the userns permission so it can create sandboxes.
+          # Without this, every internal/sandboxrun integration test that
+          # launches a real bwrap sandbox fails via requireBwrap in CI,
+          # blocking the release before GoReleaser ever runs.
+          sudo tee /etc/apparmor.d/bwrap > /dev/null <<'EOF'
+          abi <abi/4.0>,
+          /usr/bin/bwrap flags=(unconfined) {
+            userns,
+          }
+          EOF
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## What
Add the bubblewrap install step (with the Ubuntu 24.04 AppArmor userns grant) to the `test` job of `release.yml`, mirroring `ci.yml` and `e2e.yml`.

## Why
The `v0.5.0` tag push triggered the Release workflow, but the **pre-release test job failed**: it runs `go test ./...` on a plain ubuntu runner with no bubblewrap. The `internal/sandboxrun` integration tests fail-hard in CI (`GITHUB_ACTIONS=true`) when `bwrap` is absent (`requireBwrap`/`skipOrFailCI`), so GoReleaser (`needs: test`) never ran and **no release was published**.

## How
Copied the existing `Install bubblewrap (Linux only)` step from `ci.yml` into `release.yml`'s test job, before `Set up Go`.

## Verification
- Step is identical to the one CI/e2e already use to run the same tests green.
- After merge: delete the current dangling `v0.5.0` tag and re-tag the merge commit, so the release runs against a workflow that includes this fix.