### PR TITLE
Fix/serve xdg state home

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -147,6 +147,29 @@ func runServe(args []string, env *Env) int {
 		return ExitMisuse
 	}
 
+	// --for-opencode-desktop: the OpenCode Desktop app runs opencode with
+	// XDG_STATE_HOME pointing at its own data dir (auth, credentials,
+	// config), and both omac's desktop provisioning AND the inner
+	// opencode must resolve state against that same store. When the
+	// Desktop launches omac it exports XDG_STATE_HOME for us; a manual
+	// `omac serve --for-opencode-desktop` from a shell does not, so the
+	// inner reads an empty state dir, providers resolve without
+	// credentials, and opencode's /config/providers 500s (which clients
+	// like `opencode attach` report as an opaque "Unexpected server
+	// error"). Set it in omac's OWN environment when unset so it both
+	// drives our provisioning and is inherited by the sandboxed child;
+	// an explicit value is respected. The dir is granted read+write in
+	// the sandbox in the --for-opencode-desktop block below.
+	if dir, set := resolveDesktopStateDir(*forDesktop); set {
+		if err := os.Setenv("XDG_STATE_HOME", dir); err != nil {
+			fmt.Fprintln(env.Stderr, "omac serve: --for-opencode-desktop: set XDG_STATE_HOME:", err)
+			return ExitIOError
+		}
+		if *verbose {
+			fmt.Fprintf(env.Stderr, "[verbose] --for-opencode-desktop: XDG_STATE_HOME=%s\n", dir)
+		}
+	}
+
 	rtDir, err := createRuntimeDirServe(env.Workdir)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve: runtime dir:", err)
@@ -416,6 +439,15 @@ func runServe(args []string, env *Env) int {
 					argv = injectSandboxFlag(argv, "--allow", wt)
 				}
 			}
+			// Grant the Desktop's shared state dir (XDG_STATE_HOME, set
+			// above) read+write so the inner opencode can read the
+			// Desktop's auth/config there. The default profile already
+			// lists it; granting here keeps it working under trimmed
+			// custom profiles too.
+			if dir := os.Getenv("XDG_STATE_HOME"); dir != "" {
+				fmt.Fprintf(env.Stderr, "  r+w %s (shared Desktop state)\n", dir)
+				argv = injectSandboxFlag(argv, "--allow", dir)
+			}
 		}
 		// --learn: pass through to the built-in sandbox, which lifts
 		// filesystem restrictions and records folder usage.
@@ -459,6 +491,31 @@ func runServe(args []string, env *Env) int {
 		return ExitSandboxAbnormal
 	}
 	return code
+}
+
+// resolveDesktopStateDir decides the XDG_STATE_HOME to use under
+// --for-opencode-desktop, so omac and the inner opencode share the
+// Desktop app's auth/config/state (see the call site). It returns the
+// directory and whether omac should set it in its own environment.
+//
+//   - not desktop mode               -> ("", false)
+//   - XDG_STATE_HOME set (non-empty)  -> ("", false): already set (the
+//     Desktop exports it for its children); respect it, nothing to do.
+//   - XDG_STATE_HOME empty/unset      -> (Desktop data dir, true): default
+//     it, covering a manual `omac serve --for-opencode-desktop` from a
+//     shell that didn't inherit it.
+//   - empty/unset, no dir resolvable  -> ("", false)
+func resolveDesktopStateDir(forDesktop bool) (dir string, setEnv bool) {
+	if !forDesktop {
+		return "", false
+	}
+	if v := os.Getenv("XDG_STATE_HOME"); v != "" {
+		return "", false
+	}
+	if d := opencodestate.DesktopStateDir(); d != "" {
+		return d, true
+	}
+	return "", false
 }
 
 // controlPortOf returns the port the control-plane listener is bound to,

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -291,6 +291,40 @@ func TestRootsEmptyAllowsAny(t *testing.T) {
 	}
 }
 
+func TestResolveDesktopStateDir(t *testing.T) {
+	t.Run("not desktop mode: no injection", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", "/whatever")
+		dir, inject := resolveDesktopStateDir(false)
+		if dir != "" || inject {
+			t.Errorf("resolveDesktopStateDir(false) = (%q, %v), want (\"\", false)", dir, inject)
+		}
+	})
+
+	t.Run("respects an explicit XDG_STATE_HOME (nothing to set)", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", "/custom/state")
+		dir, setEnv := resolveDesktopStateDir(true)
+		if dir != "" || setEnv {
+			t.Errorf("got (%q, %v), want (\"\", false)", dir, setEnv)
+		}
+	})
+
+	t.Run("defaults to the Desktop dir when unset", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", "")
+		t.Setenv("XDG_DATA_HOME", "")
+		t.Setenv("XDG_STATE_HOME", "") // empty == unset
+		want := filepath.Join(home, "Library", "Application Support", "ai.opencode.desktop")
+		if err := os.MkdirAll(want, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		dir, setEnv := resolveDesktopStateDir(true)
+		if dir != want || !setEnv {
+			t.Errorf("got (%q, %v), want (%q, true)", dir, setEnv, want)
+		}
+	})
+}
+
 func TestBaseEnvStaticVars(t *testing.T) {
 	s := newServeServerForTest(t)
 	s.controlBase = "http://127.0.0.1:9999"

--- a/internal/opencodestate/projects.go
+++ b/internal/opencodestate/projects.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 )
@@ -158,6 +159,78 @@ func desktopDataDirs(home, appID string) []string {
 		dirs = append(dirs, filepath.Join(xdg, appID))
 	}
 	return dirs
+}
+
+// DesktopStateDir returns the OpenCode Desktop app's data directory —
+// the location the Desktop exposes to its child processes as
+// XDG_STATE_HOME so they share its auth, credentials and config.
+//
+// `omac serve --for-opencode-desktop` uses this to point the inner
+// opencode at the same state store the Desktop uses when the launching
+// shell didn't already set XDG_STATE_HOME (e.g. a manual run from a
+// terminal). Without it the inner reads an empty state dir, provider
+// credentials don't resolve, and opencode's /config/providers 500s —
+// which surfaces to clients like `opencode attach` as an opaque
+// "Unexpected server error".
+//
+// It prefers an existing stable-then-beta directory (so a machine with
+// only the beta installed still works, and so the actual on-disk
+// location is used regardless of platform); when none exists yet it
+// returns the platform-native default. Returns "" only if the home
+// directory can't be resolved.
+func DesktopStateDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	for _, appID := range []string{"ai.opencode.desktop", "ai.opencode.desktop.beta"} {
+		for _, dir := range desktopStateCandidates(home, appID) {
+			if fi, statErr := os.Stat(dir); statErr == nil && fi.IsDir() {
+				return dir
+			}
+		}
+	}
+	return defaultDesktopStateDir(home)
+}
+
+// desktopStateCandidates lists the per-user directories the OpenCode
+// Desktop (an Electron app) may use for its data/state — the location it
+// points opencode at via XDG_STATE_HOME (opencode then keeps its state
+// under <dir>/opencode). Electron's userData default is
+// ~/Library/Application Support/<id> on macOS and
+// $XDG_CONFIG_HOME (~/.config)/<id> on Linux; the XDG data dir is also
+// probed for older layouts. Candidates are listed for every platform
+// (not branched on GOOS) so the on-disk Stat check finds the real one on
+// any host and unit tests stay platform-independent. Most likely first.
+func desktopStateCandidates(home, appID string) []string {
+	dirs := []string{
+		filepath.Join(home, "Library", "Application Support", appID), // macOS (Electron userData)
+	}
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" { // Linux (Electron userData)
+		dirs = append(dirs, filepath.Join(x, appID))
+	}
+	dirs = append(dirs, filepath.Join(home, ".config", appID)) // Linux default
+	if x := os.Getenv("XDG_DATA_HOME"); x != "" {              // legacy/data layout
+		dirs = append(dirs, filepath.Join(x, appID))
+	}
+	dirs = append(dirs, filepath.Join(home, ".local", "share", appID))
+	return dirs
+}
+
+// defaultDesktopStateDir is the platform-native Electron userData path
+// for the stable Desktop app, used only when no Desktop directory exists
+// on disk yet (a degenerate case: --for-opencode-desktop with no Desktop
+// installed). macOS: ~/Library/Application Support/<id>; Linux:
+// $XDG_CONFIG_HOME (~/.config)/<id>.
+func defaultDesktopStateDir(home string) string {
+	const appID = "ai.opencode.desktop"
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(home, "Library", "Application Support", appID)
+	}
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, appID)
+	}
+	return filepath.Join(home, ".config", appID)
 }
 
 // desktopGlobalWorktrees extracts project directories from one

--- a/internal/opencodestate/projects_test.go
+++ b/internal/opencodestate/projects_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -14,6 +15,78 @@ func writeProject(t *testing.T, dir, id, worktree string) {
 	if err := os.WriteFile(filepath.Join(dir, id+".json"), []byte(data), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestDesktopStateDir(t *testing.T) {
+	// clearXDG makes a subtest hermetic against the runner's own XDG env.
+	clearXDG := func(t *testing.T, home string) {
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", "")
+		t.Setenv("XDG_DATA_HOME", "")
+	}
+
+	t.Run("prefers the macOS Application Support dir when it exists", func(t *testing.T) {
+		home := t.TempDir()
+		clearXDG(t, home)
+		want := filepath.Join(home, "Library", "Application Support", "ai.opencode.desktop")
+		if err := os.MkdirAll(want, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := DesktopStateDir(); got != want {
+			t.Errorf("DesktopStateDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("finds the Linux ~/.config dir when it exists", func(t *testing.T) {
+		home := t.TempDir()
+		clearXDG(t, home)
+		want := filepath.Join(home, ".config", "ai.opencode.desktop")
+		if err := os.MkdirAll(want, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := DesktopStateDir(); got != want {
+			t.Errorf("DesktopStateDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("honors XDG_CONFIG_HOME when set", func(t *testing.T) {
+		home := t.TempDir()
+		clearXDG(t, home)
+		xdg := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+		want := filepath.Join(xdg, "ai.opencode.desktop")
+		if err := os.MkdirAll(want, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := DesktopStateDir(); got != want {
+			t.Errorf("DesktopStateDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("falls back to beta when only beta exists", func(t *testing.T) {
+		home := t.TempDir()
+		clearXDG(t, home)
+		want := filepath.Join(home, ".config", "ai.opencode.desktop.beta")
+		if err := os.MkdirAll(want, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := DesktopStateDir(); got != want {
+			t.Errorf("DesktopStateDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns a platform default when none exists", func(t *testing.T) {
+		home := t.TempDir()
+		clearXDG(t, home)
+		want := defaultDesktopStateDir(home) // darwin: App Support; linux: ~/.config
+		got := DesktopStateDir()
+		if got != want {
+			t.Errorf("DesktopStateDir() = %q, want platform default %q", got, want)
+		}
+		if filepath.Base(got) != "ai.opencode.desktop" || !strings.HasPrefix(got, home) {
+			t.Errorf("DesktopStateDir() = %q, want basename ai.opencode.desktop under HOME %q", got, home)
+		}
+	})
 }
 
 func TestWorktrees(t *testing.T) {

--- a/internal/sandboxrun/grants.go
+++ b/internal/sandboxrun/grants.go
@@ -11,8 +11,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
 )
@@ -433,48 +435,102 @@ func pathFormDenies(deny []string, notices io.Writer) []string {
 	return out
 }
 
+// denyScanConcurrency bounds how many roots walkGlobMatches walks in
+// parallel. The walks are I/O-bound (readdir/lstat), so overlapping them
+// across the many granted roots — every project folder under
+// --for-opencode-desktop, plus large cache/toolchain dirs like
+// ~/Library/Caches, ~/go and ~/.cargo — cuts launch time substantially
+// without changing the result set. Clamped to a sensible range.
+var denyScanConcurrency = clampInt(runtime.NumCPU(), 4, 16)
+
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
 // walkGlobMatches walks each root and returns every file/dir whose base
-// name matches one of the globs. The walk is bounded by
-// maxDenyScanEntries and never descends into matched directories
-// (masking the dir is enough).
+// name matches one of the globs. Each root walk is bounded by
+// maxDenyScanEntries and never descends into a matched directory
+// (masking the dir is enough). Roots are walked concurrently (bounded by
+// denyScanConcurrency); the result set is order-independent — callers
+// dedupe+sort — so concurrency doesn't affect the resolved grants.
 func walkGlobMatches(roots, globs []string, notices io.Writer) []string {
+	if len(globs) == 0 || len(roots) == 0 {
+		return nil
+	}
+	type rootResult struct {
+		matches []string
+		hitCap  bool
+	}
+	results := make([]rootResult, len(roots))
+	sem := make(chan struct{}, denyScanConcurrency)
+	var wg sync.WaitGroup
+	for i, root := range roots {
+		i, root := i, root
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i].matches, results[i].hitCap = walkOneDenyRoot(root, globs)
+		}()
+	}
+	wg.Wait()
+
+	// Merge deterministically in root order; dedupe paths matched under
+	// overlapping roots. Cap notices are emitted here (not inside the
+	// concurrent walks) so notice output stays ordered and race-free.
 	seen := map[string]bool{}
 	var out []string
-	for _, root := range roots {
-		count := 0
-		stop := false
-		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return nil // unreadable entry: skip, don't abort the walk
+	for i, root := range roots {
+		if results[i].hitCap && notices != nil {
+			fmt.Fprintf(notices, "omac sandbox: notice: filesystem.deny scan of %s hit the %d-entry limit; some matches may be unmasked\n", root, maxDenyScanEntries)
+		}
+		for _, m := range results[i].matches {
+			if !seen[m] {
+				seen[m] = true
+				out = append(out, m)
 			}
-			count++
-			if count > maxDenyScanEntries {
-				if !stop && notices != nil {
-					fmt.Fprintf(notices, "omac sandbox: notice: filesystem.deny scan of %s hit the %d-entry limit; some matches may be unmasked\n", root, maxDenyScanEntries)
-				}
-				stop = true
-				return filepath.SkipAll
-			}
-			if path == root {
-				return nil // never match the root grant itself
-			}
-			name := d.Name()
-			for _, g := range globs {
-				if ok, _ := filepath.Match(g, name); ok {
-					if !seen[path] {
-						seen[path] = true
-						out = append(out, path)
-					}
-					if d.IsDir() {
-						return filepath.SkipDir
-					}
-					return nil
-				}
-			}
-			return nil
-		})
+		}
 	}
 	return out
+}
+
+// walkOneDenyRoot walks a single root and returns the paths whose base
+// name matches a glob, plus whether the entry cap was reached. It holds
+// no shared state so walkGlobMatches can run it concurrently per root.
+func walkOneDenyRoot(root string, globs []string) (matches []string, hitCap bool) {
+	count := 0
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // unreadable entry: skip, don't abort the walk
+		}
+		count++
+		if count > maxDenyScanEntries {
+			hitCap = true
+			return filepath.SkipAll
+		}
+		if path == root {
+			return nil // never match the root grant itself
+		}
+		name := d.Name()
+		for _, g := range globs {
+			if ok, _ := filepath.Match(g, name); ok {
+				matches = append(matches, path)
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+		return nil
+	})
+	return matches, hitCap
 }
 
 func dedupe(in []string) []string {


### PR DESCRIPTION
Running omac serve --for-opencode-desktop from a plain shell (rather than being launched by the OpenCode Desktop app) left XDG_STATE_HOME unset, so the sandboxed opencode read an empty state directory, its providers resolved without credentials, and /config/providers returned a 500 — which surfaces to clients like opencode attach as an opaque "Unexpected server error". This defaults XDG_STATE_HOME to the Desktop app's data directory when it isn't already set (an explicit value is respected), so omac's own provisioning and the inner opencode both resolve state against the same store, and it grants that directory read+write in the sandbox. The directory is resolved per-OS from the Electron userData convention (macOS Application Support, Linux ~/.config / XDG_CONFIG_HOME), preferring whichever install actually exists on disk.

It also parallelizes the filesystem.deny scan that runs during sandbox setup. That scan walks every granted root to mask secret basenames such as .env and .git, and under --for-opencode-desktop — dozens of project folders plus large cache and toolchain directories — it was walking them one at a time, which dominated launch. Walking the roots concurrently (bounded by CPU count) is behavior-preserving, since the resulting match set is deduplicated and sorted by callers, and it cut startup from roughly 24s to 11s in local testing. Unit tests, including the race detector, pass.