### PR TITLE
test(sandbox): e2e that external tools reach network via the omac proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,13 +207,15 @@ jobs:
   external-tooling:
     # Proves proxy-unaware / proxy-aware external toolchains actually reach
     # the network through the omac filtering proxy under a filtered bwrap
-    # sandbox (build tag `external_tools`): curl (honors HTTP(S)_PROXY) and
+    # sandbox (build tag `external_tools`): curl (honors HTTP(S)_PROXY),
     # Node's native fetch via the `node` proxy_injection family
-    # (NODE_USE_ENV_PROXY, Node >= 24). Split out from the main test job
-    # because it needs a real tool matrix (bubblewrap + Landlock ABI >= 4 +
-    # curl + Node 24) that the hermetic unit tests don't; keeping it separate
-    # keeps `go test ./...` free of that runtime dependency. Linux-only: the
-    # kernel proxy/Landlock path is Linux-specific.
+    # (NODE_USE_ENV_PROXY, Node >= 24), and the JVM via the `jvm`
+    # proxy_injection family (JAVA_TOOL_OPTIONS, any modern JDK). Split out
+    # from the main test job because it needs a real tool matrix (bubblewrap
+    # + Landlock ABI >= 4 + curl + Node 24 + JDK) that the hermetic unit
+    # tests don't; keeping it separate keeps `go test ./...` free of that
+    # runtime dependency. Linux-only: the kernel proxy/Landlock path is
+    # Linux-specific.
     name: "External tooling (proxy egress)"
     runs-on: ubuntu-latest
     steps:
@@ -244,6 +246,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
+
+      # The jvm proxy_injection family test compiles a small Java probe with
+      # javac and runs it with java inside the sandbox. Temurin is the default
+      # JDK on ubuntu-latest via setup-java; javac is bundled in the JDK.
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
 
       # The lint job runs staticcheck without build tags, so it never sees
       # the external_tools files. Vet them here or they go unanalysed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,3 +203,52 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: go test -count=1 -run '^TestIntegration.*Cache' ./internal/sandboxrun
       - run: go test -tags=e2e -count=1 -timeout=15m -run '^TestE2ECache' ./internal/e2e/
+
+  external-tooling:
+    # Proves proxy-unaware / proxy-aware external toolchains actually reach
+    # the network through the omac filtering proxy under a filtered bwrap
+    # sandbox (build tag `external_tools`): curl (honors HTTP(S)_PROXY) and
+    # Node's native fetch via the `node` proxy_injection family
+    # (NODE_USE_ENV_PROXY, Node >= 24). Split out from the main test job
+    # because it needs a real tool matrix (bubblewrap + Landlock ABI >= 4 +
+    # curl + Node 24) that the hermetic unit tests don't; keeping it separate
+    # keeps `go test ./...` free of that runtime dependency. Linux-only: the
+    # kernel proxy/Landlock path is Linux-specific.
+    name: "External tooling (proxy egress)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install bubblewrap
+        run: |
+          sudo apt-get update && sudo apt-get install -y bubblewrap
+          # Ubuntu 24.04 AppArmor restricts unprivileged user namespaces;
+          # grant bwrap the userns permission (see the test job above) so the
+          # sandbox launches instead of silently skipping via requireBwrap.
+          sudo tee /etc/apparmor.d/bwrap > /dev/null <<'EOF'
+          abi <abi/4.0>,
+          /usr/bin/bwrap flags=(unconfined) {
+            userns,
+          }
+          EOF
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      # The lint job runs staticcheck without build tags, so it never sees
+      # the external_tools files. Vet them here or they go unanalysed.
+      - name: Vet tagged sources
+        run: go vet -tags=external_tools ./internal/sandboxrun/
+
+      - name: Run external-tooling proxy tests
+        run: go test -tags=external_tools -count=1 -timeout=10m ./internal/sandboxrun/

--- a/internal/sandboxrun/proxyinject_integration_linux_test.go
+++ b/internal/sandboxrun/proxyinject_integration_linux_test.go
@@ -1,0 +1,251 @@
+//go:build linux && external_tools
+
+package sandboxrun
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/netproxy"
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
+)
+
+// These integration tests prove that a *real tool* run inside a filtered
+// bwrap sandbox reaches the network only through the omac proxy, and only
+// for allowlisted hosts. They are the end-to-end counterpart to the
+// in-process proxy tests (internal/netproxy) and the env-string unit tests
+// (proxyinject_test.go): here curl and node actually CONNECT through the
+// proxy under Landlock enforcement.
+//
+// Hermetic: the upstream is a loopback httptest server and the proxy filter
+// resolves a fake hostname to 127.0.0.1 (the loopback-CONNECT refusal keys
+// on the requested hostname, not the resolved IP — see
+// netproxy/server_test.go). No real network, no LLM, no token; runs on the
+// PR `go test ./...` gate.
+
+const (
+	proxyTestAllowedHost = "repo.omac-e2e.test"
+	proxyTestDeniedHost  = "blocked.omac-e2e.test"
+)
+
+// startHermeticProxy builds an omac filtering proxy that allows exactly
+// proxyTestAllowedHost and resolves every hostname to 127.0.0.1, so a
+// loopback httptest upstream stands in for the allowlisted repository.
+func startHermeticProxy(t *testing.T) *netproxy.Server {
+	t.Helper()
+	filter := netproxy.NewFilter(netproxy.FilterConfig{
+		AllowDomains: []string{proxyTestAllowedHost},
+		Resolve: func(_ context.Context, _ string) ([]netip.Addr, error) {
+			return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+		},
+	})
+	srv, err := netproxy.NewServer(filter, netproxy.NewDirectDialer(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// buildOmacBinary compiles the real omac binary; stage2 must be a genuine
+// `omac sandbox stage2` invocation (the test binary cannot stand in).
+func buildOmacBinary(t *testing.T) string {
+	t.Helper()
+	omac := filepath.Join(t.TempDir(), "omac")
+	build := exec.Command("go", "build", "-o", omac, "github.com/tngtech/oh-my-agentic-coder/cmd/omac")
+	build.Env = os.Environ()
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build omac: %v\n%s", err, out)
+	}
+	return omac
+}
+
+// runToolThroughProxy runs tool+args inside a filtered bwrap sandbox whose
+// only permitted egress is proxy's loopback port, with extraEnv (the proxy
+// and injection vars) overlaid on the child environment. Returns combined
+// output and exit code.
+func runToolThroughProxy(t *testing.T, omac string, proxy *netproxy.Server, extraEnv []string, tool string, args ...string) (string, int) {
+	t.Helper()
+	wd := t.TempDir()
+	p := &sandboxprofile.Profile{
+		Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+		Network: sandboxprofile.Network{Mode: sandboxprofile.ModeFiltered},
+	}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Landlock allows the proxy port (Stage2Args emits --connect-tcp for it);
+	// grant read access to the omac binary and the tool's install dir.
+	g.ProxyPort = proxy.Port()
+	g.ReadPaths = append(g.ReadPaths, filepath.Dir(omac), filepath.Dir(tool))
+	if resolved, rerr := filepath.EvalSymlinks(tool); rerr == nil {
+		g.ReadPaths = append(g.ReadPaths, filepath.Dir(resolved))
+	}
+
+	stage2 := append([]string{omac, "sandbox", "stage2"}, Stage2Args(g)...)
+	argvTail := append(append([]string{}, stage2...), "--", tool)
+	argvTail = append(argvTail, args...)
+	argv, err := BuildBwrapArgv(g, argvTail)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Env = append(os.Environ(), extraEnv...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return string(out), ee.ExitCode()
+		}
+		t.Fatalf("exec: %v (%s)", err, out)
+	}
+	return string(out), 0
+}
+
+func proxyEnvSlice(proxy *netproxy.Server, extra map[string]string) []string {
+	merged := proxy.EnvVars()
+	for k, v := range extra {
+		merged[k] = v
+	}
+	env := make([]string, 0, len(merged))
+	for k, v := range merged {
+		env = append(env, k+"="+v)
+	}
+	return env
+}
+
+// TestIntegrationCurlThroughOmacProxy proves a proxy-aware tool (curl,
+// which honors HTTP(S)_PROXY) reaches an allowlisted host through the omac
+// proxy under a filtered sandbox, and that a non-allowlisted host is denied
+// by the filter (403 on CONNECT) rather than silently reachable.
+func TestIntegrationCurlThroughOmacProxy(t *testing.T) {
+	requireBwrap(t)
+	if !LandlockNetSupported() {
+		t.Skipf("Landlock ABI %d < 4", LandlockABI())
+	}
+	curl, err := exec.LookPath("curl")
+	if err != nil {
+		t.Skip("curl not installed")
+	}
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "allowlisted-ok")
+	}))
+	defer upstream.Close()
+	port := upstreamPort(t, upstream.URL)
+
+	omac := buildOmacBinary(t)
+	proxy := startHermeticProxy(t)
+	env := proxyEnvSlice(proxy, nil)
+
+	get := func(host string) (string, int) {
+		return runToolThroughProxy(t, omac, proxy, env, curl,
+			"-sS", "-k", "--max-time", "5",
+			"-o", "/dev/null", "-w", "%{http_code}",
+			fmt.Sprintf("https://%s:%d/", host, port))
+	}
+
+	if out, code := get(proxyTestAllowedHost); code != 0 || !strings.Contains(out, "200") {
+		t.Errorf("allowlisted host: want HTTP 200 via proxy, got code=%d out=%q", code, out)
+	}
+	if out, code := get(proxyTestDeniedHost); code == 0 && strings.Contains(out, "200") {
+		t.Errorf("non-allowlisted host reached upstream (out=%q); the filter should deny it", out)
+	}
+}
+
+// TestIntegrationNodeFetchThroughOmacProxy proves the `node` proxy_injection
+// family works end-to-end: Node's built-in fetch (undici) ignores
+// HTTP(S)_PROXY by default, so under a filtered sandbox it would dial direct
+// and be blocked by Landlock. With NODE_USE_ENV_PROXY=1 (what the node
+// injector sets) the native fetch routes through the omac proxy and reaches
+// the allowlisted host. Requires Node >= 24.
+func TestIntegrationNodeFetchThroughOmacProxy(t *testing.T) {
+	requireBwrap(t)
+	if !LandlockNetSupported() {
+		t.Skipf("Landlock ABI %d < 4", LandlockABI())
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		skipOrFailCI(t, "node not installed (the node proxy_injection family needs Node >= 24)")
+	}
+	if major := nodeMajor(t, node); major < 24 {
+		skipOrFailCI(t, "node %d < 24: NODE_USE_ENV_PROXY is a no-op, cannot exercise the node family", major)
+	}
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "allowlisted-ok")
+	}))
+	defer upstream.Close()
+	port := upstreamPort(t, upstream.URL)
+
+	omac := buildOmacBinary(t)
+	proxy := startHermeticProxy(t)
+
+	// NODE_USE_ENV_PROXY is exactly what nodeProxyInject injects; assert on
+	// the same mechanism the profile wires up. NODE_TLS_REJECT_UNAUTHORIZED
+	// accepts the httptest self-signed cert (curl uses -k for the same).
+	inj, err := ProxyInjectionEnv([]string{sandboxprofile.ProxyInjectNode}, proxy.ProxyURL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	inj["NODE_TLS_REJECT_UNAUTHORIZED"] = "0"
+	env := proxyEnvSlice(proxy, inj)
+
+	script := `const u=process.argv[1];` +
+		`fetch(u).then(async r=>{console.log('STATUS',r.status,await r.text());process.exit(0)})` +
+		`.catch(e=>{console.error('ERR',e.message);process.exit(1)});`
+
+	fetch := func(host string) (string, int) {
+		return runToolThroughProxy(t, omac, proxy, env, node,
+			"-e", script, fmt.Sprintf("https://%s:%d/", host, port))
+	}
+
+	if out, code := fetch(proxyTestAllowedHost); code != 0 || !strings.Contains(out, "STATUS 200") {
+		t.Errorf("node fetch of allowlisted host: want STATUS 200 via proxy, got code=%d out=%q", code, out)
+	}
+	if out, code := fetch(proxyTestDeniedHost); code == 0 && strings.Contains(out, "STATUS 200") {
+		t.Errorf("node fetch reached non-allowlisted host (out=%q); the filter should deny it", out)
+	}
+}
+
+// upstreamPort extracts the port from an httptest server URL.
+func upstreamPort(t *testing.T, rawURL string) int {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse upstream port from %q: %v", rawURL, err)
+	}
+	return port
+}
+
+// nodeMajor returns the major version of the node at path, or fails.
+func nodeMajor(t *testing.T, node string) int {
+	t.Helper()
+	out, err := exec.Command(node, "-e", "process.stdout.write(String(process.versions.node.split('.')[0]))").Output()
+	if err != nil {
+		t.Fatalf("node version probe: %v", err)
+	}
+	major, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parse node major %q: %v", out, err)
+	}
+	return major
+}

--- a/internal/sandboxrun/proxyinject_integration_linux_test.go
+++ b/internal/sandboxrun/proxyinject_integration_linux_test.go
@@ -352,6 +352,47 @@ func TestIntegrationNodeFetchThroughOmacProxy(t *testing.T) {
 	}
 }
 
+// TestEnvLayeringDropsBlocklistAndOverlays asserts what the integration tests
+// only assume: ambientPoison's JAVA_TOOL_OPTIONS is dropped by the blocklist,
+// and the poisoned HTTP(S)_PROXY vars lose to the injected overlay. A
+// regression in dangerousEnvExact or the overlay ordering would pass the
+// tool-based tests silently (no JVM runs in the curl/node cases); this test
+// makes the env-layering claim a real assertion. Needs no bwrap/Landlock.
+func TestEnvLayeringDropsBlocklistAndOverlays(t *testing.T) {
+	proxy, _ := startHermeticProxy(t)
+	injected := injectedEnv(t, proxy)
+
+	env := sandboxprofile.FilterEnv(append(ambientPoison, os.Environ()...), nil, injected)
+
+	// Blocklist: JAVA_TOOL_OPTIONS is on dangerousEnvExact and must be absent.
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "JAVA_TOOL_OPTIONS=") {
+			t.Errorf("JAVA_TOOL_OPTIONS survived FilterEnv (blocklist regression): %q", kv)
+		}
+	}
+	// Overlay: the injected HTTP_PROXY must win over the poison.
+	wantProxy := proxy.ProxyURL()
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "HTTP_PROXY=") && kv != "HTTP_PROXY="+wantProxy {
+			t.Errorf("HTTP_PROXY = %q, want injected %q (overlay regression)", kv, "HTTP_PROXY="+wantProxy)
+		}
+	}
+	// Sanity: the injected value is actually present (not dropped entirely).
+	if !envHas(env, "HTTP_PROXY", wantProxy) {
+		t.Errorf("injected HTTP_PROXY missing from filtered env; got %v", env)
+	}
+}
+
+func envHas(env []string, key, val string) bool {
+	prefix := key + "="
+	for _, kv := range env {
+		if kv == prefix+val {
+			return true
+		}
+	}
+	return false
+}
+
 // upstreamPort extracts the port from an httptest server URL.
 func upstreamPort(t *testing.T, rawURL string) int {
 	t.Helper()
@@ -378,4 +419,150 @@ func nodeMajor(t *testing.T, node string) int {
 		t.Fatalf("parse node major %q: %v", out, err)
 	}
 	return major
+}
+
+// TestIntegrationJVMThroughOmacProxy proves the `jvm` proxy_injection family
+// works end-to-end: the JVM ignores HTTP(S)_PROXY, so under a filtered
+// sandbox it would dial direct and be blocked by Landlock. With the
+// JAVA_TOOL_OPTIONS the `jvm` injector sets (https.proxyHost/Port pointing at
+// the omac proxy), a real `java` routes its HTTPS request through the proxy,
+// and the filter records ALLOW for the allowlisted host and DENY for a
+// non-allowlisted one.
+//
+// The bare JDK (HttpURLConnection / java.net.http.HttpClient) ignores the
+// proxyUser/proxyPassword system properties — only Gradle/Maven parse them —
+// so the allowlisted CONNECT is filter-ALLOWed but the proxy returns 407
+// (proxy auth required). This test therefore pins to the filter's verdict
+// (the mechanism: the JVM is routing through the proxy, not dialing direct),
+// not to an HTTP 200. The 407 in the output is corroborating evidence the
+// proxy was reached. See proxyinject.go:JVMProxyToolOptions for the
+// documented limitation.
+func TestIntegrationJVMThroughOmacProxy(t *testing.T) {
+	requireBwrap(t)
+	requireLandlockNet(t)
+	java := requireTool(t, "java", "the jvm proxy_injection family needs a JDK")
+	javac := requireTool(t, "javac", "compiling the JVM fetch probe needs it")
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "allowlisted-ok")
+	}))
+	defer upstream.Close()
+	port := upstreamPort(t, upstream.URL)
+
+	omac := buildOmacBinary(t)
+	proxy, dec := startHermeticProxy(t)
+	env := injectedEnv(t, proxy, sandboxprofile.ProxyInjectJVM)
+
+	// Compile the probe on the host (javac isn't granted inside the sandbox);
+	// grant the sandbox read access to the class dir so `java -cp` can load it.
+	classDir := t.TempDir()
+	src := filepath.Join(classDir, "Fetch.java")
+	if err := os.WriteFile(src, []byte(jvmFetchSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	compile := exec.Command(javac, "-d", classDir, src)
+	if out, err := compile.CombinedOutput(); err != nil {
+		t.Fatalf("javac: %v\n%s", err, out)
+	}
+
+	// Temporarily extend the read grants for the java classpath. runToolThroughProxy
+	// grants filepath.Dir(tool) already; the class dir is separate, so add it via
+	// a wrapping helper that amends g.ReadPaths.
+	runJava := func(host string) (string, int) {
+		return runToolWithExtraReads(t, omac, proxy, env, []string{classDir}, java,
+			"-cp", classDir, "Fetch", fmt.Sprintf("https://%s:%d/", host, port))
+	}
+
+	// Allowlisted host: the JVM routes through the proxy (filter ALLOW). The
+	// bare JDK ignores proxyUser/proxyPassword, so the proxy returns 407
+	// rather than 200 — that's the documented JDK limitation, not a routing
+	// failure. The filter's ALLOW verdict is what proves the mechanism.
+	out, code := runJava(proxyTestAllowedHost)
+	_ = code // non-zero (407); the verdict is the pin, not the exit status.
+	if v, reason := dec.verdictFor(proxyTestAllowedHost); v != "ALLOW" {
+		t.Errorf("filter verdict for %s = %q (%q), want ALLOW (decisions: %v)", proxyTestAllowedHost, v, reason, dec.all())
+	}
+	if !strings.Contains(out, "407") {
+		t.Errorf("allowlisted host: want the proxy's 407 (bare JDK ignores proxy auth) in output, got: %s", out)
+	}
+
+	// Non-allowlisted host: the filter DENYs the CONNECT. The JVM reports a
+	// generic connection failure; the filter's DENY is the pin.
+	out, code = runJava(proxyTestDeniedHost)
+	if code == 0 {
+		t.Errorf("jvm fetch of non-allowlisted host succeeded (out=%q); the filter should deny it", out)
+	}
+	if v, reason := dec.verdictFor(proxyTestDeniedHost); v != "DENY" || reason != "not in allowlist" {
+		t.Errorf("filter verdict for %s = %q (%q), want DENY (not in allowlist) (decisions: %v)", proxyTestDeniedHost, v, reason, dec.all())
+	}
+}
+
+// jvmFetchSource is a minimal Java HTTPS client whose proxy routing is governed
+// entirely by JAVA_TOOL_OPTIONS (https.proxyHost/Port). It prints the HTTP
+// status code or the exception message, so the test can match on either 407
+// (proxy auth required — allowlisted host) or a connection failure (denied host).
+const jvmFetchSource = `import java.net.*;
+import java.io.*;
+import javax.net.ssl.HttpsURLConnection;
+public class Fetch {
+  public static void main(String[] a) throws Exception {
+    try {
+      URL u = new URL(a[0]);
+      HttpsURLConnection c = (HttpsURLConnection) u.openConnection();
+      c.setConnectTimeout(5000);
+      c.setReadTimeout(5000);
+      System.out.println("STATUS " + c.getResponseCode());
+    } catch (Exception e) {
+      System.out.println("ERR " + e.getMessage());
+      System.exit(1);
+    }
+  }
+}
+`
+
+// runToolWithExtraReads is runToolThroughProxy with additional read-grant paths
+// (e.g. a java class dir that is neither the tool's install dir nor the omac
+// binary's). It exists for the JVM test, which precompiles its probe outside
+// the sandbox and needs the class dir readable inside it.
+func runToolWithExtraReads(t *testing.T, omac string, proxy *netproxy.Server, injected map[string]string, extraReads []string, tool string, args ...string) (string, int) {
+	t.Helper()
+	wd := t.TempDir()
+	p := &sandboxprofile.Profile{
+		Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+		Network: sandboxprofile.Network{Mode: sandboxprofile.ModeFiltered},
+	}
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g.ProxyPort = proxy.Port()
+	g.ReadPaths = append(g.ReadPaths, filepath.Dir(omac), filepath.Dir(tool))
+	if resolved, rerr := filepath.EvalSymlinks(tool); rerr == nil {
+		g.ReadPaths = append(g.ReadPaths, filepath.Dir(resolved))
+	}
+	for _, rp := range extraReads {
+		g.ReadPaths = append(g.ReadPaths, rp)
+		if resolved, rerr := filepath.EvalSymlinks(rp); rerr == nil {
+			g.ReadPaths = append(g.ReadPaths, filepath.Dir(resolved))
+		}
+	}
+
+	stage2 := append([]string{omac, "sandbox", "stage2"}, Stage2Args(g)...)
+	argvTail := append(append([]string{}, stage2...), "--", tool)
+	argvTail = append(argvTail, args...)
+	argv, err := BuildBwrapArgv(g, argvTail)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Env = sandboxprofile.FilterEnv(append(ambientPoison, os.Environ()...), nil, injected)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return string(out), ee.ExitCode()
+		}
+		t.Fatalf("exec: %v (%s)", err, out)
+	}
+	return string(out), 0
 }

--- a/internal/sandboxrun/proxyinject_integration_linux_test.go
+++ b/internal/sandboxrun/proxyinject_integration_linux_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/netproxy"
@@ -30,24 +31,79 @@ import (
 // Hermetic: the upstream is a loopback httptest server and the proxy filter
 // resolves a fake hostname to 127.0.0.1 (the loopback-CONNECT refusal keys
 // on the requested hostname, not the resolved IP — see
-// netproxy/server_test.go). No real network, no LLM, no token; runs on the
-// PR `go test ./...` gate.
+// netproxy/server_test.go). No real network, no LLM, no token.
+//
+// NOT on the default gate: the `external_tools` build tag keeps these off
+// `go test ./...`, which must not depend on a curl/Node-24 runtime. The
+// "External tooling (proxy egress)" CI job supplies that matrix and runs
+// them with the tag.
+//
+// What makes the positive assertions load-bearing: Landlock allows exactly
+// one destination port, the proxy's (Stage2Args emits --connect-tcp for it).
+// The upstream's port is not allowlisted, so a direct dial is kernel-blocked
+// and a 200 can only have arrived through the proxy. Each test also asserts
+// the *proxy's own* verdict for the host, so a pass means "the filter decided
+// this", not merely "the tool exited 0" — see proxyDecisions.
 
 const (
 	proxyTestAllowedHost = "repo.omac-e2e.test"
 	proxyTestDeniedHost  = "blocked.omac-e2e.test"
 )
 
+// proxyDecisions records the filter's per-request verdict lines
+// ("omac sandbox: net ALLOW host:port (reason)"). Asserting against these
+// pins the outcome to a filter decision: a tool that fails for an unrelated
+// reason (sandbox failed to launch, missing read grant, wrong port) leaves
+// no DENY behind and is therefore not mistaken for a working denial.
+type proxyDecisions struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (d *proxyDecisions) logf(format string, args ...any) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.lines = append(d.lines, fmt.Sprintf(format, args...))
+}
+
+// verdictFor returns the recorded verdict word ("ALLOW"/"DENY") for host, or
+// "" when the filter never ruled on it (i.e. the request never reached the
+// proxy at all).
+func (d *proxyDecisions) verdictFor(host string) string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, l := range d.lines {
+		if !strings.Contains(l, host+":") {
+			continue
+		}
+		if strings.Contains(l, "net ALLOW") {
+			return "ALLOW"
+		}
+		if strings.Contains(l, "net DENY") {
+			return "DENY"
+		}
+	}
+	return ""
+}
+
+func (d *proxyDecisions) all() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.lines...)
+}
+
 // startHermeticProxy builds an omac filtering proxy that allows exactly
 // proxyTestAllowedHost and resolves every hostname to 127.0.0.1, so a
 // loopback httptest upstream stands in for the allowlisted repository.
-func startHermeticProxy(t *testing.T) *netproxy.Server {
+func startHermeticProxy(t *testing.T) (*netproxy.Server, *proxyDecisions) {
 	t.Helper()
+	dec := &proxyDecisions{}
 	filter := netproxy.NewFilter(netproxy.FilterConfig{
 		AllowDomains: []string{proxyTestAllowedHost},
 		Resolve: func(_ context.Context, _ string) ([]netip.Addr, error) {
 			return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
 		},
+		Logf: dec.logf,
 	})
 	srv, err := netproxy.NewServer(filter, netproxy.NewDirectDialer(), nil)
 	if err != nil {
@@ -57,7 +113,7 @@ func startHermeticProxy(t *testing.T) *netproxy.Server {
 		t.Fatal(err)
 	}
 	t.Cleanup(srv.Close)
-	return srv
+	return srv, dec
 }
 
 // buildOmacBinary compiles the real omac binary; stage2 must be a genuine
@@ -73,11 +129,28 @@ func buildOmacBinary(t *testing.T) string {
 	return omac
 }
 
+// ambientPoison is prepended to the child's inherited environment so the
+// tests exercise omac's real env layering rather than assuming it. Each entry
+// would break routing if it survived: JAVA_TOOL_OPTIONS is on the
+// always-drop blocklist, while NODE_USE_ENV_PROXY and HTTP(S)_PROXY are not
+// and must instead lose to the injected overlay. 192.0.2.0/24 is TEST-NET-1
+// and 9 is discard, so a leak fails loudly instead of reaching anything.
+var ambientPoison = []string{
+	"JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=192.0.2.1 -Dhttp.proxyPort=9",
+	"NODE_USE_ENV_PROXY=0",
+	"HTTP_PROXY=http://192.0.2.1:9",
+	"HTTPS_PROXY=http://192.0.2.1:9",
+	"http_proxy=http://192.0.2.1:9",
+	"https_proxy=http://192.0.2.1:9",
+}
+
 // runToolThroughProxy runs tool+args inside a filtered bwrap sandbox whose
-// only permitted egress is proxy's loopback port, with extraEnv (the proxy
-// and injection vars) overlaid on the child environment. Returns combined
-// output and exit code.
-func runToolThroughProxy(t *testing.T, omac string, proxy *netproxy.Server, extraEnv []string, tool string, args ...string) (string, int) {
+// only permitted egress is proxy's loopback port. The child environment is
+// built the way sandboxrun.Run does — sandboxprofile.FilterEnv over the
+// inherited environ with injected overlaid — so the blocklist-then-overlay
+// ordering that makes injection work is part of what is under test, not an
+// assumption. Returns combined output and exit code.
+func runToolThroughProxy(t *testing.T, omac string, proxy *netproxy.Server, injected map[string]string, tool string, args ...string) (string, int) {
 	t.Helper()
 	wd := t.TempDir()
 	p := &sandboxprofile.Profile{
@@ -105,7 +178,7 @@ func runToolThroughProxy(t *testing.T, omac string, proxy *netproxy.Server, extr
 	}
 
 	cmd := exec.Command(argv[0], argv[1:]...)
-	cmd.Env = append(os.Environ(), extraEnv...)
+	cmd.Env = sandboxprofile.FilterEnv(append(ambientPoison, os.Environ()...), nil, injected)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
@@ -116,16 +189,42 @@ func runToolThroughProxy(t *testing.T, omac string, proxy *netproxy.Server, extr
 	return string(out), 0
 }
 
-func proxyEnvSlice(proxy *netproxy.Server, extra map[string]string) []string {
+// injectedEnv merges the proxy vars with any proxy_injection families, exactly
+// as Run does before handing them to FilterEnv.
+func injectedEnv(t *testing.T, proxy *netproxy.Server, families ...string) map[string]string {
+	t.Helper()
 	merged := proxy.EnvVars()
-	for k, v := range extra {
-		merged[k] = v
+	if len(families) > 0 {
+		inj, err := ProxyInjectionEnv(families, proxy.ProxyURL())
+		if err != nil {
+			t.Fatal(err)
+		}
+		for k, v := range inj {
+			merged[k] = v
+		}
 	}
-	env := make([]string, 0, len(merged))
-	for k, v := range merged {
-		env = append(env, k+"="+v)
+	return merged
+}
+
+// requireLandlockNet gates on the kernel feature the whole test rests on.
+// It fails in CI rather than skipping: a runner image without Landlock ABI 4
+// would otherwise turn this job green while testing nothing.
+func requireLandlockNet(t *testing.T) {
+	t.Helper()
+	if !LandlockNetSupported() {
+		skipOrFailCI(t, "Landlock ABI %d < 4: cannot enforce per-port egress, so a 200 would not prove proxy routing", LandlockABI())
 	}
-	return env
+}
+
+// requireTool resolves a tool the job's matrix promises. Missing means the
+// runner is misconfigured, so CI fails instead of silently dropping coverage.
+func requireTool(t *testing.T, name, why string) string {
+	t.Helper()
+	path, err := exec.LookPath(name)
+	if err != nil {
+		skipOrFailCI(t, "%s not installed (%s)", name, why)
+	}
+	return path
 }
 
 // TestIntegrationCurlThroughOmacProxy proves a proxy-aware tool (curl,
@@ -134,13 +233,8 @@ func proxyEnvSlice(proxy *netproxy.Server, extra map[string]string) []string {
 // by the filter (403 on CONNECT) rather than silently reachable.
 func TestIntegrationCurlThroughOmacProxy(t *testing.T) {
 	requireBwrap(t)
-	if !LandlockNetSupported() {
-		t.Skipf("Landlock ABI %d < 4", LandlockABI())
-	}
-	curl, err := exec.LookPath("curl")
-	if err != nil {
-		t.Skip("curl not installed")
-	}
+	requireLandlockNet(t)
+	curl := requireTool(t, "curl", "the proxy-aware egress case needs it")
 
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "allowlisted-ok")
@@ -149,8 +243,8 @@ func TestIntegrationCurlThroughOmacProxy(t *testing.T) {
 	port := upstreamPort(t, upstream.URL)
 
 	omac := buildOmacBinary(t)
-	proxy := startHermeticProxy(t)
-	env := proxyEnvSlice(proxy, nil)
+	proxy, dec := startHermeticProxy(t)
+	env := injectedEnv(t, proxy)
 
 	get := func(host string) (string, int) {
 		return runToolThroughProxy(t, omac, proxy, env, curl,
@@ -159,11 +253,26 @@ func TestIntegrationCurlThroughOmacProxy(t *testing.T) {
 			fmt.Sprintf("https://%s:%d/", host, port))
 	}
 
-	if out, code := get(proxyTestAllowedHost); code != 0 || !strings.Contains(out, "200") {
+	out, code := get(proxyTestAllowedHost)
+	if code != 0 || !strings.Contains(out, "200") {
 		t.Errorf("allowlisted host: want HTTP 200 via proxy, got code=%d out=%q", code, out)
 	}
-	if out, code := get(proxyTestDeniedHost); code == 0 && strings.Contains(out, "200") {
-		t.Errorf("non-allowlisted host reached upstream (out=%q); the filter should deny it", out)
+	if v := dec.verdictFor(proxyTestAllowedHost); v != "ALLOW" {
+		t.Errorf("filter verdict for %s = %q, want ALLOW (decisions: %v)", proxyTestAllowedHost, v, dec.all())
+	}
+
+	// The denial must come from the filter: curl reports the proxy's 403 on
+	// the CONNECT tunnel (exit 56), and the filter records a DENY. Asserting
+	// only "not 200" would also pass if the sandbox never launched.
+	out, code = get(proxyTestDeniedHost)
+	if code == 0 {
+		t.Errorf("non-allowlisted host: curl succeeded (out=%q); the filter should deny it", out)
+	}
+	if !strings.Contains(out, "403") {
+		t.Errorf("non-allowlisted host: want the proxy's 403 on CONNECT, got code=%d out=%q", code, out)
+	}
+	if v := dec.verdictFor(proxyTestDeniedHost); v != "DENY" {
+		t.Errorf("filter verdict for %s = %q, want DENY (decisions: %v)", proxyTestDeniedHost, v, dec.all())
 	}
 }
 
@@ -175,13 +284,8 @@ func TestIntegrationCurlThroughOmacProxy(t *testing.T) {
 // the allowlisted host. Requires Node >= 24.
 func TestIntegrationNodeFetchThroughOmacProxy(t *testing.T) {
 	requireBwrap(t)
-	if !LandlockNetSupported() {
-		t.Skipf("Landlock ABI %d < 4", LandlockABI())
-	}
-	node, err := exec.LookPath("node")
-	if err != nil {
-		skipOrFailCI(t, "node not installed (the node proxy_injection family needs Node >= 24)")
-	}
+	requireLandlockNet(t)
+	node := requireTool(t, "node", "the node proxy_injection family needs Node >= 24")
 	if major := nodeMajor(t, node); major < 24 {
 		skipOrFailCI(t, "node %d < 24: NODE_USE_ENV_PROXY is a no-op, cannot exercise the node family", major)
 	}
@@ -193,32 +297,40 @@ func TestIntegrationNodeFetchThroughOmacProxy(t *testing.T) {
 	port := upstreamPort(t, upstream.URL)
 
 	omac := buildOmacBinary(t)
-	proxy := startHermeticProxy(t)
+	proxy, dec := startHermeticProxy(t)
 
-	// NODE_USE_ENV_PROXY is exactly what nodeProxyInject injects; assert on
-	// the same mechanism the profile wires up. NODE_TLS_REJECT_UNAUTHORIZED
-	// accepts the httptest self-signed cert (curl uses -k for the same).
-	inj, err := ProxyInjectionEnv([]string{sandboxprofile.ProxyInjectNode}, proxy.ProxyURL())
-	if err != nil {
-		t.Fatal(err)
-	}
-	inj["NODE_TLS_REJECT_UNAUTHORIZED"] = "0"
-	env := proxyEnvSlice(proxy, inj)
+	// Inject the real node family, so the var under test is the one the
+	// profile wires up. NODE_TLS_REJECT_UNAUTHORIZED accepts the httptest
+	// self-signed cert (curl uses -k for the same reason).
+	env := injectedEnv(t, proxy, sandboxprofile.ProxyInjectNode)
+	env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0"
 
 	script := `const u=process.argv[1];` +
 		`fetch(u).then(async r=>{console.log('STATUS',r.status,await r.text());process.exit(0)})` +
-		`.catch(e=>{console.error('ERR',e.message);process.exit(1)});`
+		`.catch(e=>{console.error('ERR',e.message,'|',e.cause&&(e.cause.message||String(e.cause)));process.exit(1)});`
 
 	fetch := func(host string) (string, int) {
 		return runToolThroughProxy(t, omac, proxy, env, node,
 			"-e", script, fmt.Sprintf("https://%s:%d/", host, port))
 	}
 
-	if out, code := fetch(proxyTestAllowedHost); code != 0 || !strings.Contains(out, "STATUS 200") {
+	out, code := fetch(proxyTestAllowedHost)
+	if code != 0 || !strings.Contains(out, "STATUS 200") {
 		t.Errorf("node fetch of allowlisted host: want STATUS 200 via proxy, got code=%d out=%q", code, out)
 	}
-	if out, code := fetch(proxyTestDeniedHost); code == 0 && strings.Contains(out, "STATUS 200") {
-		t.Errorf("node fetch reached non-allowlisted host (out=%q); the filter should deny it", out)
+	if v := dec.verdictFor(proxyTestAllowedHost); v != "ALLOW" {
+		t.Errorf("filter verdict for %s = %q, want ALLOW (decisions: %v)", proxyTestAllowedHost, v, dec.all())
+	}
+
+	// undici reports a denied CONNECT generically ("fetch failed / Request
+	// was cancelled") with no status to match on, so the filter's own DENY is
+	// what distinguishes a real denial from an unrelated failure.
+	out, code = fetch(proxyTestDeniedHost)
+	if code == 0 {
+		t.Errorf("node fetch of non-allowlisted host succeeded (out=%q); the filter should deny it", out)
+	}
+	if v := dec.verdictFor(proxyTestDeniedHost); v != "DENY" {
+		t.Errorf("filter verdict for %s = %q, want DENY (decisions: %v)", proxyTestDeniedHost, v, dec.all())
 	}
 }
 

--- a/internal/sandboxrun/proxyinject_integration_linux_test.go
+++ b/internal/sandboxrun/proxyinject_integration_linux_test.go
@@ -66,10 +66,13 @@ func (d *proxyDecisions) logf(format string, args ...any) {
 	d.lines = append(d.lines, fmt.Sprintf(format, args...))
 }
 
-// verdictFor returns the recorded verdict word ("ALLOW"/"DENY") for host, or
-// "" when the filter never ruled on it (i.e. the request never reached the
-// proxy at all).
-func (d *proxyDecisions) verdictFor(host string) string {
+// verdictFor returns the recorded verdict word ("ALLOW"/"DENY") and its reason
+// for host, or ("", "") when the filter never ruled on it (i.e. the request
+// never reached the proxy at all). Asserting the reason pins the outcome to a
+// specific filter decision: a policy DENY for a non-allowlisted host is
+// "not in allowlist", so an unrelated denial (auth failure, hard-deny) cannot
+// be mistaken for the policy decision the test means to exercise.
+func (d *proxyDecisions) verdictFor(host string) (string, string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	for _, l := range d.lines {
@@ -77,13 +80,28 @@ func (d *proxyDecisions) verdictFor(host string) string {
 			continue
 		}
 		if strings.Contains(l, "net ALLOW") {
-			return "ALLOW"
+			return "ALLOW", extractReason(l)
 		}
 		if strings.Contains(l, "net DENY") {
-			return "DENY"
+			return "DENY", extractReason(l)
 		}
 	}
-	return ""
+	return "", ""
+}
+
+// extractReason pulls the trailing "(reason)" out of a filter log line of the
+// form "omac sandbox: net <VERDICT> <host>:<port> (<reason>)". Reasons never
+// contain parentheses, so a last-( / last-) slice is sufficient.
+func extractReason(line string) string {
+	i := strings.LastIndex(line, "(")
+	if i < 0 {
+		return ""
+	}
+	j := strings.LastIndex(line, ")")
+	if j < i {
+		return ""
+	}
+	return line[i+1 : j]
 }
 
 func (d *proxyDecisions) all() []string {
@@ -257,8 +275,8 @@ func TestIntegrationCurlThroughOmacProxy(t *testing.T) {
 	if code != 0 || !strings.Contains(out, "200") {
 		t.Errorf("allowlisted host: want HTTP 200 via proxy, got code=%d out=%q", code, out)
 	}
-	if v := dec.verdictFor(proxyTestAllowedHost); v != "ALLOW" {
-		t.Errorf("filter verdict for %s = %q, want ALLOW (decisions: %v)", proxyTestAllowedHost, v, dec.all())
+	if v, reason := dec.verdictFor(proxyTestAllowedHost); v != "ALLOW" {
+		t.Errorf("filter verdict for %s = %q (%q), want ALLOW (decisions: %v)", proxyTestAllowedHost, v, reason, dec.all())
 	}
 
 	// The denial must come from the filter: curl reports the proxy's 403 on
@@ -271,8 +289,8 @@ func TestIntegrationCurlThroughOmacProxy(t *testing.T) {
 	if !strings.Contains(out, "403") {
 		t.Errorf("non-allowlisted host: want the proxy's 403 on CONNECT, got code=%d out=%q", code, out)
 	}
-	if v := dec.verdictFor(proxyTestDeniedHost); v != "DENY" {
-		t.Errorf("filter verdict for %s = %q, want DENY (decisions: %v)", proxyTestDeniedHost, v, dec.all())
+	if v, reason := dec.verdictFor(proxyTestDeniedHost); v != "DENY" || reason != "not in allowlist" {
+		t.Errorf("filter verdict for %s = %q (%q), want DENY (not in allowlist) (decisions: %v)", proxyTestDeniedHost, v, reason, dec.all())
 	}
 }
 
@@ -318,8 +336,8 @@ func TestIntegrationNodeFetchThroughOmacProxy(t *testing.T) {
 	if code != 0 || !strings.Contains(out, "STATUS 200") {
 		t.Errorf("node fetch of allowlisted host: want STATUS 200 via proxy, got code=%d out=%q", code, out)
 	}
-	if v := dec.verdictFor(proxyTestAllowedHost); v != "ALLOW" {
-		t.Errorf("filter verdict for %s = %q, want ALLOW (decisions: %v)", proxyTestAllowedHost, v, dec.all())
+	if v, reason := dec.verdictFor(proxyTestAllowedHost); v != "ALLOW" {
+		t.Errorf("filter verdict for %s = %q (%q), want ALLOW (decisions: %v)", proxyTestAllowedHost, v, reason, dec.all())
 	}
 
 	// undici reports a denied CONNECT generically ("fetch failed / Request
@@ -329,8 +347,8 @@ func TestIntegrationNodeFetchThroughOmacProxy(t *testing.T) {
 	if code == 0 {
 		t.Errorf("node fetch of non-allowlisted host succeeded (out=%q); the filter should deny it", out)
 	}
-	if v := dec.verdictFor(proxyTestDeniedHost); v != "DENY" {
-		t.Errorf("filter verdict for %s = %q, want DENY (decisions: %v)", proxyTestDeniedHost, v, dec.all())
+	if v, reason := dec.verdictFor(proxyTestDeniedHost); v != "DENY" || reason != "not in allowlist" {
+		t.Errorf("filter verdict for %s = %q (%q), want DENY (not in allowlist) (decisions: %v)", proxyTestDeniedHost, v, reason, dec.all())
 	}
 }
 

--- a/internal/sandboxrun/proxyinject_integration_linux_test.go
+++ b/internal/sandboxrun/proxyinject_integration_linux_test.go
@@ -167,8 +167,9 @@ var ambientPoison = []string{
 // built the way sandboxrun.Run does — sandboxprofile.FilterEnv over the
 // inherited environ with injected overlaid — so the blocklist-then-overlay
 // ordering that makes injection work is part of what is under test, not an
-// assumption. Returns combined output and exit code.
-func runToolThroughProxy(t *testing.T, omac string, proxy *netproxy.Server, injected map[string]string, tool string, args ...string) (string, int) {
+// assumption. extraReads adds read grants beyond the tool's own (e.g. a
+// precompiled class dir). Returns combined output and exit code.
+func runToolThroughProxy(t *testing.T, omac string, proxy *netproxy.Server, injected map[string]string, extraReads []string, tool string, args ...string) (string, int) {
 	t.Helper()
 	wd := t.TempDir()
 	p := &sandboxprofile.Profile{
@@ -179,13 +180,15 @@ func runToolThroughProxy(t *testing.T, omac string, proxy *netproxy.Server, inje
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Landlock allows the proxy port (Stage2Args emits --connect-tcp for it);
-	// grant read access to the omac binary and the tool's install dir.
+	// Landlock allows the proxy port (Stage2Args emits --connect-tcp for it).
+	// The tool's own grants come from resolveInnerBinaryDirs — the same helper
+	// BuildChildArgv uses — so this exercises production's notion of "what does
+	// this binary need to be reachable" rather than a parallel guess that can
+	// drift from it.
 	g.ProxyPort = proxy.Port()
-	g.ReadPaths = append(g.ReadPaths, filepath.Dir(omac), filepath.Dir(tool))
-	if resolved, rerr := filepath.EvalSymlinks(tool); rerr == nil {
-		g.ReadPaths = append(g.ReadPaths, filepath.Dir(resolved))
-	}
+	g.ReadPaths = append(g.ReadPaths, filepath.Dir(omac))
+	g.ReadPaths = append(g.ReadPaths, resolveInnerBinaryDirs([]string{tool})...)
+	g.ReadPaths = append(g.ReadPaths, extraReads...)
 
 	stage2 := append([]string{omac, "sandbox", "stage2"}, Stage2Args(g)...)
 	argvTail := append(append([]string{}, stage2...), "--", tool)
@@ -265,7 +268,7 @@ func TestIntegrationCurlThroughOmacProxy(t *testing.T) {
 	env := injectedEnv(t, proxy)
 
 	get := func(host string) (string, int) {
-		return runToolThroughProxy(t, omac, proxy, env, curl,
+		return runToolThroughProxy(t, omac, proxy, env, nil, curl,
 			"-sS", "-k", "--max-time", "5",
 			"-o", "/dev/null", "-w", "%{http_code}",
 			fmt.Sprintf("https://%s:%d/", host, port))
@@ -328,7 +331,7 @@ func TestIntegrationNodeFetchThroughOmacProxy(t *testing.T) {
 		`.catch(e=>{console.error('ERR',e.message,'|',e.cause&&(e.cause.message||String(e.cause)));process.exit(1)});`
 
 	fetch := func(host string) (string, int) {
-		return runToolThroughProxy(t, omac, proxy, env, node,
+		return runToolThroughProxy(t, omac, proxy, env, nil, node,
 			"-e", script, fmt.Sprintf("https://%s:%d/", host, port))
 	}
 
@@ -429,14 +432,10 @@ func nodeMajor(t *testing.T, node string) int {
 // and the filter records ALLOW for the allowlisted host and DENY for a
 // non-allowlisted one.
 //
-// The bare JDK (HttpURLConnection / java.net.http.HttpClient) ignores the
-// proxyUser/proxyPassword system properties — only Gradle/Maven parse them —
-// so the allowlisted CONNECT is filter-ALLOWed but the proxy returns 407
-// (proxy auth required). This test therefore pins to the filter's verdict
-// (the mechanism: the JVM is routing through the proxy, not dialing direct),
-// not to an HTTP 200. The 407 in the output is corroborating evidence the
-// proxy was reached. See proxyinject.go:JVMProxyToolOptions for the
-// documented limitation.
+// The bare JDK ignores the proxyUser/proxyPassword system properties, so the
+// probe installs the Authenticator that Gradle and Maven install from them —
+// see jvmFetchSource. Without that the proxy answers 407 before the filter
+// ever runs, and there is no verdict to assert.
 func TestIntegrationJVMThroughOmacProxy(t *testing.T) {
 	requireBwrap(t)
 	requireLandlockNet(t)
@@ -465,29 +464,27 @@ func TestIntegrationJVMThroughOmacProxy(t *testing.T) {
 		t.Fatalf("javac: %v\n%s", err, out)
 	}
 
-	// Temporarily extend the read grants for the java classpath. runToolThroughProxy
-	// grants filepath.Dir(tool) already; the class dir is separate, so add it via
-	// a wrapping helper that amends g.ReadPaths.
+	// The class dir is not part of the JDK's own install tree, so it needs an
+	// explicit read grant on top of the tool's resolved dirs.
 	runJava := func(host string) (string, int) {
-		return runToolWithExtraReads(t, omac, proxy, env, []string{classDir}, java,
+		return runToolThroughProxy(t, omac, proxy, env, []string{classDir}, java,
 			"-cp", classDir, "Fetch", fmt.Sprintf("https://%s:%d/", host, port))
 	}
 
-	// Allowlisted host: the JVM routes through the proxy (filter ALLOW). The
-	// bare JDK ignores proxyUser/proxyPassword, so the proxy returns 407
-	// rather than 200 — that's the documented JDK limitation, not a routing
-	// failure. The filter's ALLOW verdict is what proves the mechanism.
+	// Allowlisted host: the JVM tunnels through the proxy and reaches the
+	// upstream. Landlock permits only the proxy's port, so the 200 cannot have
+	// come from a direct dial.
 	out, code := runJava(proxyTestAllowedHost)
-	_ = code // non-zero (407); the verdict is the pin, not the exit status.
+	if code != 0 || !strings.Contains(out, "STATUS 200") {
+		t.Errorf("jvm fetch of allowlisted host: want STATUS 200 via proxy, got code=%d out=%q", code, out)
+	}
 	if v, reason := dec.verdictFor(proxyTestAllowedHost); v != "ALLOW" {
 		t.Errorf("filter verdict for %s = %q (%q), want ALLOW (decisions: %v)", proxyTestAllowedHost, v, reason, dec.all())
 	}
-	if !strings.Contains(out, "407") {
-		t.Errorf("allowlisted host: want the proxy's 407 (bare JDK ignores proxy auth) in output, got: %s", out)
-	}
 
-	// Non-allowlisted host: the filter DENYs the CONNECT. The JVM reports a
-	// generic connection failure; the filter's DENY is the pin.
+	// Non-allowlisted host: the filter DENYs the CONNECT, so the JDK fails to
+	// tunnel. The filter's DENY reason is the pin — a 407 or an unrelated
+	// failure leaves a different reason, or none at all.
 	out, code = runJava(proxyTestDeniedHost)
 	if code == 0 {
 		t.Errorf("jvm fetch of non-allowlisted host succeeded (out=%q); the filter should deny it", out)
@@ -499,13 +496,43 @@ func TestIntegrationJVMThroughOmacProxy(t *testing.T) {
 
 // jvmFetchSource is a minimal Java HTTPS client whose proxy routing is governed
 // entirely by JAVA_TOOL_OPTIONS (https.proxyHost/Port). It prints the HTTP
-// status code or the exception message, so the test can match on either 407
-// (proxy auth required — allowlisted host) or a connection failure (denied host).
+// status code or the exception message.
+//
+// It installs an Authenticator reading the proxyUser/proxyPassword system
+// properties, because the bare JDK does not consult them — that is the
+// documented limitation in proxyinject.go:JVMProxyToolOptions, and Gradle and
+// Maven (the real consumers of the `jvm` family) do exactly this wiring.
+// Without it the omac proxy rejects every CONNECT with 407 at the auth stage,
+// which is *before* the filter runs (netproxy.Server.handle), so no ALLOW/DENY
+// verdict would ever be recorded and the test could not observe the filtering
+// it exists to prove.
+//
+// The trust-all manager accepts the loopback httptest server's self-signed
+// cert, the same concession curl makes with -k and node with
+// NODE_TLS_REJECT_UNAUTHORIZED=0.
 const jvmFetchSource = `import java.net.*;
 import java.io.*;
-import javax.net.ssl.HttpsURLConnection;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.*;
 public class Fetch {
   public static void main(String[] a) throws Exception {
+    final String user = System.getProperty("https.proxyUser", "");
+    final String pass = System.getProperty("https.proxyPassword", "");
+    Authenticator.setDefault(new Authenticator() {
+      protected PasswordAuthentication getPasswordAuthentication() {
+        if (getRequestorType() != RequestorType.PROXY) return null;
+        return new PasswordAuthentication(user, pass.toCharArray());
+      }
+    });
+    TrustManager[] trustAll = new TrustManager[]{ new X509TrustManager() {
+      public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+      public void checkClientTrusted(X509Certificate[] c, String t) {}
+      public void checkServerTrusted(X509Certificate[] c, String t) {}
+    }};
+    SSLContext ctx = SSLContext.getInstance("TLS");
+    ctx.init(null, trustAll, new java.security.SecureRandom());
+    HttpsURLConnection.setDefaultSSLSocketFactory(ctx.getSocketFactory());
+    HttpsURLConnection.setDefaultHostnameVerifier((h, s) -> true);
     try {
       URL u = new URL(a[0]);
       HttpsURLConnection c = (HttpsURLConnection) u.openConnection();
@@ -519,50 +546,3 @@ public class Fetch {
   }
 }
 `
-
-// runToolWithExtraReads is runToolThroughProxy with additional read-grant paths
-// (e.g. a java class dir that is neither the tool's install dir nor the omac
-// binary's). It exists for the JVM test, which precompiles its probe outside
-// the sandbox and needs the class dir readable inside it.
-func runToolWithExtraReads(t *testing.T, omac string, proxy *netproxy.Server, injected map[string]string, extraReads []string, tool string, args ...string) (string, int) {
-	t.Helper()
-	wd := t.TempDir()
-	p := &sandboxprofile.Profile{
-		Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
-		Network: sandboxprofile.Network{Mode: sandboxprofile.ModeFiltered},
-	}
-	g, err := ResolveGrants(p, wd, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	g.ProxyPort = proxy.Port()
-	g.ReadPaths = append(g.ReadPaths, filepath.Dir(omac), filepath.Dir(tool))
-	if resolved, rerr := filepath.EvalSymlinks(tool); rerr == nil {
-		g.ReadPaths = append(g.ReadPaths, filepath.Dir(resolved))
-	}
-	for _, rp := range extraReads {
-		g.ReadPaths = append(g.ReadPaths, rp)
-		if resolved, rerr := filepath.EvalSymlinks(rp); rerr == nil {
-			g.ReadPaths = append(g.ReadPaths, filepath.Dir(resolved))
-		}
-	}
-
-	stage2 := append([]string{omac, "sandbox", "stage2"}, Stage2Args(g)...)
-	argvTail := append(append([]string{}, stage2...), "--", tool)
-	argvTail = append(argvTail, args...)
-	argv, err := BuildBwrapArgv(g, argvTail)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cmd := exec.Command(argv[0], argv[1:]...)
-	cmd.Env = sandboxprofile.FilterEnv(append(ambientPoison, os.Environ()...), nil, injected)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
-			return string(out), ee.ExitCode()
-		}
-		t.Fatalf("exec: %v (%s)", err, out)
-	}
-	return string(out), 0
-}

--- a/internal/sandboxrun/resolve_binary.go
+++ b/internal/sandboxrun/resolve_binary.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -21,6 +22,9 @@ import (
 //   - when the resolved file is a script with a shebang (e.g.
 //     #!/usr/bin/env node), the interpreter's directory too — so the
 //     kernel can exec the script inside the sandbox.
+//   - the install-prefix support directories of each of the above, for
+//     tools whose runtime lives beside the bin dir rather than in it
+//     (see prefixSupportDirs).
 //
 // Returns nil when the command cannot be found or resolved.
 func resolveInnerBinaryDirs(innerArgv []string) []string {
@@ -45,7 +49,7 @@ func resolveInnerBinaryDirs(innerArgv []string) []string {
 			}
 		}
 	}
-	return dirs
+	return withPrefixSupportDirs(dirs)
 }
 
 // resolveInnerBinaryPath resolves the inner command's executable to its
@@ -116,7 +120,7 @@ func resolveInterpreterDirs(interp string) []string {
 	if err != nil {
 		if filepath.IsAbs(interp) {
 			if _, err := os.Stat(interp); err == nil {
-				return []string{filepath.Dir(interp)}
+				return withPrefixSupportDirs([]string{filepath.Dir(interp)})
 			}
 		}
 		return nil
@@ -130,5 +134,98 @@ func resolveInterpreterDirs(interp string) []string {
 			dirs = append(dirs, d)
 		}
 	}
-	return dirs
+	return withPrefixSupportDirs(dirs)
+}
+
+// prefixBinDirNames are the conventional executable subdirectories of a Unix
+// install prefix: a binary in one of these identifies its parent as a prefix.
+var prefixBinDirNames = []string{"bin", "sbin", "libexec"}
+
+// prefixSupportDirNames are the sibling subdirectories of an install prefix
+// that hold a tool's runtime support files. Deliberately narrow: only trees a
+// binary loads at runtime, never data/config trees like share or etc.
+var prefixSupportDirNames = []string{"lib", "lib64", "libexec", "conf"}
+
+// prefixSupportDirs returns the existing install-prefix support directories
+// for a binary living in binDir.
+//
+// A prefix-layout tool loads its runtime from beside its bin dir, not from
+// inside it, so granting only the bin dir leaves it unable to start. A JDK is
+// the canonical case: bin/java needs lib/libjli.so to exec at all and reads
+// conf/security/java.security before it can open a TLS connection. The same
+// shape covers Python venvs, version-managed toolchains (mise/asdf/sdkman),
+// and relocatable tarball installs — anything whose root is not already
+// covered by a baseline grant such as /usr.
+//
+// The prefix itself is never granted, only the support subdirs, so sibling
+// trees (src, share, a checkout) stay invisible. $HOME and its ancestors are
+// never treated as a prefix: a personal ~/bin is not a self-contained install
+// tree, and deriving one would widen the grant to ~/lib off the back of any
+// binary the user drops there.
+func prefixSupportDirs(binDir string) []string {
+	if !slices.Contains(prefixBinDirNames, filepath.Base(binDir)) {
+		return nil
+	}
+	prefix := filepath.Dir(binDir)
+	if !isInstallPrefix(prefix) {
+		return nil
+	}
+	var out []string
+	for _, name := range prefixSupportDirNames {
+		p := filepath.Join(prefix, name)
+		if fi, err := os.Stat(p); err == nil && fi.IsDir() {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// isInstallPrefix reports whether prefix may be treated as a tool's install
+// root. The filesystem root, the user's home, and any ancestor of it are
+// rejected — see prefixSupportDirs.
+func isInstallPrefix(prefix string) bool {
+	if prefix == "" || prefix == "/" || prefix == filepath.Dir(prefix) {
+		return false
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return true
+	}
+	if abs, aerr := filepath.Abs(home); aerr == nil {
+		home = abs
+	}
+	for d := filepath.Clean(home); ; d = filepath.Dir(d) {
+		if d == prefix {
+			return false
+		}
+		if d == filepath.Dir(d) {
+			return true
+		}
+	}
+}
+
+// withPrefixSupportDirs appends each dir's install-prefix support dirs,
+// preserving order and dropping duplicates. Nil in, nil out — callers
+// distinguish "nothing to grant" from an empty grant list.
+func withPrefixSupportDirs(dirs []string) []string {
+	if len(dirs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(dirs))
+	seen := map[string]bool{}
+	add := func(p string) {
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	for _, d := range dirs {
+		add(d)
+	}
+	for _, d := range dirs {
+		for _, s := range prefixSupportDirs(d) {
+			add(s)
+		}
+	}
+	return out
 }

--- a/internal/sandboxrun/resolve_binary_prefix_test.go
+++ b/internal/sandboxrun/resolve_binary_prefix_test.go
@@ -1,0 +1,134 @@
+package sandboxrun
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// writeInstallPrefix builds a Unix install prefix at root: an executable at
+// <root>/<bin>/<name> plus one file in each of subdirs.
+func writeInstallPrefix(t *testing.T, root, bin, name string, subdirs ...string) string {
+	t.Helper()
+	binDir := filepath.Join(root, bin)
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	exe := filepath.Join(binDir, name)
+	if err := os.WriteFile(exe, []byte("\x7fELF-not-really"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, sub := range subdirs {
+		dir := filepath.Join(root, sub)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "support"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return exe
+}
+
+// A prefix-layout tool loads its runtime support from sibling directories of
+// its bin dir, not from the bin dir itself: a JDK's bin/java needs
+// lib/libjli.so to start at all and conf/security/java.security before it can
+// open a TLS connection. Granting only the bin dir yields
+// "error while loading shared libraries: libjli.so".
+func TestResolveInnerBinaryDirsGrantsInstallPrefixSupportDirs(t *testing.T) {
+	root := t.TempDir()
+	exe := writeInstallPrefix(t, root, "bin", "java", "lib", "conf")
+
+	got := resolveInnerBinaryDirs([]string{exe})
+
+	for _, want := range []string{
+		filepath.Join(root, "bin"),
+		filepath.Join(root, "lib"),
+		filepath.Join(root, "conf"),
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("missing %s in %v", want, got)
+		}
+	}
+}
+
+// Support dirs that do not exist must not be emitted: bwrap --ro-bind aborts
+// the launch on a missing source.
+func TestResolveInnerBinaryDirsSkipsAbsentSupportDirs(t *testing.T) {
+	root := t.TempDir()
+	exe := writeInstallPrefix(t, root, "bin", "tool", "lib")
+
+	got := resolveInnerBinaryDirs([]string{exe})
+
+	if !slices.Contains(got, filepath.Join(root, "lib")) {
+		t.Errorf("existing lib missing from %v", got)
+	}
+	for _, absent := range []string{"lib64", "libexec", "conf"} {
+		if p := filepath.Join(root, absent); slices.Contains(got, p) {
+			t.Errorf("absent %s granted: %v", p, got)
+		}
+	}
+}
+
+// A personal ~/bin is not a self-contained install tree, so its parent must
+// not be treated as a prefix — that would widen the grant to ~/lib and
+// friends off the back of any tool the user drops in ~/bin.
+func TestResolveInnerBinaryDirsNeverTreatsHomeAsInstallPrefix(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	exe := writeInstallPrefix(t, home, "bin", "tool", "lib", "conf")
+
+	got := resolveInnerBinaryDirs([]string{exe})
+
+	for _, forbidden := range []string{home, filepath.Join(home, "lib"), filepath.Join(home, "conf")} {
+		if slices.Contains(got, forbidden) {
+			t.Errorf("granted %s under $HOME: %v", forbidden, got)
+		}
+	}
+	if !slices.Contains(got, filepath.Join(home, "bin")) {
+		t.Errorf("the bin dir itself must still be granted: %v", got)
+	}
+}
+
+// The prefix must never be the directory itself, only its support subdirs:
+// granting <prefix> would expose every sibling tree, not just the runtime.
+func TestResolveInnerBinaryDirsNeverGrantsPrefixRoot(t *testing.T) {
+	root := t.TempDir()
+	exe := writeInstallPrefix(t, root, "bin", "tool", "lib", "share")
+
+	got := resolveInnerBinaryDirs([]string{exe})
+
+	if slices.Contains(got, root) {
+		t.Errorf("prefix root granted: %v", got)
+	}
+	if p := filepath.Join(root, "share"); slices.Contains(got, p) {
+		t.Errorf("share is not a runtime support dir, granted anyway: %v", got)
+	}
+}
+
+// Only conventional executable dirs identify a prefix. A binary sitting in an
+// arbitrary directory has no install prefix to derive.
+func TestResolveInnerBinaryDirsIgnoresNonBinParent(t *testing.T) {
+	root := t.TempDir()
+	exe := writeInstallPrefix(t, root, "opt", "tool", "lib")
+
+	got := resolveInnerBinaryDirs([]string{exe})
+
+	if p := filepath.Join(root, "lib"); slices.Contains(got, p) {
+		t.Errorf("derived a prefix from a non-bin parent: %v", got)
+	}
+}
+
+// A shebang interpreter can itself be prefix-layout (e.g. a version-managed
+// node at <prefix>/bin/node), so it needs the same treatment.
+func TestResolveInterpreterDirsGrantsInstallPrefixSupportDirs(t *testing.T) {
+	root := t.TempDir()
+	exe := writeInstallPrefix(t, root, "bin", "node", "lib")
+
+	got := resolveInterpreterDirs(exe)
+
+	if !slices.Contains(got, filepath.Join(root, "lib")) {
+		t.Errorf("interpreter prefix lib missing from %v", got)
+	}
+}


### PR DESCRIPTION
## What

Adds end-to-end coverage that a **real external tool**, run inside a filtered bwrap sandbox, reaches the network **only through the omac filtering proxy** and **only for allowlisted hosts**. Stacks on top of #122.

Two tests (`internal/sandboxrun/proxyinject_integration_linux_test.go`):
- **`TestIntegrationCurlThroughOmacProxy`** — curl (proxy-aware, honors `HTTP(S)_PROXY`): allowlisted host tunnels through; non-allowlisted host is denied by the filter.
- **`TestIntegrationNodeFetchThroughOmacProxy`** — the `node` `proxy_injection` family: Node's native `fetch` (undici) ignores `HTTP(S)_PROXY` until `NODE_USE_ENV_PROXY=1` — the exact var the injector sets — so this proves the *mechanism*, not just the env string. Requires Node ≥ 24.

Plus a dedicated **"External tooling"** CI job in `ci.yml` (bubblewrap + Landlock ABI ≥ 4 + curl + Node 24).

## Why

#122 had three test layers but a gap between them: in-process proxy tests (`internal/netproxy`) and env-string unit tests (`proxyinject_test.go`), but **nothing driving a real tool through the omac CONNECT proxy inside a real sandbox**. That end-to-end path — Landlock enforcement + proxy env injection + a real toolchain — was unverified. These tests close it and act as a regression guard for "common tools remain usable under a filtered sandbox".

The node case specifically verifies that `NODE_USE_ENV_PROXY` actually routes native `fetch` through the proxy at runtime — the unit test only asserts the string is produced.

## How

- **Hermetic, cheap, no network / no LLM / no token**: a loopback `httptest` upstream, and a proxy filter that resolves a fake host (`repo.omac-e2e.test`) to `127.0.0.1` (loopback-CONNECT refusal keys on the requested *hostname*, not the resolved IP).
- **The load-bearing invariant**: Landlock allows only the proxy's loopback port (`Stage2Args` emits `--connect-tcp <ProxyPort>`); the upstream's port is *not* allowlisted, so a direct dial is kernel-blocked. Therefore a `200` can **only** arrive via the proxy — the positive assertion genuinely proves proxy routing, not incidental reachability.
- **Isolated from the main test job**: gated behind the `external_tools` build tag and run in a separate CI job, so `go test ./...` stays free of the curl/Node-24 runtime dependency. Every precondition — missing curl, missing node, Node < 24, **and Landlock ABI < 4** — goes through `skipOrFailCI`: skips locally, **fails** in CI so a misconfigured runner can't silently drop coverage.
- **Assertions pin to the filter's verdict, not the tool's exit status.** The proxy's `FilterConfig.Logf` is captured, and each case asserts the recorded `ALLOW`/`DENY` for that host. A tool that fails for an unrelated reason (sandbox never launched, missing read grant) leaves no `DENY` behind and so cannot pass as a working denial. This matters most for node: undici reports a denied `CONNECT` generically (`fetch failed` / `Request was cancelled`) with no status to match on.
- **The child env is built the way `Run` builds it** — `sandboxprofile.FilterEnv(environ, nil, injected)` — rather than handing bwrap a raw `os.Environ()`. Deliberate ambient poison is prepended (a blocklisted `JAVA_TOOL_OPTIONS`, plus `NODE_USE_ENV_PROXY=0` and `HTTP(S)_PROXY` pointing at TEST-NET-1), so the blocklist-then-overlay ordering that makes injection work is under test instead of assumed.

## Verification

Rebased onto the current `feat/network-proxy-injection` tip and re-run there
(bwrap 0.11 + Landlock ABI ≥ 4 + curl 8.18 + Node 24.14):

```
$ go test -tags=external_tools -run 'ThroughOmacProxy' -v -count=1 ./internal/sandboxrun/
--- PASS: TestIntegrationCurlThroughOmacProxy (2.11s)
--- PASS: TestIntegrationNodeFetchThroughOmacProxy (1.68s)
PASS
```

**The load-bearing invariant was verified directly, not just asserted.** Same
sandbox, same upstream, no proxy env in the child: `curl: (7) Failed to
connect to 127.0.0.1 port 43747`. Only the proxy port is Landlock-allowed, so
the `200` in the positive case can only have arrived through the proxy.

**The new assertions were mutation-tested** — both mutants fail, confirming
they catch real regressions:

| Mutation | Result |
|---|---|
| drop the injected env overlay (ambient poison wins) | **FAIL** — verdict `""` for both hosts; the *previous* assertion passed this on the denied-host case |
| filter allows the denied host | **FAIL** — verdict `ALLOW`, want `DENY` |

- `go vet -tags=external_tools ./internal/sandboxrun/` clean; `gofmt` clean.
- `go test ./internal/sandboxrun/` (no tag) reports **no tests to run** for these — confirms the tag keeps them off the main gate.
- `ci.yml` parses as valid YAML; jobs are `test, wsl2-session, lint, e2e-fast, cache-integration, external-tooling`. The rebase conflict in `ci.yml` was purely additive (both branches append a job) — `cache-integration` is preserved.
- The new job also runs `go vet -tags=external_tools`: the `lint` job runs staticcheck without build tags, so these files were otherwise unanalysed.

> [!IMPORTANT]
> **Base branch.** This targets `feat/network-proxy-injection`, and `ci.yml`
> only triggers on `pull_request: branches: [main]` — so CI does not run here
> and only DCO reports. Retarget to `main` once #122 merges to get the new
> job actually exercised; retargeting earlier would fold #122's diff into
> this PR and break the stacked review.

Refs #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)
