### PR TITLE
fix(cache): address #104 review follow-ups

### DIFF
--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -802,7 +802,9 @@ func runLaunch(env *Env, opts launchOpts) int {
 		// sessions) read+write — only for the selected harness, not all
 		// harnesses.
 		argv = injectSandboxDirs(argv, harness.SandboxDirs)
-		argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)
+		if cacheScope != nil {
+			argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)
+		}
 		// Pass the resolved audit path down to `omac sandbox run` so the
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the

--- a/internal/e2e/cache_isolation_test.go
+++ b/internal/e2e/cache_isolation_test.go
@@ -48,6 +48,15 @@ const cacheRunTimeout = 3 * time.Minute
 func skipIfSandboxUnavailable(t *testing.T) {
 	t.Helper()
 	if unavailable, reason := sandboxUnavailable(); unavailable {
+		// Linux CI provisions a functional bubblewrap (the
+		// cache-integration and e2e jobs install it and smoke-test it),
+		// so an unavailable sandbox there is a real regression, not an
+		// environment gap — fail instead of silently passing. macOS
+		// keeps skipping: the SUN_LEN socket-path limit is a genuine
+		// per-runner constraint, not a backend regression.
+		if runtime.GOOS == "linux" && os.Getenv("GITHUB_ACTIONS") == "true" {
+			t.Fatalf("omac sandbox unavailable in CI: %s", reason)
+		}
 		t.Skipf("omac sandbox unavailable in this environment: %s; CI exercises this test", reason)
 	}
 }

--- a/internal/toolcache/clear_test.go
+++ b/internal/toolcache/clear_test.go
@@ -1092,3 +1092,108 @@ func resultStatus(results []ClearResult, path string) ClearStatus {
 	}
 	return ""
 }
+
+// TestClearWorkdirRemovesNestedSubtree exercises the recursive
+// removeRootContents path: real tool caches populate a scope with nested
+// directories (go-build/ab/cd, cargo/registry, …), so cleanup must
+// recurse rather than only unlinking top-level files.
+func TestClearWorkdirRemovesNestedSubtree(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	workdir := t.TempDir()
+	scope, err := PreparePersistent(DomainWorkdir, workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(scope.Dir, "go-build", "ab", "cd")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "obj"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scope.Dir, "go-build", "top.txt"), []byte("y"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := scope.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ClearWorkdir(workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != ClearRemoved {
+		t.Errorf("status = %q, want %q", result.Status, ClearRemoved)
+	}
+	if _, err := os.Lstat(scope.Dir); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("scope directory (with nested subtree) still exists: %v", err)
+	}
+}
+
+// TestClearWorkdirRefusesRootReplacedAfterLeafRemoval covers the final
+// verifyTrustedRoot check that runs after the leaf directory is removed.
+// The scopeDeleteHook swaps the whole cache root (via its pathname) while
+// removal proceeds over the still-open trusted descriptor; the post-removal
+// re-stat must observe the pathname now resolves to a different inode and
+// report the scope as skipped rather than silently claiming success.
+func TestClearWorkdirRefusesRootReplacedAfterLeafRemoval(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	workdir := t.TempDir()
+	scope, err := PreparePersistent(DomainWorkdir, workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scope.Dir, "cache-data"), []byte("cache"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := scope.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	root := filepath.Dir(scope.Dir)
+	parent := filepath.Dir(root)
+	replacement := filepath.Join(parent, "omac-replacement")
+	if err := os.Mkdir(replacement, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(replacement, "must-survive"), []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	displaced := filepath.Join(parent, "omac-displaced")
+
+	hookEntered := make(chan struct{})
+	replacementDone := make(chan struct{})
+	replaceErr := make(chan error, 1)
+	oldHook := scopeDeleteHook
+	scopeDeleteHook = func() {
+		close(hookEntered)
+		<-replacementDone
+	}
+	t.Cleanup(func() { scopeDeleteHook = oldHook })
+	go func() {
+		<-hookEntered
+		if err := os.Rename(root, displaced); err != nil {
+			replaceErr <- err
+			close(replacementDone)
+			return
+		}
+		replaceErr <- os.Rename(replacement, root)
+		close(replacementDone)
+	}()
+
+	result, err := ClearWorkdir(workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-replaceErr; err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != ClearSkipped || result.Reason != "cache root changed" {
+		t.Errorf("result = %+v, want skipped / cache root changed", result)
+	}
+	if _, err := os.Stat(filepath.Join(root, "must-survive")); err != nil {
+		t.Errorf("swapped-in root was modified by cleanup: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Follow-ups into #104 (`feat/cache-isolation`) closing coverage/robustness gaps from review. Minimal footprint: **3 non-test production lines**; the rest is tests.

Base is `feat/cache-isolation`, not `main`.

## Why / How

| Concern (from review) | Fix |
|---|---|
| Recursive subtree cleanup (`removeRootContents`) had **zero** test coverage, though real caches nest (`go-build/…`, `cargo/registry`) | `TestClearWorkdirRemovesNestedSubtree` populates a scope with nested dirs and asserts recursive removal |
| Post-removal `verifyTrustedRoot` (`clearTrustedScope`) untestable via existing hooks | `TestClearWorkdirRefusesRootReplacedAfterLeafRemoval` swaps the root pathname during removal (over the open trusted fd) and asserts `skipped / cache root changed` |
| `start.go` dereferenced `cacheScope.Dir` with no nil guard, unlike `serve.go` | Add `if cacheScope != nil` guard (safe by invariant today; removes asymmetry) |
| e2e cache suite used plain `t.Skip`, so a broken backend could pass CI green | Fail (not skip) when the sandbox is unavailable in **Linux** CI, where bubblewrap is provisioned + smoke-tested; **macOS keeps skipping** (SUN_LEN is a per-runner constraint) |

The doctor "stale profile" nudge from an earlier revision was dropped: the existing per-grant warnings already cover the substance, so it was bloat for marginal gain.

## Verification

- `go build ./...`, `go vet` (incl. `-tags=e2e` / `-tags=e2e_fast`), `gofmt` — clean
- `go test -race ./internal/toolcache` — pass (incl. 2 new tests)
- `HOME=/tmp go test ./internal/cli` — pass

## Note for reviewer

The e2e change flips CI behaviour from skip→fail on Linux. I verified every job running `-tags=e2e` cache tests (`ci.yml` cache-integration, `e2e.yml`) provisions functional bubblewrap on Linux, so it only fires on a genuine backend regression. Flag if you'd rather keep the skip.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)