### PR TITLE
feat(netprompt): legible network prompts — likely-cause + dialing-process attribution

### DIFF
--- a/.github/workflows/popup-visual.yml
+++ b/.github/workflows/popup-visual.yml
@@ -1,0 +1,85 @@
+name: popup-visual
+
+# Renders the real network-approval dialog headless and uploads a PNG so the
+# rendered widget — label alignment, wrapping, truncation — can be eyeballed
+# per PR. Advisory: it captures screenshots, it does not assert appearance.
+#
+# Note: this is a public repo; uploaded artifacts and job logs are public. The
+# rendered dialog contains only the static sample prompt, no secrets.
+
+on:
+  pull_request:
+    paths:
+      - 'internal/netprompt/**'
+      - '.github/workflows/popup-visual.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [zenity, kdialog]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install capture tooling + ${{ matrix.backend }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb imagemagick xdotool fonts-dejavu-core
+          sudo apt-get install -y "${{ matrix.backend }}" \
+            || echo "::warning::${{ matrix.backend }} not installable; the render test will skip"
+      - name: Render + capture (${{ matrix.backend }})
+        # Advisory only: capture is a human-review aid, never a pass/fail gate. A
+        # flaky headless render (blank window, Xvfb first-paint timing) or a
+        # missing toolkit (kdialog's heavy KDE deps) must leave the check green.
+        # Step-level (not job-level) so the job still concludes success — a
+        # job-level continue-on-error would still report the leg as a red check.
+        continue-on-error: true
+        env:
+          OMAC_POPUP_SHOT: "1"
+          OMAC_POPUP_SHOT_BACKEND: ${{ matrix.backend }}
+          OMAC_POPUP_SHOT_DIR: ${{ github.workspace }}/popup-shots
+        run: |
+          mkdir -p "$OMAC_POPUP_SHOT_DIR"
+          xvfb-run -a --server-args="-screen 0 1280x1024x24" \
+            go test ./internal/netprompt/ -run TestRenderPopupScreenshot -count=1 -v
+      - name: Upload screenshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: popup-${{ matrix.backend }}
+          path: popup-shots/*.png
+          if-no-files-found: warn
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Render + capture (osascript, best-effort)
+        # osascript GUI dialogs need a WindowServer session headless CI may lack.
+        # Step-level continue-on-error keeps the check green when the capture
+        # cannot run (a job-level one would still report the job as a red check).
+        continue-on-error: true
+        env:
+          OMAC_POPUP_SHOT: "1"
+          OMAC_POPUP_SHOT_DIR: ${{ github.workspace }}/popup-shots
+        run: |
+          mkdir -p "$OMAC_POPUP_SHOT_DIR"
+          go test ./internal/netprompt/ -run TestRenderPopupScreenshot -count=1 -v
+      - name: Upload screenshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: popup-osascript
+          path: popup-shots/*.png
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 /coverage.html
 /.ruff_cache/
 
+# Rendered dialog screenshots from the popup-shot test / popup-visual CI job.
+/popup-shots/
+
 # Per-workdir runtime state managed by `omac register` / `omac start`.
 # The registry file (`.opencode/sidecar.json`) is per-environment state:
 # it points at skill_dirs that exist on the user's machine and was written

--- a/cmd/netprompt-demo/main.go
+++ b/cmd/netprompt-demo/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 
 	logf := func(format string, a ...any) { fmt.Fprintf(os.Stderr, format+"\n", a...) }
-	p, ok := netprompt.NewPrompter(120, logf, lookupIntent, nil)
+	p, ok := netprompt.NewPrompter(120, logf, lookupIntent, nil, nil)
 	if !ok {
 		fmt.Fprintln(os.Stderr, "no dialog backend available (install zenity or kdialog on Linux, osascript ships with macOS)")
 		os.Exit(1)

--- a/cmd/netprompt-demo/main.go
+++ b/cmd/netprompt-demo/main.go
@@ -12,6 +12,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -35,14 +36,14 @@ func main() {
 	}
 
 	logf := func(format string, a ...any) { fmt.Fprintf(os.Stderr, format+"\n", a...) }
-	p, ok := netprompt.NewPrompter(120, logf, lookupIntent, nil, nil)
+	p, ok := netprompt.NewPrompter(120, logf, lookupIntent, nil, nil, nil)
 	if !ok {
 		fmt.Fprintln(os.Stderr, "no dialog backend available (install zenity or kdialog on Linux, osascript ships with macOS)")
 		os.Exit(1)
 	}
 
 	fmt.Fprintf(os.Stderr, "showing network-access dialog for %s:%d ...\n", *host, *port)
-	res := p.Prompt(*host, *port)
+	res := p.Prompt(context.Background(), *host, *port)
 	fmt.Printf("decision: allow=%v persist=%v scope=%q suffix=%q needs_intent=%v\n",
 		res.Allow, res.Persist, res.Scope, res.Suffix, res.NeedsIntent)
 }

--- a/docs/superpowers/specs/2026-07-20-network-prompt-origin-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-20-network-prompt-origin-attribution-design.md
@@ -1,9 +1,45 @@
 # Origin attribution for sandbox network prompts
 
 **Date:** 2026-07-20
-**Status:** Design. Not yet implemented.
+**Status:** Phased after independent review. **Phase 1 (cause line) implemented; Phase 2 (`/proc` Origin) deferred.**
 **Companion:** [Intent declarations for sandbox prompts](2026-07-07-intent-declarations-design.md)
 **Data dependency:** `internal/netprompt/hostmap/opencode-egress.json` (host→subsystem map, already landed).
+
+## Post-review revision (2026-07-20)
+
+An independent review confirmed the crux technical claims — the child shares the
+host **net** namespace (`internal/sandboxrun/bwrap.go` does *not* pass
+`--unshare-net`, asserted by `bwrap_test.go`), so its socket is visible in the
+host `/proc/net/tcp`; the `/proc` source-port→PID direction is right; and the
+`comm`-only (never `cmdline`) rule is the correct anti-secret-leak choice. It also
+found the design over-scoped and surfaced fixes. Resulting plan:
+
+- **Split into two phases.** The **cause line** (host map) is cross-platform and
+  needs *no* interface changes — `host` already reaches `promptText`/`Prompt`. It
+  meets the stated goal (make the prompt legible) on its own. Ship it as **Phase 1**.
+  The **`/proc` Origin line** carries marginal extra signal (opencode-core and the
+  agent share one PID; the number is a *host* PID) at high cost (interface ripple,
+  Linux-only, hex parsing). It becomes **Phase 2**, to be re-justified separately.
+- **Harness-gate the map (must-fix).** `omac sandbox run` is harness-agnostic;
+  loading the opencode map unconditionally would mislabel codex/copilot traffic. The
+  map is keyed by harness (`hostmap.For(harness)`), resolved from the inner command
+  basename (`Options.Flags.InnerArgv[0]`); non-opencode → no cause line.
+- **Don't discard disambiguation (must-fix).** The loader returns the whole `Entry`
+  (cause, `user_initiated`, `notes`), not just a string, so Phase 2 can feed the
+  resolved process into cause selection for process-dependent hosts
+  (`raw.githubusercontent.com`). Phase 1 renders the label **"Likely cause:"** —
+  the "Likely" is the honest hedge that it may be background infra, not the agent.
+- **Phase 2 corrections (when built):** match the full `/proc/net/tcp` 4-tuple
+  (`local == 127.0.0.1:<srcport>` **and** `rem == proxy LocalAddr`, state
+  ESTABLISHED), not local port alone (ephemeral ports can repeat across
+  connections); inject the resolver at `server.go` (where `conn` is in hand) via a
+  closure, rather than threading `src netip.AddrPort` through `Filter.Check`; add a
+  real-socket integration test (dial a loopback listener, assert resolved PID ==
+  `os.Getpid()`) alongside the `/proc` fixture test; note in the dialog that the PID
+  shown is the host PID.
+
+The sections below describe the full (both-phase) design; treat the `/proc`/Origin
+parts and the `Check`/`Prompt` interface change as **Phase 2**.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-07-20-network-prompt-origin-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-20-network-prompt-origin-attribution-design.md
@@ -1,7 +1,7 @@
 # Origin attribution for sandbox network prompts
 
 **Date:** 2026-07-20
-**Status:** Phased after independent review. **Phase 1 (cause line) implemented; Phase 2 (`/proc` Origin) deferred.**
+**Status:** Phased after independent review. **Phase 1 (cause line) and Phase 2 (`/proc` Origin) implemented.**
 **Companion:** [Intent declarations for sandbox prompts](2026-07-07-intent-declarations-design.md)
 **Data dependency:** `internal/netprompt/hostmap/opencode-egress.json` (host→subsystem map, already landed).
 
@@ -29,14 +29,16 @@ found the design over-scoped and surfaced fixes. Resulting plan:
   resolved process into cause selection for process-dependent hosts
   (`raw.githubusercontent.com`). Phase 1 renders the label **"Likely cause:"** —
   the "Likely" is the honest hedge that it may be background infra, not the agent.
-- **Phase 2 corrections (when built):** match the full `/proc/net/tcp` 4-tuple
-  (`local == 127.0.0.1:<srcport>` **and** `rem == proxy LocalAddr`, state
-  ESTABLISHED), not local port alone (ephemeral ports can repeat across
-  connections); inject the resolver at `server.go` (where `conn` is in hand) via a
-  closure, rather than threading `src netip.AddrPort` through `Filter.Check`; add a
-  real-socket integration test (dial a loopback listener, assert resolved PID ==
-  `os.Getpid()`) alongside the `/proc` fixture test; note in the dialog that the PID
-  shown is the host PID.
+- **Phase 2 corrections (as built):** matches the full `/proc/net/tcp` 4-tuple
+  (`local == src` **and** `rem == proxy`), not local port alone (ephemeral ports can
+  repeat across connections). The per-connection endpoints travel on the **request
+  context** (`netproxy.WithClientSource`, set in `server.go` where `conn` is in
+  hand) — `Filter.Check`/`CheckHost` gain no source parameter; only the `Prompter`
+  interface gains `ctx`, and the resolver lives in the prompter, invoked lazily on
+  the prompt path only. The `/proc` resolver is a build-tagged package
+  (`internal/netprompt/origin`, noop off-Linux). It reads `comm` only, never
+  `cmdline`. The dialog labels the number "host pid". A real-socket integration test
+  (dial a loopback listener, assert resolved PID == `os.Getpid()`) backs the parser.
 
 The sections below describe the full (both-phase) design; treat the `/proc`/Origin
 parts and the `Check`/`Prompt` interface change as **Phase 2**.

--- a/docs/superpowers/specs/2026-07-20-network-prompt-origin-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-20-network-prompt-origin-attribution-design.md
@@ -1,0 +1,272 @@
+# Origin attribution for sandbox network prompts
+
+**Date:** 2026-07-20
+**Status:** Design. Not yet implemented.
+**Companion:** [Intent declarations for sandbox prompts](2026-07-07-intent-declarations-design.md)
+**Data dependency:** `internal/netprompt/hostmap/opencode-egress.json` (host→subsystem map, already landed).
+
+## Problem
+
+In `filtered` network mode, a host that is not allowlisted and not yet learned
+produces an interactive popup (`internal/netproxy/filter.go`, step 5). For
+opencode this fires constantly on **background, non-user-initiated** dials —
+tree-sitter grammars, LSP-server downloads, the model catalog, themes. The user
+opens a Kotlin file and gets asked to approve `raw.githubusercontent.com:443`, a
+host neither they nor the agent named, with:
+
+```
+Agent intent: (not declared)
+```
+
+The intent line is empty *by construction*: the LLM never dialed this — opencode's
+runtime did. So the popup reads as "something is phoning home for no reason," and
+users are unsettled. Silently allowlisting the hosts (the obvious alternative) hides
+the traffic and weakens the guardrail's "you approve what leaves the sandbox" story.
+
+## Goal
+
+Fill the same dialog with an **auto-resolved** attribution block when the agent
+did not declare intent — say *who* is dialing and the *likely cause*, without
+weakening the guardrail:
+
+```
+The sandboxed process is trying to reach:
+
+    raw.githubusercontent.com:443
+
+Origin:       opencode  (pid 13597)
+Likely cause: syntax-highlighting grammar / query (tree-sitter)
+Agent intent: (not declared)
+
+How should omac handle this destination?
+```
+
+Two independent, best-effort signals, resolved **only on the prompt path**:
+
+1. **Origin** — the process that opened the connection, from its source port.
+2. **Likely cause** — the host's purpose, from the embedded host map.
+
+Both are advisory (like intent): shown before a decision, never auto-granting.
+
+## What this can and cannot do
+
+Established from a runtime audit + the opencode source (see the host-map README):
+
+- **Cause from hostname: yes, coarse.** opencode partitions egress by host, so the
+  hostname resolves a reliable cause without seeing the URL.
+- **Exact URL: no.** The proxy is a raw CONNECT tunnel; the request path is never
+  visible. Not solvable without terminating TLS, which omac does not do.
+- **opencode-core vs the agent within: not by process.** They share one runtime
+  (one PID dials `api.anthropic.com`, `github.com`, and telemetry). PID *can*
+  separate opencode-core from a tool subprocess it spawns (an LSP server, ripgrep).
+
+## Non-goals
+
+- **URL-path display.** Descoped for the same reason as the intent spec: CONNECT
+  never carries the path.
+- **macOS process attribution in v1.** The host-map cause line is cross-platform and
+  ships everywhere; `/proc`-based origin is Linux-first. macOS (`libproc`/`lsof`) is
+  a follow-up. On macOS v1 the Origin line is simply omitted, the cause line remains.
+- **Correlating opencode's debug log** for exact-URL precision. Brittle coupling;
+  revisit only if the coarse cause proves insufficient.
+- **Forcing/altering decisions.** Attribution changes only the dialog text. Filter
+  order, learned store, and default selection (`Deny once`) are untouched.
+- **Non-opencode harnesses.** The map is opencode-derived. Hosts like
+  `github.com`/`registry.npmjs.org` generalize, but codex/copilot maps are out of
+  scope here.
+
+## Architecture
+
+Two resolvers live in the **sandbox child** (`omac sandbox run`), alongside the
+existing prompter, and are consulted by it at prompt time. No new process, no
+supervisor round-trip (unlike the intent registry, which must cross processes).
+
+```
+   handleConnect (has conn.RemoteAddr = child src addr)
+        │  src netip.AddrPort threaded down
+        ▼
+   Filter.Check ──► defaultDecision ──► promptCoalesced ──► Prompter.Prompt(PromptRequest)
+                                                                 │
+                                                 ┌───────────────┴───────────────┐
+                                                 ▼                               ▼
+                                        origin.Resolver                    hostmap.Map
+                                     (src port → pid → comm)          (host → cause string)
+                                        Linux /proc; else ∅            embedded JSON
+```
+
+Resolution runs **only when a prompt is actually shown** — never on the allow/deny
+hot path — so there is zero per-request cost for the common allowed/denied case.
+
+## Components
+
+### 1. `internal/netprompt/hostmap` (data + loader)
+
+The JSON already exists. Add a Go loader:
+
+```go
+package hostmap
+
+//go:embed opencode-egress.json
+var raw []byte
+
+type Map struct { /* host → Entry, built once */ }
+
+func Load() (*Map, error)                       // parse embedded JSON
+func (m *Map) Cause(host string) (string, bool) // exact + suffix match
+```
+
+- `Cause` lowercases, strips a trailing dot, tries exact then `match:"suffix"`.
+- Returns the entry's `cause` string. `opt_in` and `not_egress` groups are ignored
+  for lookup (telemetry has no fixed host; `not_egress` never dials).
+- Parsed once at prompter construction; immutable thereafter.
+
+### 2. `internal/netprompt/origin` (new package, behind an interface)
+
+```go
+package origin
+
+type Origin struct {
+    PID  int
+    Name string // process basename only (e.g. "opencode", "curl") — NEVER full argv
+}
+
+type Resolver interface {
+    // Resolve maps the child's source address (as seen by the proxy's
+    // accepted conn.RemoteAddr) to the owning process. ok=false when it
+    // can't be determined (unsupported OS, race, permission).
+    Resolve(src netip.AddrPort) (Origin, bool)
+}
+
+func NewResolver() Resolver // Linux: procResolver; else: noopResolver{}
+```
+
+**Linux `procResolver`** (`resolver_linux.go`, build-tagged):
+
+1. `src` is `127.0.0.1:<srcport>` from `conn.RemoteAddr()` (the child's socket).
+2. Scan `/proc/net/tcp` (+ `tcp6`) for the row whose **local** address is
+   `<srcport>` → read its socket **inode**.
+3. Walk `/proc/*/fd/*`; the PID whose fd symlink is `socket:[<inode>]` owns it.
+4. Read `/proc/<pid>/comm` for the process name (basename only).
+
+**`noopResolver`** (`resolver_other.go`): `Resolve` always returns `ok=false`.
+
+Design constraints:
+- **Basename only, never `cmdline`.** `/proc/<pid>/cmdline` can contain secrets in
+  argv (tokens, keys). We surface `comm` (e.g. `opencode`, `bun`, `curl`) — enough to
+  answer "who," none of the risk. This is a hard rule, called out in tests.
+- Best-effort: any error → `ok=false`, dialog omits the Origin line. Never blocks the
+  prompt, never panics.
+- The child is blocked awaiting the CONNECT response during the prompt, so it is
+  alive — the lookup is reliable in practice; the race path is still handled.
+
+### 3. Prompter enrichment (`internal/netprompt/prompt.go`)
+
+- `Prompter` gains two optional fields: `hostMap *hostmap.Map`, `origin origin.Resolver`.
+  Nil → that line is omitted (tests, unsupported OS).
+- Replace the positional `Prompt(host, port)` with a small request struct so the
+  source address can travel without a growing parameter list:
+
+  ```go
+  // in netproxy (the interface owner)
+  type PromptRequest struct {
+      Host   string
+      Port   int
+      Source netip.AddrPort // child's src addr; zero value = unknown
+  }
+  type Prompter interface { Prompt(PromptRequest) PromptResult }
+  ```
+
+- `promptText` gains the two lines, rendered above the existing intent line, each
+  shown only when resolved:
+
+  ```
+  Origin:       <name>  (pid <n>)          // when origin.Resolve ok
+  Likely cause: <cause>                     // when hostMap.Cause ok
+  Agent intent: <reason | (not declared)>   // unchanged
+  ```
+
+- Ordering rationale: **who** and **what** first (the reassurance), then the agent's
+  self-declared **why**. When intent *is* declared, all three can show — origin does
+  not replace intent, it complements it.
+- Backends (osascript/zenity/kdialog) need no interface change beyond passing the
+  fuller text; they already render N-line bodies. `notificationText` stays short
+  (banner) — origin/cause are popup-only, matching the intent spec.
+
+### 4. Threading the source address (`internal/netproxy`)
+
+The source addr exists at `server.go` `handleConnect` (`conn.RemoteAddr()`), but is
+not currently threaded to the prompt. Thread it minimally:
+
+- `filter.go`: `Check`/`CheckHost` gain a `src netip.AddrPort` param (zero value
+  allowed); `defaultDecision` → `promptCoalesced` → `Prompter.Prompt` carry it into
+  `PromptRequest`.
+- `server.go`: `handleConnect`/`handleForward` capture `conn.RemoteAddr()` as
+  `netip.AddrPort` and pass it through `admit`/`checkAndDial` into `Check`.
+- Coalescing: when N requests for the same host share one in-flight prompt, the
+  Origin shown is the leader's. Acceptable — documented; the cause line is
+  host-derived and identical for all followers anyway.
+
+This is the load-bearing ripple: the `Prompter` interface and `Check` signatures
+change, touching their call sites and tests. Everything else is additive.
+
+## Wiring (`internal/sandboxrun/run.go`)
+
+At the existing `NewPrompter` call (`run.go:189`), also construct and inject the two
+resolvers:
+
+```go
+hm, _ := hostmap.Load()          // nil-safe on error; cause line just won't show
+res  := origin.NewResolver()     // noop off Linux
+np, available := netprompt.NewPrompter(timeout, logf, lookupIntent, recordExplain, hm, res)
+```
+
+`hostmap.Load` failure is non-fatal (log + continue with nil map). `doctor.go:203`
+constructs a prompter only to test backend availability — pass nils there.
+
+## Security considerations
+
+- **Advisory only.** Like intent, both lines are display text. They never enter the
+  filter verdict, are never persisted, and cannot auto-grant. A spoofed process name
+  cannot widen access — the user still chooses.
+- **No secret leakage.** Basename (`comm`) only; `cmdline` is never read or shown.
+- **Reader is the supervisor, same user.** Reading `/proc/<pid>` needs no elevation;
+  the child runs as the same uid. PID-namespaced children still resolve because the
+  socket inode is looked up in the host's `/proc` via the host PID.
+- **Host map is static, embedded** — no runtime fetch, no injection surface.
+- **Fail-open to less info, never to more access.** Every resolver failure removes a
+  line; it never changes the decision or the default (`Deny once`).
+
+## Error handling
+
+- `hostmap.Load` error → nil map → cause line omitted; prompt still works.
+- `origin.Resolve` error/unsupported → Origin line omitted.
+- Zero-value `Source` (path not threaded, e.g. some test) → treated as unresolvable.
+- `Cause` miss (host not in map) → cause line omitted (unknown host stays bare — the
+  honest signal that omac has no attribution for it).
+
+## Testing
+
+1. `internal/netprompt/hostmap/hostmap_test.go` — `Load` parses the embedded JSON;
+   `Cause` resolves a known host, exact + suffix; unknown host → `false`; `opt_in`
+   and `not_egress` hosts are not matched.
+2. `internal/netprompt/origin/resolver_linux_test.go` — parse a `/proc/net/tcp`
+   fixture + a fake `/proc/<pid>` tree (inject root dir) → correct PID/name; assert
+   **`cmdline` is never opened** (fixture omits it / fails if read); missing inode →
+   `false`.
+3. `resolver_other_test.go` — noop returns `false`.
+4. `internal/netprompt/prompt_test.go` — extend: Origin + cause lines render when
+   resolvers return values; each omitted independently when they don't; the existing
+   intent-line cases still pass.
+5. `internal/netproxy/filter_test.go` / `server_test.go` — update call sites for the
+   new `src` param / `PromptRequest`; add a case asserting `Source` reaches the
+   prompter (a fake prompter records the request).
+6. No e2e change (parity with the intent spec; the prompt path is unit-covered).
+
+## Out of scope / future
+
+- **macOS origin** via `libproc`/`lsof` — follow-up; cause line already cross-platform.
+- **Codex/copilot host maps** — same loader, additional data files, harness-keyed.
+- **Exact URL** via opencode debug-log correlation — only if coarse cause is
+  insufficient; brittle, deferred.
+- **Suppressing the prompt entirely** for known-infra hosts — deliberately *not*
+  chosen; this design keeps the user in the loop but makes the loop legible.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -210,7 +210,7 @@ func doctorBuiltinSandbox(env *Env) {
 	for _, line := range sandboxrun.DoctorNotes() {
 		fmt.Fprintln(env.Stdout, line)
 	}
-	if _, available := netprompt.NewPrompter(1, nil, nil, nil); available {
+	if _, available := netprompt.NewPrompter(1, nil, nil, nil, nil); available {
 		fmt.Fprintln(env.Stdout, "[ok] network prompt: dialog backend available")
 	} else {
 		fmt.Fprintln(env.Stdout, "[warn] network prompt: no dialog backend (osascript/zenity/kdialog); prompts fall back to the on_unavailable policy (default: deny)")

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -210,7 +210,7 @@ func doctorBuiltinSandbox(env *Env) {
 	for _, line := range sandboxrun.DoctorNotes() {
 		fmt.Fprintln(env.Stdout, line)
 	}
-	if _, available := netprompt.NewPrompter(1, nil, nil, nil, nil); available {
+	if _, available := netprompt.NewPrompter(1, nil, nil, nil, nil, nil); available {
 		fmt.Fprintln(env.Stdout, "[ok] network prompt: dialog backend available")
 	} else {
 		fmt.Fprintln(env.Stdout, "[warn] network prompt: no dialog backend (osascript/zenity/kdialog); prompts fall back to the on_unavailable policy (default: deny)")

--- a/internal/netprompt/hostmap/README.md
+++ b/internal/netprompt/hostmap/README.md
@@ -43,9 +43,9 @@ from" without weakening the guardrail by silently allowlisting the hosts.
 | `notes` | ambiguity, overrides, redirect targets |
 
 `opt_in` lists hosts dialed only under explicit env config (telemetry).
-`unattributed_runtime_hosts` records hosts seen in a runtime audit that could
-**not** be tied to opencode source — kept out of the map on purpose, flagged for
-follow-up.
+`not_egress` records hosts that look like opencode traffic but are not — e.g.
+`1.1.1.1` appears only in a webfetch test fixture and a code comment; it is
+never dialed at runtime. Documented so it is not re-investigated.
 
 ## Provenance & regeneration
 

--- a/internal/netprompt/hostmap/README.md
+++ b/internal/netprompt/hostmap/README.md
@@ -1,0 +1,73 @@
+# opencode egress host map
+
+`opencode-egress.json` maps an egress **hostname** to the opencode subsystem
+that dials it and a human-readable *cause*. It is the data behind a future
+network-prompt enhancement: because the sandbox proxy never terminates TLS,
+only `host`, `port`, and the source process are observable — this map recovers
+the *why* from the hostname alone.
+
+## Why this exists
+
+In `filtered` network mode, any host not on the allowlist and not yet learned
+triggers an interactive prompt (`internal/netproxy/filter.go`, step 5). Many of
+opencode's dials are **background, non-user-initiated** dependency fetches
+(syntax-highlighting grammars, LSP servers, model catalog, themes). Users get
+prompted for a host they never named, with an empty "Agent intent" line — which
+reads as suspicious. This map lets the prompt answer "where is this coming
+from" without weakening the guardrail by silently allowlisting the hosts.
+
+## What the map can and cannot resolve
+
+- **Cause from hostname: yes (coarse).** opencode partitions egress by host, so
+  the hostname is a reliable signal (`opencode.ai` → config/assets, `models.dev`
+  → catalog, `raw.githubusercontent.com` → tree-sitter grammar, etc.).
+- **Exact URL: no.** TLS is a raw CONNECT tunnel (by design, nono parity); the
+  request path is never visible. The cause is inferred from host + source
+  process, not read off the wire.
+- **opencode-core vs agent-within: not by process.** opencode runs the agent
+  loop, its LLM calls, and background housekeeping in the *same* runtime, so PID
+  attribution cannot split them (confirmed: one PID dials `api.anthropic.com`,
+  `github.com`, and telemetry). PID *can* distinguish opencode-core from a tool
+  subprocess it spawns (an LSP server, ripgrep) — hence the `origin` field.
+
+## Field reference
+
+| field | meaning |
+|-------|---------|
+| `host` / `match` | hostname and match mode (`exact` \| `suffix`) |
+| `origin` | `opencode-core` \| `opencode-tool` \| `provider` \| `external` (see `meta.origin_values`) |
+| `category` | `render`, `language-tooling`, `catalog`, `config-assets`, `auth`, `integration`, `llm-inference`, `telemetry` |
+| `cause` | the string a prompt would show as "likely cause" |
+| `user_initiated` | `false` = background infra; `true` = agent/user-driven |
+| `source` | opencode source call-site(s) backing the attribution |
+| `notes` | ambiguity, overrides, redirect targets |
+
+`opt_in` lists hosts dialed only under explicit env config (telemetry).
+`unattributed_runtime_hosts` records hosts seen in a runtime audit that could
+**not** be tied to opencode source — kept out of the map on purpose, flagged for
+follow-up.
+
+## Provenance & regeneration
+
+- Source: `anomalyco/opencode` @ `355a0bcf5` (`v1.17.8`), audited against the
+  installed `v1.17.12`.
+- **Manually authored, not generated.** Rebuild by re-auditing call-sites:
+
+```sh
+# hosts hardcoded in the running packages
+grep -rhoiE "https://[a-z0-9._-]+" packages --include=*.ts --include=*.go \
+  | sed -E 's#https://##' | sort | uniq -c | sort -rn
+
+# attribute a host to its subsystem
+grep -rniE "<host>" packages --include=*.ts --include=*.go | grep -viE "test|dist"
+```
+
+Key call-sites: `packages/tui/src/parsers-config.ts` (grammars/queries),
+`packages/opencode/src/lsp/server.ts` (LSP downloads),
+`packages/core/src/models-dev.ts` (catalog),
+`packages/core/src/npm-config.ts` (npm registry),
+`packages/opencode/src/installation/index.ts` (self-update),
+`packages/core/src/observability/otlp.ts` (opt-in telemetry).
+
+Re-verify on opencode minor/major bumps: new languages add grammar hosts, new
+LSPs add download hosts.

--- a/internal/netprompt/hostmap/README.md
+++ b/internal/netprompt/hostmap/README.md
@@ -1,10 +1,29 @@
-# opencode egress host map
+# Egress host maps
 
-`opencode-egress.json` maps an egress **hostname** to the opencode subsystem
-that dials it and a human-readable *cause*. It is the data behind a future
-network-prompt enhancement: because the sandbox proxy never terminates TLS,
-only `host`, `port`, and the source process are observable — this map recovers
-the *why* from the hostname alone.
+`<harness>-egress.json` maps an egress **hostname** to the harness subsystem
+that dials it and a human-readable *cause*, powering the network prompt's
+"Likely cause" line. Because the sandbox proxy never terminates TLS, only
+`host`, `port`, and the source process are observable — this map recovers the
+*why* from the hostname alone.
+
+Maps ship per harness: `opencode-egress.json`, `claude-code-egress.json`.
+
+## Multi-harness contract
+
+- **One file per harness**, named `<canonical>-egress.json` where `<canonical>`
+  is the harness's canonical name in the `config` registry (`opencode`,
+  `claude-code`, …) — *not* a binary basename or alias.
+- **`For(harness)` keys on the canonical name.** The caller resolves identity
+  once through `config.LookupHarness` (in `sandboxrun.harnessName`) so binary
+  basenames and aliases (`claude`, `cc`) collapse to `claude-code` before they
+  reach the map. This keeps harness identity single-sourced in `config`.
+- **The same host can mean different things per harness** — e.g.
+  `raw.githubusercontent.com` is a tree-sitter grammar in opencode but the
+  `/release-notes` changelog in claude-code. Keying by harness is what keeps the
+  cause honest; an unknown harness yields a nil map (no cause line), never a
+  wrong one.
+- **Adding a harness is a data task:** audit that harness's egress, drop in
+  `<canonical>-egress.json`, add one `case` + `//go:embed` in `hostmap.go`.
 
 ## Why this exists
 
@@ -35,7 +54,7 @@ from" without weakening the guardrail by silently allowlisting the hosts.
 | field | meaning |
 |-------|---------|
 | `host` / `match` | hostname and match mode (`exact` \| `suffix`) |
-| `origin` | `opencode-core` \| `opencode-tool` \| `provider` \| `external` (see `meta.origin_values`) |
+| `origin` | harness-specific — see each file's `meta.origin_values` (opencode: `opencode-core`/`opencode-tool`/`provider`/`external`; claude-code: `harness-core`/`provider`/`browser`) |
 | `category` | `render`, `language-tooling`, `catalog`, `config-assets`, `auth`, `integration`, `llm-inference`, `telemetry` |
 | `cause` | the string a prompt would show as "likely cause" |
 | `user_initiated` | `false` = background infra; `true` = agent/user-driven |
@@ -49,25 +68,42 @@ never dialed at runtime. Documented so it is not re-investigated.
 
 ## Provenance & regeneration
 
+Provenance differs per harness — each file's `meta` block records its own
+sources. Both are **manually authored, not generated.**
+
+### opencode (`opencode-egress.json`)
+
 - Source: `anomalyco/opencode` @ `355a0bcf5` (`v1.17.8`), audited against the
-  installed `v1.17.12`.
-- **Manually authored, not generated.** Rebuild by re-auditing call-sites:
+  installed `v1.17.12` — call-site attribution from the real source tree.
+- Rebuild by re-auditing call-sites:
 
 ```sh
-# hosts hardcoded in the running packages
 grep -rhoiE "https://[a-z0-9._-]+" packages --include=*.ts --include=*.go \
   | sed -E 's#https://##' | sort | uniq -c | sort -rn
-
-# attribute a host to its subsystem
 grep -rniE "<host>" packages --include=*.ts --include=*.go | grep -viE "test|dist"
 ```
 
-Key call-sites: `packages/tui/src/parsers-config.ts` (grammars/queries),
-`packages/opencode/src/lsp/server.ts` (LSP downloads),
-`packages/core/src/models-dev.ts` (catalog),
-`packages/core/src/npm-config.ts` (npm registry),
-`packages/opencode/src/installation/index.ts` (self-update),
-`packages/core/src/observability/otlp.ts` (opt-in telemetry).
+Key call-sites: `parsers-config.ts` (grammars/queries), `lsp/server.ts` (LSP
+downloads), `models-dev.ts` (catalog), `npm-config.ts` (registry),
+`installation/index.ts` (self-update), `observability/otlp.ts` (opt-in
+telemetry). Re-verify on opencode bumps: new languages/LSPs add hosts.
 
-Re-verify on opencode minor/major bumps: new languages add grammar hosts, new
-LSPs add download hosts.
+### claude-code (`claude-code-egress.json`)
+
+- **Authority:** Anthropic's documented allowlist —
+  <https://code.claude.com/docs/en/network-config> ("Network access
+  requirements") — corroborated against the Claude Code **v2.1.215** binary and
+  a sandbox-audit run.
+- **Coarser than opencode's on purpose:** the shipped Claude Code is a minified
+  bundle with no source repo, so attribution is host-level from the published
+  allowlist, not call-site. Rebuild by re-reading that doc on Claude Code
+  releases and diffing the binary's embedded hosts:
+
+```sh
+strings -n 6 "$(readlink -f "$(command -v claude)")" \
+  | grep -oiE "https://[a-z0-9._-]+" | sed -E 's#https://##' | sort | uniq -c | sort -rn
+```
+
+Re-verify when Anthropic updates the network-config allowlist (hosts and their
+purposes change across versions — e.g. the installer host moved off
+`storage.googleapis.com` in 2.1.116).

--- a/internal/netprompt/hostmap/claude-code-egress.json
+++ b/internal/netprompt/hostmap/claude-code-egress.json
@@ -1,0 +1,129 @@
+{
+  "schema_version": 1,
+  "meta": {
+    "harness": "claude-code",
+    "source": "Claude Code v2.1.215 (native binary) + omac sandbox audit",
+    "authority": "https://code.claude.com/docs/en/network-config (Anthropic's documented 'Network access requirements' allowlist)",
+    "method": "Causes taken from Anthropic's published allowlist table, corroborated against the binary's embedded hosts and a sandbox-audit run. Unlike opencode, no source repo was available (minified bundle), so attribution is host-level from the documented allowlist, not call-site.",
+    "purpose": "Map a Claude Code egress hostname to a human-readable 'likely cause' for the network prompt. The proxy never sees the URL (TLS), so the hostname is the only signal.",
+    "origin_values": {
+      "harness-core": "Dialed by Claude Code itself.",
+      "provider": "Model/auth traffic to a configured provider or gateway (Bedrock/Vertex/Foundry/LLM gateway) instead of api.anthropic.com; only when configured.",
+      "browser": "Required by a browser/viewer, NOT the CLI's own egress — documented for completeness, not shown as a CLI dial."
+    }
+  },
+  "entries": [
+    {
+      "host": "api.anthropic.com",
+      "match": "exact",
+      "origin": "harness-core",
+      "category": "llm-inference",
+      "cause": "Claude API request (model inference; also the WebFetch domain-safety preflight and the fast-mode availability check)",
+      "user_initiated": true,
+      "source": "network-config: 'Claude API requests'"
+    },
+    {
+      "host": "claude.ai",
+      "match": "exact",
+      "origin": "harness-core",
+      "category": "auth",
+      "cause": "claude.ai account authentication",
+      "user_initiated": false,
+      "source": "network-config: 'claude.ai account authentication'"
+    },
+    {
+      "host": "platform.claude.com",
+      "match": "exact",
+      "origin": "harness-core",
+      "category": "auth",
+      "cause": "Anthropic Console account authentication",
+      "user_initiated": false,
+      "source": "network-config: 'Anthropic Console account authentication'"
+    },
+    {
+      "host": "mcp-proxy.anthropic.com",
+      "match": "exact",
+      "origin": "harness-core",
+      "category": "integration",
+      "cause": "MCP connectors from claude.ai (connector traffic proxy)",
+      "user_initiated": false,
+      "source": "network-config: 'MCP connectors from claude.ai'",
+      "notes": "Enabled by default for claude.ai-authenticated users; disable via ENABLE_CLAUDEAI_MCP_SERVERS=false."
+    },
+    {
+      "host": "downloads.claude.ai",
+      "match": "exact",
+      "origin": "harness-core",
+      "category": "update",
+      "cause": "Native installer / auto-updater, and plugin executable downloads",
+      "user_initiated": false,
+      "source": "network-config: 'Plugin executable downloads; native installer and native auto-updater'",
+      "notes": "npm/self-managed installs do not use the native installer/auto-updater path."
+    },
+    {
+      "host": "storage.googleapis.com",
+      "match": "exact",
+      "origin": "harness-core",
+      "category": "catalog",
+      "cause": "Plugin metadata and install counts for /plugin; signed artifact uploads (falls back to api.anthropic.com if blocked)",
+      "user_initiated": false,
+      "source": "network-config: '/plugin metadata; artifact uploads'",
+      "notes": "Shared Google host; also the installer/auto-updater host on Claude Code versions prior to 2.1.116."
+    },
+    {
+      "host": "bridge.claudeusercontent.com",
+      "match": "exact",
+      "origin": "harness-core",
+      "category": "integration",
+      "cause": "Claude-in-Chrome extension WebSocket bridge",
+      "user_initiated": false,
+      "source": "network-config: 'Claude in Chrome extension WebSocket bridge'"
+    },
+    {
+      "host": "raw.githubusercontent.com",
+      "match": "exact",
+      "origin": "harness-core",
+      "category": "update",
+      "cause": "Changelog / release-notes feed for /release-notes",
+      "user_initiated": false,
+      "source": "network-config: 'Changelog feed for /release-notes'",
+      "notes": "Same host serves a completely different purpose in opencode (tree-sitter grammars) — this is why the map is harness-keyed."
+    },
+    {
+      "host": "code.claude.com",
+      "match": "exact",
+      "origin": "harness-core",
+      "category": "config-assets",
+      "cause": "Claude Code documentation (docs pages / docs map)",
+      "user_initiated": false,
+      "source": "binary: code.claude.com/docs/* link + docs-map references"
+    },
+    {
+      "host": "api.anthropic.com (or configured provider/gateway host)",
+      "match": "exact",
+      "origin": "provider",
+      "category": "llm-inference",
+      "cause": "Model inference / provider auth via Amazon Bedrock, Google Vertex, Microsoft Foundry, or an LLM gateway",
+      "user_initiated": true,
+      "source": "network-config: provider routing section",
+      "notes": "Representative entry: when a provider/gateway is configured, model + auth traffic go to Bedrock (bedrock-runtime.*.amazonaws.com + STS), Vertex (*.googleapis.com), Foundry (*.microsoftonline.com), or the gateway host instead of api.anthropic.com. Only dialed when configured."
+    }
+  ],
+  "opt_in": [
+    {
+      "host_pattern": "OTEL_EXPORTER_OTLP_ENDPOINT (e.g. *.datadoghq.com) and default operational telemetry",
+      "origin": "harness-core",
+      "category": "telemetry",
+      "cause": "OpenTelemetry metrics/logs export and operational telemetry",
+      "user_initiated": false,
+      "source": "network-config: 'optional operational telemetry by default'; data-usage/telemetry-services",
+      "notes": "Claude Code sends operational telemetry by default (disable via env). A Datadog intake host observed in a sandbox audit is the OTEL export configured by OTEL_EXPORTER_OTLP_ENDPOINT (local/TNG env), not a Claude Code default endpoint."
+    }
+  ],
+  "not_egress": [
+    {
+      "host": "*.claudeusercontent.com",
+      "note": "Required by the artifact VIEWER's browser (loads artifact content from a sandboxed subdomain), NOT by the Claude Code CLI. Documented for completeness; not a CLI dial, so not shown as a cause."
+    }
+  ]
+}

--- a/internal/netprompt/hostmap/hostmap.go
+++ b/internal/netprompt/hostmap/hostmap.go
@@ -1,0 +1,104 @@
+// Package hostmap resolves an egress hostname to the harness subsystem that
+// dials it, so the network prompt can show a human-readable "likely cause".
+//
+// The data is harness-specific (see opencode-egress.json); loaders are keyed
+// by harness via For, and a harness with no map yields a nil *Map whose Lookup
+// always misses. The proxy never terminates TLS, so the hostname is the only
+// signal available at prompt time — this map is what turns it into a cause.
+package hostmap
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+//go:embed opencode-egress.json
+var opencodeEgress []byte
+
+// Entry is one host→cause mapping. The whole entry is returned (not just the
+// cause string) so callers that also know the originating process can honour
+// the process-dependent disambiguation recorded in Notes.
+type Entry struct {
+	Host          string `json:"host"`
+	Match         string `json:"match"` // "exact" | "suffix"
+	Origin        string `json:"origin"`
+	Category      string `json:"category"`
+	Cause         string `json:"cause"`
+	UserInitiated bool   `json:"user_initiated"`
+	Source        string `json:"source"`
+	Notes         string `json:"notes"`
+}
+
+// Map indexes egress entries for one harness.
+type Map struct {
+	exact  map[string]Entry
+	suffix []Entry
+}
+
+type file struct {
+	Entries []Entry `json:"entries"`
+}
+
+// For returns the egress map for a harness, or nil when none is known for it.
+// A nil *Map is safe to use: its Lookup always returns (Entry{}, false), so
+// callers need no nil check.
+func For(harness string) *Map {
+	switch strings.ToLower(strings.TrimSpace(harness)) {
+	case "opencode":
+		m, err := parse(opencodeEgress)
+		if err != nil {
+			return nil
+		}
+		return m
+	default:
+		return nil
+	}
+}
+
+func parse(raw []byte) (*Map, error) {
+	var f file
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return nil, fmt.Errorf("hostmap: parse: %w", err)
+	}
+	m := &Map{exact: make(map[string]Entry)}
+	for _, e := range f.Entries {
+		h := normalize(e.Host)
+		if h == "" || e.Cause == "" {
+			continue
+		}
+		if e.Match == "suffix" {
+			m.suffix = append(m.suffix, e)
+			continue
+		}
+		m.exact[h] = e
+	}
+	return m, nil
+}
+
+// Lookup returns the entry for a host: an exact match first, then any suffix
+// entry that the host equals or is a subdomain of. Nil-safe.
+func (m *Map) Lookup(host string) (Entry, bool) {
+	if m == nil {
+		return Entry{}, false
+	}
+	h := normalize(host)
+	if h == "" {
+		return Entry{}, false
+	}
+	if e, ok := m.exact[h]; ok {
+		return e, true
+	}
+	for _, e := range m.suffix {
+		s := normalize(e.Host)
+		if h == s || strings.HasSuffix(h, "."+s) {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}
+
+func normalize(host string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+}

--- a/internal/netprompt/hostmap/hostmap.go
+++ b/internal/netprompt/hostmap/hostmap.go
@@ -17,6 +17,9 @@ import (
 //go:embed opencode-egress.json
 var opencodeEgress []byte
 
+//go:embed claude-code-egress.json
+var claudeCodeEgress []byte
+
 // Entry is one host→cause mapping. The whole entry is returned (not just the
 // cause string) so callers that also know the originating process can honour
 // the process-dependent disambiguation recorded in Notes.
@@ -44,17 +47,26 @@ type file struct {
 // For returns the egress map for a harness, or nil when none is known for it.
 // A nil *Map is safe to use: its Lookup always returns (Entry{}, false), so
 // callers need no nil check.
+//
+// harness must be a CANONICAL harness name (e.g. "opencode", "claude-code"),
+// as resolved through config.LookupHarness by the caller — not a binary
+// basename or alias ("claude"). Keying on the canonical name keeps harness
+// identity single-sourced in the config registry.
 func For(harness string) *Map {
+	var raw []byte
 	switch strings.ToLower(strings.TrimSpace(harness)) {
 	case "opencode":
-		m, err := parse(opencodeEgress)
-		if err != nil {
-			return nil
-		}
-		return m
+		raw = opencodeEgress
+	case "claude-code":
+		raw = claudeCodeEgress
 	default:
 		return nil
 	}
+	m, err := parse(raw)
+	if err != nil {
+		return nil
+	}
+	return m
 }
 
 func parse(raw []byte) (*Map, error) {

--- a/internal/netprompt/hostmap/hostmap_test.go
+++ b/internal/netprompt/hostmap/hostmap_test.go
@@ -1,0 +1,71 @@
+package hostmap
+
+import "testing"
+
+func TestForOpencodeLoads(t *testing.T) {
+	m := For("opencode")
+	if m == nil {
+		t.Fatal("For(opencode) returned nil; embedded JSON should parse")
+	}
+	if _, ok := m.Lookup("raw.githubusercontent.com"); !ok {
+		t.Error("expected raw.githubusercontent.com in the opencode map")
+	}
+}
+
+func TestForCaseInsensitiveAndTrimmed(t *testing.T) {
+	if For("  OpenCode ") == nil {
+		t.Error("harness name should be trimmed and lowercased")
+	}
+}
+
+func TestForUnknownHarnessNil(t *testing.T) {
+	for _, h := range []string{"codex", "copilot", "claude", ""} {
+		if m := For(h); m != nil {
+			t.Errorf("For(%q) = non-nil; only opencode has a map", h)
+		}
+	}
+}
+
+func TestLookupCauseNonEmpty(t *testing.T) {
+	m := For("opencode")
+	e, ok := m.Lookup("models.dev")
+	if !ok {
+		t.Fatal("models.dev not found")
+	}
+	if e.Cause == "" {
+		t.Error("entry cause is empty")
+	}
+}
+
+func TestLookupNormalizesHost(t *testing.T) {
+	m := For("opencode")
+	// Trailing dot + uppercase must still match.
+	if _, ok := m.Lookup("RAW.GithubUserContent.com."); !ok {
+		t.Error("lookup should normalize case and trailing dot")
+	}
+}
+
+func TestLookupMiss(t *testing.T) {
+	m := For("opencode")
+	if _, ok := m.Lookup("not-a-host.invalid"); ok {
+		t.Error("unknown host should miss")
+	}
+	if _, ok := m.Lookup(""); ok {
+		t.Error("empty host should miss")
+	}
+}
+
+func TestNilMapLookupSafe(t *testing.T) {
+	var m *Map
+	if _, ok := m.Lookup("raw.githubusercontent.com"); ok {
+		t.Error("nil map Lookup must return false, not panic")
+	}
+}
+
+func TestOptInAndNotEgressNotMatched(t *testing.T) {
+	m := For("opencode")
+	// 1.1.1.1 is recorded in not_egress, never as an egress entry.
+	if _, ok := m.Lookup("1.1.1.1"); ok {
+		t.Error("not_egress host must not resolve a cause")
+	}
+}

--- a/internal/netprompt/hostmap/hostmap_test.go
+++ b/internal/netprompt/hostmap/hostmap_test.go
@@ -18,11 +18,38 @@ func TestForCaseInsensitiveAndTrimmed(t *testing.T) {
 	}
 }
 
-func TestForUnknownHarnessNil(t *testing.T) {
-	for _, h := range []string{"codex", "copilot", "claude", ""} {
+func TestForClaudeCodeLoads(t *testing.T) {
+	m := For("claude-code")
+	if m == nil {
+		t.Fatal("For(claude-code) returned nil; embedded JSON should parse")
+	}
+	if _, ok := m.Lookup("downloads.claude.ai"); !ok {
+		t.Error("expected downloads.claude.ai in the claude-code map")
+	}
+}
+
+func TestForCanonicalOnly_AliasMisses(t *testing.T) {
+	// For keys on canonical names; the alias "claude" is resolved to
+	// "claude-code" upstream (config.LookupHarness), so For itself must not
+	// accept it. Unknown/empty harnesses also miss.
+	for _, h := range []string{"claude", "cc", "codex", "copilot", ""} {
 		if m := For(h); m != nil {
-			t.Errorf("For(%q) = non-nil; only opencode has a map", h)
+			t.Errorf("For(%q) = non-nil; expected no map", h)
 		}
+	}
+}
+
+// TestSameHostDivergesByHarness locks the reason the map is harness-keyed:
+// raw.githubusercontent.com is a tree-sitter grammar in opencode but a
+// release-notes changelog in claude-code.
+func TestSameHostDivergesByHarness(t *testing.T) {
+	oc, _ := For("opencode").Lookup("raw.githubusercontent.com")
+	cc, _ := For("claude-code").Lookup("raw.githubusercontent.com")
+	if oc.Cause == "" || cc.Cause == "" {
+		t.Fatal("both harnesses should map raw.githubusercontent.com")
+	}
+	if oc.Cause == cc.Cause {
+		t.Errorf("expected divergent causes per harness, both = %q", oc.Cause)
 	}
 }
 

--- a/internal/netprompt/hostmap/opencode-egress.json
+++ b/internal/netprompt/hostmap/opencode-egress.json
@@ -1,0 +1,176 @@
+{
+  "schema_version": 1,
+  "meta": {
+    "harness": "opencode",
+    "source_repo": "anomalyco/opencode",
+    "source_commit": "355a0bcf5",
+    "source_version": "1.17.8",
+    "audited_against_installed": "1.17.12",
+    "method": "manual source audit (call-site attribution); NOT auto-generated. See README.md.",
+    "purpose": "Map an egress hostname to the opencode subsystem that dials it, so the network prompt can render a human-readable 'likely cause' line. The proxy never terminates TLS, so only host+port+source-process are observable; this map resolves the cause from the hostname alone.",
+    "origin_values": {
+      "opencode-core": "Dialed by the opencode server/bun runtime itself (background). Not separable from agent LLM traffic by PID — same process.",
+      "opencode-tool": "Dialed by a subprocess opencode spawns for language tooling (LSP server, ripgrep). May appear as a distinct PID.",
+      "provider": "LLM inference endpoint; only dialed when that provider is configured.",
+      "external": "Observed at runtime but NOT attributable to opencode source (dependency/runtime). Out of scope for this map."
+    }
+  },
+  "entries": [
+    {
+      "host": "raw.githubusercontent.com",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "render",
+      "cause": "Syntax-highlighting grammar/query (tree-sitter) for the code you are viewing",
+      "user_initiated": false,
+      "source": "packages/tui/src/parsers-config.ts",
+      "notes": "Also used by the windows scoop self-update check (installation/index.ts). If the source process is an agent tool rather than opencode itself, treat as an agent-initiated fetch instead."
+    },
+    {
+      "host": "github.com",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "language-tooling",
+      "cause": "Asset download: tree-sitter grammar (.wasm), an LSP server, the ripgrep binary, or a self-update",
+      "user_initiated": false,
+      "source": "packages/tui/src/parsers-config.ts, packages/opencode/src/lsp/server.ts, packages/core/src/ripgrep/binary.ts, packages/opencode/src/installation/index.ts"
+    },
+    {
+      "host": "objects.githubusercontent.com",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "language-tooling",
+      "cause": "GitHub release-asset CDN (redirect target of a github.com release download)",
+      "user_initiated": false,
+      "source": "(redirect target; not a literal in source)"
+    },
+    {
+      "host": "codeload.github.com",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "language-tooling",
+      "cause": "GitHub source-archive download for an LSP (e.g. vscode-eslint, elixir-ls)",
+      "user_initiated": false,
+      "source": "packages/opencode/src/lsp/server.ts (archive/refs/heads/*.zip; redirects to codeload)"
+    },
+    {
+      "host": "api.github.com",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "language-tooling",
+      "cause": "GitHub API: latest-release lookup for an LSP server (kotlin, lua, texlab, tinymist, zls), opencode self-update, or GitHub app integration",
+      "user_initiated": false,
+      "source": "packages/opencode/src/lsp/server.ts, packages/opencode/src/installation/index.ts, packages/opencode/src/cli/cmd/github.handler.ts"
+    },
+    {
+      "host": "download-cdn.jetbrains.com",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "language-tooling",
+      "cause": "Kotlin LSP server download",
+      "user_initiated": false,
+      "source": "packages/opencode/src/lsp/server.ts:1330"
+    },
+    {
+      "host": "api.releases.hashicorp.com",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "language-tooling",
+      "cause": "terraform-ls (Terraform LSP) release lookup/download",
+      "user_initiated": false,
+      "source": "packages/opencode/src/lsp/server.ts:1632"
+    },
+    {
+      "host": "www.eclipse.org",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "language-tooling",
+      "cause": "Eclipse JDT (Java LSP) download",
+      "user_initiated": false,
+      "source": "packages/opencode/src/lsp/server.ts:1207"
+    },
+    {
+      "host": "registry.npmjs.org",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "language-tooling",
+      "cause": "npm registry: installing an LSP server (typescript, pyright, ...) or a plugin",
+      "user_initiated": false,
+      "source": "packages/core/src/npm-config.ts:37",
+      "notes": "Default registry; overridable via .npmrc `registry`. A custom registry host serves the same purpose."
+    },
+    {
+      "host": "models.dev",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "catalog",
+      "cause": "Model catalog (provider/model metadata)",
+      "user_initiated": false,
+      "source": "packages/core/src/models-dev.ts:142",
+      "notes": "Overridable via OPENCODE_MODELS_URL."
+    },
+    {
+      "host": "opencode.ai",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "config-assets",
+      "cause": "opencode config schema, TUI manifest, install script, docs, changelog, or the Zen LLM gateway (/zen/v1)",
+      "user_initiated": false,
+      "source": "packages/opencode/src/config/config.ts, packages/cli/src/tui.ts"
+    },
+    {
+      "host": "api.opencode.ai",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "integration",
+      "cause": "GitHub app installation lookup",
+      "user_initiated": false,
+      "source": "packages/opencode/src/cli/cmd/github.handler.ts"
+    },
+    {
+      "host": "console.opencode.ai",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "auth",
+      "cause": "opencode auth (device-code login) and Zen gateway connection setup",
+      "user_initiated": false,
+      "source": "packages/opencode (auth/device flow)"
+    },
+    {
+      "host": "app.opencode.ai",
+      "match": "exact",
+      "origin": "opencode-core",
+      "category": "config-assets",
+      "cause": "Desktop/web app assets",
+      "user_initiated": false,
+      "source": "packages/app"
+    },
+    {
+      "host": "api.anthropic.com",
+      "match": "exact",
+      "origin": "provider",
+      "category": "llm-inference",
+      "cause": "LLM inference (Anthropic provider)",
+      "user_initiated": true,
+      "source": "provider config",
+      "notes": "Representative of the provider class. Any configured provider host (openai, x.ai, openrouter, bedrock, vertex/googleapis, a self-hosted gateway, etc.) is category llm-inference. Cannot be separated from opencode-core background traffic by PID — same process."
+    }
+  ],
+  "opt_in": [
+    {
+      "host_pattern": "OTEL_EXPORTER_OTLP_ENDPOINT (e.g. *.datadoghq.com)",
+      "origin": "opencode-core",
+      "category": "telemetry",
+      "cause": "OpenTelemetry trace/log export",
+      "user_initiated": false,
+      "source": "packages/core/src/observability/otlp.ts:7,51-72",
+      "notes": "OPT-IN ONLY: no export unless OTEL_EXPORTER_OTLP_ENDPOINT is set. A Datadog intake host seen at runtime comes from local/TNG env config, not an opencode default."
+    }
+  ],
+  "unattributed_runtime_hosts": [
+    {
+      "hosts": ["apple.com", "google.com", "microsoft.com", "1.1.1.1"],
+      "note": "Observed dialed at runtime in an omac sandbox audit but NOT attributable to any opencode source call-site (1.1.1.1 appears only in a code comment). Likely a dependency/runtime connectivity probe. Flagged for follow-up; deliberately excluded from the attribution map."
+    }
+  ]
+}

--- a/internal/netprompt/hostmap/opencode-egress.json
+++ b/internal/netprompt/hostmap/opencode-egress.json
@@ -167,10 +167,10 @@
       "notes": "OPT-IN ONLY: no export unless OTEL_EXPORTER_OTLP_ENDPOINT is set. A Datadog intake host seen at runtime comes from local/TNG env config, not an opencode default."
     }
   ],
-  "unattributed_runtime_hosts": [
+  "not_egress": [
     {
-      "hosts": ["apple.com", "google.com", "microsoft.com", "1.1.1.1"],
-      "note": "Observed dialed at runtime in an omac sandbox audit but NOT attributable to any opencode source call-site (1.1.1.1 appears only in a code comment). Likely a dependency/runtime connectivity probe. Flagged for follow-up; deliberately excluded from the attribution map."
+      "host": "1.1.1.1",
+      "note": "NOT an opencode egress. Appears only as source text — a webfetch test fixture (packages/core/test/tool-webfetch.test.ts, a dummy 'Unable to fetch' target) and a code comment (packages/opencode/src/permission/arity.ts:96). Never dialed at runtime (absent from the sandbox audit). Documented so it is not re-investigated."
     }
   ]
 }

--- a/internal/netprompt/origin/origin.go
+++ b/internal/netprompt/origin/origin.go
@@ -32,7 +32,3 @@ type Resolver interface {
 // NewResolver returns the platform resolver: a /proc-backed resolver on Linux,
 // a noop everywhere else.
 func NewResolver() Resolver { return platformResolver() }
-
-type noopResolver struct{}
-
-func (noopResolver) Resolve(_, _ netip.AddrPort) (Origin, bool) { return Origin{}, false }

--- a/internal/netprompt/origin/origin.go
+++ b/internal/netprompt/origin/origin.go
@@ -1,0 +1,38 @@
+// Package origin attributes a proxied connection to the process that opened
+// it, for display in the network prompt. Given the child's source address (the
+// proxy's accepted conn.RemoteAddr) and the proxy's own address, it resolves
+// the owning PID and process name.
+//
+// It is best-effort and display-only: any failure yields ok=false and the
+// prompt simply omits the Origin line. It never influences the access verdict.
+// Resolution is Linux-only (via /proc); other platforms return a noop resolver.
+package origin
+
+import "net/netip"
+
+// Origin is the process that opened a proxied connection. Name is the basename
+// (comm) only — never the full command line, which can carry secrets in argv.
+// PID is the host PID (the supervisor's namespace), which is what `ps` on the
+// host shows; it may differ from the number the child sees in its own PID
+// namespace.
+type Origin struct {
+	PID  int
+	Name string
+}
+
+// Resolver maps a proxied connection to its originating process.
+type Resolver interface {
+	// Resolve returns the process that owns the connection whose local
+	// endpoint is src and whose remote endpoint is proxy (i.e. the child's
+	// socket to the omac proxy). ok=false when it cannot be determined
+	// (unsupported OS, closed socket, permission, ambiguity).
+	Resolve(src, proxy netip.AddrPort) (Origin, bool)
+}
+
+// NewResolver returns the platform resolver: a /proc-backed resolver on Linux,
+// a noop everywhere else.
+func NewResolver() Resolver { return platformResolver() }
+
+type noopResolver struct{}
+
+func (noopResolver) Resolve(_, _ netip.AddrPort) (Origin, bool) { return Origin{}, false }

--- a/internal/netprompt/origin/resolver_linux.go
+++ b/internal/netprompt/origin/resolver_linux.go
@@ -1,0 +1,120 @@
+//go:build linux
+
+package origin
+
+import (
+	"bufio"
+	"fmt"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func platformResolver() Resolver { return procResolver{} }
+
+// procResolver attributes a loopback connection via /proc. It finds the child's
+// socket in /proc/net/tcp by matching the full 4-tuple (local == src AND
+// rem == proxy) — matching the ephemeral local port alone is ambiguous, since
+// the kernel may reuse it across connections to different remotes — then maps
+// the socket inode to a PID by scanning /proc/<pid>/fd, and reads the PID's
+// comm. Reads comm only; never /proc/<pid>/cmdline (argv can carry secrets).
+type procResolver struct{}
+
+func (procResolver) Resolve(src, proxy netip.AddrPort) (Origin, bool) {
+	inode, ok := inodeForTuple(src, proxy)
+	if !ok {
+		return Origin{}, false
+	}
+	pid, ok := pidForInode(inode)
+	if !ok {
+		return Origin{}, false
+	}
+	name := commForPID(pid)
+	if name == "" {
+		return Origin{}, false
+	}
+	return Origin{PID: pid, Name: name}, true
+}
+
+// inodeForTuple scans /proc/net/tcp for the row whose local and remote
+// endpoints equal src and proxy respectively, and returns its socket inode.
+func inodeForTuple(src, proxy netip.AddrPort) (string, bool) {
+	local, ok := hexEndpoint(src)
+	if !ok {
+		return "", false
+	}
+	rem, ok := hexEndpoint(proxy)
+	if !ok {
+		return "", false
+	}
+	f, err := os.Open("/proc/net/tcp")
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Scan() // header
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		// 0:sl 1:local 2:rem 3:st ... 9:inode
+		if len(fields) < 10 {
+			continue
+		}
+		if strings.EqualFold(fields[1], local) && strings.EqualFold(fields[2], rem) {
+			return fields[9], true
+		}
+	}
+	return "", false
+}
+
+// hexEndpoint renders an IPv4 AddrPort in /proc/net/tcp form:
+// little-endian address bytes + big-endian port, e.g. 127.0.0.1:443 ->
+// "0100007F:01BB". Returns false for non-IPv4 (loopback proxy traffic is IPv4).
+func hexEndpoint(ap netip.AddrPort) (string, bool) {
+	a := ap.Addr().Unmap()
+	if !a.Is4() {
+		return "", false
+	}
+	b := a.As4()
+	return fmt.Sprintf("%02X%02X%02X%02X:%04X", b[3], b[2], b[1], b[0], ap.Port()), true
+}
+
+// pidForInode finds the PID owning the socket with the given inode by scanning
+// /proc/<pid>/fd for a "socket:[<inode>]" symlink.
+func pidForInode(inode string) (int, bool) {
+	target := "socket:[" + inode + "]"
+	procs, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0, false
+	}
+	for _, p := range procs {
+		if !p.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(p.Name())
+		if err != nil {
+			continue
+		}
+		fdDir := filepath.Join("/proc", p.Name(), "fd")
+		fds, err := os.ReadDir(fdDir)
+		if err != nil {
+			continue // process gone or not ours
+		}
+		for _, fd := range fds {
+			if link, err := os.Readlink(filepath.Join(fdDir, fd.Name())); err == nil && link == target {
+				return pid, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func commForPID(pid int) string {
+	b, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "comm"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/internal/netprompt/origin/resolver_linux_test.go
+++ b/internal/netprompt/origin/resolver_linux_test.go
@@ -1,0 +1,72 @@
+//go:build linux
+
+package origin
+
+import (
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestResolveRealSocket dials a loopback listener within this process and
+// asserts the resolver attributes the connection to this very PID via the full
+// 4-tuple — a real-socket check that a /proc/net/tcp fixture cannot give.
+func TestResolveRealSocket(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	server, err := ln.Accept()
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	defer server.Close()
+
+	// From the proxy's vantage the accepted conn.RemoteAddr is the client's
+	// source; conn.LocalAddr is the proxy endpoint.
+	src := server.RemoteAddr().(*net.TCPAddr).AddrPort()
+	proxy := server.LocalAddr().(*net.TCPAddr).AddrPort()
+
+	o, ok := procResolver{}.Resolve(src, proxy)
+	if !ok {
+		t.Fatal("expected to resolve the loopback connection")
+	}
+	if o.PID != os.Getpid() {
+		t.Errorf("PID = %d, want this process %d", o.PID, os.Getpid())
+	}
+	// Name is comm — verify it matches /proc/self/comm (proving we read comm,
+	// not cmdline).
+	want, _ := os.ReadFile("/proc/self/comm")
+	if o.Name != strings.TrimSpace(string(want)) {
+		t.Errorf("Name = %q, want comm %q", o.Name, strings.TrimSpace(string(want)))
+	}
+}
+
+func TestResolveUnknownTupleMisses(t *testing.T) {
+	// A src/proxy pair that is not an open connection must not resolve.
+	src := netip.MustParseAddrPort("127.0.0.1:1")
+	proxy := netip.MustParseAddrPort("127.0.0.1:2")
+	if _, ok := (procResolver{}).Resolve(src, proxy); ok {
+		t.Error("nonexistent tuple should miss")
+	}
+}
+
+func TestHexEndpoint(t *testing.T) {
+	got, ok := hexEndpoint(netip.MustParseAddrPort("127.0.0.1:443"))
+	if !ok || got != "0100007F:01BB" {
+		t.Errorf("hexEndpoint(127.0.0.1:443) = %q,%v; want 0100007F:01BB,true", got, ok)
+	}
+	if _, ok := hexEndpoint(netip.MustParseAddrPort("[::1]:443")); ok {
+		t.Error("IPv6 should report ok=false (loopback proxy traffic is IPv4)")
+	}
+}

--- a/internal/netprompt/origin/resolver_other.go
+++ b/internal/netprompt/origin/resolver_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package origin
+
+func platformResolver() Resolver { return noopResolver{} }

--- a/internal/netprompt/origin/resolver_other.go
+++ b/internal/netprompt/origin/resolver_other.go
@@ -2,4 +2,10 @@
 
 package origin
 
+import "net/netip"
+
 func platformResolver() Resolver { return noopResolver{} }
+
+type noopResolver struct{}
+
+func (noopResolver) Resolve(_, _ netip.AddrPort) (Origin, bool) { return Origin{}, false }

--- a/internal/netprompt/origin_prompt_test.go
+++ b/internal/netprompt/origin_prompt_test.go
@@ -55,7 +55,7 @@ func TestResolveOriginOmittedWhenResolveFails(t *testing.T) {
 
 func TestPromptTextOriginOrdering(t *testing.T) {
 	got := promptText("raw.githubusercontent.com", 443, "", "grammar", "opencode")
-	if !strings.Contains(got, "Origin:       opencode\n") {
+	if !strings.Contains(got, "Origin: opencode\n") {
 		t.Errorf("missing origin line: %q", got)
 	}
 	// Origin precedes cause precedes intent.

--- a/internal/netprompt/origin_prompt_test.go
+++ b/internal/netprompt/origin_prompt_test.go
@@ -54,7 +54,7 @@ func TestResolveOriginOmittedWhenResolveFails(t *testing.T) {
 }
 
 func TestPromptTextOriginOrdering(t *testing.T) {
-	got := promptText("raw.githubusercontent.com", 443, "", "grammar", "opencode")
+	got := promptText("raw.githubusercontent.com", 443, "", "grammar", "opencode", 7)
 	if !strings.Contains(got, "Origin: opencode\n") {
 		t.Errorf("missing origin line: %q", got)
 	}
@@ -66,7 +66,7 @@ func TestPromptTextOriginOrdering(t *testing.T) {
 }
 
 func TestPromptTextOriginOmittedWhenEmpty(t *testing.T) {
-	if strings.Contains(promptText("api.example.com", 443, "", "", ""), "Origin:") {
+	if strings.Contains(promptText("api.example.com", 443, "", "", "", 7), "Origin:") {
 		t.Error("empty origin must omit the line")
 	}
 }

--- a/internal/netprompt/origin_prompt_test.go
+++ b/internal/netprompt/origin_prompt_test.go
@@ -1,0 +1,72 @@
+package netprompt
+
+import (
+	"context"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt/origin"
+	"github.com/tngtech/oh-my-agentic-coder/internal/netproxy"
+)
+
+type fakeResolver struct {
+	o  origin.Origin
+	ok bool
+}
+
+func (f fakeResolver) Resolve(_, _ netip.AddrPort) (origin.Origin, bool) { return f.o, f.ok }
+
+func ctxWithSource(t *testing.T) context.Context {
+	t.Helper()
+	src := netip.MustParseAddrPort("127.0.0.1:54321")
+	proxy := netip.MustParseAddrPort("127.0.0.1:443")
+	return netproxy.WithClientSource(context.Background(), src, proxy)
+}
+
+func TestResolveOriginRendersLine(t *testing.T) {
+	p := &Prompter{origin: fakeResolver{o: origin.Origin{PID: 4242, Name: "opencode"}, ok: true}}
+	got := p.resolveOrigin(ctxWithSource(t))
+	if got != "opencode (host pid 4242)" {
+		t.Errorf("origin line = %q", got)
+	}
+}
+
+func TestResolveOriginOmittedWhenNoResolver(t *testing.T) {
+	p := &Prompter{}
+	if got := p.resolveOrigin(ctxWithSource(t)); got != "" {
+		t.Errorf("no resolver should omit, got %q", got)
+	}
+}
+
+func TestResolveOriginOmittedWhenNoClientSource(t *testing.T) {
+	p := &Prompter{origin: fakeResolver{o: origin.Origin{PID: 1, Name: "x"}, ok: true}}
+	if got := p.resolveOrigin(context.Background()); got != "" {
+		t.Errorf("no ClientSource should omit, got %q", got)
+	}
+}
+
+func TestResolveOriginOmittedWhenResolveFails(t *testing.T) {
+	p := &Prompter{origin: fakeResolver{ok: false}}
+	if got := p.resolveOrigin(ctxWithSource(t)); got != "" {
+		t.Errorf("failed resolve should omit, got %q", got)
+	}
+}
+
+func TestPromptTextOriginOrdering(t *testing.T) {
+	got := promptText("raw.githubusercontent.com", 443, "", "grammar", "opencode (host pid 42)")
+	if !strings.Contains(got, "Origin: opencode (host pid 42)\n") {
+		t.Errorf("missing origin line: %q", got)
+	}
+	// Origin precedes cause precedes intent.
+	oi, ci, ii := strings.Index(got, "Origin:"), strings.Index(got, "Likely cause:"), strings.Index(got, "Agent intent:")
+	if !(oi < ci && ci < ii) {
+		t.Errorf("expected Origin < cause < intent, got %d %d %d in %q", oi, ci, ii, got)
+	}
+}
+
+func TestPromptTextOriginOmittedWhenEmpty(t *testing.T) {
+	if strings.Contains(promptText("api.example.com", 443, "", "", ""), "Origin:") {
+		t.Error("empty origin must omit the line")
+	}
+}

--- a/internal/netprompt/origin_prompt_test.go
+++ b/internal/netprompt/origin_prompt_test.go
@@ -27,7 +27,7 @@ func ctxWithSource(t *testing.T) context.Context {
 func TestResolveOriginRendersLine(t *testing.T) {
 	p := &Prompter{origin: fakeResolver{o: origin.Origin{PID: 4242, Name: "opencode"}, ok: true}}
 	got := p.resolveOrigin(ctxWithSource(t))
-	if got != "opencode (host pid 4242)" {
+	if got != "opencode" {
 		t.Errorf("origin line = %q", got)
 	}
 }
@@ -54,8 +54,8 @@ func TestResolveOriginOmittedWhenResolveFails(t *testing.T) {
 }
 
 func TestPromptTextOriginOrdering(t *testing.T) {
-	got := promptText("raw.githubusercontent.com", 443, "", "grammar", "opencode (host pid 42)")
-	if !strings.Contains(got, "Origin: opencode (host pid 42)\n") {
+	got := promptText("raw.githubusercontent.com", 443, "", "grammar", "opencode")
+	if !strings.Contains(got, "Origin:       opencode\n") {
 		t.Errorf("missing origin line: %q", got)
 	}
 	// Origin precedes cause precedes intent.

--- a/internal/netprompt/popupshot_darwin_test.go
+++ b/internal/netprompt/popupshot_darwin_test.go
@@ -1,0 +1,51 @@
+//go:build darwin
+
+package netprompt
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestRenderPopupScreenshot renders the osascript network dialog and captures a
+// full-screen PNG. Best-effort: osascript GUI dialogs need a WindowServer
+// session, which headless CI runners may not provide — the CI job is
+// continue-on-error and a desktop-only capture is itself the signal that the
+// dialog did not render. Advisory only; appearance is not asserted.
+//
+// Gated on OMAC_POPUP_SHOT=1 so it never runs in the normal unit suite. There
+// is no reliable per-window wait without accessibility permissions, so it uses
+// a fixed settle delay before screencapture.
+func TestRenderPopupScreenshot(t *testing.T) {
+	if os.Getenv("OMAC_POPUP_SHOT") == "" {
+		t.Skip("set OMAC_POPUP_SHOT=1 to render the real dialog")
+	}
+	for _, bin := range []string{"osascript", "screencapture"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%q not found on PATH", bin)
+		}
+	}
+
+	shot := shotPath(t, "osascript")
+	errc := make(chan error, 1)
+	go func() {
+		_, err := osascriptBackend{}.show(context.Background(), shotHost, shotPort,
+			RegisteredSuffixHint(shotHost), shotIntent, shotCause, shotOrigin)
+		errc <- err
+	}()
+
+	time.Sleep(3 * time.Second) // no window-id wait available; let the dialog map
+	if out, err := exec.Command("screencapture", "-x", shot).CombinedOutput(); err != nil {
+		t.Fatalf("screencapture failed: %v: %s", err, out)
+	}
+	// Dismiss with Escape via System Events; best-effort (may lack permission).
+	_ = exec.Command("osascript", "-e", `tell application "System Events" to key code 53`).Run()
+	select {
+	case <-errc:
+	case <-time.After(3 * time.Second):
+	}
+	assertShot(t, shot)
+}

--- a/internal/netprompt/popupshot_linux_test.go
+++ b/internal/netprompt/popupshot_linux_test.go
@@ -1,0 +1,118 @@
+//go:build linux
+
+package netprompt
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRenderPopupScreenshot renders the real network-approval dialog under an
+// X display and captures a PNG, so CI can surface how the dialog actually looks
+// — label alignment (space-padding aligns only in monospace; GTK/Qt draw
+// proportional), wrapping, and truncation against the fixed height. It is
+// advisory: the artifact is for human eyes, not a pass/fail assertion on
+// appearance.
+//
+// Gated on OMAC_POPUP_SHOT=1 so it never runs in the normal unit suite; needs
+// the chosen dialog tool plus imagemagick (import) and xdotool, and a DISPLAY
+// (xvfb-run in CI). OMAC_POPUP_SHOT_BACKEND selects zenity (default) or kdialog.
+func TestRenderPopupScreenshot(t *testing.T) {
+	if os.Getenv("OMAC_POPUP_SHOT") == "" {
+		t.Skip("set OMAC_POPUP_SHOT=1 to render the real dialog (needs a dialog tool + DISPLAY)")
+	}
+	if os.Getenv("DISPLAY") == "" {
+		t.Skip("no DISPLAY set; render under xvfb-run")
+	}
+	backend := linuxShotBackend(os.Getenv("OMAC_POPUP_SHOT_BACKEND"))
+	for _, bin := range []string{backend.name(), "import", "xdotool"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%q not found on PATH", bin)
+		}
+	}
+
+	shot := shotPath(t, backend.name())
+	errc := make(chan error, 1)
+	go func() {
+		_, err := backend.show(context.Background(), shotHost, shotPort,
+			RegisteredSuffixHint(shotHost), shotIntent, shotCause, shotOrigin)
+		errc <- err
+	}()
+
+	win := waitForWindow(t, shotTitle, 15*time.Second)
+	err := captureWindow(win, shot, 6, time.Second)
+	_ = exec.Command("xdotool", "windowkill", win).Run() // let the backend goroutine return
+	select {
+	case <-errc:
+	case <-time.After(3 * time.Second):
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertShot(t, shot)
+}
+
+// captureWindow grabs window win to out, retrying until the image is painted.
+// xdotool --sync waits for the window to exist, not to draw, so a fresh grab
+// can be a blank rectangle; a painted dialog has many colours, a blank window
+// only one or two. Retries settle GTK/Qt's first paint.
+func captureWindow(win, out string, attempts int, wait time.Duration) error {
+	var colors int
+	for i := 0; i < attempts; i++ {
+		time.Sleep(wait)
+		if o, err := exec.Command("import", "-window", win, out).CombinedOutput(); err != nil {
+			return fmt.Errorf("import failed: %v: %s", err, o)
+		}
+		var err error
+		if colors, err = pngColors(out); err != nil {
+			return err
+		}
+		if colors > 4 {
+			return nil
+		}
+	}
+	return fmt.Errorf("captured a blank window (%d colours) after %d attempts — dialog did not paint", colors, attempts)
+}
+
+// pngColors returns the number of distinct colours in an image (ImageMagick %k).
+func pngColors(path string) (int, error) {
+	out, err := exec.Command("identify", "-format", "%k", path).Output()
+	if err != nil {
+		return 0, fmt.Errorf("identify failed: %v", err)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("parse colour count %q: %v", out, err)
+	}
+	return n, nil
+}
+
+func linuxShotBackend(name string) dialogBackend {
+	if strings.EqualFold(name, "kdialog") {
+		return kdialogBackend{}
+	}
+	return zenityBackend{}
+}
+
+// waitForWindow blocks until a window titled title exists (xdotool --sync),
+// bounded by timeout, and returns its id.
+func waitForWindow(t *testing.T, title string, timeout time.Duration) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "xdotool", "search", "--sync", "--name", title).Output()
+	if err != nil {
+		t.Fatalf("dialog window %q did not appear within %s: %v", title, timeout, err)
+	}
+	ids := strings.Fields(string(out))
+	if len(ids) == 0 {
+		t.Fatalf("no window id for %q", title)
+	}
+	return ids[len(ids)-1]
+}

--- a/internal/netprompt/popupshot_shared_test.go
+++ b/internal/netprompt/popupshot_shared_test.go
@@ -1,0 +1,46 @@
+package netprompt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Representative network prompt for the screenshot tests. Every optional line
+// is present (Origin + Likely cause + Agent intent), and the cause is long
+// enough to expose wrapping, truncation, and the fixed dialog height — the
+// things promptText's golden string tests cannot see. Kept in one place so the
+// per-platform render tests (popupshot_linux_test.go / _darwin_test.go) agree
+// on what is drawn.
+const (
+	shotHost   = "raw.githubusercontent.com"
+	shotPort   = 443
+	shotTitle  = "omac: network access"
+	shotIntent = "" // renders "(not declared)"
+	shotCause  = "Syntax-highlighting grammar/query (tree-sitter) for the code you are viewing"
+	shotOrigin = "opencode"
+)
+
+// shotPath returns where a backend's PNG should be written: OMAC_POPUP_SHOT_DIR
+// when set (CI uploads it as an artifact), else a per-test temp dir.
+func shotPath(t *testing.T, backend string) string {
+	t.Helper()
+	dir := os.Getenv("OMAC_POPUP_SHOT_DIR")
+	if dir == "" {
+		dir = t.TempDir()
+	}
+	return filepath.Join(dir, "network-prompt-"+backend+".png")
+}
+
+// assertShot fails when the capture produced no usable file.
+func assertShot(t *testing.T, path string) {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("screenshot not written: %v", err)
+	}
+	if fi.Size() == 0 {
+		t.Fatalf("screenshot is empty: %s", path)
+	}
+	t.Logf("wrote popup screenshot: %s (%d bytes)", path, fi.Size())
+}

--- a/internal/netprompt/prompt.go
+++ b/internal/netprompt/prompt.go
@@ -130,7 +130,7 @@ func RegisteredSuffixHint(host string) string {
 // host (empty means unknown, line omitted). cause is labelled "Likely" because
 // it is inferred from the hostname alone — the proxy never sees the URL — and
 // may reflect background harness infrastructure rather than the agent.
-func promptText(host string, port int, intent, cause, originLine string) string {
+func promptText(host string, port int, intent, cause, originLine string, numOptions int) string {
 	target := fmt.Sprintf("%s:%d", host, port)
 	var b strings.Builder
 	fmt.Fprintf(&b, "The sandboxed process is trying to reach:\n\n    %s\n\n", target)
@@ -145,7 +145,9 @@ func promptText(host string, port int, intent, cause, originLine string) string 
 	} else {
 		b.WriteString("Agent intent: (not declared)")
 	}
-	b.WriteString("\n\nHow should omac handle this destination?")
+	// State the option count so the user knows how many choices exist even when
+	// the list scrolls and the scrollbar is faint (thin GTK/Qt scrollbars).
+	fmt.Fprintf(&b, "\n\nHow should omac handle this destination? (%d options)", numOptions)
 	return b.String()
 }
 
@@ -343,7 +345,7 @@ func (osascriptBackend) show(ctx context.Context, host string, port int, suffix,
 	script := fmt.Sprintf(
 		`choose from list {%s} with title "omac: network access" with prompt %s default items {%s} OK button name "Select" cancel button name "Cancel"`,
 		strings.Join(quoted, ", "),
-		appleScriptString(promptText(host, port, intent, cause, originLine)),
+		appleScriptString(promptText(host, port, intent, cause, originLine, len(opts))),
 		appleScriptString("Deny once"),
 	)
 	out, err := exec.CommandContext(ctx, "osascript", "-e", script).Output()
@@ -386,16 +388,17 @@ func (zenityBackend) available() bool {
 // window size. Extracted so the sizing can be asserted without launching a
 // dialog.
 func zenityArgs(host string, port int, suffix, intent, cause, originLine string) []string {
+	opts := optionLabels(suffix)
 	width, height := dialogDimensions()
 	args := []string{
 		"--list", "--radiolist",
 		"--title", "omac: network access",
-		"--text", promptText(host, port, intent, cause, originLine),
+		"--text", promptText(host, port, intent, cause, originLine, len(opts)),
 		"--column", "", "--column", "Decision",
 		"--width", strconv.Itoa(width),
 		"--height", strconv.Itoa(height),
 	}
-	for _, o := range optionLabels(suffix) {
+	for _, o := range opts {
 		sel := "FALSE"
 		if o == "Deny once" {
 			sel = "TRUE"
@@ -448,7 +451,7 @@ func kdialogArgs(host string, port int, suffix, intent, cause, originLine string
 	args := []string{
 		"--geometry", fmt.Sprintf("%dx%d", width, height),
 		"--title", "omac: network access",
-		"--radiolist", promptText(host, port, intent, cause, originLine),
+		"--radiolist", promptText(host, port, intent, cause, originLine, len(opts)),
 	}
 	for i, o := range opts {
 		state := "off"

--- a/internal/netprompt/prompt.go
+++ b/internal/netprompt/prompt.go
@@ -135,15 +135,15 @@ func promptText(host string, port int, intent, cause, originLine string) string 
 	var b strings.Builder
 	fmt.Fprintf(&b, "The sandboxed process is trying to reach:\n\n    %s\n\n", target)
 	if originLine != "" {
-		fmt.Fprintf(&b, "%-13s %s\n", "Origin:", originLine)
+		fmt.Fprintf(&b, "Origin: %s\n", originLine)
 	}
 	if cause != "" {
-		fmt.Fprintf(&b, "%-13s %s\n", "Likely cause:", cause)
+		fmt.Fprintf(&b, "Likely cause: %s\n", cause)
 	}
 	if intent != "" {
-		fmt.Fprintf(&b, "%-13s %q", "Agent intent:", intent)
+		fmt.Fprintf(&b, "Agent intent: %q", intent)
 	} else {
-		fmt.Fprintf(&b, "%-13s (not declared)", "Agent intent:")
+		b.WriteString("Agent intent: (not declared)")
 	}
 	b.WriteString("\n\nHow should omac handle this destination?")
 	return b.String()

--- a/internal/netprompt/prompt.go
+++ b/internal/netprompt/prompt.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt/hostmap"
+	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt/origin"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netproxy"
 )
 
@@ -129,10 +130,13 @@ func RegisteredSuffixHint(host string) string {
 // host (empty means unknown, line omitted). cause is labelled "Likely" because
 // it is inferred from the hostname alone — the proxy never sees the URL — and
 // may reflect background harness infrastructure rather than the agent.
-func promptText(host string, port int, intent, cause string) string {
+func promptText(host string, port int, intent, cause, originLine string) string {
 	target := fmt.Sprintf("%s:%d", host, port)
 	var b strings.Builder
 	fmt.Fprintf(&b, "The sandboxed process is trying to reach:\n\n    %s\n\n", target)
+	if originLine != "" {
+		fmt.Fprintf(&b, "Origin: %s\n", originLine)
+	}
 	if cause != "" {
 		fmt.Fprintf(&b, "Likely cause: %s\n", cause)
 	}
@@ -157,7 +161,7 @@ type dialogBackend interface {
 	// show blocks until the user chooses, the dialog is cancelled, or
 	// ctx is done (the implementation must kill the dialog process).
 	// Returns the chosen label ("" on cancel).
-	show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error)
+	show(ctx context.Context, host string, port int, suffix, intent, cause, originLine string) (string, error)
 }
 
 // Prompter implements netproxy.Prompter with native dialogs.
@@ -168,7 +172,8 @@ type Prompter struct {
 	logf              func(format string, args ...any)
 	lookupIntent      func(host string) (string, bool)
 	recordExplainMore func(host string)
-	hostMap           *hostmap.Map // harness egress map; nil => no cause line
+	hostMap           *hostmap.Map    // harness egress map; nil => no cause line
+	origin            origin.Resolver // process attribution; nil => no origin line
 }
 
 // isTruthyEnv reports whether an env var value means "on". Anything else
@@ -190,8 +195,10 @@ func isTruthyEnv(v string) bool {
 // so the click is recorded where the agent's out-of-band GET lookup can
 // reach it (an HTTPS/CONNECT denial cannot carry the re-ask in-band).
 // hostMap, when non-nil, supplies the "likely cause" line for a host; nil (a
-// non-opencode harness, or a load failure) omits the line.
-func NewPrompter(timeoutSecs int, logf func(string, ...any), lookupIntent func(host string) (string, bool), recordExplainMore func(host string), hostMap *hostmap.Map) (*Prompter, bool) {
+// non-opencode harness, or a load failure) omits the line. resolver, when
+// non-nil, supplies the originating-process "Origin" line; nil (or an
+// unsupported OS) omits it.
+func NewPrompter(timeoutSecs int, logf func(string, ...any), lookupIntent func(host string) (string, bool), recordExplainMore func(host string), hostMap *hostmap.Map, resolver origin.Resolver) (*Prompter, bool) {
 	if logf == nil {
 		logf = func(string, ...any) {}
 	}
@@ -201,6 +208,7 @@ func NewPrompter(timeoutSecs int, logf func(string, ...any), lookupIntent func(h
 		lookupIntent:      lookupIntent,
 		recordExplainMore: recordExplainMore,
 		hostMap:           hostMap,
+		origin:            resolver,
 	}
 	// Stub backend: activated by a truthy OMAC_PROMPT_STUB (1/true/yes/on).
 	// Reads per-host decisions from OMAC_PROMPT_DECISIONS (JSON file). Used
@@ -237,7 +245,7 @@ func NewPrompter(timeoutSecs int, logf func(string, ...any), lookupIntent func(h
 // (run.go) wires OnUnavailableAllow into the filter, which handles the
 // no-backend case before Prompt is ever called. A timed-out dialog is
 // always deny (nono: "a missed prompt never silently allows").
-func (p *Prompter) Prompt(host string, port int) netproxy.PromptResult {
+func (p *Prompter) Prompt(ctx context.Context, host string, port int) netproxy.PromptResult {
 	var backend dialogBackend
 	for _, b := range p.backends {
 		if b.available() {
@@ -273,11 +281,12 @@ func (p *Prompter) Prompt(host string, port int) netproxy.PromptResult {
 	if e, ok := p.hostMap.Lookup(host); ok {
 		cause = e.Cause
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+	originLine := p.resolveOrigin(ctx)
+	dctx, cancel := context.WithTimeout(context.Background(), p.timeout)
 	defer cancel()
-	label, err := backend.show(ctx, host, port, suffix, intent, cause)
+	label, err := backend.show(dctx, host, port, suffix, intent, cause, originLine)
 	if err != nil {
-		if ctx.Err() != nil {
+		if dctx.Err() != nil {
 			p.logf("omac sandbox: network prompt for %s:%d timed out", host, port)
 		} else {
 			p.logf("omac sandbox: network prompt failed: %v", err)
@@ -295,6 +304,25 @@ func (p *Prompter) Prompt(host string, port int) netproxy.PromptResult {
 	return result
 }
 
+// resolveOrigin attributes the dial to a process for the "Origin" line. It runs
+// only here (the prompt path), never on the allow/deny hot path. Empty string
+// when there is no resolver, no ClientSource on ctx, or resolution fails —
+// which simply omits the line. The PID is the host PID (see origin.Origin).
+func (p *Prompter) resolveOrigin(ctx context.Context) string {
+	if p.origin == nil {
+		return ""
+	}
+	cs, ok := netproxy.ClientSourceFromContext(ctx)
+	if !ok {
+		return ""
+	}
+	o, ok := p.origin.Resolve(cs.Src, cs.Proxy)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%s (host pid %d)", o.Name, o.PID)
+}
+
 // --- macOS ---
 
 type osascriptBackend struct{}
@@ -306,7 +334,7 @@ func (osascriptBackend) available() bool {
 	return err == nil
 }
 
-func (osascriptBackend) show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error) {
+func (osascriptBackend) show(ctx context.Context, host string, port int, suffix, intent, cause, originLine string) (string, error) {
 	opts := optionLabels(suffix)
 	quoted := make([]string, len(opts))
 	for i, o := range opts {
@@ -315,7 +343,7 @@ func (osascriptBackend) show(ctx context.Context, host string, port int, suffix,
 	script := fmt.Sprintf(
 		`choose from list {%s} with title "omac: network access" with prompt %s default items {%s} OK button name "Select" cancel button name "Cancel"`,
 		strings.Join(quoted, ", "),
-		appleScriptString(promptText(host, port, intent, cause)),
+		appleScriptString(promptText(host, port, intent, cause, originLine)),
 		appleScriptString("Deny once"),
 	)
 	out, err := exec.CommandContext(ctx, "osascript", "-e", script).Output()
@@ -357,12 +385,12 @@ func (zenityBackend) available() bool {
 // zenityArgs builds the full zenity radiolist argv, including the explicit
 // window size. Extracted so the sizing can be asserted without launching a
 // dialog.
-func zenityArgs(host string, port int, suffix, intent, cause string) []string {
+func zenityArgs(host string, port int, suffix, intent, cause, originLine string) []string {
 	width, height := dialogDimensions()
 	args := []string{
 		"--list", "--radiolist",
 		"--title", "omac: network access",
-		"--text", promptText(host, port, intent, cause),
+		"--text", promptText(host, port, intent, cause, originLine),
 		"--column", "", "--column", "Decision",
 		"--width", strconv.Itoa(width),
 		"--height", strconv.Itoa(height),
@@ -377,8 +405,8 @@ func zenityArgs(host string, port int, suffix, intent, cause string) []string {
 	return args
 }
 
-func (zenityBackend) show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error) {
-	out, err := exec.CommandContext(ctx, "zenity", zenityArgs(host, port, suffix, intent, cause)...).Output()
+func (zenityBackend) show(ctx context.Context, host string, port int, suffix, intent, cause, originLine string) (string, error) {
+	out, err := exec.CommandContext(ctx, "zenity", zenityArgs(host, port, suffix, intent, cause, originLine)...).Output()
 	if err != nil {
 		// zenity exits 1 on Cancel; treat as cancel unless ctx expired.
 		if ctx.Err() != nil {
@@ -409,13 +437,13 @@ func (kdialogBackend) available() bool {
 // positional argument, before the option triples. Verified against
 // KDE/kdialog master; geometry is applied under X11/XWayland (on a pure
 // Wayland build kdialog accepts but may ignore it — never errors).
-func kdialogArgs(host string, port int, suffix, intent, cause string) []string {
+func kdialogArgs(host string, port int, suffix, intent, cause, originLine string) []string {
 	opts := optionLabels(suffix)
 	width, height := dialogDimensions()
 	args := []string{
 		"--geometry", fmt.Sprintf("%dx%d", width, height),
 		"--title", "omac: network access",
-		"--radiolist", promptText(host, port, intent, cause),
+		"--radiolist", promptText(host, port, intent, cause, originLine),
 	}
 	for i, o := range opts {
 		state := "off"
@@ -427,9 +455,9 @@ func kdialogArgs(host string, port int, suffix, intent, cause string) []string {
 	return args
 }
 
-func (kdialogBackend) show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error) {
+func (kdialogBackend) show(ctx context.Context, host string, port int, suffix, intent, cause, originLine string) (string, error) {
 	opts := optionLabels(suffix)
-	out, err := exec.CommandContext(ctx, "kdialog", kdialogArgs(host, port, suffix, intent, cause)...).Output()
+	out, err := exec.CommandContext(ctx, "kdialog", kdialogArgs(host, port, suffix, intent, cause, originLine)...).Output()
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", ctx.Err()

--- a/internal/netprompt/prompt.go
+++ b/internal/netprompt/prompt.go
@@ -406,7 +406,12 @@ func zenityArgs(host string, port int, suffix, intent, cause, originLine string)
 }
 
 func (zenityBackend) show(ctx context.Context, host string, port int, suffix, intent, cause, originLine string) (string, error) {
-	out, err := exec.CommandContext(ctx, "zenity", zenityArgs(host, port, suffix, intent, cause, originLine)...).Output()
+	cmd := exec.CommandContext(ctx, "zenity", zenityArgs(host, port, suffix, intent, cause, originLine)...)
+	// GTK3 hides the overlay scrollbar until hover, so an option list that
+	// overflows the window looks complete and the choices below the fold are
+	// undiscoverable. Force a persistent scrollbar so it is always visible.
+	cmd.Env = append(os.Environ(), "GTK_OVERLAY_SCROLLING=0")
+	out, err := cmd.Output()
 	if err != nil {
 		// zenity exits 1 on Cancel; treat as cancel unless ctx expired.
 		if ctx.Err() != nil {

--- a/internal/netprompt/prompt.go
+++ b/internal/netprompt/prompt.go
@@ -135,15 +135,15 @@ func promptText(host string, port int, intent, cause, originLine string) string 
 	var b strings.Builder
 	fmt.Fprintf(&b, "The sandboxed process is trying to reach:\n\n    %s\n\n", target)
 	if originLine != "" {
-		fmt.Fprintf(&b, "Origin: %s\n", originLine)
+		fmt.Fprintf(&b, "%-13s %s\n", "Origin:", originLine)
 	}
 	if cause != "" {
-		fmt.Fprintf(&b, "Likely cause: %s\n", cause)
+		fmt.Fprintf(&b, "%-13s %s\n", "Likely cause:", cause)
 	}
 	if intent != "" {
-		fmt.Fprintf(&b, "Agent intent: %q", intent)
+		fmt.Fprintf(&b, "%-13s %q", "Agent intent:", intent)
 	} else {
-		b.WriteString("Agent intent: (not declared)")
+		fmt.Fprintf(&b, "%-13s (not declared)", "Agent intent:")
 	}
 	b.WriteString("\n\nHow should omac handle this destination?")
 	return b.String()
@@ -307,7 +307,7 @@ func (p *Prompter) Prompt(ctx context.Context, host string, port int) netproxy.P
 // resolveOrigin attributes the dial to a process for the "Origin" line. It runs
 // only here (the prompt path), never on the allow/deny hot path. Empty string
 // when there is no resolver, no ClientSource on ctx, or resolution fails —
-// which simply omits the line. The PID is the host PID (see origin.Origin).
+// which simply omits the line.
 func (p *Prompter) resolveOrigin(ctx context.Context) string {
 	if p.origin == nil {
 		return ""
@@ -320,7 +320,7 @@ func (p *Prompter) resolveOrigin(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
-	return fmt.Sprintf("%s (host pid %d)", o.Name, o.PID)
+	return o.Name
 }
 
 // --- macOS ---

--- a/internal/netprompt/prompt.go
+++ b/internal/netprompt/prompt.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt/hostmap"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netproxy"
 )
 
@@ -123,15 +124,25 @@ func RegisteredSuffixHint(host string) string {
 	return host
 }
 
-// promptText is the dialog body. intent is the agent-declared reason;
-// empty means "not declared".
-func promptText(host string, port int, intent string) string {
+// promptText is the dialog body. intent is the agent-declared reason (empty
+// means "not declared"); cause is the harness-attributed likely purpose of the
+// host (empty means unknown, line omitted). cause is labelled "Likely" because
+// it is inferred from the hostname alone — the proxy never sees the URL — and
+// may reflect background harness infrastructure rather than the agent.
+func promptText(host string, port int, intent, cause string) string {
 	target := fmt.Sprintf("%s:%d", host, port)
-	intentLine := "Agent intent: (not declared)"
-	if intent != "" {
-		intentLine = fmt.Sprintf("Agent intent: %q", intent)
+	var b strings.Builder
+	fmt.Fprintf(&b, "The sandboxed process is trying to reach:\n\n    %s\n\n", target)
+	if cause != "" {
+		fmt.Fprintf(&b, "Likely cause: %s\n", cause)
 	}
-	return fmt.Sprintf("The sandboxed process is trying to reach:\n\n    %s\n\n%s\n\nHow should omac handle this destination?", target, intentLine)
+	if intent != "" {
+		fmt.Fprintf(&b, "Agent intent: %q", intent)
+	} else {
+		b.WriteString("Agent intent: (not declared)")
+	}
+	b.WriteString("\n\nHow should omac handle this destination?")
+	return b.String()
 }
 
 // notificationText is the parallel OS notification body.
@@ -146,7 +157,7 @@ type dialogBackend interface {
 	// show blocks until the user chooses, the dialog is cancelled, or
 	// ctx is done (the implementation must kill the dialog process).
 	// Returns the chosen label ("" on cancel).
-	show(ctx context.Context, host string, port int, suffix, intent string) (string, error)
+	show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error)
 }
 
 // Prompter implements netproxy.Prompter with native dialogs.
@@ -157,6 +168,7 @@ type Prompter struct {
 	logf              func(format string, args ...any)
 	lookupIntent      func(host string) (string, bool)
 	recordExplainMore func(host string)
+	hostMap           *hostmap.Map // harness egress map; nil => no cause line
 }
 
 // isTruthyEnv reports whether an env var value means "on". Anything else
@@ -177,7 +189,9 @@ func isTruthyEnv(v string) bool {
 // when non-nil, is called with the host when the user picks "Explain more",
 // so the click is recorded where the agent's out-of-band GET lookup can
 // reach it (an HTTPS/CONNECT denial cannot carry the re-ask in-band).
-func NewPrompter(timeoutSecs int, logf func(string, ...any), lookupIntent func(host string) (string, bool), recordExplainMore func(host string)) (*Prompter, bool) {
+// hostMap, when non-nil, supplies the "likely cause" line for a host; nil (a
+// non-opencode harness, or a load failure) omits the line.
+func NewPrompter(timeoutSecs int, logf func(string, ...any), lookupIntent func(host string) (string, bool), recordExplainMore func(host string), hostMap *hostmap.Map) (*Prompter, bool) {
 	if logf == nil {
 		logf = func(string, ...any) {}
 	}
@@ -186,6 +200,7 @@ func NewPrompter(timeoutSecs int, logf func(string, ...any), lookupIntent func(h
 		logf:              logf,
 		lookupIntent:      lookupIntent,
 		recordExplainMore: recordExplainMore,
+		hostMap:           hostMap,
 	}
 	// Stub backend: activated by a truthy OMAC_PROMPT_STUB (1/true/yes/on).
 	// Reads per-host decisions from OMAC_PROMPT_DECISIONS (JSON file). Used
@@ -254,9 +269,13 @@ func (p *Prompter) Prompt(host string, port int) netproxy.PromptResult {
 		declared = "declared"
 	}
 	p.logf("omac sandbox: intent-signal: network prompt host=%s port=%d intent=%s", host, port, declared)
+	cause := ""
+	if e, ok := p.hostMap.Lookup(host); ok {
+		cause = e.Cause
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
 	defer cancel()
-	label, err := backend.show(ctx, host, port, suffix, intent)
+	label, err := backend.show(ctx, host, port, suffix, intent, cause)
 	if err != nil {
 		if ctx.Err() != nil {
 			p.logf("omac sandbox: network prompt for %s:%d timed out", host, port)
@@ -287,7 +306,7 @@ func (osascriptBackend) available() bool {
 	return err == nil
 }
 
-func (osascriptBackend) show(ctx context.Context, host string, port int, suffix, intent string) (string, error) {
+func (osascriptBackend) show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error) {
 	opts := optionLabels(suffix)
 	quoted := make([]string, len(opts))
 	for i, o := range opts {
@@ -296,7 +315,7 @@ func (osascriptBackend) show(ctx context.Context, host string, port int, suffix,
 	script := fmt.Sprintf(
 		`choose from list {%s} with title "omac: network access" with prompt %s default items {%s} OK button name "Select" cancel button name "Cancel"`,
 		strings.Join(quoted, ", "),
-		appleScriptString(promptText(host, port, intent)),
+		appleScriptString(promptText(host, port, intent, cause)),
 		appleScriptString("Deny once"),
 	)
 	out, err := exec.CommandContext(ctx, "osascript", "-e", script).Output()
@@ -338,12 +357,12 @@ func (zenityBackend) available() bool {
 // zenityArgs builds the full zenity radiolist argv, including the explicit
 // window size. Extracted so the sizing can be asserted without launching a
 // dialog.
-func zenityArgs(host string, port int, suffix, intent string) []string {
+func zenityArgs(host string, port int, suffix, intent, cause string) []string {
 	width, height := dialogDimensions()
 	args := []string{
 		"--list", "--radiolist",
 		"--title", "omac: network access",
-		"--text", promptText(host, port, intent),
+		"--text", promptText(host, port, intent, cause),
 		"--column", "", "--column", "Decision",
 		"--width", strconv.Itoa(width),
 		"--height", strconv.Itoa(height),
@@ -358,8 +377,8 @@ func zenityArgs(host string, port int, suffix, intent string) []string {
 	return args
 }
 
-func (zenityBackend) show(ctx context.Context, host string, port int, suffix, intent string) (string, error) {
-	out, err := exec.CommandContext(ctx, "zenity", zenityArgs(host, port, suffix, intent)...).Output()
+func (zenityBackend) show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error) {
+	out, err := exec.CommandContext(ctx, "zenity", zenityArgs(host, port, suffix, intent, cause)...).Output()
 	if err != nil {
 		// zenity exits 1 on Cancel; treat as cancel unless ctx expired.
 		if ctx.Err() != nil {
@@ -390,13 +409,13 @@ func (kdialogBackend) available() bool {
 // positional argument, before the option triples. Verified against
 // KDE/kdialog master; geometry is applied under X11/XWayland (on a pure
 // Wayland build kdialog accepts but may ignore it — never errors).
-func kdialogArgs(host string, port int, suffix, intent string) []string {
+func kdialogArgs(host string, port int, suffix, intent, cause string) []string {
 	opts := optionLabels(suffix)
 	width, height := dialogDimensions()
 	args := []string{
 		"--geometry", fmt.Sprintf("%dx%d", width, height),
 		"--title", "omac: network access",
-		"--radiolist", promptText(host, port, intent),
+		"--radiolist", promptText(host, port, intent, cause),
 	}
 	for i, o := range opts {
 		state := "off"
@@ -408,9 +427,9 @@ func kdialogArgs(host string, port int, suffix, intent string) []string {
 	return args
 }
 
-func (kdialogBackend) show(ctx context.Context, host string, port int, suffix, intent string) (string, error) {
+func (kdialogBackend) show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error) {
 	opts := optionLabels(suffix)
-	out, err := exec.CommandContext(ctx, "kdialog", kdialogArgs(host, port, suffix, intent)...).Output()
+	out, err := exec.CommandContext(ctx, "kdialog", kdialogArgs(host, port, suffix, intent, cause)...).Output()
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", ctx.Err()

--- a/internal/netprompt/prompt_size_test.go
+++ b/internal/netprompt/prompt_size_test.go
@@ -54,7 +54,7 @@ func TestDialogWidthFitsLongestLabel(t *testing.T) {
 // asserted to sit above the known-bad 320 so the regression cannot creep back.
 func TestDialogHeightFitsAllRowsAndPrompt(t *testing.T) {
 	opts := optionLabels("example.com")
-	lines := strings.Count(promptText("api.github.com", 443, ""), "\n") + 1
+	lines := strings.Count(promptText("api.github.com", 443, "", "", "", len(opts)), "\n") + 1
 	need := len(opts)*perRowPx + lines*perLinePx + heightChrome
 	if need <= knownBadHeight {
 		t.Fatalf("derived height floor %d <= known-bad %d; estimates too low to guard the regression",
@@ -67,7 +67,7 @@ func TestDialogHeightFitsAllRowsAndPrompt(t *testing.T) {
 }
 
 func TestZenityArgsCarrySize(t *testing.T) {
-	args := zenityArgs("api.github.com", 443, "github.com", "")
+	args := zenityArgs("api.github.com", 443, "github.com", "", "", "")
 	if got := flagValue(args, "--width"); got != strconv.Itoa(dialogWidth) {
 		t.Errorf("zenity --width = %q, want %d", got, dialogWidth)
 	}
@@ -84,7 +84,7 @@ func TestZenityArgsCarrySize(t *testing.T) {
 // prompt text as the immediate positional argument, ahead of the option
 // triples.
 func TestKdialogGeometryFormatAndOrdering(t *testing.T) {
-	args := kdialogArgs("api.github.com", 443, "github.com", "")
+	args := kdialogArgs("api.github.com", 443, "github.com", "", "", "")
 
 	geo := flagValue(args, "--geometry")
 	if !regexp.MustCompile(`^\d+x\d+$`).MatchString(geo) {
@@ -98,7 +98,7 @@ func TestKdialogGeometryFormatAndOrdering(t *testing.T) {
 	if gi < 0 || ri < 0 || gi > ri {
 		t.Fatalf("--geometry (idx %d) must appear before --radiolist (idx %d)", gi, ri)
 	}
-	if got := args[ri+1]; got != promptText("api.github.com", 443, "") {
+	if got := args[ri+1]; got != promptText("api.github.com", 443, "", "", "", len(optionLabels("github.com"))) {
 		t.Errorf("arg after --radiolist = %q, want the prompt text", got)
 	}
 }
@@ -111,10 +111,10 @@ func TestDialogDimensionsEnvOverride(t *testing.T) {
 	if w != 800 || h != 900 {
 		t.Fatalf("dialogDimensions() = %dx%d, want 800x900", w, h)
 	}
-	if got := flagValue(zenityArgs("h", 1, "s", ""), "--width"); got != "800" {
+	if got := flagValue(zenityArgs("h", 1, "s", "", "", ""), "--width"); got != "800" {
 		t.Errorf("zenity --width = %q, want 800", got)
 	}
-	if got := flagValue(kdialogArgs("h", 1, "s", ""), "--geometry"); got != "800x900" {
+	if got := flagValue(kdialogArgs("h", 1, "s", "", "", ""), "--geometry"); got != "800x900" {
 		t.Errorf("kdialog --geometry = %q, want 800x900", got)
 	}
 }

--- a/internal/netprompt/prompt_test.go
+++ b/internal/netprompt/prompt_test.go
@@ -17,7 +17,7 @@ type signalBackend struct{ label string }
 
 func (signalBackend) name() string    { return "signal-test" }
 func (signalBackend) available() bool { return true }
-func (b signalBackend) show(ctx context.Context, host string, port int, suffix, intent string) (string, error) {
+func (b signalBackend) show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error) {
 	return b.label, nil
 }
 
@@ -190,7 +190,7 @@ func TestOptionLabelsExactAndDefault(t *testing.T) {
 }
 
 func TestPromptTextParity(t *testing.T) {
-	got := promptText("api.example.com", 443, "")
+	got := promptText("api.example.com", 443, "", "")
 	want := "The sandboxed process is trying to reach:\n\n    api.example.com:443\n\nAgent intent: (not declared)\n\nHow should omac handle this destination?"
 	if got != want {
 		t.Errorf("promptText (no intent) = %q", got)
@@ -198,7 +198,7 @@ func TestPromptTextParity(t *testing.T) {
 }
 
 func TestPromptTextWithIntent(t *testing.T) {
-	got := promptText("api.example.com", 443, "fetch release notes")
+	got := promptText("api.example.com", 443, "fetch release notes", "")
 	want := "The sandboxed process is trying to reach:\n\n    api.example.com:443\n\nAgent intent: \"fetch release notes\"\n\nHow should omac handle this destination?"
 	if got != want {
 		t.Errorf("promptText (with intent) = %q", got)
@@ -206,12 +206,32 @@ func TestPromptTextWithIntent(t *testing.T) {
 }
 
 func TestPromptTextIntentOnly(t *testing.T) {
-	got := promptText("api.example.com", 443, "verify the version")
+	got := promptText("api.example.com", 443, "verify the version", "")
 	if !strings.Contains(got, "api.example.com:443") {
 		t.Errorf("missing host:port: %q", got)
 	}
 	if !strings.Contains(got, `"verify the version"`) {
 		t.Errorf("missing intent: %q", got)
+	}
+}
+
+func TestPromptTextWithCause(t *testing.T) {
+	got := promptText("raw.githubusercontent.com", 443, "", "syntax-highlighting grammar")
+	if !strings.Contains(got, "Likely cause: syntax-highlighting grammar\n") {
+		t.Errorf("missing cause line: %q", got)
+	}
+	if !strings.Contains(got, "Agent intent: (not declared)") {
+		t.Errorf("cause must not replace intent line: %q", got)
+	}
+	// Cause precedes intent.
+	if strings.Index(got, "Likely cause") > strings.Index(got, "Agent intent") {
+		t.Errorf("cause should precede intent: %q", got)
+	}
+}
+
+func TestPromptTextCauseOmittedWhenEmpty(t *testing.T) {
+	if strings.Contains(promptText("api.example.com", 443, "", ""), "Likely cause") {
+		t.Error("empty cause must omit the line")
 	}
 }
 

--- a/internal/netprompt/prompt_test.go
+++ b/internal/netprompt/prompt_test.go
@@ -17,7 +17,7 @@ type signalBackend struct{ label string }
 
 func (signalBackend) name() string    { return "signal-test" }
 func (signalBackend) available() bool { return true }
-func (b signalBackend) show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error) {
+func (b signalBackend) show(ctx context.Context, host string, port int, suffix, intent, cause, originLine string) (string, error) {
 	return b.label, nil
 }
 
@@ -44,7 +44,7 @@ func TestPromptEmitsIntentSignal(t *testing.T) {
 				backends:     []dialogBackend{signalBackend{label: "Allow once"}},
 				lookupIntent: c.lookup,
 			}
-			p.Prompt("api.example.com", 443)
+			p.Prompt(context.Background(), "api.example.com", 443)
 			var signals []string
 			for _, l := range logs {
 				if strings.Contains(l, "intent-signal:") {
@@ -88,7 +88,7 @@ func TestPromptRecordsExplainMore(t *testing.T) {
 					recorded = true
 				},
 			}
-			res := p.Prompt("api.example.com", 443)
+			res := p.Prompt(context.Background(), "api.example.com", 443)
 			if res.NeedsIntent != c.wantIntent {
 				t.Errorf("NeedsIntent = %v; want %v", res.NeedsIntent, c.wantIntent)
 			}
@@ -190,7 +190,7 @@ func TestOptionLabelsExactAndDefault(t *testing.T) {
 }
 
 func TestPromptTextParity(t *testing.T) {
-	got := promptText("api.example.com", 443, "", "")
+	got := promptText("api.example.com", 443, "", "", "")
 	want := "The sandboxed process is trying to reach:\n\n    api.example.com:443\n\nAgent intent: (not declared)\n\nHow should omac handle this destination?"
 	if got != want {
 		t.Errorf("promptText (no intent) = %q", got)
@@ -198,7 +198,7 @@ func TestPromptTextParity(t *testing.T) {
 }
 
 func TestPromptTextWithIntent(t *testing.T) {
-	got := promptText("api.example.com", 443, "fetch release notes", "")
+	got := promptText("api.example.com", 443, "fetch release notes", "", "")
 	want := "The sandboxed process is trying to reach:\n\n    api.example.com:443\n\nAgent intent: \"fetch release notes\"\n\nHow should omac handle this destination?"
 	if got != want {
 		t.Errorf("promptText (with intent) = %q", got)
@@ -206,7 +206,7 @@ func TestPromptTextWithIntent(t *testing.T) {
 }
 
 func TestPromptTextIntentOnly(t *testing.T) {
-	got := promptText("api.example.com", 443, "verify the version", "")
+	got := promptText("api.example.com", 443, "verify the version", "", "")
 	if !strings.Contains(got, "api.example.com:443") {
 		t.Errorf("missing host:port: %q", got)
 	}
@@ -216,7 +216,7 @@ func TestPromptTextIntentOnly(t *testing.T) {
 }
 
 func TestPromptTextWithCause(t *testing.T) {
-	got := promptText("raw.githubusercontent.com", 443, "", "syntax-highlighting grammar")
+	got := promptText("raw.githubusercontent.com", 443, "", "syntax-highlighting grammar", "")
 	if !strings.Contains(got, "Likely cause: syntax-highlighting grammar\n") {
 		t.Errorf("missing cause line: %q", got)
 	}
@@ -230,7 +230,7 @@ func TestPromptTextWithCause(t *testing.T) {
 }
 
 func TestPromptTextCauseOmittedWhenEmpty(t *testing.T) {
-	if strings.Contains(promptText("api.example.com", 443, "", ""), "Likely cause") {
+	if strings.Contains(promptText("api.example.com", 443, "", "", ""), "Likely cause") {
 		t.Error("empty cause must omit the line")
 	}
 }

--- a/internal/netprompt/prompt_test.go
+++ b/internal/netprompt/prompt_test.go
@@ -190,23 +190,23 @@ func TestOptionLabelsExactAndDefault(t *testing.T) {
 }
 
 func TestPromptTextParity(t *testing.T) {
-	got := promptText("api.example.com", 443, "", "", "")
-	want := "The sandboxed process is trying to reach:\n\n    api.example.com:443\n\nAgent intent: (not declared)\n\nHow should omac handle this destination?"
+	got := promptText("api.example.com", 443, "", "", "", 7)
+	want := "The sandboxed process is trying to reach:\n\n    api.example.com:443\n\nAgent intent: (not declared)\n\nHow should omac handle this destination? (7 options)"
 	if got != want {
 		t.Errorf("promptText (no intent) = %q", got)
 	}
 }
 
 func TestPromptTextWithIntent(t *testing.T) {
-	got := promptText("api.example.com", 443, "fetch release notes", "", "")
-	want := "The sandboxed process is trying to reach:\n\n    api.example.com:443\n\nAgent intent: \"fetch release notes\"\n\nHow should omac handle this destination?"
+	got := promptText("api.example.com", 443, "fetch release notes", "", "", 7)
+	want := "The sandboxed process is trying to reach:\n\n    api.example.com:443\n\nAgent intent: \"fetch release notes\"\n\nHow should omac handle this destination? (7 options)"
 	if got != want {
 		t.Errorf("promptText (with intent) = %q", got)
 	}
 }
 
 func TestPromptTextIntentOnly(t *testing.T) {
-	got := promptText("api.example.com", 443, "verify the version", "", "")
+	got := promptText("api.example.com", 443, "verify the version", "", "", 7)
 	if !strings.Contains(got, "api.example.com:443") {
 		t.Errorf("missing host:port: %q", got)
 	}
@@ -216,7 +216,7 @@ func TestPromptTextIntentOnly(t *testing.T) {
 }
 
 func TestPromptTextWithCause(t *testing.T) {
-	got := promptText("raw.githubusercontent.com", 443, "", "syntax-highlighting grammar", "")
+	got := promptText("raw.githubusercontent.com", 443, "", "syntax-highlighting grammar", "", 7)
 	if !strings.Contains(got, "Likely cause: syntax-highlighting grammar\n") {
 		t.Errorf("missing cause line: %q", got)
 	}
@@ -230,7 +230,7 @@ func TestPromptTextWithCause(t *testing.T) {
 }
 
 func TestPromptTextCauseOmittedWhenEmpty(t *testing.T) {
-	if strings.Contains(promptText("api.example.com", 443, "", "", ""), "Likely cause") {
+	if strings.Contains(promptText("api.example.com", 443, "", "", "", 7), "Likely cause") {
 		t.Error("empty cause must omit the line")
 	}
 }

--- a/internal/netprompt/stub.go
+++ b/internal/netprompt/stub.go
@@ -113,7 +113,7 @@ func (stubBackend) name() string { return "stub" }
 
 func (s stubBackend) available() bool { return s.source != nil }
 
-func (s stubBackend) show(ctx context.Context, host string, port int, suffix, intent string) (string, error) {
+func (s stubBackend) show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error) {
 	d, ok := s.source.lookup(host)
 	if !ok {
 		s.logf("omac sandbox: stub prompt: no decision for %s; denying", host)

--- a/internal/netprompt/stub.go
+++ b/internal/netprompt/stub.go
@@ -113,7 +113,7 @@ func (stubBackend) name() string { return "stub" }
 
 func (s stubBackend) available() bool { return s.source != nil }
 
-func (s stubBackend) show(ctx context.Context, host string, port int, suffix, intent, cause string) (string, error) {
+func (s stubBackend) show(ctx context.Context, host string, port int, suffix, intent, cause, originLine string) (string, error) {
 	d, ok := s.source.lookup(host)
 	if !ok {
 		s.logf("omac sandbox: stub prompt: no decision for %s; denying", host)

--- a/internal/netprompt/stub_test.go
+++ b/internal/netprompt/stub_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestStubActivatedOnlyByTruthyEnv(t *testing.T) {
 	isStub := func() bool {
-		p, _ := NewPrompter(1, nil, nil, nil)
+		p, _ := NewPrompter(1, nil, nil, nil, nil)
 		_, ok := p.backends[0].(stubBackend)
 		return len(p.backends) == 1 && ok
 	}
@@ -68,7 +68,7 @@ func TestStubBackendShow(t *testing.T) {
 	ctx := context.Background()
 
 	// Allow
-	label, err := b.show(ctx, "allow.example", 443, "example.com", "")
+	label, err := b.show(ctx, "allow.example", 443, "example.com", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,13 +77,13 @@ func TestStubBackendShow(t *testing.T) {
 	}
 
 	// Deny
-	label, _ = b.show(ctx, "deny.example", 443, "example.com", "")
+	label, _ = b.show(ctx, "deny.example", 443, "example.com", "", "")
 	if label != "Deny once" {
 		t.Errorf("deny label = %q; want 'Deny once'", label)
 	}
 
 	// Explain more
-	label, _ = b.show(ctx, "explain.example", 443, "example.com", "fetch data")
+	label, _ = b.show(ctx, "explain.example", 443, "example.com", "fetch data", "")
 	if label != "Explain more" {
 		t.Errorf("explain label = %q; want 'Explain more'", label)
 	}
@@ -92,7 +92,7 @@ func TestStubBackendShow(t *testing.T) {
 func TestStubBackendNoDecisionDenies(t *testing.T) {
 	src := &fileDecisionSource{loaded: true, decisions: map[string]stubDecision{}}
 	b := stubBackend{source: src, logf: func(string, ...any) {}}
-	label, _ := b.show(context.Background(), "unknown.example", 443, "example.com", "")
+	label, _ := b.show(context.Background(), "unknown.example", 443, "example.com", "", "")
 	if label != "Deny once" {
 		t.Errorf("unknown host label = %q; want 'Deny once'", label)
 	}
@@ -103,7 +103,7 @@ func TestStubBackendWildcard(t *testing.T) {
 		"*": {Allow: true, Persist: true, Scope: "host"},
 	}}
 	b := stubBackend{source: src, logf: func(string, ...any) {}}
-	label, _ := b.show(context.Background(), "anything.example", 443, "example.com", "")
+	label, _ := b.show(context.Background(), "anything.example", 443, "example.com", "", "")
 	if label != "Allow permanently (this host)" {
 		t.Errorf("wildcard label = %q; want 'Allow permanently (this host)'", label)
 	}
@@ -204,7 +204,7 @@ func TestStubBackendIntentLogged(t *testing.T) {
 	b := stubBackend{source: src, logf: func(format string, args ...any) {
 		logged = append(logged, format)
 	}}
-	b.show(context.Background(), "test.example", 443, "example.com", "fetch data")
+	b.show(context.Background(), "test.example", 443, "example.com", "fetch data", "")
 	if len(logged) != 1 {
 		t.Fatalf("expected 1 log line, got %d", len(logged))
 	}

--- a/internal/netprompt/stub_test.go
+++ b/internal/netprompt/stub_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestStubActivatedOnlyByTruthyEnv(t *testing.T) {
 	isStub := func() bool {
-		p, _ := NewPrompter(1, nil, nil, nil, nil)
+		p, _ := NewPrompter(1, nil, nil, nil, nil, nil)
 		_, ok := p.backends[0].(stubBackend)
 		return len(p.backends) == 1 && ok
 	}
@@ -68,7 +68,7 @@ func TestStubBackendShow(t *testing.T) {
 	ctx := context.Background()
 
 	// Allow
-	label, err := b.show(ctx, "allow.example", 443, "example.com", "", "")
+	label, err := b.show(ctx, "allow.example", 443, "example.com", "", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,13 +77,13 @@ func TestStubBackendShow(t *testing.T) {
 	}
 
 	// Deny
-	label, _ = b.show(ctx, "deny.example", 443, "example.com", "", "")
+	label, _ = b.show(ctx, "deny.example", 443, "example.com", "", "", "")
 	if label != "Deny once" {
 		t.Errorf("deny label = %q; want 'Deny once'", label)
 	}
 
 	// Explain more
-	label, _ = b.show(ctx, "explain.example", 443, "example.com", "fetch data", "")
+	label, _ = b.show(ctx, "explain.example", 443, "example.com", "fetch data", "", "")
 	if label != "Explain more" {
 		t.Errorf("explain label = %q; want 'Explain more'", label)
 	}
@@ -92,7 +92,7 @@ func TestStubBackendShow(t *testing.T) {
 func TestStubBackendNoDecisionDenies(t *testing.T) {
 	src := &fileDecisionSource{loaded: true, decisions: map[string]stubDecision{}}
 	b := stubBackend{source: src, logf: func(string, ...any) {}}
-	label, _ := b.show(context.Background(), "unknown.example", 443, "example.com", "", "")
+	label, _ := b.show(context.Background(), "unknown.example", 443, "example.com", "", "", "")
 	if label != "Deny once" {
 		t.Errorf("unknown host label = %q; want 'Deny once'", label)
 	}
@@ -103,7 +103,7 @@ func TestStubBackendWildcard(t *testing.T) {
 		"*": {Allow: true, Persist: true, Scope: "host"},
 	}}
 	b := stubBackend{source: src, logf: func(string, ...any) {}}
-	label, _ := b.show(context.Background(), "anything.example", 443, "example.com", "", "")
+	label, _ := b.show(context.Background(), "anything.example", 443, "example.com", "", "", "")
 	if label != "Allow permanently (this host)" {
 		t.Errorf("wildcard label = %q; want 'Allow permanently (this host)'", label)
 	}
@@ -204,7 +204,7 @@ func TestStubBackendIntentLogged(t *testing.T) {
 	b := stubBackend{source: src, logf: func(format string, args ...any) {
 		logged = append(logged, format)
 	}}
-	b.show(context.Background(), "test.example", 443, "example.com", "fetch data", "")
+	b.show(context.Background(), "test.example", 443, "example.com", "fetch data", "", "")
 	if len(logged) != 1 {
 		t.Fatalf("expected 1 log line, got %d", len(logged))
 	}

--- a/internal/netproxy/clientsource.go
+++ b/internal/netproxy/clientsource.go
@@ -1,0 +1,45 @@
+package netproxy
+
+import (
+	"context"
+	"net"
+	"net/netip"
+)
+
+// ClientSource identifies the sandboxed connection the proxy is handling: the
+// child's socket endpoint (Src) and the proxy's own endpoint (Proxy). It is
+// carried on the request context purely so the prompt can attribute the dial
+// to a process — the filter's admission logic never reads it.
+type ClientSource struct {
+	Src   netip.AddrPort
+	Proxy netip.AddrPort
+}
+
+type clientSourceKey struct{}
+
+// WithClientSource returns ctx annotated with the connection's endpoints.
+func WithClientSource(ctx context.Context, src, proxy netip.AddrPort) context.Context {
+	return context.WithValue(ctx, clientSourceKey{}, ClientSource{Src: src, Proxy: proxy})
+}
+
+// ClientSourceFromContext recovers endpoints stored by WithClientSource.
+func ClientSourceFromContext(ctx context.Context) (ClientSource, bool) {
+	cs, ok := ctx.Value(clientSourceKey{}).(ClientSource)
+	return cs, ok
+}
+
+// addrPort converts a net.Addr (as returned by conn.RemoteAddr/LocalAddr) to a
+// netip.AddrPort, returning the zero value when it is not a TCP address.
+func addrPort(a net.Addr) netip.AddrPort {
+	if ta, ok := a.(*net.TCPAddr); ok {
+		return ta.AddrPort()
+	}
+	ap, _ := netip.ParseAddrPort(a.String())
+	return ap
+}
+
+// clientSourceCtx returns a background context annotated with conn's endpoints,
+// so the prompt (reached deep inside the filter) can attribute the dial.
+func clientSourceCtx(conn net.Conn) context.Context {
+	return WithClientSource(context.Background(), addrPort(conn.RemoteAddr()), addrPort(conn.LocalAddr()))
+}

--- a/internal/netproxy/direct_path_single_check_test.go
+++ b/internal/netproxy/direct_path_single_check_test.go
@@ -15,7 +15,7 @@ import (
 // "allow once" (Persist:false, so it is never cached as a learned rule).
 type countingPrompter struct{ n atomic.Int32 }
 
-func (p *countingPrompter) Prompt(host string, port int) PromptResult {
+func (p *countingPrompter) Prompt(ctx context.Context, host string, port int) PromptResult {
 	p.n.Add(1)
 	return PromptResult{Allow: true, Persist: false}
 }

--- a/internal/netproxy/filter.go
+++ b/internal/netproxy/filter.go
@@ -53,8 +53,10 @@ var hardDenyHosts = map[string]bool{
 type Prompter interface {
 	// Prompt blocks until a decision is made (or times out). scopeHost
 	// and scopeSuffix report what was decided for persistence handling;
-	// persist=true means the decision was "permanently".
-	Prompt(host string, port int) PromptResult
+	// persist=true means the decision was "permanently". ctx carries the
+	// per-connection ClientSource (when set) so the prompt can attribute the
+	// dial to a process; it does not gate the decision.
+	Prompt(ctx context.Context, host string, port int) PromptResult
 }
 
 // PromptResult is the parsed outcome of an interactive prompt.
@@ -162,7 +164,7 @@ func (f *Filter) Check(ctx context.Context, host string, port int) (Verdict, []n
 		if v := f.checkRules(h); v != nil {
 			return f.log(h, port, *v), []netip.Addr{ip}
 		}
-		if v, ok := f.defaultDecision(h, port); ok {
+		if v, ok := f.defaultDecision(ctx, h, port); ok {
 			return f.log(h, port, v), []netip.Addr{ip}
 		}
 		return f.log(h, port, Verdict{Decision: Deny, Reason: "default deny"}), nil
@@ -190,7 +192,7 @@ func (f *Filter) Check(ctx context.Context, host string, port int) (Verdict, []n
 	}
 
 	// 5. Default.
-	if v, ok := f.defaultDecision(h, port); ok {
+	if v, ok := f.defaultDecision(ctx, h, port); ok {
 		if v.Decision == Deny {
 			return f.log(h, port, v), nil
 		}
@@ -206,7 +208,7 @@ func (f *Filter) Check(ctx context.Context, host string, port int) (Verdict, []n
 // rebinding IP pinning does not: on the chained path omac never dials the
 // pinned IPs, so the hostname the child requested is the admission
 // boundary (the upstream proxy resolves it).
-func (f *Filter) CheckHost(host string, port int) Verdict {
+func (f *Filter) CheckHost(ctx context.Context, host string, port int) Verdict {
 	h := strings.ToLower(strings.TrimSuffix(host, "."))
 	if hardDenyHosts[h] {
 		return f.log(h, port, Verdict{Decision: Deny, Reason: "hard-deny metadata host"})
@@ -217,7 +219,7 @@ func (f *Filter) CheckHost(host string, port int) Verdict {
 	if v := f.checkRules(h); v != nil {
 		return f.log(h, port, *v)
 	}
-	if v, ok := f.defaultDecision(h, port); ok {
+	if v, ok := f.defaultDecision(ctx, h, port); ok {
 		return f.log(h, port, v)
 	}
 	return f.log(h, port, Verdict{Decision: Deny, Reason: "default deny"})
@@ -247,9 +249,9 @@ func (f *Filter) checkRules(host string) *Verdict {
 
 // defaultDecision handles step 5. ok=false means "no decision" (treat
 // as deny).
-func (f *Filter) defaultDecision(host string, port int) (Verdict, bool) {
+func (f *Filter) defaultDecision(ctx context.Context, host string, port int) (Verdict, bool) {
 	if f.cfg.PromptEnabled {
-		res, prompted := f.promptCoalesced(host, port)
+		res, prompted := f.promptCoalesced(ctx, host, port)
 		if !prompted {
 			if f.cfg.OnUnavailableAllow {
 				return Verdict{Decision: Allow, Reason: "prompt unavailable: on_unavailable=allow"}, true
@@ -286,7 +288,7 @@ func (f *Filter) defaultDecision(host string, port int) (Verdict, bool) {
 
 // promptCoalesced ensures concurrent requests for the same host share
 // one dialog. prompted=false means no prompter is available.
-func (f *Filter) promptCoalesced(host string, port int) (PromptResult, bool) {
+func (f *Filter) promptCoalesced(ctx context.Context, host string, port int) (PromptResult, bool) {
 	if f.cfg.Prompter == nil {
 		return PromptResult{}, false
 	}
@@ -303,7 +305,7 @@ func (f *Filter) promptCoalesced(host string, port int) (PromptResult, bool) {
 	f.inflight[host] = w
 	f.promptMu.Unlock()
 
-	w.res = f.cfg.Prompter.Prompt(host, port)
+	w.res = f.cfg.Prompter.Prompt(ctx, host, port)
 
 	f.promptMu.Lock()
 	delete(f.inflight, host)

--- a/internal/netproxy/filter_test.go
+++ b/internal/netproxy/filter_test.go
@@ -65,7 +65,7 @@ type fakePrompter struct {
 	res   PromptResult
 }
 
-func (p *fakePrompter) Prompt(host string, port int) PromptResult {
+func (p *fakePrompter) Prompt(ctx context.Context, host string, port int) PromptResult {
 	p.mu.Lock()
 	p.calls++
 	p.mu.Unlock()

--- a/internal/netproxy/server.go
+++ b/internal/netproxy/server.go
@@ -258,7 +258,7 @@ func (s *Server) authorized(req *http.Request) bool {
 // chained path, where the dialer ignores them).
 func (s *Server) admit(ctx context.Context, host string, port int) (Verdict, []netip.Addr) {
 	if planner, ok := s.dialer.(TunnelPlanner); ok && planner.ChainsHost(host) {
-		return s.filter.CheckHost(host, port), nil
+		return s.filter.CheckHost(ctx, host, port), nil
 	}
 	return s.filter.Check(ctx, host, port)
 }
@@ -278,7 +278,7 @@ func (s *Server) handleConnect(conn net.Conn, req *http.Request) {
 			fmt.Sprintf("omac sandbox: CONNECT to loopback %q refused by the sandbox (loopback traffic must use a granted open_port, not the proxy)\n", host))
 		return
 	}
-	upstream, verdict, err := s.checkAndDial(host, port)
+	upstream, verdict, err := s.checkAndDial(clientSourceCtx(conn), host, port)
 	if verdict.Decision != Allow {
 		writeRawResponse(conn, http.StatusForbidden, sandboxDenyHeader, denyBody(host, verdict.Reason))
 		return
@@ -308,12 +308,13 @@ func (s *Server) handleConnect(conn net.Conn, req *http.Request) {
 // spend the dial budget, or a granted host would fail on an
 // already-expired context. verdict is always meaningful; upstream/err
 // are only set when the verdict is Allow.
-func (s *Server) checkAndDial(host string, port int) (net.Conn, Verdict, error) {
+func (s *Server) checkAndDial(base context.Context, host string, port int) (net.Conn, Verdict, error) {
 	// The check phase runs in its own scope so checkCancel is deferred
 	// (fires even if the filter panics) yet still releases the check
-	// context before the dial phase begins.
+	// context before the dial phase begins. It derives from base so the
+	// per-connection ClientSource reaches the prompt.
 	verdict, addrs := func() (Verdict, []netip.Addr) {
-		checkCtx, checkCancel := context.WithTimeout(context.Background(), connectTimeout)
+		checkCtx, checkCancel := context.WithTimeout(base, connectTimeout)
 		defer checkCancel()
 		return s.admit(checkCtx, host, port)
 	}()
@@ -349,7 +350,7 @@ func (s *Server) handleForward(conn net.Conn, br *bufio.Reader, req *http.Reques
 			fmt.Sprintf("omac sandbox: forward to loopback %q refused by the sandbox (loopback traffic must use a granted open_port, not the proxy)\n", host))
 		return
 	}
-	upstream, verdict, err := s.checkAndDial(host, port)
+	upstream, verdict, err := s.checkAndDial(clientSourceCtx(conn), host, port)
 	if verdict.Decision != Allow {
 		writeRawResponse(conn, http.StatusForbidden, sandboxDenyHeader, denyBody(host, verdict.Reason))
 		return

--- a/internal/netproxy/server_test.go
+++ b/internal/netproxy/server_test.go
@@ -27,7 +27,7 @@ type blockingPrompter struct {
 	started atomic.Int32
 }
 
-func (p *blockingPrompter) Prompt(host string, port int) PromptResult {
+func (p *blockingPrompter) Prompt(ctx context.Context, host string, port int) PromptResult {
 	p.started.Add(1)
 	<-p.block
 	return p.res
@@ -681,7 +681,7 @@ func TestServerForwardThroughUpstreamWithAuth(t *testing.T) {
 // delayedAllowPrompter sleeps (simulating a slow human) then allows.
 type delayedAllowPrompter struct{ delay time.Duration }
 
-func (p delayedAllowPrompter) Prompt(host string, port int) PromptResult {
+func (p delayedAllowPrompter) Prompt(ctx context.Context, host string, port int) PromptResult {
 	time.Sleep(p.delay)
 	return PromptResult{Allow: true}
 }

--- a/internal/sandboxrun/harness_test.go
+++ b/internal/sandboxrun/harness_test.go
@@ -11,7 +11,11 @@ func TestHarnessName(t *testing.T) {
 		{[]string{"/usr/bin/opencode.exe", "serve"}, "opencode"},
 		{[]string{"OpenCode"}, "opencode"},
 		{[]string{"codex"}, "codex"},
-		{[]string{"~/.bun/bin/claude"}, "claude"},
+		// Binary "claude" resolves to the canonical harness name "claude-code"
+		// (alias -> canonical), the single source of truth the host map keys on.
+		{[]string{"~/.bun/bin/claude"}, "claude-code"},
+		{[]string{"cc"}, "claude-code"}, // alias
+		{[]string{"node"}, ""},          // not a known harness
 		{nil, ""},
 		{[]string{}, ""},
 	}

--- a/internal/sandboxrun/harness_test.go
+++ b/internal/sandboxrun/harness_test.go
@@ -1,0 +1,23 @@
+package sandboxrun
+
+import "testing"
+
+func TestHarnessName(t *testing.T) {
+	cases := []struct {
+		argv []string
+		want string
+	}{
+		{[]string{"opencode", "serve"}, "opencode"},
+		{[]string{"/usr/bin/opencode.exe", "serve"}, "opencode"},
+		{[]string{"OpenCode"}, "opencode"},
+		{[]string{"codex"}, "codex"},
+		{[]string{"~/.bun/bin/claude"}, "claude"},
+		{nil, ""},
+		{[]string{}, ""},
+	}
+	for _, c := range cases {
+		if got := harnessName(c.argv); got != c.want {
+			t.Errorf("harnessName(%v) = %q, want %q", c.argv, got, c.want)
+		}
+	}
+}

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/intent"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt/hostmap"
+	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt/origin"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netproxy"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandbox"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxdeny"
@@ -270,7 +271,7 @@ func buildProxy(p *sandboxprofile.Profile, profilePath string, stderr io.Writer,
 			return intent.LookupOverHTTP(intentBase, host)
 		}, func(host string) {
 			intent.MarkExplainMoreOverHTTP(intentBase, host)
-		}, hostmap.For(harness))
+		}, hostmap.For(harness), origin.NewResolver())
 		if available {
 			prompter = np
 		} else {

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/intent"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt/hostmap"
@@ -238,17 +239,22 @@ func canonicalCachePath(path string) (string, error) {
 	return abs, nil
 }
 
-// harnessName derives the harness identity from the sandboxed command's
-// binary (e.g. ["opencode","serve"] -> "opencode"), lowercased and stripped of
-// any directory and ".exe" suffix. It gates harness-specific behaviour such as
-// the egress host map; an unknown or empty command yields "".
+// harnessName resolves the canonical harness identity from the sandboxed
+// command's binary (e.g. ["claude"] -> "claude-code"), so harness-specific
+// behaviour such as the egress host map keys on one source of truth — the
+// config registry — rather than the raw binary basename (which diverges from
+// the canonical name, e.g. "claude" vs "claude-code"). Returns "" when the
+// command is empty or names no known harness.
 func harnessName(innerArgv []string) string {
 	if len(innerArgv) == 0 {
 		return ""
 	}
 	base := filepath.Base(innerArgv[0])
-	base = strings.TrimSuffix(base, filepath.Ext(base))
-	return strings.ToLower(base)
+	base = strings.ToLower(strings.TrimSuffix(base, filepath.Ext(base)))
+	if h, ok := config.LookupHarness(base); ok {
+		return h.Name
+	}
+	return ""
 }
 
 // buildProxy assembles page policy, prompter, filter and server. The

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
 	"github.com/tngtech/oh-my-agentic-coder/internal/intent"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt"
+	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt/hostmap"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netproxy"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandbox"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxdeny"
@@ -130,7 +131,7 @@ func Run(opts Options) int {
 				"filtering relies on HTTP(S)_PROXY env vars only and is trivially bypassable. "+
 				"No kernel network guarantee is in effect.")
 		}
-		proxy, err = buildProxy(merged, profilePath, diag.Writer(), logf, netAuditor, intentBase)
+		proxy, err = buildProxy(merged, profilePath, diag.Writer(), logf, netAuditor, intentBase, harnessName(opts.Flags.InnerArgv))
 		if err != nil {
 			return fail("%v", err)
 		}
@@ -236,10 +237,23 @@ func canonicalCachePath(path string) (string, error) {
 	return abs, nil
 }
 
+// harnessName derives the harness identity from the sandboxed command's
+// binary (e.g. ["opencode","serve"] -> "opencode"), lowercased and stripped of
+// any directory and ".exe" suffix. It gates harness-specific behaviour such as
+// the egress host map; an unknown or empty command yields "".
+func harnessName(innerArgv []string) string {
+	if len(innerArgv) == 0 {
+		return ""
+	}
+	base := filepath.Base(innerArgv[0])
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	return strings.ToLower(base)
+}
+
 // buildProxy assembles page policy, prompter, filter and server. The
 // page policy (learned website decisions) lives next to the profile:
 // <profile>.pages.json (e.g. default.pages.json).
-func buildProxy(p *sandboxprofile.Profile, profilePath string, stderr io.Writer, logf func(string, ...any), auditor audit.Auditor, intentBase string) (*netproxy.Server, error) {
+func buildProxy(p *sandboxprofile.Profile, profilePath string, stderr io.Writer, logf func(string, ...any), auditor audit.Auditor, intentBase, harness string) (*netproxy.Server, error) {
 	var learned netproxy.LearnedStore
 	pagesPath := sandboxprofile.PagesPath(profilePath)
 	lp, lerr := netprompt.LoadLearnedPolicy(pagesPath)
@@ -256,7 +270,7 @@ func buildProxy(p *sandboxprofile.Profile, profilePath string, stderr io.Writer,
 			return intent.LookupOverHTTP(intentBase, host)
 		}, func(host string) {
 			intent.MarkExplainMoreOverHTTP(intentBase, host)
-		})
+		}, hostmap.For(harness))
 		if available {
 			prompter = np
 		} else {

--- a/scripts/popup-shot.sh
+++ b/scripts/popup-shot.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Render the real network-approval dialog headless and save a PNG, the same way
+# the popup-visual CI job does. Linux only; needs xvfb, imagemagick, xdotool and
+# the chosen dialog tool (zenity or kdialog).
+#
+# Usage: scripts/popup-shot.sh [zenity|kdialog]
+set -euo pipefail
+
+backend="${1:-zenity}"
+outdir="${OMAC_POPUP_SHOT_DIR:-$(pwd)/popup-shots}"
+mkdir -p "$outdir"
+
+OMAC_POPUP_SHOT=1 \
+OMAC_POPUP_SHOT_BACKEND="$backend" \
+OMAC_POPUP_SHOT_DIR="$outdir" \
+  xvfb-run -a --server-args="-screen 0 1280x1024x24" \
+  go test ./internal/netprompt/ -run TestRenderPopupScreenshot -count=1 -v
+
+echo "screenshot(s) written to $outdir"


### PR DESCRIPTION
## What

Makes the sandbox network-approval popup **legible**: it now names *what* a host is for and *who* is dialing it, instead of showing a bare `host:port` with an empty "Agent intent" line.

```
    raw.githubusercontent.com:443

Origin: opencode
Likely cause: syntax-highlighting grammar / query (tree-sitter)
Agent intent: (not declared)

How should omac handle this destination? (7 options)
```

Delivered in two phases plus the data + design artifacts:

- **Host map** (`internal/netprompt/hostmap/opencode-egress.json` + loader) — a source-audited map from each opencode egress host to its subsystem and a human cause. Harness-keyed via `hostmap.For(harness)`.
- **Phase 1 — cause line**: renders "Likely cause" from the map. No interface changes.
- **Phase 2 — origin line**: names the dialing process via a Linux `/proc` resolver.
- **Design note**: `docs/superpowers/specs/2026-07-20-network-prompt-origin-attribution-design.md` (companion to the intent-declarations spec).

## Why

opencode makes background, non-user-initiated dials — tree-sitter grammars, LSP-server downloads, the model catalog, themes. In `filtered` mode each new host pops an approval dialog for something the user never named, with an empty intent line, which reads as phoning home for no reason. This makes the traffic legible **without** silently allowlisting the hosts or weakening the guardrail. The two lines together also let the user tell opencode's own fetch apart from a tool the agent spawned (`curl`/`git`/an LSP).

## How

- **Cause**: embedded JSON loaded once, keyed by harness (from `InnerArgv[0]` basename). Non-opencode harnesses get no map, so codex/copilot traffic is never mislabelled. Loader returns the whole `Entry` (cause, `user_initiated`, `notes`) to preserve disambiguation data.
- **Origin**: `internal/netprompt/origin` — `Resolver` interface; Linux `/proc` resolver behind a build tag (noop elsewhere). Matches the **full `/proc/net/tcp` 4-tuple** (`local==src` AND `rem==proxy`), not the ephemeral port alone; inode → PID via `/proc/<pid>/fd`; reads **`comm` only, never `cmdline`** (argv can carry secrets). Only the process **name** is shown — the PID is resolved but not displayed.
- **Plumbing**: per-connection endpoints travel on the **request context** (`netproxy.WithClientSource`, set in `server.go` from `conn`). `Filter.Check`/`CheckHost` gain **no** source parameter; only `Prompter.Prompt` gains `ctx`. Resolution runs **lazily in the prompter, prompt-path only** — zero cost on the allow/deny hot path.
- **Advisory / display-only**: neither line ever enters the access verdict. The dialing process name is display-only; the PID is not shown.

### Reviewed before implementation

An independent critical review validated the crux claims (child shares the host net namespace — bwrap omits `--unshare-net`; the `/proc` direction is right) and drove the phasing and the must-fixes above (4-tuple match, context-not-`Check` threading, harness gating, `comm`-only). Design decision left to judgment: the cause is **not** auto-rewritten by process name (opencode's dialing worker `comm` is unreliable, e.g. `bun`); the visible Origin line lets the user judge instead.

## Verification

- `go build/vet/test ./...` green; `gofmt` clean.
- New tests: host-map loader (load / normalize / harness gating / nil-safety / `not_egress` exclusion); cause + origin line rendering, ordering (`Origin < cause < intent`), omission; `resolveOrigin` gating (nil resolver / no ClientSource / failed resolve); **real-socket `/proc` resolver** (asserts resolved PID == `os.Getpid()` and `Name == /proc/self/comm`), unknown-tuple miss, `hexEndpoint` encoding; `harnessName`.

## Notes

- Scope is **opencode**; codex/copilot maps are future work (same loader, harness-keyed).
- Telemetry (`OTEL_EXPORTER_OTLP_ENDPOINT` → e.g. Datadog) is opt-in and recorded as such; `1.1.1.1` is documented as non-egress (test fixture / comment only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


