### PR TITLE
feat(release): LLM-generate user-facing Slack thread bullets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,10 @@ jobs:
               req=$(jq -n --arg m "$model" --arg s "$sys" --arg u "$commits" \
                 '{model:$m,temperature:0.2,max_tokens:1500,messages:[{role:"system",content:$s},{role:"user",content:$u}]}')
               # X-Separate-Reasoning routes GLM reasoning out of message.content.
-              resp=$(curl -sS --max-time 120 "$SKAINET_INTERNAL/chat/completions" \
+              # Generous timeout: release notes aren't latency-sensitive, and
+              # GLM-5.2 reasoning over a full release can take a while. Better a
+              # slow, good summary than falling back to raw dev-facing bullets.
+              resp=$(curl -sS --max-time 300 "$SKAINET_INTERNAL/chat/completions" \
                 -H "Authorization: Bearer $SKAINET_TOKEN" -H 'Content-Type: application/json' \
                 -H 'X-Separate-Reasoning: 1' -H 'X-User-Agent: omac-ci' \
                 --data "$req" || true)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,13 +160,17 @@ jobs:
             if [ -n "$prev_tag" ] && [ "$prev_tag" != "$VERSION" ]; then
               range="$prev_tag..$VERSION"
             fi
-            # Capture then truncate in-shell. Piping git into `head -c` makes
-            # git die with SIGPIPE (141) once head closes the pipe, which under
-            # the runner's default `-eo pipefail` shell aborts the whole step
-            # for any release whose commit dump exceeds the cap.
+            # Feed the model EVERY commit since the last release (subject +
+            # body). Capture then truncate in-shell: piping git into `head -c`
+            # makes git die with SIGPIPE (141) once head closes the pipe, which
+            # under the runner's default `-eo pipefail` shell aborts the step.
+            # The cap only guards a pathologically huge range; when it trips we
+            # keep the MOST RECENT commits (reverse order puts newest last, so
+            # tail-truncate) rather than dropping the latest work.
             commits=$(git log --no-merges --reverse \
               --pretty=format:'### %s%n%b' "$range" 2>/dev/null || true)
-            commits=${commits:0:6000}
+            max=48000
+            [ "${#commits}" -gt "$max" ] && commits=${commits: -max}
             if [ -n "$commits" ]; then
               # Single source of truth for the model id: internal/e2e/versions.go.
               model=$(awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' internal/e2e/versions.go \
@@ -174,9 +178,9 @@ jobs:
               [ -z "$model" ] && model="zai-org/GLM-5.2"
               sys="You are the release-notes editor for oh-my-agentic-coder (omac), a CLI that runs coding agents in a sandbox. Below are the raw git commit messages for one release. Rewrite them into concise, user-facing highlights grouped into features (new capabilities) and fixes (bugs resolved). Write for end users: state what they can now do and why it matters. IGNORE anything only project developers care about: PR/issue numbers like (#123), commit SHAs, author or co-author trailers, internal refactors, and test/ci/build/chore changes. Drop internal module and scope names. Merge related commits into one bullet. Output ONLY minified JSON of the form {\"features\":[\"...\"],\"fixes\":[\"...\"]} with at most 6 items per group, each under 140 characters and starting with a capital letter. Use an empty array for a group with nothing user-facing. No preamble, no explanation, no chain-of-thought, no <think> tags."
               req=$(jq -n --arg m "$model" --arg s "$sys" --arg u "$commits" \
-                '{model:$m,temperature:0.2,max_tokens:700,messages:[{role:"system",content:$s},{role:"user",content:$u}]}')
+                '{model:$m,temperature:0.2,max_tokens:1500,messages:[{role:"system",content:$s},{role:"user",content:$u}]}')
               # X-Separate-Reasoning routes GLM reasoning out of message.content.
-              resp=$(curl -sS --max-time 60 "$SKAINET_INTERNAL/chat/completions" \
+              resp=$(curl -sS --max-time 120 "$SKAINET_INTERNAL/chat/completions" \
                 -H "Authorization: Bearer $SKAINET_TOKEN" -H 'Content-Type: application/json' \
                 -H 'X-Separate-Reasoning: 1' -H 'X-User-Agent: omac-ci' \
                 --data "$req" || true)
@@ -199,7 +203,7 @@ jobs:
           # bullets come from the LLM reply ($LLM) when it parsed; otherwise
           # they fall back to the release body, cleaned (SHAs, author groups
           # and type prefixes stripped). Other commit types -> a footer count.
-          payload=$(BODY="$body" LLM="$llm_json" python3 - "$emoji" "$VERSION" "$kind" "$RELEASE_URL" <<'PY'
+          payload=$(BODY="$body" LLM="$llm_json" MODEL="${model:-}" python3 - "$emoji" "$VERSION" "$kind" "$RELEASE_URL" <<'PY'
           import json, os, re, sys
 
           def strip_trailing_author(s):
@@ -302,7 +306,10 @@ jobs:
 
           other = sum(len(v) for k, v in sections.items()
                       if k.lower() not in ("features", "bug fixes"))
-          footer = (f"+{other} internal changes (tests/ci/docs) · " if other else "") + f"Full notes: {url}"
+          # Credit the summarizing model only when the LLM bullets were used.
+          model = os.environ.get("MODEL", "").strip()
+          model_note = f" · Summarized by {model}" if (llm and model) else ""
+          footer = (f"+{other} internal changes (tests/ci/docs) · " if other else "") + f"Full notes: {url}" + model_note
           print(json.dumps({
               "summary":  f"{emoji} oh-my-agentic-coder {version} released ({kind})\n\n{url}",
               "features": features,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,8 +160,13 @@ jobs:
             if [ -n "$prev_tag" ] && [ "$prev_tag" != "$VERSION" ]; then
               range="$prev_tag..$VERSION"
             fi
+            # Capture then truncate in-shell. Piping git into `head -c` makes
+            # git die with SIGPIPE (141) once head closes the pipe, which under
+            # the runner's default `-eo pipefail` shell aborts the whole step
+            # for any release whose commit dump exceeds the cap.
             commits=$(git log --no-merges --reverse \
-              --pretty=format:'### %s%n%b' "$range" 2>/dev/null | head -c 6000)
+              --pretty=format:'### %s%n%b' "$range" 2>/dev/null || true)
+            commits=${commits:0:6000}
             if [ -n "$commits" ]; then
               # Single source of truth for the model id: internal/e2e/versions.go.
               model=$(awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' internal/e2e/versions.go \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,10 @@ jobs:
           REPO: ${{ github.repository }}
           VERSION: ${{ github.ref_name }}
           RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+          # Optional: when present, the thread bullets are rewritten by the LLM
+          # into user-facing highlights. Absent -> deterministic commit bullets.
+          SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+          SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "SLACK_RELEASE_WEBHOOK not set — skipping Slack notification"
@@ -145,14 +149,52 @@ jobs:
             patch) emoji="🔧" ;;   # fixes
           esac
           body=$(gh release view "$VERSION" --repo "$REPO" --json body --jq .body 2>/dev/null || true)
+          # LLM thread summary: feed the RAW commit messages (subject + body,
+          # which carry the What/Why here) for this release range to the model
+          # and let it write user-facing highlights, dropping PR refs, SHAs,
+          # author trailers and internal/ci/refactor noise. Any failure leaves
+          # llm_json empty and the deterministic commit bullets take over below.
+          llm_json=""
+          if [ -n "$SKAINET_TOKEN" ] && [ -n "$SKAINET_INTERNAL" ]; then
+            range="$VERSION"
+            if [ -n "$prev_tag" ] && [ "$prev_tag" != "$VERSION" ]; then
+              range="$prev_tag..$VERSION"
+            fi
+            commits=$(git log --no-merges --reverse \
+              --pretty=format:'### %s%n%b' "$range" 2>/dev/null | head -c 6000)
+            if [ -n "$commits" ]; then
+              # Single source of truth for the model id: internal/e2e/versions.go.
+              model=$(awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' internal/e2e/versions.go \
+                | grep '"opencode"' | sed -E 's/.*:\s*"([^"]+)".*/\1/')
+              [ -z "$model" ] && model="zai-org/GLM-5.2"
+              sys="You are the release-notes editor for oh-my-agentic-coder (omac), a CLI that runs coding agents in a sandbox. Below are the raw git commit messages for one release. Rewrite them into concise, user-facing highlights grouped into features (new capabilities) and fixes (bugs resolved). Write for end users: state what they can now do and why it matters. IGNORE anything only project developers care about: PR/issue numbers like (#123), commit SHAs, author or co-author trailers, internal refactors, and test/ci/build/chore changes. Drop internal module and scope names. Merge related commits into one bullet. Output ONLY minified JSON of the form {\"features\":[\"...\"],\"fixes\":[\"...\"]} with at most 6 items per group, each under 140 characters and starting with a capital letter. Use an empty array for a group with nothing user-facing. No preamble, no explanation, no chain-of-thought, no <think> tags."
+              req=$(jq -n --arg m "$model" --arg s "$sys" --arg u "$commits" \
+                '{model:$m,temperature:0.2,max_tokens:700,messages:[{role:"system",content:$s},{role:"user",content:$u}]}')
+              # X-Separate-Reasoning routes GLM reasoning out of message.content.
+              resp=$(curl -sS --max-time 60 "$SKAINET_INTERNAL/chat/completions" \
+                -H "Authorization: Bearer $SKAINET_TOKEN" -H 'Content-Type: application/json' \
+                -H 'X-Separate-Reasoning: 1' -H 'X-User-Agent: omac-ci' \
+                --data "$req" || true)
+              llm_json=$(printf '%s' "$resp" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)
+              if [ -n "$llm_json" ]; then
+                echo "LLM thread summary received"
+              else
+                echo "LLM returned no content — falling back to commit bullets (resp head: $(printf '%s' "$resp" | head -c 200))"
+              fi
+            fi
+          else
+            echo "SKAINET creds not set — using deterministic commit bullets"
+          fi
           # Workflow Builder variables render as plain text only (no bold or
           # headings). So the changelog is emitted as SEPARATE variables —
           # features, fixes (plain bullet lists) and footer — and the bold
           # "Features"/"Bug fixes" headings are typed statically in the
           # Reply-in-thread step, each variable inserted beneath its heading.
-          # summary is the channel message. Items are cleaned (SHAs, author
-          # groups and type prefixes stripped); other commit types -> a count.
-          payload=$(BODY="$body" python3 - "$emoji" "$VERSION" "$kind" "$RELEASE_URL" <<'PY'
+          # summary is the channel message and stays deterministic. The thread
+          # bullets come from the LLM reply ($LLM) when it parsed; otherwise
+          # they fall back to the release body, cleaned (SHAs, author groups
+          # and type prefixes stripped). Other commit types -> a footer count.
+          payload=$(BODY="$body" LLM="$llm_json" python3 - "$emoji" "$VERSION" "$kind" "$RELEASE_URL" <<'PY'
           import json, os, re, sys
 
           def strip_trailing_author(s):
@@ -208,10 +250,11 @@ jobs:
           emoji, version, kind, url = sys.argv[1:5]
           sections = parse_sections(os.environ.get("BODY", ""))
 
-          def section_list(names, cap=1800):
-              items = [it for k in sections if k.lower() in names for it in sections[k]]
+          def cap_bullets(items, cap=1800):
+              items = [re.sub(r"\s+", " ", str(it)).strip().lstrip("•").strip()
+                       for it in items if str(it).strip()]
               if not items:
-                  return "(none)"
+                  return None
               text = "\n".join(f"• {it}" for it in items)
               if len(text) > cap:
                   cut = text[:cap]
@@ -221,13 +264,44 @@ jobs:
                   text = cut.rstrip() + "\n• …"
               return text
 
+          def section_list(names):
+              items = [it for k in sections if k.lower() in names for it in sections[k]]
+              return cap_bullets(items) or "(none)"
+
+          def llm_lists():
+              """Parse the LLM's JSON reply into (features, fixes) bullet blocks.
+              Returns None on any parse failure so the deterministic path wins.
+              When it parses, the LLM reply is authoritative for both groups —
+              an empty group renders as "(none)", not the raw commit bullets."""
+              raw = os.environ.get("LLM", "").strip()
+              if not raw:
+                  return None
+              raw = re.sub(r"<think>.*?</think>", "", raw, flags=re.S).strip()
+              m = re.search(r"\{.*\}", raw, re.S)   # tolerate code fences / prose
+              if not m:
+                  return None
+              try:
+                  d = json.loads(m.group(0))
+              except Exception:
+                  return None
+              if not isinstance(d, dict):
+                  return None
+              return {
+                  "features": cap_bullets(d.get("features") or []) or "(none)",
+                  "fixes":    cap_bullets(d.get("fixes") or []) or "(none)",
+              }
+
+          llm = llm_lists()
+          features = llm["features"] if llm else section_list({"features"})
+          fixes    = llm["fixes"]    if llm else section_list({"bug fixes"})
+
           other = sum(len(v) for k, v in sections.items()
                       if k.lower() not in ("features", "bug fixes"))
           footer = (f"+{other} internal changes (tests/ci/docs) · " if other else "") + f"Full notes: {url}"
           print(json.dumps({
               "summary":  f"{emoji} oh-my-agentic-coder {version} released ({kind})\n\n{url}",
-              "features": section_list({"features"}),
-              "fixes":    section_list({"bug fixes"}),
+              "features": features,
+              "fixes":    fixes,
               "footer":   footer,
           }))
           PY


### PR DESCRIPTION
## What

Rewrite the **Features / Bug fixes bullets in the release Slack thread** with an LLM-generated, user-facing summary. The channel headline (`summary`) and the internal-changes footer are unchanged.

## Why

The thread previously shipped raw cleaned commit subjects — dev-facing text littered with scopes and PR refs — which read as confusing to users. A short, benefit-oriented rewrite is more useful to them.

## How

- Feed the **raw git commit messages** (subject + body, which carry the What/Why in this repo) for the release range to the SKAINET `chat/completions` endpoint, mirroring the "Summarize failures" pattern in `e2e-smoke.yml` (bearer token, model id read from `internal/e2e/versions.go`, `X-Separate-Reasoning` header).
- Prompt asks for minified JSON `{features:[...],fixes:[...]}`, explicitly dropping PR/issue numbers, SHAs, author trailers, and internal/ci/test/refactor noise.
- Parsing tolerates `<think>` blocks and code fences; when it parses, the LLM reply is authoritative for both thread groups (empty group → `(none)`).
- **Graceful fallback**: no SKAINET creds, or any call/parse failure → the original deterministic commit-derived bullets, so releases never break.

## Verification

- `python3` unit-tested the embedded parser across 4 cases (no LLM, valid JSON, think+fenced+empty group, garbage) — all correct.
- `YAML` load, `bash -n`, and `actionlint` all pass; model-id `awk` resolves to `zai-org/GLM-5.2`.

> Note: only fires if the `notify` job can see `SLACK_RELEASE_WEBHOOK` and the `SKAINET_TOKEN` / `SKAINET_EXTERNAL` secrets (same names as `e2e-smoke.yml`). Without them it silently uses the deterministic bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)