### PR TITLE
feat(update): fix shadowed-binary update loop — prefer no-sudo self-replace + warn on shadow

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -90,7 +90,27 @@ func runUpdateWithDeps(env *Env, yes bool, deps updater.Deps) int {
 		return ExitIOError
 	}
 	fmt.Fprintf(env.Stdout, "[ok] updated omac %s -> %s\n", plan.CurrentVersion, plan.LatestVersion)
+	reportShadowedBinary(env, ctx, plan, deps)
 	return ExitOK
+}
+
+// reportShadowedBinary runs the post-install self-check and, if an older omac
+// earlier on PATH is shadowing the freshly-installed one, warns the user and
+// suggests removing the stale binary. A probe failure is silent: the update
+// already succeeded, and a missing/unreadable omac on PATH is not worth a
+// scary message.
+func reportShadowedBinary(env *Env, ctx context.Context, plan updater.Plan, deps updater.Deps) {
+	if deps.PathLookup == nil || deps.VersionProbe == nil {
+		return
+	}
+	res, err := updater.SelfCheck(ctx, plan, deps)
+	if err != nil || !res.Shadowed {
+		return
+	}
+	fmt.Fprintf(env.Stdout, "[warn] `omac` on your PATH still resolves to an older binary:\n")
+	fmt.Fprintf(env.Stdout, "         %s (%s)\n", res.ResolvedPath, res.ResolvedVersion)
+	fmt.Fprintf(env.Stdout, "       it shadows the %s you just installed. To use the new version, remove the stale binary:\n", plan.LatestVersion)
+	fmt.Fprintf(env.Stdout, "         rm %s && hash -r\n", res.ResolvedPath)
 }
 
 func printUpdatePlan(env *Env, plan updater.Plan) {

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -217,6 +217,76 @@ func TestRunUpdate_YesSkipsPromptAndApplies(t *testing.T) {
 	}
 }
 
+// debUpdateDeps builds Deps that install a 2.0.0 .deb via a fake dpkg,
+// letting a test focus on what happens after a successful Apply.
+func debUpdateDeps(t *testing.T) updater.Deps {
+	t.Helper()
+	debURL := "https://example.invalid/x.deb"
+	sumsURL := "https://example.invalid/checksums.txt"
+	deps := baseTestDeps(t)
+	deps.Source = fakeSource{rel: updater.Release{TagName: "v2.0.0", Assets: []updater.Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.deb", BrowserDownloadURL: debURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	body := []byte("deb-bytes")
+	deps.Fetcher = fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.deb", body),
+		debURL:  body,
+	}}
+	deps.PkgManagers = []updater.PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+	deps.Runner = fakeRunner{}
+	return deps
+}
+
+func TestRunUpdate_WarnsWhenShadowedByOlderBinary(t *testing.T) {
+	deps := debUpdateDeps(t)
+	deps.PathLookup = func(string) (string, error) { return "/home/u/.local/bin/omac", nil }
+	deps.VersionProbe = func(context.Context, string) (string, error) { return "1.0.0", nil }
+
+	out, _, code := runUpdateCapture(t, true, deps, "")
+	if code != ExitOK {
+		t.Fatalf("code = %d, want ExitOK; out=%s", code, out)
+	}
+	if !strings.Contains(out, "updated omac 1.0.0 -> 2.0.0") {
+		t.Fatalf("out = %q, want update confirmation", out)
+	}
+	if !strings.Contains(out, "[warn]") || !strings.Contains(out, "/home/u/.local/bin/omac") {
+		t.Fatalf("out = %q, want a shadow warning naming the stale binary", out)
+	}
+	if !strings.Contains(out, "rm /home/u/.local/bin/omac") {
+		t.Fatalf("out = %q, want a removal suggestion", out)
+	}
+}
+
+func TestRunUpdate_NoWarnWhenResolvedIsInstalledVersion(t *testing.T) {
+	deps := debUpdateDeps(t)
+	deps.PathLookup = func(string) (string, error) { return "/usr/bin/omac", nil }
+	deps.VersionProbe = func(context.Context, string) (string, error) { return "2.0.0", nil }
+
+	out, _, code := runUpdateCapture(t, true, deps, "")
+	if code != ExitOK {
+		t.Fatalf("code = %d, want ExitOK; out=%s", code, out)
+	}
+	if strings.Contains(out, "[warn]") {
+		t.Fatalf("out = %q, must not warn when PATH resolves to the installed version", out)
+	}
+}
+
+func TestRunUpdate_SelfCheckProbeFailureIsSilent(t *testing.T) {
+	deps := debUpdateDeps(t)
+	deps.PathLookup = func(string) (string, error) { return "", errors.New("not found") }
+
+	out, _, code := runUpdateCapture(t, true, deps, "")
+	if code != ExitOK {
+		t.Fatalf("code = %d, want ExitOK; out=%s", code, out)
+	}
+	if strings.Contains(out, "[warn]") {
+		t.Fatalf("out = %q, a self-check probe failure must stay silent", out)
+	}
+}
+
 func TestRunUpdate_ChecksumMismatch(t *testing.T) {
 	debURL := "https://example.invalid/x.deb"
 	sumsURL := "https://example.invalid/checksums.txt"

--- a/internal/updater/selfcheck.go
+++ b/internal/updater/selfcheck.go
@@ -1,0 +1,68 @@
+package updater
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+// SelfCheckResult reports whether the omac a shell will actually invoke after
+// an update is the freshly-installed version, or an older binary earlier on
+// PATH shadowing it.
+type SelfCheckResult struct {
+	// ResolvedPath is where `omac` resolves on PATH after the install.
+	ResolvedPath string
+	// ResolvedVersion is that binary's self-reported version.
+	ResolvedVersion string
+	// Shadowed is true when ResolvedVersion is not the version just installed,
+	// i.e. a stale binary earlier on PATH is shadowing the update.
+	Shadowed bool
+}
+
+// SelfCheck runs after a successful install to confirm the `omac` a user's
+// shell will pick up is the version that was just installed. Package-manager
+// and brew installs write to a fixed, package-owned path; if an older binary
+// (e.g. a prior tarball self-replace in ~/.local/bin) sits earlier on PATH,
+// it silently shadows the update and every subsequent `omac update` re-runs
+// against the stale version. This detects exactly that so the caller can
+// suggest removing the shadow.
+//
+// A probe failure (omac not found on PATH, version subcommand errors) returns
+// an error; the caller treats it as a soft, non-fatal note since the install
+// itself already succeeded.
+func SelfCheck(ctx context.Context, plan Plan, deps Deps) (SelfCheckResult, error) {
+	path, err := deps.PathLookup("omac")
+	if err != nil {
+		return SelfCheckResult{}, err
+	}
+	version, err := deps.VersionProbe(ctx, path)
+	if err != nil {
+		return SelfCheckResult{ResolvedPath: path}, err
+	}
+	version = strings.TrimPrefix(strings.TrimSpace(version), "v")
+	return SelfCheckResult{
+		ResolvedPath:    path,
+		ResolvedVersion: version,
+		Shadowed:        version != plan.LatestVersion,
+	}, nil
+}
+
+// probeVersion runs `<path> version` and extracts the reported version token
+// from its "omac <version>" output.
+func probeVersion(ctx context.Context, path string) (string, error) {
+	out, err := exec.CommandContext(ctx, path, "version").Output()
+	if err != nil {
+		return "", err
+	}
+	return parseVersionOutput(string(out)), nil
+}
+
+// parseVersionOutput pulls the version token out of `omac version` output,
+// which is a single "omac <version>" line.
+func parseVersionOutput(out string) string {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[len(fields)-1]
+}

--- a/internal/updater/selfcheck.go
+++ b/internal/updater/selfcheck.go
@@ -43,8 +43,20 @@ func SelfCheck(ctx context.Context, plan Plan, deps Deps) (SelfCheckResult, erro
 	return SelfCheckResult{
 		ResolvedPath:    path,
 		ResolvedVersion: version,
-		Shadowed:        version != plan.LatestVersion,
+		Shadowed:        isShadowedBy(version, plan.LatestVersion),
 	}, nil
+}
+
+// isShadowedBy reports whether a binary self-reporting resolved is an older
+// binary shadowing the freshly-installed latest. Only a strictly-older semver
+// counts: a newer resolved version (e.g. a local dev build past the last tag)
+// is not a stale shadow and must not be flagged. When the versions are not
+// comparable as semver, fall back to plain inequality.
+func isShadowedBy(resolved, latest string) bool {
+	if cmp, ok := compareVersions(resolved, latest); ok {
+		return cmp < 0
+	}
+	return resolved != latest
 }
 
 // probeVersion runs `<path> version` and extracts the reported version token

--- a/internal/updater/selfcheck_test.go
+++ b/internal/updater/selfcheck_test.go
@@ -40,6 +40,40 @@ func TestSelfCheck_ShadowedByOlderBinary(t *testing.T) {
 	}
 }
 
+// TestSelfCheck_NewerBinaryNotShadowed guards against mislabeling a *newer*
+// binary earlier on PATH (e.g. a local dev build past the last release tag) as
+// a stale shadow. The warning and its "rm <path>" suggestion assume the
+// resolved binary is older; a newer one must never be reported as shadowed.
+func TestSelfCheck_NewerBinaryNotShadowed(t *testing.T) {
+	deps := Deps{
+		PathLookup:   func(string) (string, error) { return "/home/u/.local/bin/omac", nil },
+		VersionProbe: func(context.Context, string) (string, error) { return "1.3.0", nil },
+	}
+	res, err := SelfCheck(context.Background(), Plan{LatestVersion: "1.2.0"}, deps)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if res.Shadowed {
+		t.Fatalf("Shadowed = true, want false (resolved binary is newer than the release)")
+	}
+}
+
+// TestSelfCheck_UnparseableFallsBackToInequality keeps the conservative behavior
+// when versions are not comparable as semver: any mismatch is flagged.
+func TestSelfCheck_UnparseableFallsBackToInequality(t *testing.T) {
+	deps := Deps{
+		PathLookup:   func(string) (string, error) { return "/usr/bin/omac", nil },
+		VersionProbe: func(context.Context, string) (string, error) { return "dev-abc", nil },
+	}
+	res, err := SelfCheck(context.Background(), Plan{LatestVersion: "1.2.0"}, deps)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !res.Shadowed {
+		t.Fatalf("Shadowed = false, want true (unparseable version differs from installed)")
+	}
+}
+
 func TestSelfCheck_ProbeErrorPropagates(t *testing.T) {
 	sentinel := errors.New("boom")
 	deps := Deps{

--- a/internal/updater/selfcheck_test.go
+++ b/internal/updater/selfcheck_test.go
@@ -1,0 +1,76 @@
+package updater
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestSelfCheck_UpToDateNotShadowed(t *testing.T) {
+	deps := Deps{
+		PathLookup:   func(string) (string, error) { return "/usr/bin/omac", nil },
+		VersionProbe: func(context.Context, string) (string, error) { return "1.2.0", nil },
+	}
+	res, err := SelfCheck(context.Background(), Plan{LatestVersion: "1.2.0"}, deps)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if res.Shadowed {
+		t.Fatalf("Shadowed = true, want false (resolved binary is the installed version)")
+	}
+	if res.ResolvedVersion != "1.2.0" {
+		t.Fatalf("ResolvedVersion = %q, want 1.2.0", res.ResolvedVersion)
+	}
+}
+
+func TestSelfCheck_ShadowedByOlderBinary(t *testing.T) {
+	deps := Deps{
+		PathLookup:   func(string) (string, error) { return "/home/u/.local/bin/omac", nil },
+		VersionProbe: func(context.Context, string) (string, error) { return "1.1.0", nil },
+	}
+	res, err := SelfCheck(context.Background(), Plan{LatestVersion: "1.2.0"}, deps)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !res.Shadowed {
+		t.Fatalf("Shadowed = false, want true (PATH resolves to an older binary)")
+	}
+	if res.ResolvedPath != "/home/u/.local/bin/omac" {
+		t.Fatalf("ResolvedPath = %q", res.ResolvedPath)
+	}
+}
+
+func TestSelfCheck_ProbeErrorPropagates(t *testing.T) {
+	sentinel := errors.New("boom")
+	deps := Deps{
+		PathLookup:   func(string) (string, error) { return "/usr/bin/omac", nil },
+		VersionProbe: func(context.Context, string) (string, error) { return "", sentinel },
+	}
+	_, err := SelfCheck(context.Background(), Plan{LatestVersion: "1.2.0"}, deps)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel", err)
+	}
+}
+
+func TestSelfCheck_StripsLeadingV(t *testing.T) {
+	deps := Deps{
+		PathLookup:   func(string) (string, error) { return "/usr/bin/omac", nil },
+		VersionProbe: func(context.Context, string) (string, error) { return "v1.2.0", nil },
+	}
+	res, err := SelfCheck(context.Background(), Plan{LatestVersion: "1.2.0"}, deps)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Shadowed {
+		t.Fatalf("Shadowed = true, want false; a leading v must not cause a spurious mismatch")
+	}
+}
+
+func TestParseVersionOutput(t *testing.T) {
+	if got := parseVersionOutput("omac 1.2.0\n"); got != "1.2.0" {
+		t.Fatalf("got %q, want 1.2.0", got)
+	}
+	if got := parseVersionOutput(""); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -92,6 +92,15 @@ type Deps struct {
 	// Executable resolves the path of the running binary (for self-replace).
 	Executable func() (string, error)
 
+	// PathLookup resolves a command name against PATH, as the user's shell
+	// would. Used by the post-install SelfCheck to find which omac a shell
+	// will actually invoke.
+	PathLookup func(name string) (string, error)
+
+	// VersionProbe runs `<path> version` and returns the reported version.
+	// Used by SelfCheck to detect a stale binary shadowing the update.
+	VersionProbe func(ctx context.Context, path string) (string, error)
+
 	GOOS, GOARCH string
 	TempDir      string
 
@@ -110,6 +119,8 @@ func RealDeps(stdin io.Reader, stdout, stderr io.Writer) Deps {
 		BrewInstalled: func() bool { return DetectBrewInstalled(os.Executable, exec.LookPath, runCommand) },
 		PkgManagers:   DetectPackageManagers(exec.LookPath),
 		Executable:    os.Executable,
+		PathLookup:    exec.LookPath,
+		VersionProbe:  probeVersion,
 		GOOS:          runtime.GOOS,
 		GOARCH:        runtime.GOARCH,
 		TempDir:       os.TempDir(),

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -101,6 +101,12 @@ type Deps struct {
 	// Used by SelfCheck to detect a stale binary shadowing the update.
 	VersionProbe func(ctx context.Context, path string) (string, error)
 
+	// SelfReplaceable reports whether the running binary can be replaced
+	// without elevation, i.e. its containing directory is writable by the
+	// current user. When true, Check prefers self-replacing the exact binary
+	// in use over a sudo-requiring package-manager install.
+	SelfReplaceable func(path string) bool
+
 	GOOS, GOARCH string
 	TempDir      string
 
@@ -112,21 +118,22 @@ type Deps struct {
 // filesystem replace, real host detection.
 func RealDeps(stdin io.Reader, stdout, stderr io.Writer) Deps {
 	return Deps{
-		Source:        NewGitHubReleaseSource(),
-		Fetcher:       NewHTTPFetcher(),
-		Runner:        execRunner{},
-		Replacer:      fsSelfReplacer{},
-		BrewInstalled: func() bool { return DetectBrewInstalled(os.Executable, exec.LookPath, runCommand) },
-		PkgManagers:   DetectPackageManagers(exec.LookPath),
-		Executable:    os.Executable,
-		PathLookup:    exec.LookPath,
-		VersionProbe:  probeVersion,
-		GOOS:          runtime.GOOS,
-		GOARCH:        runtime.GOARCH,
-		TempDir:       os.TempDir(),
-		Stdin:         stdin,
-		Stdout:        stdout,
-		Stderr:        stderr,
+		Source:          NewGitHubReleaseSource(),
+		Fetcher:         NewHTTPFetcher(),
+		Runner:          execRunner{},
+		Replacer:        fsSelfReplacer{},
+		BrewInstalled:   func() bool { return DetectBrewInstalled(os.Executable, exec.LookPath, runCommand) },
+		PkgManagers:     DetectPackageManagers(exec.LookPath),
+		Executable:      os.Executable,
+		PathLookup:      exec.LookPath,
+		VersionProbe:    probeVersion,
+		SelfReplaceable: selfReplaceable,
+		GOOS:            runtime.GOOS,
+		GOARCH:          runtime.GOARCH,
+		TempDir:         os.TempDir(),
+		Stdin:           stdin,
+		Stdout:          stdout,
+		Stderr:          stderr,
 	}
 }
 
@@ -169,6 +176,23 @@ func Check(ctx context.Context, opts Options, deps Deps) (Plan, error) {
 	if deps.GOOS == "darwin" && deps.BrewInstalled != nil && deps.BrewInstalled() {
 		p.Method = MethodBrew
 		return p, nil
+	}
+
+	// Prefer self-replacing the running binary when that needs no elevation
+	// (its directory is writable) and a tarball asset exists. This updates the
+	// exact binary the user invokes, so it needs no sudo and sidesteps the
+	// shadowed-binary trap where a package install writes a different path than
+	// the omac on PATH. A root-owned install (e.g. /usr/bin from a package)
+	// isn't writable, so it falls through to the package manager below.
+	if exe, err := runningBinary(deps); err == nil && deps.SelfReplaceable != nil && deps.SelfReplaceable(exe) {
+		if asset, ok := matchAsset(rel.Assets, deps.GOOS, deps.GOARCH, ".tar.gz"); ok {
+			p.Method = MethodTarballSelfReplace
+			p.Asset = asset
+			if err := downloadAndVerify(ctx, &p, rel, deps); err != nil {
+				return Plan{}, err
+			}
+			return p, nil
+		}
 	}
 
 	if deps.GOOS == "linux" && len(deps.PkgManagers) > 0 {
@@ -315,13 +339,42 @@ func applySelfReplace(plan Plan, deps Deps) error {
 		return fmt.Errorf("extract omac from %s: %w", plan.Asset.Name, err)
 	}
 
-	target, err := deps.Executable()
+	target, err := runningBinary(deps)
 	if err != nil {
 		return fmt.Errorf("resolve running binary path: %w", err)
 	}
-	if real, err := filepath.EvalSymlinks(target); err == nil {
-		target = real
-	}
 
 	return deps.Replacer.Replace(target, bytes.NewReader(data), mode)
+}
+
+// runningBinary resolves the path of the executable currently running,
+// following symlinks so callers act on the real file that a self-replace
+// would rewrite.
+func runningBinary(deps Deps) (string, error) {
+	if deps.Executable == nil {
+		return "", errors.New("no Executable resolver configured")
+	}
+	p, err := deps.Executable()
+	if err != nil {
+		return "", err
+	}
+	if real, err := filepath.EvalSymlinks(p); err == nil {
+		p = real
+	}
+	return p, nil
+}
+
+// selfReplaceable reports whether path can be atomically replaced without
+// elevation. It probes the containing directory the same way fsSelfReplacer
+// does — create-a-temp-file — so it honors read-only mounts and ACLs rather
+// than guessing from mode bits.
+func selfReplaceable(path string) bool {
+	f, err := os.CreateTemp(filepath.Dir(path), ".omac-wtest-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	f.Close()
+	os.Remove(name)
+	return true
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -233,6 +233,74 @@ func TestCheck_LinuxPackageManagerPriority(t *testing.T) {
 	}
 }
 
+func TestCheck_PrefersSelfReplaceWhenBinaryWritable(t *testing.T) {
+	tgzBody := []byte("fake-tar-gz-bytes")
+	sumsURL := "https://example.invalid/checksums.txt"
+	tgzURL := "https://example.invalid/oh-my-agentic-coder_2.0.0_linux_x86_64.tar.gz"
+	debURL := "https://example.invalid/oh-my-agentic-coder_2.0.0_linux_x86_64.deb"
+
+	deps := baseDeps(t)
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v2.0.0", Assets: []Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.deb", BrowserDownloadURL: debURL},
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.tar.gz", BrowserDownloadURL: tgzURL},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	deps.Fetcher = &fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.tar.gz", tgzBody),
+		tgzURL:  tgzBody,
+	}}
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+	// A package manager is present, but the running binary is user-writable,
+	// so Check must prefer the no-sudo self-replace over the package manager.
+	deps.PkgManagers = []PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+	deps.SelfReplaceable = func(string) bool { return true }
+
+	plan, err := Check(context.Background(), Options{CurrentVersion: "1.0.0"}, deps)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if plan.Method != MethodTarballSelfReplace {
+		t.Fatalf("Method = %v, want MethodTarballSelfReplace (writable binary → no sudo)", plan.Method)
+	}
+	if !plan.ChecksumVerified {
+		t.Fatalf("expected checksum verified")
+	}
+}
+
+func TestCheck_UsesPackageManagerWhenBinaryNotWritable(t *testing.T) {
+	debBody := []byte("deb-bytes")
+	sumsURL := "https://example.invalid/checksums.txt"
+	debURL := "https://example.invalid/oh-my-agentic-coder_2.0.0_linux_x86_64.deb"
+
+	deps := baseDeps(t)
+	deps.Source = fakeReleaseSource{rel: Release{TagName: "v2.0.0", Assets: []Asset{
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.deb", BrowserDownloadURL: debURL},
+		{Name: "oh-my-agentic-coder_2.0.0_linux_x86_64.tar.gz", BrowserDownloadURL: "https://example.invalid/x.tar.gz"},
+		{Name: "checksums.txt", BrowserDownloadURL: sumsURL},
+	}}}
+	deps.Fetcher = &fakeFetcher{files: map[string][]byte{
+		sumsURL: checksumsFile("oh-my-agentic-coder_2.0.0_linux_x86_64.deb", debBody),
+		debURL:  debBody,
+	}}
+	deps.GOOS, deps.GOARCH = "linux", "amd64"
+	deps.PkgManagers = []PackageManager{
+		{Name: "dpkg", AssetSuffix: ".deb", InstallArgs: func(p string) []string { return []string{"-i", p} }},
+	}
+	// Root-owned install: self-replace would need elevation, so keep the
+	// package manager even though a tarball asset exists.
+	deps.SelfReplaceable = func(string) bool { return false }
+
+	plan, err := Check(context.Background(), Options{CurrentVersion: "1.0.0"}, deps)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if plan.Method != MethodLinuxPackage || plan.PackageManager != "dpkg" {
+		t.Fatalf("plan = %+v, want MethodLinuxPackage/dpkg", plan)
+	}
+}
+
 func TestCheck_LinuxNoPackageManagerFallsBackToTarball(t *testing.T) {
 	tgzBody := []byte("fake-tar-gz-bytes")
 	sumsURL := "https://example.invalid/checksums.txt"
@@ -427,6 +495,36 @@ func TestApply_SelfReplace_PermissionDenied(t *testing.T) {
 	err := Apply(context.Background(), plan, deps)
 	if !errors.Is(err, fs.ErrPermission) {
 		t.Fatalf("err = %v, want fs.ErrPermission", err)
+	}
+}
+
+func TestSelfReplaceable(t *testing.T) {
+	dir := t.TempDir()
+	if !selfReplaceable(filepath.Join(dir, "omac")) {
+		t.Fatalf("selfReplaceable = false for a writable temp dir, want true")
+	}
+	if selfReplaceable(filepath.Join(dir, "no-such-subdir", "omac")) {
+		t.Fatalf("selfReplaceable = true for a non-existent directory, want false")
+	}
+}
+
+func TestRunningBinary_FollowsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "omac-real")
+	if err := os.WriteFile(real, []byte("bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "omac-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	deps := Deps{Executable: func() (string, error) { return link, nil }}
+	got, err := runningBinary(deps)
+	if err != nil {
+		t.Fatalf("runningBinary: %v", err)
+	}
+	if got != real {
+		t.Fatalf("runningBinary = %q, want resolved %q", got, real)
 	}
 }
 

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -523,8 +523,14 @@ func TestRunningBinary_FollowsSymlink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runningBinary: %v", err)
 	}
-	if got != real {
-		t.Fatalf("runningBinary = %q, want resolved %q", got, real)
+	// Resolve the expected path too: on macOS the temp dir itself lives under
+	// /var -> /private/var, so EvalSymlinks rewrites the parent as well.
+	want, err := filepath.EvalSymlinks(real)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("runningBinary = %q, want resolved %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## What

Makes `omac update` robust against a **shadowed binary** — the case where the `omac` a shell invokes is not the one the update touches:

1. **Prefer no-sudo self-replace** when the running binary is user-writable. If the `omac` in use lives in a writable directory (e.g. `~/.local/bin`), `omac update` self-replaces that exact binary from the release tarball instead of shelling out to a sudo-requiring package-manager install. Root-owned installs (e.g. `/usr/bin` from an rpm/deb) are not writable, so they still go through the package manager unchanged.
2. **Post-install self-check.** After a successful package-manager/brew install, verify the `omac` on PATH is the version just installed; if an older binary earlier on PATH shadows it, print a warning naming the stale binary and suggest `rm <path> && hash -r`.

## Why

A tarball install in `~/.local/bin` can shadow a package-managed `/usr/bin/omac` on PATH. The old logic picked the package manager (because one was present on the host), which:
- needed `sudo`, and
- updated a *different path* than the one actually invoked.

So the running binary kept self-reporting the old version, every `omac update` re-ran against it, and `rpm -U` looped on an already-installed NVR:

```
package oh-my-agentic-coder-0.5.1-1.x86_64 is already installed
omac update: exit status 2
```

Self-replacing the running binary updates precisely what the shell runs, and needs no elevation when its directory is writable. The self-check catches any residual shadow (e.g. a genuine root-owned package install still shadowed by an older user-local binary) and tells the user exactly which file is in the way.

## How

- `Deps.SelfReplaceable` reports whether the running binary's directory is writable; `RealDeps` probes it the same way `fsSelfReplacer` does (create a temp file), so it honors read-only mounts and ACLs, not just mode bits.
- `Check` prefers `MethodTarballSelfReplace` when `SelfReplaceable` is true and a matching tarball asset exists, ahead of the package-manager branch; falls through otherwise.
- `runningBinary()` (symlink-resolving) is extracted and reused from `applySelfReplace`.
- `updater.SelfCheck` resolves `omac` on PATH (`Deps.PathLookup`) and probes its version (`Deps.VersionProbe`), comparing against `Plan.LatestVersion`. The CLI runs it after `Apply`; a probe failure is silent since the install already succeeded.

## Verification

- `go test ./...` — pass, 0 failures
- `go vet`, `gofmt` — clean
- New tests: prefer self-replace when writable; keep the package manager when not writable; `selfReplaceable` on writable/missing dirs; `runningBinary` follows symlinks; self-check shadowed / up-to-date / probe-error / leading-`v` cases; CLI warning, no-warn, and silent-probe-failure paths. Existing package-manager tests leave `SelfReplaceable` nil, so they exercise the sudo path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)