### PR TITLE
test(netprompt): headless popup screenshot CI job (zenity/kdialog/osascript)

### DIFF
--- a/.github/workflows/popup-visual.yml
+++ b/.github/workflows/popup-visual.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install capture tooling + ${{ matrix.backend }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb imagemagick xdotool
+          sudo apt-get install -y xvfb imagemagick xdotool fonts-dejavu-core
           sudo apt-get install -y "${{ matrix.backend }}" \
             || echo "::warning::${{ matrix.backend }} not installable; the render test will skip"
       - name: Render + capture (${{ matrix.backend }})

--- a/.github/workflows/popup-visual.yml
+++ b/.github/workflows/popup-visual.yml
@@ -1,0 +1,79 @@
+name: popup-visual
+
+# Renders the real network-approval dialog headless and uploads a PNG so the
+# rendered widget — label alignment, wrapping, truncation — can be eyeballed
+# per PR. Advisory: it captures screenshots, it does not assert appearance.
+#
+# Note: this is a public repo; uploaded artifacts and job logs are public. The
+# rendered dialog contains only the static sample prompt, no secrets.
+
+on:
+  pull_request:
+    paths:
+      - 'internal/netprompt/**'
+      - '.github/workflows/popup-visual.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    # kdialog pulls heavy KDE deps and may be unavailable; never block on it.
+    continue-on-error: ${{ matrix.backend == 'kdialog' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [zenity, kdialog]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install capture tooling + ${{ matrix.backend }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb imagemagick xdotool
+          sudo apt-get install -y "${{ matrix.backend }}" \
+            || echo "::warning::${{ matrix.backend }} not installable; the render test will skip"
+      - name: Render + capture (${{ matrix.backend }})
+        env:
+          OMAC_POPUP_SHOT: "1"
+          OMAC_POPUP_SHOT_BACKEND: ${{ matrix.backend }}
+          OMAC_POPUP_SHOT_DIR: ${{ github.workspace }}/popup-shots
+        run: |
+          mkdir -p "$OMAC_POPUP_SHOT_DIR"
+          xvfb-run -a --server-args="-screen 0 1280x1024x24" \
+            go test ./internal/netprompt/ -run TestRenderPopupScreenshot -count=1 -v
+      - name: Upload screenshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: popup-${{ matrix.backend }}
+          path: popup-shots/*.png
+          if-no-files-found: warn
+
+  macos:
+    runs-on: macos-latest
+    # osascript GUI dialogs need a WindowServer session headless CI may lack.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Render + capture (osascript, best-effort)
+        env:
+          OMAC_POPUP_SHOT: "1"
+          OMAC_POPUP_SHOT_DIR: ${{ github.workspace }}/popup-shots
+        run: |
+          mkdir -p "$OMAC_POPUP_SHOT_DIR"
+          go test ./internal/netprompt/ -run TestRenderPopupScreenshot -count=1 -v
+      - name: Upload screenshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: popup-osascript
+          path: popup-shots/*.png
+          if-no-files-found: warn

--- a/.github/workflows/popup-visual.yml
+++ b/.github/workflows/popup-visual.yml
@@ -20,10 +20,6 @@ permissions:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    # Advisory only: capture is a human-review aid, never a pass/fail gate. A
-    # flaky headless render (blank window, Xvfb first-paint timing) or a missing
-    # toolkit (kdialog's heavy KDE deps) must not turn the PR check red.
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -40,6 +36,12 @@ jobs:
           sudo apt-get install -y "${{ matrix.backend }}" \
             || echo "::warning::${{ matrix.backend }} not installable; the render test will skip"
       - name: Render + capture (${{ matrix.backend }})
+        # Advisory only: capture is a human-review aid, never a pass/fail gate. A
+        # flaky headless render (blank window, Xvfb first-paint timing) or a
+        # missing toolkit (kdialog's heavy KDE deps) must leave the check green.
+        # Step-level (not job-level) so the job still concludes success — a
+        # job-level continue-on-error would still report the leg as a red check.
+        continue-on-error: true
         env:
           OMAC_POPUP_SHOT: "1"
           OMAC_POPUP_SHOT_BACKEND: ${{ matrix.backend }}
@@ -58,14 +60,16 @@ jobs:
 
   macos:
     runs-on: macos-latest
-    # osascript GUI dialogs need a WindowServer session headless CI may lack.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Render + capture (osascript, best-effort)
+        # osascript GUI dialogs need a WindowServer session headless CI may lack.
+        # Step-level continue-on-error keeps the check green when the capture
+        # cannot run (a job-level one would still report the job as a red check).
+        continue-on-error: true
         env:
           OMAC_POPUP_SHOT: "1"
           OMAC_POPUP_SHOT_DIR: ${{ github.workspace }}/popup-shots

--- a/.github/workflows/popup-visual.yml
+++ b/.github/workflows/popup-visual.yml
@@ -20,8 +20,10 @@ permissions:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    # kdialog pulls heavy KDE deps and may be unavailable; never block on it.
-    continue-on-error: ${{ matrix.backend == 'kdialog' }}
+    # Advisory only: capture is a human-review aid, never a pass/fail gate. A
+    # flaky headless render (blank window, Xvfb first-paint timing) or a missing
+    # toolkit (kdialog's heavy KDE deps) must not turn the PR check red.
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 /coverage.html
 /.ruff_cache/
 
+# Rendered dialog screenshots from the popup-shot test / popup-visual CI job.
+/popup-shots/
+
 # Per-workdir runtime state managed by `omac register` / `omac start`.
 # The registry file (`.opencode/sidecar.json`) is per-environment state:
 # it points at skill_dirs that exist on the user's machine and was written

--- a/internal/netprompt/popupshot_darwin_test.go
+++ b/internal/netprompt/popupshot_darwin_test.go
@@ -1,0 +1,51 @@
+//go:build darwin
+
+package netprompt
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestRenderPopupScreenshot renders the osascript network dialog and captures a
+// full-screen PNG. Best-effort: osascript GUI dialogs need a WindowServer
+// session, which headless CI runners may not provide — the CI job is
+// continue-on-error and a desktop-only capture is itself the signal that the
+// dialog did not render. Advisory only; appearance is not asserted.
+//
+// Gated on OMAC_POPUP_SHOT=1 so it never runs in the normal unit suite. There
+// is no reliable per-window wait without accessibility permissions, so it uses
+// a fixed settle delay before screencapture.
+func TestRenderPopupScreenshot(t *testing.T) {
+	if os.Getenv("OMAC_POPUP_SHOT") == "" {
+		t.Skip("set OMAC_POPUP_SHOT=1 to render the real dialog")
+	}
+	for _, bin := range []string{"osascript", "screencapture"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%q not found on PATH", bin)
+		}
+	}
+
+	shot := shotPath(t, "osascript")
+	errc := make(chan error, 1)
+	go func() {
+		_, err := osascriptBackend{}.show(context.Background(), shotHost, shotPort,
+			RegisteredSuffixHint(shotHost), shotIntent, shotCause, shotOrigin)
+		errc <- err
+	}()
+
+	time.Sleep(3 * time.Second) // no window-id wait available; let the dialog map
+	if out, err := exec.Command("screencapture", "-x", shot).CombinedOutput(); err != nil {
+		t.Fatalf("screencapture failed: %v: %s", err, out)
+	}
+	// Dismiss with Escape via System Events; best-effort (may lack permission).
+	_ = exec.Command("osascript", "-e", `tell application "System Events" to key code 53`).Run()
+	select {
+	case <-errc:
+	case <-time.After(3 * time.Second):
+	}
+	assertShot(t, shot)
+}

--- a/internal/netprompt/popupshot_linux_test.go
+++ b/internal/netprompt/popupshot_linux_test.go
@@ -47,6 +47,15 @@ func TestRenderPopupScreenshot(t *testing.T) {
 
 	win := waitForWindow(t, shotTitle, 15*time.Second)
 	err := captureWindow(win, shot, 6, time.Second)
+	if err == nil {
+		// Best-effort second frame with the pointer over the scrollbar, so the
+		// artifact shows the hover state (GTK/Qt scrollbars are thin at rest and
+		// prelight on hover). A failure here must not fail the test.
+		hover := strings.Replace(shot, ".png", "-hover.png", 1)
+		if herr := captureHover(win, hover); herr != nil {
+			t.Logf("hover capture skipped: %v", herr)
+		}
+	}
 	_ = exec.Command("xdotool", "windowkill", win).Run() // let the backend goroutine return
 	select {
 	case <-errc:
@@ -56,6 +65,43 @@ func TestRenderPopupScreenshot(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertShot(t, shot)
+}
+
+// captureHover moves the pointer over the list's right edge, where the
+// scrollbar sits, and grabs a second frame so the artifact shows the
+// hover-widened / prelit scrollbar. Best-effort.
+func captureHover(win, out string) error {
+	x, y, w, h, err := windowGeometry(win)
+	if err != nil {
+		return err
+	}
+	px, py := x+w-6, y+h*3/4 // right edge, lower half where the option list sits
+	if o, err := exec.Command("xdotool", "mousemove", "--sync", strconv.Itoa(px), strconv.Itoa(py)).CombinedOutput(); err != nil {
+		return fmt.Errorf("mousemove failed: %v: %s", err, o)
+	}
+	time.Sleep(time.Second) // let the scrollbar react
+	if o, err := exec.Command("import", "-window", win, out).CombinedOutput(); err != nil {
+		return fmt.Errorf("import failed: %v: %s", err, o)
+	}
+	return nil
+}
+
+// windowGeometry returns win's absolute X, Y, width and height (xdotool --shell).
+func windowGeometry(win string) (x, y, w, h int, err error) {
+	out, err := exec.Command("xdotool", "getwindowgeometry", "--shell", win).Output()
+	if err != nil {
+		return 0, 0, 0, 0, fmt.Errorf("getwindowgeometry: %v", err)
+	}
+	m := map[string]int{}
+	for _, line := range strings.Split(string(out), "\n") {
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		n, _ := strconv.Atoi(strings.TrimSpace(v))
+		m[strings.TrimSpace(k)] = n
+	}
+	return m["X"], m["Y"], m["WIDTH"], m["HEIGHT"], nil
 }
 
 // captureWindow grabs window win to out, retrying until the image is painted.

--- a/internal/netprompt/popupshot_linux_test.go
+++ b/internal/netprompt/popupshot_linux_test.go
@@ -1,0 +1,80 @@
+//go:build linux
+
+package netprompt
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRenderPopupScreenshot renders the real network-approval dialog under an
+// X display and captures a PNG, so CI can surface how the dialog actually looks
+// — label alignment (space-padding aligns only in monospace; GTK/Qt draw
+// proportional), wrapping, and truncation against the fixed height. It is
+// advisory: the artifact is for human eyes, not a pass/fail assertion on
+// appearance.
+//
+// Gated on OMAC_POPUP_SHOT=1 so it never runs in the normal unit suite; needs
+// the chosen dialog tool plus imagemagick (import) and xdotool, and a DISPLAY
+// (xvfb-run in CI). OMAC_POPUP_SHOT_BACKEND selects zenity (default) or kdialog.
+func TestRenderPopupScreenshot(t *testing.T) {
+	if os.Getenv("OMAC_POPUP_SHOT") == "" {
+		t.Skip("set OMAC_POPUP_SHOT=1 to render the real dialog (needs a dialog tool + DISPLAY)")
+	}
+	if os.Getenv("DISPLAY") == "" {
+		t.Skip("no DISPLAY set; render under xvfb-run")
+	}
+	backend := linuxShotBackend(os.Getenv("OMAC_POPUP_SHOT_BACKEND"))
+	for _, bin := range []string{backend.name(), "import", "xdotool"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%q not found on PATH", bin)
+		}
+	}
+
+	shot := shotPath(t, backend.name())
+	errc := make(chan error, 1)
+	go func() {
+		_, err := backend.show(context.Background(), shotHost, shotPort,
+			RegisteredSuffixHint(shotHost), shotIntent, shotCause, shotOrigin)
+		errc <- err
+	}()
+
+	win := waitForWindow(t, shotTitle, 15*time.Second)
+	if out, err := exec.Command("import", "-window", win, shot).CombinedOutput(); err != nil {
+		t.Fatalf("screenshot failed: %v: %s", err, out)
+	}
+	_ = exec.Command("xdotool", "windowkill", win).Run() // let the backend goroutine return
+	select {
+	case <-errc:
+	case <-time.After(3 * time.Second):
+	}
+	assertShot(t, shot)
+}
+
+func linuxShotBackend(name string) dialogBackend {
+	if strings.EqualFold(name, "kdialog") {
+		return kdialogBackend{}
+	}
+	return zenityBackend{}
+}
+
+// waitForWindow blocks until a window titled title exists (xdotool --sync),
+// bounded by timeout, and returns its id.
+func waitForWindow(t *testing.T, title string, timeout time.Duration) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "xdotool", "search", "--sync", "--name", title).Output()
+	if err != nil {
+		t.Fatalf("dialog window %q did not appear within %s: %v", title, timeout, err)
+	}
+	ids := strings.Fields(string(out))
+	if len(ids) == 0 {
+		t.Fatalf("no window id for %q", title)
+	}
+	return ids[len(ids)-1]
+}

--- a/internal/netprompt/popupshot_linux_test.go
+++ b/internal/netprompt/popupshot_linux_test.go
@@ -4,8 +4,10 @@ package netprompt
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -44,15 +46,51 @@ func TestRenderPopupScreenshot(t *testing.T) {
 	}()
 
 	win := waitForWindow(t, shotTitle, 15*time.Second)
-	if out, err := exec.Command("import", "-window", win, shot).CombinedOutput(); err != nil {
-		t.Fatalf("screenshot failed: %v: %s", err, out)
-	}
+	err := captureWindow(win, shot, 6, time.Second)
 	_ = exec.Command("xdotool", "windowkill", win).Run() // let the backend goroutine return
 	select {
 	case <-errc:
 	case <-time.After(3 * time.Second):
 	}
+	if err != nil {
+		t.Fatal(err)
+	}
 	assertShot(t, shot)
+}
+
+// captureWindow grabs window win to out, retrying until the image is painted.
+// xdotool --sync waits for the window to exist, not to draw, so a fresh grab
+// can be a blank rectangle; a painted dialog has many colours, a blank window
+// only one or two. Retries settle GTK/Qt's first paint.
+func captureWindow(win, out string, attempts int, wait time.Duration) error {
+	var colors int
+	for i := 0; i < attempts; i++ {
+		time.Sleep(wait)
+		if o, err := exec.Command("import", "-window", win, out).CombinedOutput(); err != nil {
+			return fmt.Errorf("import failed: %v: %s", err, o)
+		}
+		var err error
+		if colors, err = pngColors(out); err != nil {
+			return err
+		}
+		if colors > 4 {
+			return nil
+		}
+	}
+	return fmt.Errorf("captured a blank window (%d colours) after %d attempts — dialog did not paint", colors, attempts)
+}
+
+// pngColors returns the number of distinct colours in an image (ImageMagick %k).
+func pngColors(path string) (int, error) {
+	out, err := exec.Command("identify", "-format", "%k", path).Output()
+	if err != nil {
+		return 0, fmt.Errorf("identify failed: %v", err)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("parse colour count %q: %v", out, err)
+	}
+	return n, nil
 }
 
 func linuxShotBackend(name string) dialogBackend {

--- a/internal/netprompt/popupshot_linux_test.go
+++ b/internal/netprompt/popupshot_linux_test.go
@@ -47,15 +47,6 @@ func TestRenderPopupScreenshot(t *testing.T) {
 
 	win := waitForWindow(t, shotTitle, 15*time.Second)
 	err := captureWindow(win, shot, 6, time.Second)
-	if err == nil {
-		// Best-effort second frame with the pointer over the scrollbar, so the
-		// artifact shows the hover state (GTK/Qt scrollbars are thin at rest and
-		// prelight on hover). A failure here must not fail the test.
-		hover := strings.Replace(shot, ".png", "-hover.png", 1)
-		if herr := captureHover(win, hover); herr != nil {
-			t.Logf("hover capture skipped: %v", herr)
-		}
-	}
 	_ = exec.Command("xdotool", "windowkill", win).Run() // let the backend goroutine return
 	select {
 	case <-errc:
@@ -65,43 +56,6 @@ func TestRenderPopupScreenshot(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertShot(t, shot)
-}
-
-// captureHover moves the pointer over the list's right edge, where the
-// scrollbar sits, and grabs a second frame so the artifact shows the
-// hover-widened / prelit scrollbar. Best-effort.
-func captureHover(win, out string) error {
-	x, y, w, h, err := windowGeometry(win)
-	if err != nil {
-		return err
-	}
-	px, py := x+w-6, y+h*3/4 // right edge, lower half where the option list sits
-	if o, err := exec.Command("xdotool", "mousemove", "--sync", strconv.Itoa(px), strconv.Itoa(py)).CombinedOutput(); err != nil {
-		return fmt.Errorf("mousemove failed: %v: %s", err, o)
-	}
-	time.Sleep(time.Second) // let the scrollbar react
-	if o, err := exec.Command("import", "-window", win, out).CombinedOutput(); err != nil {
-		return fmt.Errorf("import failed: %v: %s", err, o)
-	}
-	return nil
-}
-
-// windowGeometry returns win's absolute X, Y, width and height (xdotool --shell).
-func windowGeometry(win string) (x, y, w, h int, err error) {
-	out, err := exec.Command("xdotool", "getwindowgeometry", "--shell", win).Output()
-	if err != nil {
-		return 0, 0, 0, 0, fmt.Errorf("getwindowgeometry: %v", err)
-	}
-	m := map[string]int{}
-	for _, line := range strings.Split(string(out), "\n") {
-		k, v, ok := strings.Cut(line, "=")
-		if !ok {
-			continue
-		}
-		n, _ := strconv.Atoi(strings.TrimSpace(v))
-		m[strings.TrimSpace(k)] = n
-	}
-	return m["X"], m["Y"], m["WIDTH"], m["HEIGHT"], nil
 }
 
 // captureWindow grabs window win to out, retrying until the image is painted.

--- a/internal/netprompt/popupshot_shared_test.go
+++ b/internal/netprompt/popupshot_shared_test.go
@@ -1,0 +1,46 @@
+package netprompt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Representative network prompt for the screenshot tests. Every optional line
+// is present (Origin + Likely cause + Agent intent), and the cause is long
+// enough to expose wrapping, truncation, and the fixed dialog height — the
+// things promptText's golden string tests cannot see. Kept in one place so the
+// per-platform render tests (popupshot_linux_test.go / _darwin_test.go) agree
+// on what is drawn.
+const (
+	shotHost   = "raw.githubusercontent.com"
+	shotPort   = 443
+	shotTitle  = "omac: network access"
+	shotIntent = "" // renders "(not declared)"
+	shotCause  = "Syntax-highlighting grammar/query (tree-sitter) for the code you are viewing"
+	shotOrigin = "opencode"
+)
+
+// shotPath returns where a backend's PNG should be written: OMAC_POPUP_SHOT_DIR
+// when set (CI uploads it as an artifact), else a per-test temp dir.
+func shotPath(t *testing.T, backend string) string {
+	t.Helper()
+	dir := os.Getenv("OMAC_POPUP_SHOT_DIR")
+	if dir == "" {
+		dir = t.TempDir()
+	}
+	return filepath.Join(dir, "network-prompt-"+backend+".png")
+}
+
+// assertShot fails when the capture produced no usable file.
+func assertShot(t *testing.T, path string) {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("screenshot not written: %v", err)
+	}
+	if fi.Size() == 0 {
+		t.Fatalf("screenshot is empty: %s", path)
+	}
+	t.Logf("wrote popup screenshot: %s (%d bytes)", path, fi.Size())
+}

--- a/scripts/popup-shot.sh
+++ b/scripts/popup-shot.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Render the real network-approval dialog headless and save a PNG, the same way
+# the popup-visual CI job does. Linux only; needs xvfb, imagemagick, xdotool and
+# the chosen dialog tool (zenity or kdialog).
+#
+# Usage: scripts/popup-shot.sh [zenity|kdialog]
+set -euo pipefail
+
+backend="${1:-zenity}"
+outdir="${OMAC_POPUP_SHOT_DIR:-$(pwd)/popup-shots}"
+mkdir -p "$outdir"
+
+OMAC_POPUP_SHOT=1 \
+OMAC_POPUP_SHOT_BACKEND="$backend" \
+OMAC_POPUP_SHOT_DIR="$outdir" \
+  xvfb-run -a --server-args="-screen 0 1280x1024x24" \
+  go test ./internal/netprompt/ -run TestRenderPopupScreenshot -count=1 -v
+
+echo "screenshot(s) written to $outdir"


### PR DESCRIPTION
## What

An **advisory** `popup-visual` CI job that renders the real sandbox
network-approval dialog headless and uploads the PNG as an artifact, so the
*rendered widget* can be eyeballed per PR. Includes the render test and a local
repro script (`scripts/popup-shot.sh`).

Covers **different platforms / toolkits**:
- **Linux — zenity (GTK)** via Xvfb — the primary, reliable target.
- **Linux — kdialog (Qt)** via Xvfb — `continue-on-error` (heavy KDE deps; skips if unavailable).
- **macOS — osascript** — `continue-on-error`, best-effort (headless runners may lack a WindowServer session; a desktop-only capture is itself the signal it didn't render).

## Why

`promptText`'s golden tests assert the dialog **string**, not the rendered
widget. The label alignment shipped in #132 uses space padding, which only
lines up in a **monospace** context — GTK and Qt draw `--text` in a
**proportional** font, so the columns may still look ragged in the real dialog.
That is exactly what a screenshot reveals and a string test cannot. The artifact
also surfaces wrapping and truncation against the fixed dialog height.

## How

- `TestRenderPopupScreenshot` (gated on `OMAC_POPUP_SHOT=1`, **skipped in the
  normal unit suite**) drives the real dialog backend in a goroutine, waits for
  the window (`xdotool --sync` on Linux; a fixed settle on macOS), captures it
  (`import` / `screencapture`), then dismisses it.
- The CI job installs the toolkit + capture tools, runs the test under
  `xvfb-run`, and uploads `popup-shots/*.png`.
- **Appearance is captured, never asserted** — this is a human-review aid, not a
  pass/fail gate. (An LLM vision check could sit on top later, advisory-only.)

## Verification

- `gofmt` clean; `go vet ./internal/netprompt/` green on Linux **and**
  `GOOS=darwin`.
- The render test SKIPs cleanly without `OMAC_POPUP_SHOT`, so `go test ./...` is
  unaffected.
- Full headless render not runnable in the authoring env (no `xvfb`/`xdotool`);
  the CI job is the intended execution path.

## Notes

- **Stacked on #132** (base `feat/opencode-egress-host-map`) because it renders
  the aligned labels introduced there. Retarget to `main` once #132 merges.
- Public repo: uploaded artifacts/logs are public; the rendered dialog shows
  only the static sample prompt, no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
