### PR TITLE
feat(start): --auto-register-skills for workdir-local skills with no required values

### DIFF
--- a/CREATING_A_SKILL.md
+++ b/CREATING_A_SKILL.md
@@ -596,9 +596,13 @@ checked:
 2. **Unregistered skill on disk** (a directory with an `omac.yaml` under
    *either* skill source — the workdir-local layer or the user-global
    layer, see §2 — that omac has never seen). Refuses to start;
-   prints the exact register command for each one. Re-registration is
-   mandatory because it's the only point at which secret-prompting and
-   config-prompting happen.
+   prints the exact register command for each one. Standard `omac start`
+   always takes this path. The explicit `--auto-register-skills` start-family
+   opt-in silently registers only workdir-local skills whose required config
+   and secrets resolve without prompting; it never bypasses an unresolved
+   required value. All other unregistered skills remain rejected with their
+   registration command. Explicit registration remains the normal path for
+   config and secret prompting.
 
 3. **Bundle hash drift** (the registered skill's source files changed
    since register). The bundle hash covers `omac.yaml` and every

--- a/README.md
+++ b/README.md
@@ -888,7 +888,12 @@ omac [--workdir <dir>] <subcommand> [flags] [args]
                roots (workdir-local .agents/skills + .opencode/skills,
                plus the user-global layers), or if a registered skill's
                bundle changed since register, or if a required config
-               field is unresolvable. Auto-deregisters
+               field is unresolvable. `--auto-register-skills` is an
+               opt-in for this start-family launch: it silently registers
+               only workdir-local skills whose required config and secrets
+               resolve without prompting. Other unregistered skills still
+               refuse launch and print their registration command.
+               Auto-deregisters
                (silently) skills whose directory has vanished; secrets +
                config persist for safety. Flags:
                  --sandbox <profile>     pick a sandbox profile
@@ -901,6 +906,8 @@ omac [--workdir <dir>] <subcommand> [flags] [args]
                                          scope; removed on exit
                  --keep-running          don't stop sidecars on exit
                  --accept-skill-changes  tolerate bundle_hash drift
+                 --auto-register-skills  silently register eligible
+                                         workdir-local skills only
                  --skip-secret-pattern   don't enforce a secret's pattern
                                          on an env_passthrough value
                  --verbose               lifecycle logging (prints cache

--- a/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
+++ b/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
@@ -596,9 +596,13 @@ checked:
 2. **Unregistered skill on disk** (a directory with an `omac.yaml` under
    *either* skill source — the workdir-local layer or the user-global
    layer, see §2 — that omac has never seen). Refuses to start;
-   prints the exact register command for each one. Re-registration is
-   mandatory because it's the only point at which secret-prompting and
-   config-prompting happen.
+   prints the exact register command for each one. Standard `omac start`
+   always takes this path. The explicit `--auto-register-skills` start-family
+   opt-in silently registers only workdir-local skills whose required config
+   and secrets resolve without prompting; it never bypasses an unresolved
+   required value. All other unregistered skills remain rejected with their
+   registration command. Explicit registration remains the normal path for
+   config and secret prompting.
 
 3. **Bundle hash drift** (the registered skill's source files changed
    since register). The bundle hash covers `omac.yaml` and every

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -50,15 +50,15 @@ type launchOpts struct {
 	skipSecretPattern  bool
 	verbose            bool
 	// autoRegisterSkills, when set, silently registers discovered
-	// workdir-local skills that declare no required secrets and no
-	// required config fields, mirroring `omac serve`'s autoRegister
-	// (serve.go). Skills with required secrets/fields are NOT
-	// auto-registered — they still surface in the unregistered list so
-	// the user is prompted for values. Used by launchers (e.g. the `oco`
-	// wrapper) that run `omac start` against a freshly cloned workdir
-	// whose workdir-local skills are committed but whose per-workdir
-	// registry (.opencode/sidecar.json) is gitignored and therefore
-	// empty on every fresh checkout.
+	// workdir-local skills whose required values resolve without prompting,
+	// mirroring `omac serve`'s autoRegister (serve.go). Skills with a
+	// required value that cannot resolve are NOT auto-registered — they
+	// still surface in the unregistered list so the user is prompted for
+	// values. Used by launchers (e.g. the `oco` wrapper) that run `omac
+	// start` against a freshly cloned workdir whose workdir-local skills
+	// are committed but whose per-workdir registry
+	// (.opencode/sidecar.json) is gitignored and therefore empty on every
+	// fresh checkout.
 	autoRegisterSkills bool
 	// audit flags (see internal/audit). auditLog overrides the config/default
 	// path; noAudit disables; auditStrict makes an unwritable log fatal.
@@ -90,7 +90,7 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 		acceptSkillChanges = fs.Bool("accept-skill-changes", false, "Tolerate bundle_hash drift in registered skills (proceed even if the on-disk skill differs from what was registered).")
 		skipSecretPattern  = fs.Bool("skip-secret-pattern", false, "Do not enforce a secret's pattern against an env_passthrough-supplied value (escape hatch for an outdated pattern; the raw value is still passed through).")
 		verbose            = fs.Bool("verbose", false, "Verbose lifecycle logging.")
-		autoRegisterSkills = fs.Bool("auto-register-skills", false, "Silently register discovered workdir-local skills that declare no required secrets and no required config fields, instead of refusing to start. Skills with required secrets/fields still prompt via `omac register`.")
+		autoRegisterSkills = fs.Bool("auto-register-skills", false, "Silently register discovered workdir-local skills whose required values resolve without prompting, instead of refusing to start. Skills with unresolved required values still prompt via `omac register`.")
 		auditLog           = fs.String("audit-log", "", "Path to the audit log (default: persistent central location). Overrides config.")
 		noAudit            = fs.Bool("no-audit", false, "Disable the security audit trail.")
 		auditStrict        = fs.Bool("audit-strict", false, "Fail-closed: abort if the audit log cannot be written.")
@@ -318,15 +318,32 @@ func runLaunch(env *Env, opts launchOpts) int {
 	// name.
 	reg := mergeRegistries(globalReg, workdirReg)
 
-	// 2a-bis. Optional auto-registration of workdir-local skills that
-	//         declare no required secrets and no required config fields.
-	//         Mirrors `omac serve`'s autoRegister (serve.go): the
-	//         workdir-local skill source roots are scanned, and every
-	//         discovered skill absent from the registry whose
-	//         omac.yaml sidecar has no required secrets/fields is
-	//         registered silently. Skills WITH required secrets/fields
-	//         are left untouched so the findUnregisteredSkills gate
-	//         below still surfaces them and prompts the user.
+	// Load the config stores once before auto-registration eligibility and
+	// runtime resolution. A broken store is a launch-wide I/O failure, not a
+	// per-skill condition that can be deferred to registration guidance.
+	workdirCfg, err := skillconfig.Load(env.Workdir)
+	if err != nil {
+		fmt.Fprintln(env.Stderr, prefix+": skill-config:", err)
+		return ExitIOError
+	}
+	globalCfg, err := skillconfig.LoadGlobal()
+	if err != nil {
+		fmt.Fprintln(env.Stderr, prefix+": global skill-config:", err)
+		return ExitIOError
+	}
+	// Merge config the same way as the registry: workdir values
+	// override global values per (skill, field).
+	configStore := mergeConfig(globalCfg, workdirCfg)
+
+	// 2a-bis. Optional auto-registration of workdir-local skills whose
+	//         required values resolve without prompting. Mirrors `omac
+	//         serve`'s autoRegister (serve.go): the workdir-local skill
+	//         source roots are scanned, and every discovered skill absent
+	//         from the registry whose omac.yaml sidecar has all required
+	//         values resolved is registered silently. Skills with
+	//         unresolved required values are left untouched so the
+	//         findUnregisteredSkills gate below still surfaces them and
+	//         prompts the user.
 	//
 	//         This is the path launchers like the `oco` wrapper use to
 	//         avoid forcing the user to run `omac register` on every
@@ -335,7 +352,11 @@ func runLaunch(env *Env, opts launchOpts) int {
 	//         for omac's own repo and any repo that ships example
 	//         skills).
 	if autoRegisterSkills {
-		registered, errs := startAutoRegisterWorkdirSkills(env, harness, reg)
+		registered, errs, err := startAutoRegisterWorkdirSkills(env, harness, reg, configStore, skipSecretPattern)
+		if err != nil {
+			fmt.Fprintln(env.Stderr, prefix+": keychain:", err)
+			return ExitKeychainError
+		}
 		for _, r := range registered {
 			fmt.Fprintf(env.Stderr, "[ok] auto-registered skill %s (no prompting required)\n", r)
 		}
@@ -420,20 +441,6 @@ func runLaunch(env *Env, opts launchOpts) int {
 			allSecrets[i].Zero()
 		}
 	}()
-
-	workdirCfg, err := skillconfig.Load(env.Workdir)
-	if err != nil {
-		fmt.Fprintln(env.Stderr, prefix+": skill-config:", err)
-		return ExitIOError
-	}
-	globalCfg, err := skillconfig.LoadGlobal()
-	if err != nil {
-		fmt.Fprintln(env.Stderr, prefix+": global skill-config:", err)
-		return ExitIOError
-	}
-	// Merge config the same way as the registry: workdir values
-	// override global values per (skill, field).
-	configStore := mergeConfig(globalCfg, workdirCfg)
 
 	// Per-class problem accumulators. Each maps a hint template to
 	// the affected skill names so we can render "do X for these N
@@ -1215,22 +1222,22 @@ func findUnregisteredSkills(workdir string, harness config.Harness, reg *registr
 
 // startAutoRegisterWorkdirSkills silently registers every discovered
 // workdir-local skill (Kind == "workdir") that is absent from reg AND
-// whose omac.yaml sidecar declares no required secrets and no required
-// config fields. Mirrors `omac serve`'s autoRegister (serve.go), but
-// scoped to "no required values" so a skill that needs a keychain
-// secret or a config value still surfaces through findUnregisteredSkills
-// and prompts the user — auto-registration never silently skips a
-// registration prompt that would otherwise have asked for a value.
+// whose omac.yaml sidecar has every required value resolved without
+// prompting. Mirrors `omac serve`'s autoRegister (serve.go), but
+// scoped to values that are resolved at launch so a skill with a missing
+// keychain secret or config value still surfaces through
+// findUnregisteredSkills and prompts the user — auto-registration never
+// silently skips a registration prompt that would otherwise have asked
+// for a value.
 //
-// Returns the names of skills that were registered (sorted) and a slice
-// of per-skill errors (skill name + error) for skills that looked
-// eligible but failed to register (e.g. omac.yaml unreadable). The
-// caller decides whether a per-skill error is fatal; this function
-// registers what it can and reports the rest.
-func startAutoRegisterWorkdirSkills(env *Env, harness config.Harness, reg *registry.Registry) ([]string, []string) {
+// Returns the names of skills that were registered (sorted), per-skill
+// diagnostics for metadata/registration failures, and a fatal keychain read
+// error. Metadata errors remain diagnostic so one malformed skill does not
+// hide actionable results for other skills.
+func startAutoRegisterWorkdirSkills(env *Env, harness config.Harness, reg *registry.Registry, configStore *skillconfig.Store, skipSecretPattern bool) ([]string, []string, error) {
 	discovered, err := skillsource.Discover(env.Workdir, harness)
 	if err != nil {
-		return nil, []string{fmt.Sprintf("scan skills: %v", err)}
+		return nil, []string{fmt.Sprintf("scan skills: %v", err)}, nil
 	}
 	registered := map[string]struct{}{}
 	for _, e := range reg.Registered {
@@ -1245,10 +1252,14 @@ func startAutoRegisterWorkdirSkills(env *Env, harness config.Harness, reg *regis
 		if _, ok := registered[ent.Name]; ok {
 			continue
 		}
-		eligible, err := skillEligibleForAutoRegister(ent.Dir)
+		meta, err := config.LoadMeta(filepath.Join(ent.Dir, config.MetaFileName))
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("%s: %v", ent.Name, err))
 			continue
+		}
+		eligible, err := skillEligibleForAutoRegister(env.Workdir, ent.Name, meta, configStore, skipSecretPattern)
+		if err != nil {
+			return done, errs, err
 		}
 		if !eligible {
 			// A required secret/field is the user's signal to run
@@ -1263,33 +1274,28 @@ func startAutoRegisterWorkdirSkills(env *Env, harness config.Harness, reg *regis
 		done = append(done, ent.Name)
 	}
 	sort.Strings(done)
-	return done, errs
+	return done, errs, nil
 }
 
-// skillEligibleForAutoRegister reports whether the skill at absDir is
-// eligible for silent auto-registration: its omac.yaml must parse, must
-// have a sidecar block, and every declared secret/config field must be
-// satisfiable at start time WITHOUT prompting the user.
+// skillEligibleForAutoRegister reports whether parsed metadata is eligible
+// for silent auto-registration: it must have a sidecar block, and every
+// declared secret/config field must be satisfiable at start time WITHOUT
+// prompting the user.
 //
 // "Satisfiable without prompting" mirrors the resolution precedence in
 // runLaunch (start.go):
-//   - a config field is satisfiable if it has a default, a
-//     DefaultFromEnv, or is explicitly required:false (a field with a
-//     default but no explicit required:false is still satisfiable —
-//     IsRequired() returns true for nil Required, but the default fills
-//     the value without user input);
-//   - a secret is satisfiable if it is in env_passthrough (the host env
-//     supplies it at runtime) or is explicitly required:false.
+//   - a required secret is satisfiable when its workdir-scoped or unscoped
+//     keychain value exists; only when both are absent can a non-empty
+//     env_passthrough value satisfy it, subject to its pattern unless
+//     skipSecretPattern is set;
+//   - a required config field is satisfiable from the merged stored
+//     workdir/global config, then a non-empty default, then a non-empty
+//     DefaultFromEnv host environment value.
 //
 // A skill with at least one required-and-unsatisfiable secret/field is
 // NOT eligible — the findUnregisteredSkills gate surfaces it so the
 // user is prompted for the missing value.
-func skillEligibleForAutoRegister(absDir string) (eligible bool, err error) {
-	metaPath := filepath.Join(absDir, config.MetaFileName)
-	m, err := config.LoadMeta(metaPath)
-	if err != nil {
-		return false, err
-	}
+func skillEligibleForAutoRegister(workdir, skillName string, m *config.Meta, configStore *skillconfig.Store, skipSecretPattern bool) (eligible bool, err error) {
 	if m.Sidecar == nil {
 		return false, nil
 	}
@@ -1301,8 +1307,22 @@ func skillEligibleForAutoRegister(absDir string) (eligible bool, err error) {
 		if !sp.IsRequired() {
 			continue
 		}
-		if _, ok := passthrough[sp.Name]; ok {
-			continue // env supplies it at runtime
+		keychainValue, err := keychain.GetWithFallback(keychain.WorkdirID(workdir), skillName, sp.Name)
+		if err == nil {
+			keychainValue.Zero()
+			continue
+		}
+		if !errors.Is(err, keychain.ErrNotFound) {
+			return false, err
+		}
+		envValue, suppliedByEnv := secretFromEnv(sp.Name, passthrough)
+		if suppliedByEnv {
+			if !skipSecretPattern {
+				if err := validatePattern(sp, envValue); err != nil {
+					return false, nil
+				}
+			}
+			continue
 		}
 		return false, nil
 	}
@@ -1310,8 +1330,16 @@ func skillEligibleForAutoRegister(absDir string) (eligible bool, err error) {
 		if !fp.IsRequired() {
 			continue
 		}
-		if fp.Default != "" || fp.DefaultFromEnv != "" {
-			continue // satisfiable without user input
+		if _, ok := configStore.Get(skillName, fp.Name); ok {
+			continue
+		}
+		if fp.Default != "" {
+			continue
+		}
+		if fp.DefaultFromEnv != "" {
+			if value, ok := os.LookupEnv(fp.DefaultFromEnv); ok && value != "" {
+				continue
+			}
 		}
 		return false, nil
 	}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -49,6 +49,17 @@ type launchOpts struct {
 	acceptSkillChanges bool
 	skipSecretPattern  bool
 	verbose            bool
+	// autoRegisterSkills, when set, silently registers discovered
+	// workdir-local skills that declare no required secrets and no
+	// required config fields, mirroring `omac serve`'s autoRegister
+	// (serve.go). Skills with required secrets/fields are NOT
+	// auto-registered — they still surface in the unregistered list so
+	// the user is prompted for values. Used by launchers (e.g. the `oco`
+	// wrapper) that run `omac start` against a freshly cloned workdir
+	// whose workdir-local skills are committed but whose per-workdir
+	// registry (.opencode/sidecar.json) is gitignored and therefore
+	// empty on every fresh checkout.
+	autoRegisterSkills bool
 	// audit flags (see internal/audit). auditLog overrides the config/default
 	// path; noAudit disables; auditStrict makes an unwritable log fatal.
 	auditLog    string
@@ -79,6 +90,7 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 		acceptSkillChanges = fs.Bool("accept-skill-changes", false, "Tolerate bundle_hash drift in registered skills (proceed even if the on-disk skill differs from what was registered).")
 		skipSecretPattern  = fs.Bool("skip-secret-pattern", false, "Do not enforce a secret's pattern against an env_passthrough-supplied value (escape hatch for an outdated pattern; the raw value is still passed through).")
 		verbose            = fs.Bool("verbose", false, "Verbose lifecycle logging.")
+		autoRegisterSkills = fs.Bool("auto-register-skills", false, "Silently register discovered workdir-local skills that declare no required secrets and no required config fields, instead of refusing to start. Skills with required secrets/fields still prompt via `omac register`.")
 		auditLog           = fs.String("audit-log", "", "Path to the audit log (default: persistent central location). Overrides config.")
 		noAudit            = fs.Bool("no-audit", false, "Disable the security audit trail.")
 		auditStrict        = fs.Bool("audit-strict", false, "Fail-closed: abort if the audit log cannot be written.")
@@ -135,6 +147,7 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 		acceptSkillChanges: *acceptSkillChanges,
 		skipSecretPattern:  *skipSecretPattern,
 		verbose:            *verbose,
+		autoRegisterSkills: *autoRegisterSkills,
 		auditLog:           *auditLog,
 		noAudit:            *noAudit,
 		auditStrict:        *auditStrict,
@@ -178,6 +191,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	skipSecretPattern := opts.skipSecretPattern
 	verbose := opts.verbose
 	innerArgs := opts.innerArgs
+	autoRegisterSkills := opts.autoRegisterSkills
 
 	// Diagnostics are prefixed with the invoking subcommand so a failure
 	// surfaced through `omac continue`/`omac resume` is not mislabeled.
@@ -303,6 +317,43 @@ func runLaunch(env *Env, opts launchOpts) int {
 	// of start. Workdir entries win over global entries with the same
 	// name.
 	reg := mergeRegistries(globalReg, workdirReg)
+
+	// 2a-bis. Optional auto-registration of workdir-local skills that
+	//         declare no required secrets and no required config fields.
+	//         Mirrors `omac serve`'s autoRegister (serve.go): the
+	//         workdir-local skill source roots are scanned, and every
+	//         discovered skill absent from the registry whose
+	//         omac.yaml sidecar has no required secrets/fields is
+	//         registered silently. Skills WITH required secrets/fields
+	//         are left untouched so the findUnregisteredSkills gate
+	//         below still surfaces them and prompts the user.
+	//
+	//         This is the path launchers like the `oco` wrapper use to
+	//         avoid forcing the user to run `omac register` on every
+	//         fresh workdir whose committed skills ship with a
+	//         gitignored per-workdir registry (the documented default
+	//         for omac's own repo and any repo that ships example
+	//         skills).
+	if autoRegisterSkills {
+		registered, errs := startAutoRegisterWorkdirSkills(env, harness, reg)
+		for _, r := range registered {
+			fmt.Fprintf(env.Stderr, "[ok] auto-registered skill %s (no required secrets/fields)\n", r)
+		}
+		for _, e := range errs {
+			fmt.Fprintln(env.Stderr, prefix+": auto-register:", e)
+		}
+		if len(registered) > 0 {
+			// Reload the workdir registry + re-merge so the gate and
+			// the rest of start see the freshly-registered skills.
+			workdirReg, err = registry.Load(env.Workdir)
+			if err != nil {
+				fmt.Fprintln(env.Stderr, prefix+": registry:", err)
+				return ExitIOError
+			}
+			workdirReg = filterRegistryByHarness(workdirReg, env.Workdir, harness)
+			reg = mergeRegistries(globalReg, workdirReg)
+		}
+	}
 
 	// 2b. Refuse if any unregistered skill exists under any of the
 	//     skill source roots (workdir-local .agents/skills and
@@ -1159,6 +1210,131 @@ func findUnregisteredSkills(workdir string, harness config.Harness, reg *registr
 		}
 	}
 	sort.Strings(out)
+	return out, nil
+}
+
+// startAutoRegisterWorkdirSkills silently registers every discovered
+// workdir-local skill (Kind == "workdir") that is absent from reg AND
+// whose omac.yaml sidecar declares no required secrets and no required
+// config fields. Mirrors `omac serve`'s autoRegister (serve.go), but
+// scoped to "no required values" so a skill that needs a keychain
+// secret or a config value still surfaces through findUnregisteredSkills
+// and prompts the user — auto-registration never silently skips a
+// registration prompt that would otherwise have asked for a value.
+//
+// Returns the names of skills that were registered (sorted) and a slice
+// of per-skill errors (skill name + error) for skills that looked
+// eligible but failed to register (e.g. omac.yaml unreadable). The
+// caller decides whether a per-skill error is fatal; this function
+// registers what it can and reports the rest.
+func startAutoRegisterWorkdirSkills(env *Env, harness config.Harness, reg *registry.Registry) ([]string, []string) {
+	discovered, err := skillsource.Discover(env.Workdir, harness)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("scan skills: %v", err)}
+	}
+	registered := map[string]struct{}{}
+	for _, e := range reg.Registered {
+		registered[e.Name] = struct{}{}
+	}
+	var done []string
+	var errs []string
+	for _, ent := range discovered {
+		if ent.Kind != "workdir" {
+			continue // user-global skills are registered once, globally
+		}
+		if _, ok := registered[ent.Name]; ok {
+			continue
+		}
+		eligible, err := skillEligibleForAutoRegister(ent.Dir)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", ent.Name, err))
+			continue
+		}
+		if !eligible {
+			// A required secret/field is the user's signal to run
+			// `omac register` themselves; we don't auto-register so
+			// the findUnregisteredSkills gate below still surfaces it.
+			continue
+		}
+		if _, err := startAutoRegisterOne(env.Workdir, ent); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", ent.Name, err))
+			continue
+		}
+		done = append(done, ent.Name)
+	}
+	sort.Strings(done)
+	return done, errs
+}
+
+// skillEligibleForAutoRegister reports whether the skill at absDir is
+// eligible for silent auto-registration: its omac.yaml must parse, must
+// have a sidecar block, and must declare no required secrets and no
+// required config fields. A non-required secret/field is fine (the user
+// can supply it later via `omac register --reprompt-*`).
+func skillEligibleForAutoRegister(absDir string) (eligible bool, err error) {
+	metaPath := filepath.Join(absDir, config.MetaFileName)
+	m, err := config.LoadMeta(metaPath)
+	if err != nil {
+		return false, err
+	}
+	if m.Sidecar == nil {
+		return false, nil
+	}
+	for _, sp := range m.Sidecar.Secrets {
+		if sp.IsRequired() {
+			return false, nil
+		}
+	}
+	for _, fp := range m.Sidecar.Config {
+		if fp.IsRequired() {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// startAutoRegisterOne writes a registry entry for a discovered
+// workdir-local skill without prompting, mirroring serve.go's autoRegister.
+func startAutoRegisterOne(workdir string, ent skillsource.Entry) (*registry.Entry, error) {
+	bundle, err := config.BundleHash(ent.Dir)
+	if err != nil {
+		return nil, err
+	}
+	m, err := config.LoadMeta(filepath.Join(ent.Dir, config.MetaFileName))
+	if err != nil {
+		return nil, err
+	}
+	declared := make([]string, 0, len(m.Sidecar.Secrets))
+	for _, sp := range m.Sidecar.Secrets {
+		declared = append(declared, sp.Name)
+	}
+	var out *registry.Entry
+	err = registry.WithLock(workdir, func() error {
+		reg, err := registry.Load(workdir)
+		if err != nil {
+			return err
+		}
+		stored := ent.Dir
+		if rel, rerr := filepath.Rel(workdir, ent.Dir); rerr == nil {
+			stored = rel
+		}
+		reg.Upsert(registry.Entry{
+			Name:                ent.Name,
+			SkillDir:            stored,
+			BundleHash:          bundle,
+			RegisteredAt:        time.Now().UTC(),
+			DeclaredSecretNames: declared,
+		})
+		if err := registry.Save(workdir, reg); err != nil {
+			return err
+		}
+		e, _ := reg.Find(ent.Name)
+		out = e
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -1268,9 +1268,22 @@ func startAutoRegisterWorkdirSkills(env *Env, harness config.Harness, reg *regis
 
 // skillEligibleForAutoRegister reports whether the skill at absDir is
 // eligible for silent auto-registration: its omac.yaml must parse, must
-// have a sidecar block, and must declare no required secrets and no
-// required config fields. A non-required secret/field is fine (the user
-// can supply it later via `omac register --reprompt-*`).
+// have a sidecar block, and every declared secret/config field must be
+// satisfiable at start time WITHOUT prompting the user.
+//
+// "Satisfiable without prompting" mirrors the resolution precedence in
+// runLaunch (start.go):
+//   - a config field is satisfiable if it has a default, a
+//     DefaultFromEnv, or is explicitly required:false (a field with a
+//     default but no explicit required:false is still satisfiable —
+//     IsRequired() returns true for nil Required, but the default fills
+//     the value without user input);
+//   - a secret is satisfiable if it is in env_passthrough (the host env
+//     supplies it at runtime) or is explicitly required:false.
+//
+// A skill with at least one required-and-unsatisfiable secret/field is
+// NOT eligible — the findUnregisteredSkills gate surfaces it so the
+// user is prompted for the missing value.
 func skillEligibleForAutoRegister(absDir string) (eligible bool, err error) {
 	metaPath := filepath.Join(absDir, config.MetaFileName)
 	m, err := config.LoadMeta(metaPath)
@@ -1280,15 +1293,27 @@ func skillEligibleForAutoRegister(absDir string) (eligible bool, err error) {
 	if m.Sidecar == nil {
 		return false, nil
 	}
+	passthrough := map[string]struct{}{}
+	for _, name := range m.Sidecar.EnvPassthrough {
+		passthrough[name] = struct{}{}
+	}
 	for _, sp := range m.Sidecar.Secrets {
-		if sp.IsRequired() {
-			return false, nil
+		if !sp.IsRequired() {
+			continue
 		}
+		if _, ok := passthrough[sp.Name]; ok {
+			continue // env supplies it at runtime
+		}
+		return false, nil
 	}
 	for _, fp := range m.Sidecar.Config {
-		if fp.IsRequired() {
-			return false, nil
+		if !fp.IsRequired() {
+			continue
 		}
+		if fp.Default != "" || fp.DefaultFromEnv != "" {
+			continue // satisfiable without user input
+		}
+		return false, nil
 	}
 	return true, nil
 }

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -337,7 +337,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	if autoRegisterSkills {
 		registered, errs := startAutoRegisterWorkdirSkills(env, harness, reg)
 		for _, r := range registered {
-			fmt.Fprintf(env.Stderr, "[ok] auto-registered skill %s (no required secrets/fields)\n", r)
+			fmt.Fprintf(env.Stderr, "[ok] auto-registered skill %s (no prompting required)\n", r)
 		}
 		for _, e := range errs {
 			fmt.Fprintln(env.Stderr, prefix+": auto-register:", e)

--- a/internal/cli/start_autoregister_test.go
+++ b/internal/cli/start_autoregister_test.go
@@ -1,0 +1,239 @@
+package cli
+
+// Tests for the --auto-register-skills path in start.go:
+//   - startAutoRegisterWorkdirSkills: silently registers discovered
+//     workdir-local skills whose omac.yaml declares no required
+//     secrets/fields, leaves skills with required values for the
+//     findUnregisteredSkills gate to surface.
+//   - skillEligibleForAutoRegister: the eligibility predicate.
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/tngtech/oh-my-agentic-coder/internal/registry"
+)
+
+// stageSkillWithSidecar creates .opencode/skills/<name>/omac.yaml with
+// the given omac.yaml body (a sidecar block). Returns the skill's
+// absolute directory.
+func stageSkillWithSidecar(t *testing.T, workdir, name, body string) string {
+	t.Helper()
+	skillDir := filepath.Join(workdir, ".opencode", "skills", name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", skillDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "omac.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write omac.yaml: %v", err)
+	}
+	return skillDir
+}
+
+const sidecarNoRequired = `name: no-required
+type: skill
+sidecar:
+  command: ["python3", "x.py"]
+  mount: no-required
+  secrets:
+    - name: OPT_SECRET
+      description: "optional"
+      required: false
+  config:
+    - name: OPT_FIELD
+      type: string
+      description: "optional"
+      required: false
+`
+
+const sidecarWithRequiredSecret = `name: needs-secret
+type: skill
+sidecar:
+  command: ["python3", "x.py"]
+  mount: needs-secret
+  secrets:
+    - name: MUST_SECRET
+      description: "required"
+      required: true
+`
+
+const sidecarWithRequiredField = `name: needs-field
+type: skill
+sidecar:
+  command: ["python3", "x.py"]
+  mount: needs-field
+  config:
+    - name: MUST_FIELD
+      type: string
+      description: "required"
+      required: true
+`
+
+// TestSkillEligibleForAutoRegister_NoSidecarBlock: a directory with a
+// bare omac.yaml (no sidecar) is NOT eligible — it would be a skill
+// omac can't activate, so we don't auto-register it. The
+// findUnregisteredSkills gate surfaces it instead.
+func TestSkillEligibleForAutoRegister_NoSidecarBlock(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "omac.yaml"), []byte("name: bare\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := skillEligibleForAutoRegister(dir)
+	if err != nil {
+		t.Fatalf("skillEligibleForAutoRegister: %v", err)
+	}
+	if got {
+		t.Error("a skill with no sidecar block must not be auto-registered")
+	}
+}
+
+// TestSkillEligibleForAutoRegister_NoRequiredValues: a skill whose
+// secrets and config fields are all optional IS eligible.
+func TestSkillEligibleForAutoRegister_NoRequiredValues(t *testing.T) {
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "no-required", sidecarNoRequired)
+	got, err := skillEligibleForAutoRegister(filepath.Join(wd, ".opencode", "skills", "no-required"))
+	if err != nil {
+		t.Fatalf("skillEligibleForAutoRegister: %v", err)
+	}
+	if !got {
+		t.Error("a skill with only optional secrets/fields should be eligible")
+	}
+}
+
+// TestSkillEligibleForAutoRegister_RequiredSecret: a skill with a
+// required secret is NOT eligible.
+func TestSkillEligibleForAutoRegister_RequiredSecret(t *testing.T) {
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "needs-secret", sidecarWithRequiredSecret)
+	got, err := skillEligibleForAutoRegister(filepath.Join(wd, ".opencode", "skills", "needs-secret"))
+	if err != nil {
+		t.Fatalf("skillEligibleForAutoRegister: %v", err)
+	}
+	if got {
+		t.Error("a skill with a required secret must not be auto-registered")
+	}
+}
+
+// TestSkillEligibleForAutoRegister_RequiredField: a skill with a
+// required config field is NOT eligible.
+func TestSkillEligibleForAutoRegister_RequiredField(t *testing.T) {
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "needs-field", sidecarWithRequiredField)
+	got, err := skillEligibleForAutoRegister(filepath.Join(wd, ".opencode", "skills", "needs-field"))
+	if err != nil {
+		t.Fatalf("skillEligibleForAutoRegister: %v", err)
+	}
+	if got {
+		t.Error("a skill with a required config field must not be auto-registered")
+	}
+}
+
+// TestStartAutoRegisterWorkdirSkills_OnlyEligible: with the flag set,
+// an eligible skill is registered and a skill with a required value is
+// left for the gate to surface.
+func TestStartAutoRegisterWorkdirSkills_OnlyEligible(t *testing.T) {
+	isolateHome(t)
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "no-required", sidecarNoRequired)
+	stageSkillWithSidecar(t, wd, "needs-secret", sidecarWithRequiredSecret)
+
+	env := makeEnv(wd)
+	reg := &registry.Registry{} // empty: nothing registered yet
+
+	done, errs := startAutoRegisterWorkdirSkills(env, config.DefaultHarness(), reg)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	want := []string{"no-required"}
+	if !reflect.DeepEqual(done, want) {
+		t.Errorf("auto-registered = %v, want %v", done, want)
+	}
+
+	// The eligible skill is now in the workdir registry.
+	loaded, err := registry.Load(wd)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	if e, _ := loaded.Find("no-required"); e == nil {
+		t.Error("no-required was not persisted to the registry")
+	}
+	// The required-secret skill was NOT registered.
+	if e, _ := loaded.Find("needs-secret"); e != nil {
+		t.Error("needs-secret must not be auto-registered (it has a required secret)")
+	}
+
+	// The required-secret skill must still be surfaced by
+	// findUnregisteredSkills so the user gets the prompt.
+	unreg, err := findUnregisteredSkills(wd, config.DefaultHarness(), loaded)
+	if err != nil {
+		t.Fatalf("findUnregisteredSkills: %v", err)
+	}
+	if want := []string{"needs-secret"}; !reflect.DeepEqual(unreg, want) {
+		t.Errorf("unregistered after auto-register = %v, want %v", unreg, want)
+	}
+}
+
+// TestStartAutoRegisterWorkdirSkills_SkipsAlreadyRegistered: an
+// already-registered skill is not re-registered.
+func TestStartAutoRegisterWorkdirSkills_SkipsAlreadyRegistered(t *testing.T) {
+	isolateHome(t)
+	wd := t.TempDir()
+	skillDir := stageSkillWithSidecar(t, wd, "no-required", sidecarNoRequired)
+
+	bundle := mustBundleHash(t, skillDir)
+	reg := &registry.Registry{Registered: []registry.Entry{{
+		Name:       "no-required",
+		SkillDir:   filepath.Join(".opencode", "skills", "no-required"),
+		BundleHash: bundle,
+	}}}
+	env := makeEnv(wd)
+
+	done, errs := startAutoRegisterWorkdirSkills(env, config.DefaultHarness(), reg)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(done) != 0 {
+		t.Errorf("already-registered skill was re-registered: %v", done)
+	}
+}
+
+// TestStartAutoRegisterWorkdirSkills_SkipsUserGlobal: user-global
+// skills are NOT auto-registered by the start path (they're registered
+// once, globally, via `omac register --global`); only workdir-local
+// skills are in scope.
+func TestStartAutoRegisterWorkdirSkills_SkipsUserGlobal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	wd := t.TempDir()
+	// Stage a user-global skill with an eligible sidecar.
+	globalDir := filepath.Join(home, ".config", "opencode", "skills", "global-eligible")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "omac.yaml"), []byte(sidecarNoRequired), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := makeEnv(wd)
+	done, errs := startAutoRegisterWorkdirSkills(env, config.DefaultHarness(), &registry.Registry{})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(done) != 0 {
+		t.Errorf("user-global skill must not be auto-registered by `omac start`: %v", done)
+	}
+}
+
+func mustBundleHash(t *testing.T, dir string) string {
+	t.Helper()
+	h, err := config.BundleHash(dir)
+	if err != nil {
+		t.Fatalf("BundleHash: %v", err)
+	}
+	return h
+}

--- a/internal/cli/start_autoregister_test.go
+++ b/internal/cli/start_autoregister_test.go
@@ -2,8 +2,8 @@ package cli
 
 // Tests for the --auto-register-skills path in start.go:
 //   - startAutoRegisterWorkdirSkills: silently registers discovered
-//     workdir-local skills whose omac.yaml declares no required
-//     secrets/fields, leaves skills with required values for the
+//     workdir-local skills whose required values resolve at launch time,
+//     leaves skills with missing required values for the
 //     findUnregisteredSkills gate to surface.
 //   - skillEligibleForAutoRegister: the eligibility predicate.
 
@@ -11,10 +11,14 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/tngtech/oh-my-agentic-coder/internal/keychain"
 	"github.com/tngtech/oh-my-agentic-coder/internal/registry"
+	"github.com/tngtech/oh-my-agentic-coder/internal/secrets"
+	"github.com/tngtech/oh-my-agentic-coder/internal/skillconfig"
 )
 
 // stageSkillWithSidecar creates .opencode/skills/<name>/omac.yaml with
@@ -30,6 +34,37 @@ func stageSkillWithSidecar(t *testing.T, workdir, name, body string) string {
 		t.Fatalf("write omac.yaml: %v", err)
 	}
 	return skillDir
+}
+
+func autoRegisterConfig(t *testing.T, workdir string) *skillconfig.Store {
+	t.Helper()
+	workdirStore, err := skillconfig.Load(workdir)
+	if err != nil {
+		t.Fatalf("skillconfig.Load: %v", err)
+	}
+	globalStore, err := skillconfig.LoadGlobal()
+	if err != nil {
+		t.Fatalf("skillconfig.LoadGlobal: %v", err)
+	}
+	return mergeConfig(globalStore, workdirStore)
+}
+
+func autoRegisterEligible(t *testing.T, workdir, skillName, skillDir string, skipSecretPattern bool) (bool, error) {
+	t.Helper()
+	meta, err := config.LoadMeta(filepath.Join(skillDir, config.MetaFileName))
+	if err != nil {
+		return false, err
+	}
+	return skillEligibleForAutoRegister(workdir, skillName, meta, autoRegisterConfig(t, workdir), skipSecretPattern)
+}
+
+func runAutoRegisterWorkdirSkills(t *testing.T, env *Env, harness config.Harness, reg *registry.Registry, skipSecretPattern bool) ([]string, []string) {
+	t.Helper()
+	done, diagnostics, err := startAutoRegisterWorkdirSkills(env, harness, reg, autoRegisterConfig(t, env.Workdir), skipSecretPattern)
+	if err != nil {
+		t.Fatalf("startAutoRegisterWorkdirSkills: %v", err)
+	}
+	return done, diagnostics
 }
 
 const sidecarNoRequired = `name: no-required
@@ -74,10 +109,7 @@ sidecar:
 // sidecarWithRequiredFieldButDefault mirrors the echo-rest shape: a
 // config field with NO explicit `required:` (so IsRequired()==true) but
 // a non-empty `default:`. At start time the default fills the value
-// without user input (start.go precedence: stored > spec.Default > …),
-// so this skill IS eligible for auto-registration. This is the case
-// that previously bit the user: echo-rest was refused even though all
-// its fields had defaults.
+// without user input, so this skill IS eligible for auto-registration.
 const sidecarWithRequiredFieldButDefault = `name: has-default
 type: skill
 sidecar:
@@ -88,6 +120,14 @@ sidecar:
       type: string
       description: "no explicit required, but has a default"
       default: "hello"
+`
+
+const sidecarWithRequiredFieldDefaultFromEnv = `name: has-default-from-env
+type: skill
+sidecar:
+  command: ["python3", "x.py"]
+  mount: has-default-from-env
+  config:
     - name: FIELD_WITH_DEFAULT_FROM_ENV
       type: string
       description: "no explicit required, but has a default_from_env"
@@ -111,16 +151,106 @@ sidecar:
       required: true
 `
 
+const sidecarWithPatternedSecretInEnvPassthrough = `name: patterned-passthrough-secret
+type: skill
+sidecar:
+  command: ["python3", "x.py"]
+  mount: patterned-passthrough-secret
+  env_passthrough:
+    - MUST_SECRET
+  secrets:
+    - name: MUST_SECRET
+      description: "required token supplied via env_passthrough"
+      pattern: "^valid-[a-z]+$"
+      required: true
+`
+
+func TestParseLaunchArgs_AutoRegisterSkills(t *testing.T) {
+	opts, ok := parseLaunchArgs("start", []string{"--auto-register-skills"}, devnullEnv(t))
+	if !ok || !opts.autoRegisterSkills {
+		t.Fatal("--auto-register-skills was not parsed")
+	}
+}
+
+func TestRunStart_AutoRegistersEligibleWorkdirSkill(t *testing.T) {
+	isolateHome(t)
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "eligible", `name: eligible
+type: skill
+sidecar:
+  command: ["true"]
+  mount: eligible
+`)
+
+	env, _ := launchTestEnv(t, wd)
+	runStart([]string{"--auto-register-skills", "--no-sandbox", "--inner", "/bin/true"}, env)
+
+	loaded, err := registry.Load(wd)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	if entry, _ := loaded.Find("eligible"); entry == nil {
+		t.Error("eligible was not persisted to the registry")
+	}
+}
+
+func TestRunStart_AutoRegisterCorruptWorkdirConfigFailsIO(t *testing.T) {
+	isolateHome(t)
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "eligible", `name: eligible
+type: skill
+sidecar:
+  command: ["true"]
+  mount: eligible
+`)
+	if err := os.WriteFile(skillconfig.Path(wd), []byte("skills: ["), 0o600); err != nil {
+		t.Fatalf("write corrupt skill config: %v", err)
+	}
+
+	env, stderr := launchTestEnv(t, wd)
+	code := runStart([]string{"--auto-register-skills", "--no-sandbox", "--inner", "/bin/true"}, env)
+	if code != ExitIOError {
+		t.Fatalf("runStart() = %d, want ExitIOError (%d)\nstderr:\n%s", code, ExitIOError, stderr())
+	}
+	if output := stderr(); strings.Contains(output, "unregistered skills") || strings.Contains(output, "register with:") {
+		t.Errorf("runStart() reported registration guidance after config load failure:\n%s", output)
+	}
+}
+
+func TestRunStart_AutoRegistersEligibleBeforeRequiredSkillGate(t *testing.T) {
+	isolateHome(t)
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "no-required", sidecarNoRequired)
+	stageSkillWithSidecar(t, wd, "needs-secret", sidecarWithRequiredSecret)
+
+	env, _ := launchTestEnv(t, wd)
+	if code := runStart([]string{"--auto-register-skills", "--no-sandbox", "--inner", "/bin/true"}, env); code != ExitPrerequisiteMissing {
+		t.Fatalf("runStart() = %d, want ExitPrerequisiteMissing (%d)", code, ExitPrerequisiteMissing)
+	}
+
+	loaded, err := registry.Load(wd)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	if entry, _ := loaded.Find("no-required"); entry == nil {
+		t.Error("no-required was not persisted to the registry")
+	}
+	if entry, _ := loaded.Find("needs-secret"); entry != nil {
+		t.Error("needs-secret must remain unregistered")
+	}
+}
+
 // TestSkillEligibleForAutoRegister_NoSidecarBlock: a directory with a
 // bare omac.yaml (no sidecar) is NOT eligible — it would be a skill
 // omac can't activate, so we don't auto-register it. The
 // findUnregisteredSkills gate surfaces it instead.
 func TestSkillEligibleForAutoRegister_NoSidecarBlock(t *testing.T) {
+	isolateHome(t)
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "omac.yaml"), []byte("name: bare\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := skillEligibleForAutoRegister(dir)
+	got, err := autoRegisterEligible(t, dir, "bare", dir, false)
 	if err != nil {
 		t.Fatalf("skillEligibleForAutoRegister: %v", err)
 	}
@@ -132,9 +262,10 @@ func TestSkillEligibleForAutoRegister_NoSidecarBlock(t *testing.T) {
 // TestSkillEligibleForAutoRegister_NoRequiredValues: a skill whose
 // secrets and config fields are all optional IS eligible.
 func TestSkillEligibleForAutoRegister_NoRequiredValues(t *testing.T) {
+	isolateHome(t)
 	wd := t.TempDir()
 	stageSkillWithSidecar(t, wd, "no-required", sidecarNoRequired)
-	got, err := skillEligibleForAutoRegister(filepath.Join(wd, ".opencode", "skills", "no-required"))
+	got, err := autoRegisterEligible(t, wd, "no-required", filepath.Join(wd, ".opencode", "skills", "no-required"), false)
 	if err != nil {
 		t.Fatalf("skillEligibleForAutoRegister: %v", err)
 	}
@@ -146,9 +277,10 @@ func TestSkillEligibleForAutoRegister_NoRequiredValues(t *testing.T) {
 // TestSkillEligibleForAutoRegister_RequiredSecret: a skill with a
 // required secret is NOT eligible.
 func TestSkillEligibleForAutoRegister_RequiredSecret(t *testing.T) {
+	isolateHome(t)
 	wd := t.TempDir()
 	stageSkillWithSidecar(t, wd, "needs-secret", sidecarWithRequiredSecret)
-	got, err := skillEligibleForAutoRegister(filepath.Join(wd, ".opencode", "skills", "needs-secret"))
+	got, err := autoRegisterEligible(t, wd, "needs-secret", filepath.Join(wd, ".opencode", "skills", "needs-secret"), false)
 	if err != nil {
 		t.Fatalf("skillEligibleForAutoRegister: %v", err)
 	}
@@ -160,9 +292,10 @@ func TestSkillEligibleForAutoRegister_RequiredSecret(t *testing.T) {
 // TestSkillEligibleForAutoRegister_RequiredField: a skill with a
 // required config field (no default) is NOT eligible.
 func TestSkillEligibleForAutoRegister_RequiredField(t *testing.T) {
+	isolateHome(t)
 	wd := t.TempDir()
 	stageSkillWithSidecar(t, wd, "needs-field", sidecarWithRequiredField)
-	got, err := skillEligibleForAutoRegister(filepath.Join(wd, ".opencode", "skills", "needs-field"))
+	got, err := autoRegisterEligible(t, wd, "needs-field", filepath.Join(wd, ".opencode", "skills", "needs-field"), false)
 	if err != nil {
 		t.Fatalf("skillEligibleForAutoRegister: %v", err)
 	}
@@ -173,13 +306,13 @@ func TestSkillEligibleForAutoRegister_RequiredField(t *testing.T) {
 
 // TestSkillEligibleForAutoRegister_RequiredFieldWithDefault: a skill
 // whose config field is implicitly required (no `required:` key) but
-// has a `default:` (or `default_from_env:`) IS eligible — at start
-// time the default fills the value without user input. This is the
-// echo-rest shape and was the case that previously bit the user.
+// has a non-empty `default:` IS eligible. A `default_from_env:` is
+// eligible only when its named environment variable is non-empty.
 func TestSkillEligibleForAutoRegister_RequiredFieldWithDefault(t *testing.T) {
+	isolateHome(t)
 	wd := t.TempDir()
 	stageSkillWithSidecar(t, wd, "has-default", sidecarWithRequiredFieldButDefault)
-	got, err := skillEligibleForAutoRegister(filepath.Join(wd, ".opencode", "skills", "has-default"))
+	got, err := autoRegisterEligible(t, wd, "has-default", filepath.Join(wd, ".opencode", "skills", "has-default"), false)
 	if err != nil {
 		t.Fatalf("skillEligibleForAutoRegister: %v", err)
 	}
@@ -188,18 +321,288 @@ func TestSkillEligibleForAutoRegister_RequiredFieldWithDefault(t *testing.T) {
 	}
 }
 
+// TestSkillEligibleForAutoRegister_RequiredFieldWithDefaultFromEnvUnset
+// verifies that default_from_env only satisfies a required field when the
+// named environment variable is non-empty.
+func TestSkillEligibleForAutoRegister_RequiredFieldWithDefaultFromEnvUnset(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("SOME_ENV_VAR", "")
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "has-default-from-env", sidecarWithRequiredFieldDefaultFromEnv)
+	got, err := autoRegisterEligible(t, wd, "has-default-from-env", filepath.Join(wd, ".opencode", "skills", "has-default-from-env"), false)
+	if err != nil {
+		t.Fatalf("skillEligibleForAutoRegister: %v", err)
+	}
+	if got {
+		t.Error("a skill with an unset required default_from_env must not be auto-registered")
+	}
+}
+
+func TestSkillEligibleForAutoRegister_RequiredFieldWithDefaultFromEnv(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("SOME_ENV_VAR", "configured")
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "has-default-from-env", sidecarWithRequiredFieldDefaultFromEnv)
+	got, err := autoRegisterEligible(t, wd, "has-default-from-env", filepath.Join(wd, ".opencode", "skills", "has-default-from-env"), false)
+	if err != nil {
+		t.Fatalf("skillEligibleForAutoRegister: %v", err)
+	}
+	if !got {
+		t.Error("a skill with a configured required default_from_env should be eligible")
+	}
+}
+
 // TestSkillEligibleForAutoRegister_SecretInEnvPassthrough: a required
 // secret that is in env_passthrough is satisfiable from the host env
 // at runtime, so the skill IS eligible.
 func TestSkillEligibleForAutoRegister_SecretInEnvPassthrough(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("MUST_SECRET", "non-empty-test-secret")
 	wd := t.TempDir()
 	stageSkillWithSidecar(t, wd, "passthrough-secret", sidecarWithSecretInEnvPassthrough)
-	got, err := skillEligibleForAutoRegister(filepath.Join(wd, ".opencode", "skills", "passthrough-secret"))
+	got, err := autoRegisterEligible(t, wd, "passthrough-secret", filepath.Join(wd, ".opencode", "skills", "passthrough-secret"), false)
 	if err != nil {
 		t.Fatalf("skillEligibleForAutoRegister: %v", err)
 	}
 	if !got {
 		t.Error("a skill whose required secret is in env_passthrough should be eligible")
+	}
+}
+
+// TestStartAutoRegisterWorkdirSkills_RequiresNonEmptyPassthroughSecret
+// verifies that a passthrough secret only makes a skill eligible when the
+// environment supplies a non-empty value.
+func TestStartAutoRegisterWorkdirSkills_RequiresNonEmptyPassthroughSecret(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("MUST_SECRET", "")
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "passthrough-secret", sidecarWithSecretInEnvPassthrough)
+
+	env := makeEnv(wd)
+	done, errs := runAutoRegisterWorkdirSkills(t, env, config.DefaultHarness(), &registry.Registry{}, false)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(done) != 0 {
+		t.Errorf("auto-registered = %v, want []", done)
+	}
+
+	loaded, err := registry.Load(wd)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	if e, _ := loaded.Find("passthrough-secret"); e != nil {
+		t.Error("passthrough-secret must not be persisted without MUST_SECRET")
+	}
+
+	unreg, err := findUnregisteredSkills(wd, config.DefaultHarness(), loaded)
+	if err != nil {
+		t.Fatalf("findUnregisteredSkills: %v", err)
+	}
+	if want := []string{"passthrough-secret"}; !reflect.DeepEqual(unreg, want) {
+		t.Errorf("unregistered after auto-register = %v, want %v", unreg, want)
+	}
+}
+
+// TestStartAutoRegisterWorkdirSkills_RejectsInvalidPassthroughSecretPattern
+// verifies auto-registration uses the same pattern check as launch before it
+// accepts a required env_passthrough secret as satisfying the skill.
+func TestStartAutoRegisterWorkdirSkills_RejectsInvalidPassthroughSecretPattern(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("MUST_SECRET", "invalid-token")
+	wd := t.TempDir()
+	skillDir := stageSkillWithSidecar(t, wd, "patterned-passthrough-secret", sidecarWithPatternedSecretInEnvPassthrough)
+
+	eligible, err := autoRegisterEligible(t, wd, "patterned-passthrough-secret", skillDir, false)
+	if err != nil {
+		t.Fatalf("skillEligibleForAutoRegister: %v", err)
+	}
+	if eligible {
+		t.Error("a required passthrough secret that violates its pattern must not be eligible")
+	}
+
+	done, errs := runAutoRegisterWorkdirSkills(t, makeEnv(wd), config.DefaultHarness(), &registry.Registry{}, false)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(done) != 0 {
+		t.Errorf("auto-registered = %v, want []", done)
+	}
+
+	loaded, err := registry.Load(wd)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	if entry, _ := loaded.Find("patterned-passthrough-secret"); entry != nil {
+		t.Error("an invalid passthrough secret must not be persisted to the registry")
+	}
+
+	unregistered, err := findUnregisteredSkills(wd, config.DefaultHarness(), loaded)
+	if err != nil {
+		t.Fatalf("findUnregisteredSkills: %v", err)
+	}
+	if want := []string{"patterned-passthrough-secret"}; !reflect.DeepEqual(unregistered, want) {
+		t.Errorf("unregistered after auto-register = %v, want %v", unregistered, want)
+	}
+}
+
+func TestStartAutoRegisterWorkdirSkills_KeychainSecretBeatsInvalidPassthroughValue(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("MUST_SECRET", "invalid-token")
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "patterned-passthrough-secret", sidecarWithPatternedSecretInEnvPassthrough)
+
+	scope := keychain.WorkdirID(wd)
+	value := secrets.NewSecretString("valid-keychain")
+	defer value.Zero()
+	if err := keychain.SetScoped(scope, "patterned-passthrough-secret", "MUST_SECRET", value); err != nil {
+		t.Fatalf("keychain.SetScoped: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := keychain.DeleteScoped(scope, "patterned-passthrough-secret", "MUST_SECRET"); err != nil {
+			t.Errorf("keychain.DeleteScoped: %v", err)
+		}
+	})
+
+	done, errs := runAutoRegisterWorkdirSkills(t, makeEnv(wd), config.DefaultHarness(), &registry.Registry{}, false)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if want := []string{"patterned-passthrough-secret"}; !reflect.DeepEqual(done, want) {
+		t.Errorf("auto-registered = %v, want %v", done, want)
+	}
+
+	loaded, err := registry.Load(wd)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	if entry, _ := loaded.Find("patterned-passthrough-secret"); entry == nil {
+		t.Error("patterned-passthrough-secret was not persisted from its keychain secret")
+	}
+}
+
+func TestStartAutoRegisterWorkdirSkills_UnscopedKeychainSecretBeatsInvalidPassthroughValue(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("MUST_SECRET", "invalid-token")
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "patterned-passthrough-secret", sidecarWithPatternedSecretInEnvPassthrough)
+
+	value := secrets.NewSecretString("valid-keychain")
+	defer value.Zero()
+	if err := keychain.Set("patterned-passthrough-secret", "MUST_SECRET", value); err != nil {
+		t.Fatalf("keychain.Set: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := keychain.Delete("patterned-passthrough-secret", "MUST_SECRET"); err != nil {
+			t.Errorf("keychain.Delete: %v", err)
+		}
+	})
+
+	done, errs := runAutoRegisterWorkdirSkills(t, makeEnv(wd), config.DefaultHarness(), &registry.Registry{}, false)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if want := []string{"patterned-passthrough-secret"}; !reflect.DeepEqual(done, want) {
+		t.Errorf("auto-registered = %v, want %v", done, want)
+	}
+}
+
+func TestStartAutoRegisterWorkdirSkills_StoredConfigSatisfiesRequiredField(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		save func(*testing.T, string)
+	}{
+		{
+			name: "workdir",
+			save: func(t *testing.T, workdir string) {
+				t.Helper()
+				store, err := skillconfig.Load(workdir)
+				if err != nil {
+					t.Fatalf("skillconfig.Load: %v", err)
+				}
+				store.Set("needs-field", "MUST_FIELD", "from-workdir")
+				if err := skillconfig.Save(workdir, store); err != nil {
+					t.Fatalf("skillconfig.Save: %v", err)
+				}
+			},
+		},
+		{
+			name: "global",
+			save: func(t *testing.T, _ string) {
+				t.Helper()
+				store, err := skillconfig.LoadGlobal()
+				if err != nil {
+					t.Fatalf("skillconfig.LoadGlobal: %v", err)
+				}
+				store.Set("needs-field", "MUST_FIELD", "from-global")
+				if err := skillconfig.SaveGlobal(store); err != nil {
+					t.Fatalf("skillconfig.SaveGlobal: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			wd := t.TempDir()
+			stageSkillWithSidecar(t, wd, "needs-field", sidecarWithRequiredField)
+			tc.save(t, wd)
+
+			done, errs := runAutoRegisterWorkdirSkills(t, makeEnv(wd), config.DefaultHarness(), &registry.Registry{}, false)
+			if len(errs) != 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			if want := []string{"needs-field"}; !reflect.DeepEqual(done, want) {
+				t.Errorf("auto-registered = %v, want %v", done, want)
+			}
+
+			loaded, err := registry.Load(wd)
+			if err != nil {
+				t.Fatalf("registry.Load: %v", err)
+			}
+			if entry, _ := loaded.Find("needs-field"); entry == nil {
+				t.Error("needs-field was not persisted from its stored config value")
+			}
+		})
+	}
+}
+
+func TestStartAutoRegisterWorkdirSkills_InvalidPassthroughSecretRequiresSkipPattern(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("MUST_SECRET", "invalid-token")
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "patterned-passthrough-secret", sidecarWithPatternedSecretInEnvPassthrough)
+
+	env := makeEnv(wd)
+	withoutSkip, errs := runAutoRegisterWorkdirSkills(t, env, config.DefaultHarness(), &registry.Registry{}, false)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors without --skip-secret-pattern: %v", errs)
+	}
+	if len(withoutSkip) != 0 {
+		t.Errorf("auto-registered without --skip-secret-pattern = %v, want []", withoutSkip)
+	}
+
+	loaded, err := registry.Load(wd)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	if entry, _ := loaded.Find("patterned-passthrough-secret"); entry != nil {
+		t.Error("patterned-passthrough-secret must not persist without --skip-secret-pattern")
+	}
+
+	withSkip, errs := runAutoRegisterWorkdirSkills(t, env, config.DefaultHarness(), &registry.Registry{}, true)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors with --skip-secret-pattern: %v", errs)
+	}
+	if want := []string{"patterned-passthrough-secret"}; !reflect.DeepEqual(withSkip, want) {
+		t.Errorf("auto-registered with --skip-secret-pattern = %v, want %v", withSkip, want)
+	}
+
+	loaded, err = registry.Load(wd)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	if entry, _ := loaded.Find("patterned-passthrough-secret"); entry == nil {
+		t.Error("patterned-passthrough-secret was not persisted with --skip-secret-pattern")
 	}
 }
 
@@ -215,7 +618,7 @@ func TestStartAutoRegisterWorkdirSkills_OnlyEligible(t *testing.T) {
 	env := makeEnv(wd)
 	reg := &registry.Registry{} // empty: nothing registered yet
 
-	done, errs := startAutoRegisterWorkdirSkills(env, config.DefaultHarness(), reg)
+	done, errs := runAutoRegisterWorkdirSkills(t, env, config.DefaultHarness(), reg, false)
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
@@ -263,7 +666,7 @@ func TestStartAutoRegisterWorkdirSkills_SkipsAlreadyRegistered(t *testing.T) {
 	}}}
 	env := makeEnv(wd)
 
-	done, errs := startAutoRegisterWorkdirSkills(env, config.DefaultHarness(), reg)
+	done, errs := runAutoRegisterWorkdirSkills(t, env, config.DefaultHarness(), reg, false)
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
@@ -292,7 +695,7 @@ func TestStartAutoRegisterWorkdirSkills_SkipsUserGlobal(t *testing.T) {
 	}
 
 	env := makeEnv(wd)
-	done, errs := startAutoRegisterWorkdirSkills(env, config.DefaultHarness(), &registry.Registry{})
+	done, errs := runAutoRegisterWorkdirSkills(t, env, config.DefaultHarness(), &registry.Registry{}, false)
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
@@ -314,7 +717,7 @@ func TestStartAutoRegisterWorkdirSkills_RequiredFieldWithDefault(t *testing.T) {
 	env := makeEnv(wd)
 	reg := &registry.Registry{}
 
-	done, errs := startAutoRegisterWorkdirSkills(env, config.DefaultHarness(), reg)
+	done, errs := runAutoRegisterWorkdirSkills(t, env, config.DefaultHarness(), reg, false)
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}

--- a/internal/cli/start_autoregister_test.go
+++ b/internal/cli/start_autoregister_test.go
@@ -71,6 +71,46 @@ sidecar:
       required: true
 `
 
+// sidecarWithRequiredFieldButDefault mirrors the echo-rest shape: a
+// config field with NO explicit `required:` (so IsRequired()==true) but
+// a non-empty `default:`. At start time the default fills the value
+// without user input (start.go precedence: stored > spec.Default > …),
+// so this skill IS eligible for auto-registration. This is the case
+// that previously bit the user: echo-rest was refused even though all
+// its fields had defaults.
+const sidecarWithRequiredFieldButDefault = `name: has-default
+type: skill
+sidecar:
+  command: ["python3", "x.py"]
+  mount: has-default
+  config:
+    - name: FIELD_WITH_DEFAULT
+      type: string
+      description: "no explicit required, but has a default"
+      default: "hello"
+    - name: FIELD_WITH_DEFAULT_FROM_ENV
+      type: string
+      description: "no explicit required, but has a default_from_env"
+      default_from_env: "SOME_ENV_VAR"
+`
+
+// sidecarWithSecretInEnvPassthrough: a required secret that is also
+// listed in env_passthrough is satisfiable at runtime from the host
+// env (start.go resolves env_passthrough secrets without keychain),
+// so the skill IS eligible for auto-registration.
+const sidecarWithSecretInEnvPassthrough = `name: passthrough-secret
+type: skill
+sidecar:
+  command: ["python3", "x.py"]
+  mount: passthrough-secret
+  env_passthrough:
+    - MUST_SECRET
+  secrets:
+    - name: MUST_SECRET
+      description: "required but supplied via env_passthrough"
+      required: true
+`
+
 // TestSkillEligibleForAutoRegister_NoSidecarBlock: a directory with a
 // bare omac.yaml (no sidecar) is NOT eligible — it would be a skill
 // omac can't activate, so we don't auto-register it. The
@@ -118,7 +158,7 @@ func TestSkillEligibleForAutoRegister_RequiredSecret(t *testing.T) {
 }
 
 // TestSkillEligibleForAutoRegister_RequiredField: a skill with a
-// required config field is NOT eligible.
+// required config field (no default) is NOT eligible.
 func TestSkillEligibleForAutoRegister_RequiredField(t *testing.T) {
 	wd := t.TempDir()
 	stageSkillWithSidecar(t, wd, "needs-field", sidecarWithRequiredField)
@@ -127,7 +167,39 @@ func TestSkillEligibleForAutoRegister_RequiredField(t *testing.T) {
 		t.Fatalf("skillEligibleForAutoRegister: %v", err)
 	}
 	if got {
-		t.Error("a skill with a required config field must not be auto-registered")
+		t.Error("a skill with a required config field (no default) must not be auto-registered")
+	}
+}
+
+// TestSkillEligibleForAutoRegister_RequiredFieldWithDefault: a skill
+// whose config field is implicitly required (no `required:` key) but
+// has a `default:` (or `default_from_env:`) IS eligible — at start
+// time the default fills the value without user input. This is the
+// echo-rest shape and was the case that previously bit the user.
+func TestSkillEligibleForAutoRegister_RequiredFieldWithDefault(t *testing.T) {
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "has-default", sidecarWithRequiredFieldButDefault)
+	got, err := skillEligibleForAutoRegister(filepath.Join(wd, ".opencode", "skills", "has-default"))
+	if err != nil {
+		t.Fatalf("skillEligibleForAutoRegister: %v", err)
+	}
+	if !got {
+		t.Error("a skill whose required fields all have defaults should be eligible (echo-rest shape)")
+	}
+}
+
+// TestSkillEligibleForAutoRegister_SecretInEnvPassthrough: a required
+// secret that is in env_passthrough is satisfiable from the host env
+// at runtime, so the skill IS eligible.
+func TestSkillEligibleForAutoRegister_SecretInEnvPassthrough(t *testing.T) {
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "passthrough-secret", sidecarWithSecretInEnvPassthrough)
+	got, err := skillEligibleForAutoRegister(filepath.Join(wd, ".opencode", "skills", "passthrough-secret"))
+	if err != nil {
+		t.Fatalf("skillEligibleForAutoRegister: %v", err)
+	}
+	if !got {
+		t.Error("a skill whose required secret is in env_passthrough should be eligible")
 	}
 }
 
@@ -226,6 +298,46 @@ func TestStartAutoRegisterWorkdirSkills_SkipsUserGlobal(t *testing.T) {
 	}
 	if len(done) != 0 {
 		t.Errorf("user-global skill must not be auto-registered by `omac start`: %v", done)
+	}
+}
+
+// TestStartAutoRegisterWorkdirSkills_RequiredFieldWithDefault: the
+// echo-rest shape — a config field with no explicit `required:` (so
+// IsRequired()==true) but a `default:` — must be auto-registered,
+// not surfaced by the gate. This is the regression that bit the user
+// (echo-rest was refused even though all its fields had defaults).
+func TestStartAutoRegisterWorkdirSkills_RequiredFieldWithDefault(t *testing.T) {
+	isolateHome(t)
+	wd := t.TempDir()
+	stageSkillWithSidecar(t, wd, "has-default", sidecarWithRequiredFieldButDefault)
+
+	env := makeEnv(wd)
+	reg := &registry.Registry{}
+
+	done, errs := startAutoRegisterWorkdirSkills(env, config.DefaultHarness(), reg)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	want := []string{"has-default"}
+	if !reflect.DeepEqual(done, want) {
+		t.Errorf("auto-registered = %v, want %v", done, want)
+	}
+
+	loaded, err := registry.Load(wd)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	if e, _ := loaded.Find("has-default"); e == nil {
+		t.Error("has-default was not persisted to the registry")
+	}
+
+	// Nothing should be left for the gate to surface.
+	unreg, err := findUnregisteredSkills(wd, config.DefaultHarness(), loaded)
+	if err != nil {
+		t.Fatalf("findUnregisteredSkills: %v", err)
+	}
+	if len(unreg) != 0 {
+		t.Errorf("unregistered after auto-register = %v, want []", unreg)
 	}
 }
 

--- a/oh-my-agentic-coder.md
+++ b/oh-my-agentic-coder.md
@@ -705,6 +705,7 @@ Common flags:
 - `--ephemeral-cache` — use a per-launch cache directory under the sandbox temp dir instead of the persistent workdir cache scope; removed on exit. Use it for a clean-room build or when persistent-scope setup fails (omac's failure hint names the flag). Cannot be combined with `--no-sandbox` (no sandbox to grant the temp dir).
 - `--keep-running` — do not stop sidecars when the inner command exits (useful when iterating on sidecar development).
 - `--accept-skill-changes` — tolerate `bundle_hash` drift.
+- `--auto-register-skills` — opt in for this start-family launch to silently register only discovered workdir-local skills whose required config and secrets resolve without prompting. Other unregistered skills, including user-global skills and any skill with an unresolved required value, still refuse launch and print their registration command.
 - `--skip-secret-pattern` — do not enforce a secret's `pattern` against an `env_passthrough`-supplied value (escape hatch for an outdated pattern; the raw value is still passed through to the sidecar).
 - `--verbose`, `--log-level <level>`. `--verbose` prints the resolved cache mode/path, the sandbox TMPDIR, the control-plane URL, and the sandbox argv before exec.
 


### PR DESCRIPTION
Closes #136

## What

Add a `--auto-register-skills` flag to `omac start` (and the shared `start`/`continue`/`resume` launch pipeline) that silently registers discovered workdir-local skills whose `omac.yaml` declares no required-and-unsatisfiable secrets or config fields, instead of refusing to start with `ExitPrerequisiteMissing`.

## Why

`omac start` hard-fails whenever a discovered skill directory has an `omac.yaml` but no entry in `.opencode/sidecar.json`. The registry is deliberately gitignored per-environment state (commit `c5ef7cd`), so every fresh clone / worktree / Superset workspace of a repo that ships committed skill bundles forces an interactive `omac register <skill>` before the agent can start.

This bites the omac repo itself (ships `.opencode/skills/{echo-rest,self-audit}` with `omac.yaml`, registry gitignored) on every fresh workspace, and any downstream repo that ships example skills the same way. `omac serve` already has an `autoRegister` path (`serve.go`); `omac start` does not. Launchers like the personal `oco` wrapper can opt in without forcing prompts on every workspace.

## How

- Add `--auto-register-skills` to the shared launch flags (`launchOpts` + `parseLaunchArgs`), inherited by `start`/`continue`/`resume`.
- Before the `findUnregisteredSkills` gate, when the flag is set: scan discovered workdir-local skills (Kind == \"workdir\"), and for each absent from the registry AND whose `omac.yaml` sidecar is fully satisfiable at start time without prompting, write a registry entry mirroring `serve.go`'s `autoRegister` (bundle hash, declared secret names, relative SkillDir).
- \"Satisfiable without prompting\" mirrors `runLaunch`'s resolution precedence (`start.go`):
  - a config field is satisfiable if it has a `default:`, a `default_from_env:`, or is explicitly `required: false` (a field with a default but no explicit `required: false` is still satisfiable — `IsRequired()` returns true for nil `Required`, but the default fills the value without user input);
  - a secret is satisfiable if it is in `env_passthrough` (host env supplies it at runtime) or is explicitly `required: false`.
- Skills with at least one required-and-unsatisfiable secret/field are NOT auto-registered — they still surface via the gate so the user is prompted. Auto-registration never silently skips a registration prompt that would otherwise have asked for a value.
- After auto-registering, reload the workdir registry and re-merge so the gate and the rest of `runLaunch` see the freshly-registered skills.
- Scope is workdir-local only; user-global skills continue to be registered once, globally, via `omac register --global`.

## Verification

- `gofmt -l` clean, `go vet` clean.
- `go test ./internal/...` — all packages green.
- New tests in `internal/cli/start_autoregister_test.go` (10 tests): eligibility predicate (no sidecar / optional-only / required secret / required field no default / required field with default → eligible / required secret in env_passthrough → eligible), the auto-register flow (only eligible skills registered, required-value skills still surfaced by the gate, has-default skill registered end-to-end), already-registered skip, user-global skip.
- `omac start --help` shows the new flag.
- Manual end-to-end: `oco --prompt 'hi'` in a fresh workdir of the omac repo auto-registers both `echo-rest` and `self-audit` and launches without the refusal.

## Non-goals

- Changing the gitignore policy for `.opencode/sidecar.json` (stays per-environment by design).
- Auto-registering skills with required-and-unsatisfiable secrets/fields (those still prompt).
- Backfilling the Superset `SUPERSET_*` routing vars into the compiled-in `DefaultAllowVars` — that stays a per-user profile edit since Superset is a single-user deployment for now (tracked in the user's personal `tng-customized.json`, not in this repo).

🤖 Generated with opencode