### PR TITLE
fix(sandbox): add COLORTERM to default env allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,8 +621,8 @@ sandbox:
 > does **not** inherit every ambient var. It prints a warning, pauses briefly
 > so you can read it, then forwards **only the operational minimum** —
 > `sandboxprofile.DefaultAllowVars()`: `HOME`, `PATH`, `PWD`, `TMPDIR`, `LANG`,
-> `LC_*`, `TERM`, `SHELL`, `USER`, `LOGNAME`, `TZ`, `EDITOR`, `VISUAL`,
-> `XDG_*`, `NPM_CONFIG_PREFIX`, `OMAC_*`.
+> `LC_*`, `TERM`, `COLORTERM`, `SHELL`, `USER`, `LOGNAME`, `TZ`, `EDITOR`,
+> `VISUAL`, `XDG_*`, `NPM_CONFIG_PREFIX`, `OMAC_*`.
 >
 > Everything else is **stripped** — secrets, *and* provider-auth vars.
 > omac deliberately does **not** auto-forward the harness's auth variables for

--- a/internal/sandboxprofile/env.go
+++ b/internal/sandboxprofile/env.go
@@ -57,8 +57,9 @@ var dangerousEnvPrefixes = []string{
 // the child through inheritance rather than the injected overlay.
 //
 // USER/LOGNAME (default identity for git/npm/ssh — also forwarded to the
-// facade via FacadeConfig.BaseEnvPassthrough), TZ (date formatting), and
-// EDITOR/VISUAL (harnesses that shell out to an editor) round out the
+// facade via FacadeConfig.BaseEnvPassthrough), TZ (date formatting),
+// EDITOR/VISUAL (harnesses that shell out to an editor), and COLORTERM
+// (truecolor capability hint, paired with TERM) round out the
 // operational minimum; all are non-secret.
 func DefaultAllowVars() []string {
 	return []string{
@@ -70,6 +71,7 @@ func DefaultAllowVars() []string {
 		"LANG",
 		"LC_*",
 		"TERM",
+		"COLORTERM",
 		"SHELL",
 		"USER",
 		"LOGNAME",

--- a/internal/sandboxprofile/profile_test.go
+++ b/internal/sandboxprofile/profile_test.go
@@ -769,6 +769,7 @@ func TestDefaultAllowVarsGoldenList(t *testing.T) {
 		"LANG",
 		"LC_*",
 		"TERM",
+		"COLORTERM",
 		"SHELL",
 		"USER",
 		"LOGNAME",


### PR DESCRIPTION
## What

Adds `COLORTERM` to `sandboxprofile.DefaultAllowVars()` — the standard env allowlist compiled into the scaffolded `default.json`. Also updates the golden-list test and the README allowlist enumeration.

## Why

Since #102/#111 the default sandbox profile ships an **explicit** `environment.allow_vars` and strips every ambient var not on the list. `TERM` was allowed but its companion `COLORTERM` was not, so it was stripped entering the sandbox. `COLORTERM` (e.g. `truecolor`) is the standard hint CLI tools/TUIs use to detect 24-bit color; without it, color output degrades for no security benefit. It is a non-secret terminal-capability hint that pairs naturally with the already-allowed `TERM`.

## How

- `internal/sandboxprofile/env.go`: add `"COLORTERM"` right after `"TERM"` in `DefaultAllowVars()`; extend the docstring.
- `internal/sandboxprofile/profile_test.go`: add `COLORTERM` to the `TestDefaultAllowVarsGoldenList` golden list.
- `README.md`: add `COLORTERM` to the documented allowlist.

## Verification

- `go build ./...` — clean.
- `go test ./internal/sandboxprofile/` — all pass, including `TestDefaultAllowVarsGoldenList` and `TestFilterEnv`.

Closes #139