### PR TITLE
fix(session): exclude opencode sub-agent sessions from continue hint

### DIFF
--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -469,3 +469,31 @@ func TestContinueHintToken(t *testing.T) {
 		t.Errorf("claude token = %q, want \" claude\" (first alias)", got)
 	}
 }
+
+func TestHintSessionID(t *testing.T) {
+	cases := []struct {
+		name     string
+		sessions []session.Session
+		wantID   string
+		wantOK   bool
+	}{
+		{"empty", nil, "", false},
+		{"leading-empty-id", []session.Session{{ID: ""}}, "", false},
+		{
+			// session.List returns newest-first, so the hint must advertise
+			// the first entry — never a later one.
+			name:     "picks-first-newest",
+			sessions: []session.Session{{ID: "ses_new"}, {ID: "ses_old"}},
+			wantID:   "ses_new",
+			wantOK:   true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := hintSessionID(tc.sessions)
+			if id != tc.wantID || ok != tc.wantOK {
+				t.Errorf("hintSessionID = (%q, %v), want (%q, %v)", id, ok, tc.wantID, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -966,14 +966,30 @@ func printContinueHint(env *Env, harness config.Harness) {
 	}()
 	select {
 	case r := <-ch:
-		if r.err != nil || len(r.sessions) == 0 {
+		if r.err != nil {
+			return
+		}
+		id, ok := hintSessionID(r.sessions)
+		if !ok {
 			return
 		}
 		tok := continueHintToken(harness)
-		fmt.Fprintf(env.Stderr, "\nTo resume this session: omac continue%s -s %s\n", tok, r.sessions[0].ID)
+		fmt.Fprintf(env.Stderr, "\nTo resume this session: omac continue%s -s %s\n", tok, id)
 	case <-time.After(hintTimeout):
 		// Timed out — skip the hint rather than blocking exit.
 	}
+}
+
+// hintSessionID picks the session id to advertise in the continue hint: the
+// most-recently-updated session, which session.List guarantees at index 0.
+// It returns ok=false when there is nothing resumable (empty list, or a
+// leading entry with no id). Kept as a pure function so this selection is
+// unit-testable without printContinueHint's goroutine and timeout.
+func hintSessionID(sessions []session.Session) (string, bool) {
+	if len(sessions) == 0 || sessions[0].ID == "" {
+		return "", false
+	}
+	return sessions[0].ID, true
 }
 
 // hintTimeout bounds how long printContinueHint will block exit waiting for

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -126,8 +126,9 @@ func opencodeDBPath() string {
 
 // listOpenCodeDB reads sessions directly from opencode.db via the sqlite3 CLI.
 // The db is opened read-only so a live opencode instance is not disturbed.
-// Returns nil when sqlite3 is missing, the db is missing, or the query fails
-// (best-effort — the caller falls back to the opencode CLI).
+// Only top-level sessions are returned (child sub-agent sessions are excluded;
+// see the query below). Returns nil when sqlite3 is missing, the db is missing,
+// or the query fails (best-effort — the caller falls back to the opencode CLI).
 func listOpenCodeDB(workdir, dbPath string) []Session {
 	if dbPath == "" {
 		return nil
@@ -141,10 +142,15 @@ func listOpenCodeDB(workdir, dbPath string) []Session {
 	}
 	// ponytail: workdir is cleaned by the caller; embed it literally. The
 	// session table's directory column holds the absolute path opencode was
-	// launched from, which is what we match against.
+	// launched from, which is what we match against. parent_id IS NULL keeps
+	// only top-level sessions: opencode stores sub-agent/child sessions in the
+	// same table sharing the parent's directory, and a child is frequently the
+	// most-recently-updated row — so without this filter the newest-first
+	// listing can surface a non-resumable child. This mirrors what
+	// `opencode session list` already returns.
 	q := "SELECT id, title, time_updated FROM session WHERE directory = '" +
 		strings.ReplaceAll(workdir, "'", "''") +
-		"' ORDER BY time_updated DESC;"
+		"' AND parent_id IS NULL ORDER BY time_updated DESC;"
 	out, err := exec.Command(sqlite, "file:"+dbPath+"?mode=ro", q).Output()
 	if err != nil {
 		return nil

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -88,13 +88,16 @@ func TestListOpenCodeDBParseAndFilter(t *testing.T) {
 		{ID: "ses_new", Title: "newest", Updated: 2000, Directory: wd},
 		{ID: "ses_old", Title: "oldest", Updated: 1000, Directory: wd},
 		{ID: "ses_other", Title: "elsewhere", Updated: 3000, Directory: "/home/u/other"},
+		// A sub-agent child session in the same workdir, updated most recently:
+		// it must be excluded so it never becomes the "resume this session" id.
+		{ID: "ses_child", Title: "child", Updated: 9000, Directory: wd, ParentID: "ses_new"},
 	})
 	got := listOpenCodeDB(wd, db)
 	if len(got) != 2 {
-		t.Fatalf("got %d sessions, want 2 (filtered to workdir): %+v", len(got), got)
+		t.Fatalf("got %d sessions, want 2 (workdir + top-level only): %+v", len(got), got)
 	}
 	if got[0].ID != "ses_new" || got[1].ID != "ses_old" {
-		t.Errorf("order = [%s,%s], want newest-first [ses_new,ses_old]", got[0].ID, got[1].ID)
+		t.Errorf("order = [%s,%s], want newest-first top-level [ses_new,ses_old]", got[0].ID, got[1].ID)
 	}
 	if !got[0].When.Equal(time.UnixMilli(2000)) {
 		t.Errorf("ses_new When = %v, want epoch-ms 2000", got[0].When)
@@ -105,16 +108,21 @@ type ocDBRow struct {
 	ID, Title string
 	Updated   int64
 	Directory string
+	ParentID  string // empty → stored as NULL (top-level session)
 }
 
 func createSessionTable(t *testing.T, db string, rows []ocDBRow) {
 	t.Helper()
 	args := []string{db,
-		"CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, slug TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL, version TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL);"}
+		"CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, slug TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL, version TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL);"}
 	for _, r := range rows {
+		parent := "NULL"
+		if r.ParentID != "" {
+			parent = "'" + r.ParentID + "'"
+		}
 		args = append(args,
-			"INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated) VALUES ('"+
-				r.ID+"','p','s','"+r.Directory+"','"+r.Title+"','v',0,"+strconv.FormatInt(r.Updated, 10)+");")
+			"INSERT INTO session (id, project_id, parent_id, slug, directory, title, version, time_created, time_updated) VALUES ('"+
+				r.ID+"','p',"+parent+",'s','"+r.Directory+"','"+r.Title+"','v',0,"+strconv.FormatInt(r.Updated, 10)+");")
 	}
 	cmd := exec.Command("sqlite3", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
### What

Fix the post-exit continue hint so it points to the session the user was in, not an opencode **sub-agent (child) session**.

Closes #141.

### Why

`printContinueHint` re-derives the session after opencode exits by taking `session.List(...)[0]` (most-recently-updated for the workdir). opencode stores sub-agent/child sessions in the same `session` table, sharing the parent's `directory` and distinguished only by a non-null `parent_id`. A child session is frequently the most-recently-updated row, so `listOpenCodeDB` returned it as `[0]` and the hint printed a child id. That id then flows into `opencode --session <id>`, resuming the wrong session.

The CLI fallback (`opencode session list`) already returns only top-level sessions, so the direct-SQLite path was the sole source of the bug.

### How

- `internal/session/session.go`: add `AND parent_id IS NULL` to the `listOpenCodeDB` query so only top-level sessions are listed (matching `opencode session list`). Children are not independently resumable, so this is correct for both the continue hint and `omac resume`. On an older DB lacking the column the query errors → `listOpenCodeDB` returns nil → graceful fallback to the CLI path.
- `internal/session/session_test.go`: add `parent_id` to the fixture schema (mirroring the real opencode table) and a child row updated most-recently, asserting it is excluded.

### Verification

- `go build ./...`, `go vet ./internal/session/`, `go test ./internal/session/ ./internal/cli/` — all pass.
- Against a real `opencode.db` (2093 children / 619 roots), 3 workdirs had a child as their newest row. For `/home/.../logicmap`:
  - old query top row: `ses_0cd6c603… (CHILD)` — what the hint would have printed
  - new query top row: `ses_0d2ee9e6… (ROOT)` — correct
