### PR TITLE
fix(toolcache): persist harness plugin cache across workdirs

### DIFF
--- a/docs/NONO_SANDBOX.md
+++ b/docs/NONO_SANDBOX.md
@@ -74,6 +74,9 @@ environment:
     - CARGO_HOME
 ```
 
+If an external nono profile sets `environment.allow_vars`, it must also
+include `OMAC_XDG_CACHE_DIR` (covered by the `OMAC_*` glob above).
+
 External nono profiles do not receive the built-in sandbox re-exec's trusted
 cache reinjection. Omitting a redirect lets that tool use its default cache
 location; omac does not provide an automatic substitute.
@@ -97,14 +100,24 @@ launcher-config schema. Available placeholders: `{{socket}}`,
 
 ### Tool-cache redirection and external nono-profile limitations
 
-For sandboxed launches, omac prepares a per-scope tool-cache directory
-(`~/.cache/omac/<sha256(identity)>` for persistent mode, a per-launch
-temp dir for `--ephemeral-cache`) and redirects the caches supported by
-`XDG_CACHE_HOME`, `GOCACHE`, `GOMODCACHE`, `NPM_CONFIG_CACHE`,
-`PIP_CACHE_DIR`, and `CARGO_HOME`. It injects `OMAC_CACHE_DIR` /
-`OMAC_CACHE_MODE` plus those six redirects into the sandbox runtime's
-process environment, then grants only that scope leaf read+write in
-the sandbox argv. Unsupported third-party tools that hardcode another
+For sandboxed launches, omac prepares tool-cache directories under
+`~/.cache/omac/<sha256(identity)>` (persistent mode) or a per-launch temp dir
+(`--ephemeral-cache`) and redirects the caches supported by `XDG_CACHE_HOME`,
+`GOCACHE`, `GOMODCACHE`, `NPM_CONFIG_CACHE`, `PIP_CACHE_DIR`, and `CARGO_HOME`.
+
+Persistent mode uses **two** scopes. The build caches (`GOCACHE`, `GOMODCACHE`,
+`NPM_CONFIG_CACHE`, `PIP_CACHE_DIR`, `CARGO_HOME`) live in a **per-workdir**
+scope (`OMAC_CACHE_DIR`) — untrusted project code writes here, so it stays
+isolated per project. `XDG_CACHE_HOME` lives in a **per-harness** scope
+(`OMAC_XDG_CACHE_DIR`), keyed by harness name and shared across every workdir:
+the harness's own cache holds the plugins/extensions declared in the user's
+harness config, which are user-controlled and installed once rather than
+re-fetched from a registry in every project directory (a per-project re-fetch
+the sandbox network policy may block). In `--ephemeral-cache` mode both scopes
+are the same per-launch directory. omac injects `OMAC_CACHE_DIR`,
+`OMAC_XDG_CACHE_DIR`, and `OMAC_CACHE_MODE` plus the six redirects into the
+sandbox runtime's process environment, then grants only those scope leaves
+read+write in the sandbox argv. Unsupported third-party tools that hardcode another
 cache path need explicit profile configuration; omac does not redirect
 them automatically. `~/.rustup` may be read-only runtime-visible for
 toolchain execution, but it is not a writable or cache grant. See the

--- a/docs/superpowers/specs/2026-07-10-cache-isolation-design.md
+++ b/docs/superpowers/specs/2026-07-10-cache-isolation-design.md
@@ -131,13 +131,14 @@ The inner harness receives these injected values, overriding inherited values:
 
 | Variable | Isolated location |
 |---|---|
-| `XDG_CACHE_HOME` | `<cache>/xdg` |
+| `XDG_CACHE_HOME` | `<xdg-cache>/xdg` |
 | `GOCACHE` | `<cache>/go-build` |
 | `GOMODCACHE` | `<cache>/go-mod` |
 | `NPM_CONFIG_CACHE` | `<cache>/npm` |
 | `PIP_CACHE_DIR` | `<cache>/pip` |
 | `CARGO_HOME` | `<cache>/cargo` |
 | `OMAC_CACHE_DIR` | `<cache>` |
+| `OMAC_XDG_CACHE_DIR` | `<xdg-cache>` |
 | `OMAC_CACHE_MODE` | `persistent` or `ephemeral` |
 
 The hybrid redirect is intentional. `XDG_CACHE_HOME` covers OpenCode and other
@@ -145,9 +146,21 @@ XDG-aware software. The tool-specific variables are still required because
 local macOS probes showed that Go, npm, pip, and Cargo did not change their
 cache locations when only `XDG_CACHE_HOME` was set.
 
-XDG-aware tools receive a cold, isolated cache on their first launch in a trust
-domain. They do not inherit data from the host's previous XDG cache; that is the
-intended boundary rather than a compatibility fallback.
+**Scope split (follow-up, #143).** `<cache>` is the per-workdir build scope
+(`OMAC_CACHE_DIR`); `<xdg-cache>` is a per-harness scope (`OMAC_XDG_CACHE_DIR`,
+`toolcache.DomainHarness`) shared across workdirs (same dir as `<cache>` in
+ephemeral mode). Build caches are populated by untrusted project code and stay
+per-workdir. `XDG_CACHE_HOME` is the harness's *own* cache — config-declared
+plugins (e.g. OpenCode under `$XDG_CACHE_HOME/<harness>/packages`), which are
+user- not project-controlled. Per-workdir scoping forced a registry re-fetch in
+every new directory (silently dropped when the sandbox network policy denies
+it), so the harness scope restores install-once reuse — without a global
+`~/.cache` grant, matching the already-shared `~/.config`/`~/.local/share`
+harness dirs.
+
+Build (tool) caches receive a cold, isolated cache on their first launch in a
+trust domain. They do not inherit data from the host's previous cache; that is
+the intended boundary rather than a compatibility fallback.
 
 Injected values use the existing environment overlay path, so they win over
 host values and survive a profile `environment.allow_vars` filter in the same

--- a/internal/cli/briefing.go
+++ b/internal/cli/briefing.go
@@ -18,7 +18,7 @@ import (
 // The cache guidance paragraph is always appended (default or custom
 // briefing) because hardcoded host caches are denied by the sandbox —
 // an override must not be able to suppress it.
-func briefingInjection(noSandbox bool, inner []string, harness config.Harness, override string, cacheScope *toolcache.Scope) (string, bool) {
+func briefingInjection(noSandbox bool, inner []string, harness config.Harness, override string, cacheScope, xdgScope *toolcache.Scope) (string, bool) {
 	if noSandbox || len(inner) == 0 || len(harness.InnerCmd) == 0 {
 		return "", false
 	}
@@ -26,12 +26,16 @@ func briefingInjection(noSandbox bool, inner []string, harness config.Harness, o
 		return "", false
 	}
 	text := sandboxbrief.Resolve(override)
-	var dir string
+	var dir, xdgDir string
 	var mode toolcache.Mode
 	if cacheScope != nil {
 		dir = cacheScope.Dir
+		xdgDir = dir
 		mode = cacheScope.Mode
 	}
-	text += sandboxbrief.CacheGuidance(dir, mode)
+	if xdgScope != nil {
+		xdgDir = xdgScope.Dir
+	}
+	text += sandboxbrief.CacheGuidance(dir, xdgDir, mode)
 	return text, true
 }

--- a/internal/cli/briefing_test.go
+++ b/internal/cli/briefing_test.go
@@ -21,7 +21,7 @@ func claudeHarness(t *testing.T) config.Harness {
 
 func TestBriefingInjectionActiveForAgent(t *testing.T) {
 	h := claudeHarness(t)
-	text, ok := briefingInjection(false, []string{"claude"}, h, "OVERRIDE", nil)
+	text, ok := briefingInjection(false, []string{"claude"}, h, "OVERRIDE", nil, nil)
 	if !ok {
 		t.Fatal("expected injection to be active for the harness's own binary")
 	}
@@ -36,7 +36,7 @@ func TestBriefingInjectionActiveForAgent(t *testing.T) {
 func TestBriefingInjectionAcceptsCacheScope(t *testing.T) {
 	h := claudeHarness(t)
 	scope := &toolcache.Scope{Mode: toolcache.ModeEphemeral, Dir: "/sandbox/cache"}
-	text, ok := briefingInjection(false, []string{"claude"}, h, "OVERRIDE", scope)
+	text, ok := briefingInjection(false, []string{"claude"}, h, "OVERRIDE", scope, nil)
 	if !ok {
 		t.Fatal("expected injection to be active for the harness's own binary")
 	}
@@ -53,7 +53,7 @@ func TestBriefingInjectionAcceptsCacheScope(t *testing.T) {
 
 func TestBriefingInjectionAppendsCacheGuidanceAfterDefault(t *testing.T) {
 	h := claudeHarness(t)
-	text, ok := briefingInjection(false, []string{"claude"}, h, "", nil)
+	text, ok := briefingInjection(false, []string{"claude"}, h, "", nil, nil)
 	if !ok {
 		t.Fatal("expected injection to be active for the harness's own binary")
 	}
@@ -68,7 +68,7 @@ func TestBriefingInjectionAppendsCacheGuidanceAfterDefault(t *testing.T) {
 func TestBriefingInjectionAppendsCacheGuidanceAfterCustom(t *testing.T) {
 	h := claudeHarness(t)
 	const custom = "CUSTOM BRIEFING TEXT"
-	text, ok := briefingInjection(false, []string{"claude"}, h, custom, nil)
+	text, ok := briefingInjection(false, []string{"claude"}, h, custom, nil, nil)
 	if !ok {
 		t.Fatal("expected injection to be active")
 	}
@@ -82,21 +82,21 @@ func TestBriefingInjectionAppendsCacheGuidanceAfterCustom(t *testing.T) {
 
 func TestBriefingInjectionSkippedWhenNoSandbox(t *testing.T) {
 	h := claudeHarness(t)
-	if _, ok := briefingInjection(true, []string{"claude"}, h, "", nil); ok {
+	if _, ok := briefingInjection(true, []string{"claude"}, h, "", nil, nil); ok {
 		t.Error("expected injection skipped when noSandbox is true")
 	}
 }
 
 func TestBriefingInjectionSkippedForNonHarnessBinary(t *testing.T) {
 	h := claudeHarness(t)
-	if _, ok := briefingInjection(false, []string{"bash"}, h, "", nil); ok {
+	if _, ok := briefingInjection(false, []string{"bash"}, h, "", nil, nil); ok {
 		t.Error("expected injection skipped when inner command is not the harness binary")
 	}
 }
 
 func TestBriefingInjectionSkippedForEmptyInner(t *testing.T) {
 	h := claudeHarness(t)
-	if _, ok := briefingInjection(false, nil, h, "", nil); ok {
+	if _, ok := briefingInjection(false, nil, h, "", nil, nil); ok {
 		t.Error("expected injection skipped for empty inner command")
 	}
 }

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -113,15 +113,15 @@ func TestLaunchCachePersistentAndEphemeral(t *testing.T) {
 	workdir := t.TempDir()
 	sandboxTmp := t.TempDir()
 
-	scope, err := prepareLaunchCache(true, false, workdir, sandboxTmp)
+	scope, xdgScope, err := prepareLaunchCache(true, false, "claude-code", workdir, sandboxTmp)
 	if err != nil {
 		t.Fatalf("no-sandbox cache: %v", err)
 	}
-	if scope != nil {
-		t.Errorf("no-sandbox scope = %#v, want nil", scope)
+	if scope != nil || xdgScope != nil {
+		t.Errorf("no-sandbox scopes = %#v/%#v, want nil", scope, xdgScope)
 	}
 
-	ephemeral, err := prepareLaunchCache(false, true, workdir, sandboxTmp)
+	ephemeral, ephemeralXDG, err := prepareLaunchCache(false, true, "claude-code", workdir, sandboxTmp)
 	if err != nil {
 		t.Fatalf("ephemeral cache: %v", err)
 	}
@@ -131,11 +131,14 @@ func TestLaunchCachePersistentAndEphemeral(t *testing.T) {
 	if ephemeral.Dir != filepath.Join(sandboxTmp, "cache") {
 		t.Errorf("ephemeral dir = %q, want %q", ephemeral.Dir, filepath.Join(sandboxTmp, "cache"))
 	}
+	if ephemeralXDG != ephemeral {
+		t.Errorf("ephemeral XDG scope should equal the build scope (single scope), got %#v", ephemeralXDG)
+	}
 	if _, err := os.Stat(filepath.Join(home, ".cache", "omac")); !os.IsNotExist(err) {
 		t.Errorf("persistent cache root exists or stat failed: %v", err)
 	}
 
-	persistent, err := prepareLaunchCache(false, false, workdir, sandboxTmp)
+	persistent, persistentXDG, err := prepareLaunchCache(false, false, "claude-code", workdir, sandboxTmp)
 	if err != nil {
 		t.Fatalf("persistent cache: %v", err)
 	}
@@ -143,12 +146,21 @@ func TestLaunchCachePersistentAndEphemeral(t *testing.T) {
 		if err := persistent.Close(); err != nil {
 			t.Errorf("close persistent cache: %v", err)
 		}
+		if err := persistentXDG.Close(); err != nil {
+			t.Errorf("close persistent XDG cache: %v", err)
+		}
 	})
 	if persistent.Domain != toolcache.DomainWorkdir {
 		t.Errorf("persistent domain = %q, want %q", persistent.Domain, toolcache.DomainWorkdir)
 	}
 	if persistent.Mode != toolcache.ModePersistent {
 		t.Errorf("persistent mode = %q, want %q", persistent.Mode, toolcache.ModePersistent)
+	}
+	if persistentXDG.Domain != toolcache.DomainHarness {
+		t.Errorf("persistent XDG domain = %q, want %q", persistentXDG.Domain, toolcache.DomainHarness)
+	}
+	if persistentXDG.Dir == persistent.Dir {
+		t.Errorf("harness XDG scope should differ from the workdir build scope: %s", persistentXDG.Dir)
 	}
 }
 

--- a/internal/cli/provenance.go
+++ b/internal/cli/provenance.go
@@ -69,9 +69,11 @@ type skillsView struct {
 
 // cacheView describes the default persistent tool-cache scope for the
 // current workdir — not a live ephemeral/serve process's scope. The
-// environment field is the eight-variable map toolcache.Environment
-// produces for this scope; provenance does not re-derive hashing or
-// environment mappings.
+// environment field is the map toolcache.Environment produces for this
+// scope; provenance does not re-derive hashing or environment mappings.
+// It reports the single-scope view (XDG_CACHE_HOME under the workdir
+// scope); at a real launch XDG_CACHE_HOME is redirected to the harness's
+// own cross-workdir scope (see toolcache.DomainHarness / OMAC_XDG_CACHE_DIR).
 type cacheView struct {
 	Scope       string            `json:"scope"`
 	Mode        string            `json:"mode"`

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -218,13 +218,16 @@ func runServe(args []string, env *Env) int {
 		return ExitIOError
 	}
 	defer os.RemoveAll(sandboxTmp)
-	cacheScope, err := prepareServeCache(*noSandbox, *noInner, *ephemeralCache, *workdir, env.Workdir, sandboxTmp)
+	cacheScope, xdgScope, err := prepareServeCache(*noSandbox, *noInner, *ephemeralCache, harness.Name, *workdir, env.Workdir, sandboxTmp)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve: cache:", err)
 		return ExitIOError
 	}
 	if cacheScope != nil {
 		defer cacheScope.Close()
+		if xdgScope != nil && xdgScope != cacheScope {
+			defer xdgScope.Close()
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -274,6 +277,9 @@ func runServe(args []string, env *Env) int {
 		srv.cacheEnv = map[string]string{
 			"OMAC_CACHE_DIR":  cacheScope.Dir,
 			"OMAC_CACHE_MODE": string(cacheScope.Mode),
+		}
+		if xdgScope != nil {
+			srv.cacheEnv["OMAC_XDG_CACHE_DIR"] = xdgScope.Dir
 		}
 	}
 
@@ -379,7 +385,7 @@ func runServe(args []string, env *Env) int {
 	// mode leave the inner command unchanged.
 	inner = harness.ApplyServerLaunch(inner, innerArgs)
 	// Inject the sandbox briefing on the same terms as `omac start` (see there).
-	briefingText, injectBriefing := briefingInjection(*noSandbox, inner, harness, lc.Sandbox.Briefing, cacheScope)
+	briefingText, injectBriefing := briefingInjection(*noSandbox, inner, harness, lc.Sandbox.Briefing, cacheScope, xdgScope)
 	if injectBriefing && harness.SystemContextArgs != nil {
 		inner = append(inner, harness.SystemContextArgs(briefingText)...)
 	}
@@ -421,6 +427,9 @@ func runServe(args []string, env *Env) int {
 		}
 		if cacheScope != nil {
 			argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)
+			if xdgScope != nil && xdgScope.Dir != cacheScope.Dir {
+				argv = injectSandboxFlag(argv, "--allow", xdgScope.Dir)
+			}
 		}
 		// Forward the selected harness's auth env vars through the default
 		// profile's restrictive allow_vars filter. (Control-plane port and
@@ -1425,17 +1434,31 @@ func (s *serveServer) baseEnv() map[string]string {
 	return extra
 }
 
-func prepareServeCache(noSandbox, noInner, ephemeral bool, explicitWorkdir, launchWorkdir, sandboxTmp string) (*toolcache.Scope, error) {
+// prepareServeCache resolves the build scope (per-workdir or serve-scoped tool
+// caches, OMAC_CACHE_DIR) and the XDG scope (the harness's own cache, shared
+// across workdirs). See prepareLaunchCache for the split rationale.
+func prepareServeCache(noSandbox, noInner, ephemeral bool, harnessName, explicitWorkdir, launchWorkdir, sandboxTmp string) (build, xdg *toolcache.Scope, err error) {
 	if noSandbox || noInner {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if ephemeral {
-		return toolcache.PrepareEphemeral(sandboxTmp)
+		s, err := toolcache.PrepareEphemeral(sandboxTmp)
+		return s, s, err
 	}
 	if explicitWorkdir != "" {
-		return toolcache.PreparePersistent(toolcache.DomainWorkdir, explicitWorkdir)
+		build, err = toolcache.PreparePersistent(toolcache.DomainWorkdir, explicitWorkdir)
+	} else {
+		build, err = toolcache.PreparePersistent(toolcache.DomainServe, launchWorkdir)
 	}
-	return toolcache.PreparePersistent(toolcache.DomainServe, launchWorkdir)
+	if err != nil {
+		return nil, nil, err
+	}
+	xdg, err = toolcache.PrepareHarness(harnessName)
+	if err != nil {
+		_ = build.Close()
+		return nil, nil, err
+	}
+	return build, xdg, nil
 }
 
 // facadeMounts returns the set of facade mount segments to advertise to the

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -612,13 +612,13 @@ func TestPrepareServeCache(t *testing.T) {
 		{name: "ephemeral cache", ephemeral: true, explicitWorkdir: explicitWorkdir, wantMode: toolcache.ModeEphemeral, wantPath: filepath.Join(sandboxTmp, "cache")},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			scope, err := prepareServeCache(c.noSandbox, c.noInner, c.ephemeral, c.explicitWorkdir, launchWorkdir, sandboxTmp)
+			scope, xdgScope, err := prepareServeCache(c.noSandbox, c.noInner, c.ephemeral, "claude-code", c.explicitWorkdir, launchWorkdir, sandboxTmp)
 			if err != nil {
 				t.Fatalf("prepareServeCache: %v", err)
 			}
 			if c.wantNil {
-				if scope != nil {
-					t.Errorf("scope = %#v, want nil", scope)
+				if scope != nil || xdgScope != nil {
+					t.Errorf("scopes = %#v/%#v, want nil", scope, xdgScope)
 				}
 				return
 			}
@@ -629,7 +629,21 @@ func TestPrepareServeCache(t *testing.T) {
 				if err := scope.Close(); err != nil {
 					t.Errorf("close scope: %v", err)
 				}
+				if xdgScope != nil && xdgScope != scope {
+					if err := xdgScope.Close(); err != nil {
+						t.Errorf("close xdg scope: %v", err)
+					}
+				}
 			})
+			// The harness XDG scope is shared across workdirs (persistent) or
+			// the same per-launch scope (ephemeral).
+			if c.wantMode == toolcache.ModeEphemeral {
+				if xdgScope != scope {
+					t.Errorf("ephemeral xdg scope should equal build scope, got %#v", xdgScope)
+				}
+			} else if xdgScope == nil || xdgScope.Domain != toolcache.DomainHarness {
+				t.Errorf("persistent xdg scope domain = %v, want %q", xdgScope, toolcache.DomainHarness)
+			}
 			if scope.Domain != c.wantDomain {
 				t.Errorf("domain = %q, want %q", scope.Domain, c.wantDomain)
 			}
@@ -738,13 +752,19 @@ func TestRunServeRetainsCacheLockAndAllowsOnlyScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("describe serve cache: %v", err)
 	}
+	// serve locks both the per-workdir build scope and the harness's own
+	// cross-workdir XDG scope (the `claude` alias resolves to "claude-code").
+	harnessScope, err := toolcache.DescribeHarness("claude-code")
+	if err != nil {
+		t.Fatalf("describe harness cache: %v", err)
+	}
 	args, err := os.ReadFile(argsPath)
 	if err != nil {
 		t.Fatalf("read captured args: %v", err)
 	}
 	capturedArgs := strings.Fields(string(args))
 	var cacheAllows []string
-	scopeAllows := 0
+	scopeAllows, harnessAllows := 0, 0
 	for i, arg := range capturedArgs {
 		if arg == "--allow" && i+1 < len(capturedArgs) {
 			allowed := capturedArgs[i+1]
@@ -752,10 +772,16 @@ func TestRunServeRetainsCacheLockAndAllowsOnlyScope(t *testing.T) {
 			if allowed == scope.Dir {
 				scopeAllows++
 			}
+			if allowed == harnessScope.Dir {
+				harnessAllows++
+			}
 		}
 	}
 	if scopeAllows != 1 {
-		t.Errorf("cache scope %q appears in --allow %d times, want 1: %v", scope.Dir, scopeAllows, cacheAllows)
+		t.Errorf("build cache scope %q appears in --allow %d times, want 1: %v", scope.Dir, scopeAllows, cacheAllows)
+	}
+	if harnessAllows != 1 {
+		t.Errorf("harness cache scope %q appears in --allow %d times, want 1: %v", harnessScope.Dir, harnessAllows, cacheAllows)
 	}
 	for _, allowed := range cacheAllows {
 		if allowed == filepath.Dir(scope.Dir) {
@@ -767,10 +793,10 @@ func TestRunServeRetainsCacheLockAndAllowsOnlyScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read captured environment: %v", err)
 	}
-	for _, key := range []string{"OMAC_CACHE_DIR", "OMAC_CACHE_MODE"} {
-		want := toolcache.Environment(scope.Dir, toolcache.ModePersistent)[key]
-		if got := parseEnvironment(string(envData))[key]; got != want {
-			t.Errorf("%s = %q, want %q", key, got, want)
+	wantEnv := toolcache.EnvironmentSplit(scope.Dir, harnessScope.Dir, toolcache.ModePersistent)
+	for _, key := range []string{"OMAC_CACHE_DIR", "OMAC_CACHE_MODE", "OMAC_XDG_CACHE_DIR"} {
+		if got := parseEnvironment(string(envData))[key]; got != wantEnv[key] {
+			t.Errorf("%s = %q, want %q", key, got, wantEnv[key])
 		}
 	}
 
@@ -778,9 +804,10 @@ func TestRunServeRetainsCacheLockAndAllowsOnlyScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clear active cache: %v", err)
 	}
-	if len(active) != 1 || active[0].Path != scope.Dir || active[0].Status != toolcache.ClearActive {
-		t.Errorf("active clear results = %#v, want active %q", active, scope.Dir)
-	}
+	assertClearStatus(t, "active", active, map[string]toolcache.ClearStatus{
+		scope.Dir:        toolcache.ClearActive,
+		harnessScope.Dir: toolcache.ClearActive,
+	})
 
 	if err := os.WriteFile(releasePath, nil, 0o600); err != nil {
 		t.Fatalf("release capture process: %v", err)
@@ -798,8 +825,28 @@ func TestRunServeRetainsCacheLockAndAllowsOnlyScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clear inactive cache: %v", err)
 	}
-	if len(inactive) != 1 || inactive[0].Path != scope.Dir || inactive[0].Status != toolcache.ClearRemoved {
-		t.Errorf("inactive clear results = %#v, want removed %q", inactive, scope.Dir)
+	assertClearStatus(t, "inactive", inactive, map[string]toolcache.ClearStatus{
+		scope.Dir:        toolcache.ClearRemoved,
+		harnessScope.Dir: toolcache.ClearRemoved,
+	})
+}
+
+// assertClearStatus checks that clear results contain exactly the wanted
+// path→status pairs, order-independent.
+func assertClearStatus(t *testing.T, label string, results []toolcache.ClearResult, want map[string]toolcache.ClearStatus) {
+	t.Helper()
+	got := map[string]toolcache.ClearStatus{}
+	for _, r := range results {
+		got[r.Path] = r.Status
+	}
+	if len(got) != len(want) {
+		t.Errorf("%s clear results = %#v, want %d entries %v", label, results, len(want), want)
+		return
+	}
+	for path, status := range want {
+		if got[path] != status {
+			t.Errorf("%s clear status for %q = %q, want %q (all: %#v)", label, path, got[path], status, results)
+		}
 	}
 }
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -641,7 +641,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	if verbose {
 		fmt.Fprintf(env.Stderr, "[verbose] sandbox TMPDIR: %s\n", sandboxTmp)
 	}
-	cacheScope, err := prepareLaunchCache(noSandbox, opts.ephemeralCache, env.Workdir, sandboxTmp)
+	cacheScope, xdgScope, err := prepareLaunchCache(noSandbox, opts.ephemeralCache, harness.Name, env.Workdir, sandboxTmp)
 	if err != nil {
 		if opts.ephemeralCache {
 			fmt.Fprintln(env.Stderr, prefix+": cache:", err)
@@ -652,8 +652,11 @@ func runLaunch(env *Env, opts launchOpts) int {
 		return ExitIOError
 	}
 	defer cacheScope.Close()
+	if xdgScope != cacheScope {
+		defer xdgScope.Close()
+	}
 	if verbose && cacheScope != nil {
-		fmt.Fprintf(env.Stderr, "[verbose] cache mode=%s path=%s\n", cacheScope.Mode, cacheScope.Dir)
+		fmt.Fprintf(env.Stderr, "[verbose] cache mode=%s path=%s xdg=%s\n", cacheScope.Mode, cacheScope.Dir, xdgScope.Dir)
 	}
 
 	// 5. Spawn sidecars.
@@ -766,7 +769,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 	inner := harness.ResolveInnerCmd(prof.InnerCmd, innerCmdOverride)
 	// Inject the sandbox briefing: Claude via its --append-system-prompt flag
 	// (SystemContextArgs), OpenCode via OMAC_SANDBOX_BRIEFING set below.
-	briefingText, injectBriefing := briefingInjection(noSandbox, inner, harness, lc.Sandbox.Briefing, cacheScope)
+	briefingText, injectBriefing := briefingInjection(noSandbox, inner, harness, lc.Sandbox.Briefing, cacheScope, xdgScope)
 	if injectBriefing && harness.SystemContextArgs != nil {
 		inner = append(inner, harness.SystemContextArgs(briefingText)...)
 	}
@@ -804,6 +807,9 @@ func runLaunch(env *Env, opts launchOpts) int {
 		argv = injectSandboxDirs(argv, harness.SandboxDirs)
 		if cacheScope != nil {
 			argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)
+			if xdgScope != nil && xdgScope.Dir != cacheScope.Dir {
+				argv = injectSandboxFlag(argv, "--allow", xdgScope.Dir)
+			}
 		}
 		// Forward the selected harness's auth env vars through the
 		// default profile's restrictive allow_vars filter — only for the
@@ -862,6 +868,9 @@ func runLaunch(env *Env, opts launchOpts) int {
 	if cacheScope != nil {
 		extra["OMAC_CACHE_DIR"] = cacheScope.Dir
 		extra["OMAC_CACHE_MODE"] = string(cacheScope.Mode)
+		if xdgScope != nil {
+			extra["OMAC_XDG_CACHE_DIR"] = xdgScope.Dir
+		}
 	}
 	if controlOK {
 		extra["OMAC_CONTROL_BASE"] = controlURL
@@ -913,14 +922,29 @@ func runLaunch(env *Env, opts launchOpts) int {
 	return code
 }
 
-func prepareLaunchCache(noSandbox, ephemeral bool, workdir, sandboxTmp string) (*toolcache.Scope, error) {
+// prepareLaunchCache resolves the two cache scopes a launch uses: the build
+// scope (per-workdir tool caches, OMAC_CACHE_DIR) and the XDG scope (the
+// harness's own cache, shared across workdirs so plugins install once). In
+// ephemeral mode both are the same per-launch scope; with --no-sandbox neither
+// applies. The returned xdg scope is never nil unless build is nil.
+func prepareLaunchCache(noSandbox, ephemeral bool, harnessName, workdir, sandboxTmp string) (build, xdg *toolcache.Scope, err error) {
 	if noSandbox {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if ephemeral {
-		return toolcache.PrepareEphemeral(sandboxTmp)
+		s, err := toolcache.PrepareEphemeral(sandboxTmp)
+		return s, s, err
 	}
-	return toolcache.PreparePersistent(toolcache.DomainWorkdir, workdir)
+	build, err = toolcache.PreparePersistent(toolcache.DomainWorkdir, workdir)
+	if err != nil {
+		return nil, nil, err
+	}
+	xdg, err = toolcache.PrepareHarness(harnessName)
+	if err != nil {
+		_ = build.Close()
+		return nil, nil, err
+	}
+	return build, xdg, nil
 }
 
 // continueHintToken returns the harness token to embed in the post-exit

--- a/internal/e2e/cache_isolation_test.go
+++ b/internal/e2e/cache_isolation_test.go
@@ -560,8 +560,12 @@ func rustupUpdateHashesDirs(t *testing.T) []string {
 	return []string{filepath.Join(rustupHome, "update-hashes")}
 }
 
-func validateCacheRedirects(cacheDir string, environment map[string]string) error {
-	expected := toolcache.Environment(cacheDir, toolcache.ModePersistent)
+// validateCacheRedirects checks the injected cache env. Build caches
+// (Go/npm/pip/Cargo) live under the per-workdir build scope (cacheDir);
+// XDG_CACHE_HOME lives under the harness scope (xdgDir), which is shared
+// across workdirs. Pass cacheDir==xdgDir for the single-scope (ephemeral) case.
+func validateCacheRedirects(cacheDir, xdgDir string, environment map[string]string) error {
+	expected := toolcache.EnvironmentSplit(cacheDir, xdgDir, toolcache.ModePersistent)
 	for _, name := range []string{"XDG_CACHE_HOME", "GOCACHE", "GOMODCACHE", "NPM_CONFIG_CACHE", "PIP_CACHE_DIR", "CARGO_HOME"} {
 		if environment[name] != expected[name] {
 			return fmt.Errorf("%s = %q; want %q", name, environment[name], expected[name])
@@ -574,7 +578,7 @@ func TestValidateCacheRedirectsRejectsScopePrefixEscape(t *testing.T) {
 	cacheDir := filepath.Join(t.TempDir(), "cache")
 	environment := toolcache.Environment(cacheDir, toolcache.ModePersistent)
 	environment["GOCACHE"] = cacheDir + "-escape/go-build"
-	if err := validateCacheRedirects(cacheDir, environment); err == nil {
+	if err := validateCacheRedirects(cacheDir, cacheDir, environment); err == nil {
 		t.Fatal("cache redirects accepted a sibling prefix escape")
 	}
 }
@@ -583,8 +587,21 @@ func TestValidateCacheRedirectsRequiresXDGCacheHome(t *testing.T) {
 	cacheDir := filepath.Join(t.TempDir(), "cache")
 	environment := toolcache.Environment(cacheDir, toolcache.ModePersistent)
 	delete(environment, "XDG_CACHE_HOME")
-	if err := validateCacheRedirects(cacheDir, environment); err == nil {
+	if err := validateCacheRedirects(cacheDir, cacheDir, environment); err == nil {
 		t.Fatal("cache redirects accepted a missing XDG_CACHE_HOME mapping")
+	}
+}
+
+// TestValidateCacheRedirectsRejectsXDGUnderBuildScope asserts the harness XDG
+// cache is checked against its own (harness) scope, not the build scope — so a
+// stale per-workdir XDG mapping is rejected.
+func TestValidateCacheRedirectsRejectsXDGUnderBuildScope(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	xdgDir := filepath.Join(t.TempDir(), "harness-cache")
+	environment := toolcache.EnvironmentSplit(cacheDir, xdgDir, toolcache.ModePersistent)
+	environment["XDG_CACHE_HOME"] = filepath.Join(cacheDir, "xdg")
+	if err := validateCacheRedirects(cacheDir, xdgDir, environment); err == nil {
+		t.Fatal("cache redirects accepted XDG_CACHE_HOME under the build scope")
 	}
 }
 
@@ -700,7 +717,7 @@ func TestE2ECacheEnvironmentOverridesAllowlist(t *testing.T) {
 
 	out, code := runOmacShellWithEnv(t, omacBin, home, workdir, nil,
 		[]string{"GOCACHE=" + hostileGOCACHE, "CARGO_HOME=" + hostileCARGO},
-		"/bin/sh", "-c", "echo XDG_CACHE_HOME=$XDG_CACHE_HOME; echo GOCACHE=$GOCACHE; echo GOMODCACHE=$GOMODCACHE; echo NPM_CONFIG_CACHE=$NPM_CONFIG_CACHE; echo PIP_CACHE_DIR=$PIP_CACHE_DIR; echo CARGO_HOME=$CARGO_HOME; echo OMAC_CACHE_DIR=$OMAC_CACHE_DIR")
+		"/bin/sh", "-c", "echo XDG_CACHE_HOME=$XDG_CACHE_HOME; echo GOCACHE=$GOCACHE; echo GOMODCACHE=$GOMODCACHE; echo NPM_CONFIG_CACHE=$NPM_CONFIG_CACHE; echo PIP_CACHE_DIR=$PIP_CACHE_DIR; echo CARGO_HOME=$CARGO_HOME; echo OMAC_CACHE_DIR=$OMAC_CACHE_DIR; echo OMAC_XDG_CACHE_DIR=$OMAC_XDG_CACHE_DIR")
 	if code != 0 {
 		t.Fatalf("launch failed (exit %d): %s", code, out)
 	}
@@ -714,11 +731,15 @@ func TestE2ECacheEnvironmentOverridesAllowlist(t *testing.T) {
 	if cacheDir == "" {
 		t.Fatalf("OMAC_CACHE_DIR not exposed: %s", out)
 	}
+	xdgDir := extractEnv(out, "OMAC_XDG_CACHE_DIR=")
+	if xdgDir == "" {
+		t.Fatalf("OMAC_XDG_CACHE_DIR not exposed: %s", out)
+	}
 	environment := map[string]string{}
 	for _, name := range []string{"XDG_CACHE_HOME", "GOCACHE", "GOMODCACHE", "NPM_CONFIG_CACHE", "PIP_CACHE_DIR", "CARGO_HOME"} {
 		environment[name] = extractEnv(out, name+"=")
 	}
-	if err := validateCacheRedirects(cacheDir, environment); err != nil {
+	if err := validateCacheRedirects(cacheDir, xdgDir, environment); err != nil {
 		t.Error(err)
 	}
 }
@@ -799,6 +820,70 @@ func TestE2ECacheMainAndLinkedWorktreesAreIsolated(t *testing.T) {
 	}
 	if strings.Contains(out, marker) {
 		t.Errorf("SECURITY: linked worktree saw main worktree's cache marker: %s", out)
+	}
+}
+
+// TestE2ECacheHarnessXDGSharedAcrossWorkdirs: the harness's own XDG cache is
+// keyed by harness, not workdir, so a plugin/extension installed under
+// XDG_CACHE_HOME in one project is visible from another project (install once,
+// no per-project registry re-fetch). The per-workdir build cache
+// (OMAC_CACHE_DIR) stays isolated. This is the regression fix: cache isolation
+// must not force a cold harness cache in every directory.
+func TestE2ECacheHarnessXDGSharedAcrossWorkdirs(t *testing.T) {
+	skipIfSandboxUnavailable(t)
+	home := cacheTestHome(t)
+	// Two unrelated projects under HOME (read-only baseline home does not
+	// grant sibling temp dirs).
+	dirA := filepath.Join(home, "project-a")
+	dirB := filepath.Join(home, "project-b")
+	for _, d := range []string{dirA, dirB} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeCacheTestProfile(t, home, nil, nil, 0)
+	omacBin := buildOmac(t)
+
+	marker := "harness-plugin-marker"
+	// Project A installs something into the harness XDG cache.
+	outA, code := runOmacShell(t, omacBin, home, dirA, nil,
+		"/bin/sh", "-c",
+		"echo OMAC_CACHE_DIR=$OMAC_CACHE_DIR; echo OMAC_XDG_CACHE_DIR=$OMAC_XDG_CACHE_DIR; "+
+			"mkdir -p \"$XDG_CACHE_HOME/opencode\" && echo "+marker+" > \"$XDG_CACHE_HOME/opencode/plugin.txt\" && echo WROTE_A")
+	if code != 0 {
+		t.Fatalf("project A launch failed (exit %d): %s", code, outA)
+	}
+	if !strings.Contains(outA, "WROTE_A") {
+		t.Fatalf("project A did not write into XDG cache: %s", outA)
+	}
+
+	// Project B (different workdir) sees the same harness XDG cache.
+	outB, code := runOmacShell(t, omacBin, home, dirB, nil,
+		"/bin/sh", "-c",
+		"echo OMAC_CACHE_DIR=$OMAC_CACHE_DIR; echo OMAC_XDG_CACHE_DIR=$OMAC_XDG_CACHE_DIR; "+
+			"cat \"$XDG_CACHE_HOME/opencode/plugin.txt\" 2>&1 || echo NOT_FOUND")
+	if code != 0 {
+		t.Fatalf("project B launch failed (exit %d): %s", code, outB)
+	}
+	if !strings.Contains(outB, marker) {
+		t.Errorf("harness XDG cache not shared across workdirs: project B could not read project A's marker: %s", outB)
+	}
+
+	xdgA := extractEnv(outA, "OMAC_XDG_CACHE_DIR=")
+	xdgB := extractEnv(outB, "OMAC_XDG_CACHE_DIR=")
+	buildA := extractEnv(outA, "OMAC_CACHE_DIR=")
+	buildB := extractEnv(outB, "OMAC_CACHE_DIR=")
+	if xdgA == "" || xdgB == "" || buildA == "" || buildB == "" {
+		t.Fatalf("cache dirs not exposed: xdgA=%q xdgB=%q buildA=%q buildB=%q", xdgA, xdgB, buildA, buildB)
+	}
+	if xdgA != xdgB {
+		t.Errorf("harness XDG scope should be shared across workdirs: A=%s B=%s", xdgA, xdgB)
+	}
+	if buildA == buildB {
+		t.Errorf("per-workdir build scope should differ across workdirs: A=%s B=%s", buildA, buildB)
+	}
+	if xdgA == buildA {
+		t.Errorf("harness XDG scope and build scope should differ: %s", xdgA)
 	}
 }
 
@@ -1327,7 +1412,9 @@ func TestE2ECacheProvenance(t *testing.T) {
 	})
 
 	// Verify all supported cache redirects match the selected scope exactly.
-	if err := validateCacheRedirects(view.Cache.Path, view.Cache.Environment); err != nil {
+	// Provenance reports the single-scope (workdir) view, so build and XDG
+	// share the reported path here.
+	if err := validateCacheRedirects(view.Cache.Path, view.Cache.Path, view.Cache.Environment); err != nil {
 		t.Error(err)
 	}
 }

--- a/internal/sandboxbrief/sandboxbrief.go
+++ b/internal/sandboxbrief/sandboxbrief.go
@@ -34,11 +34,18 @@ func Resolve(override string) string {
 
 // CacheGuidance renders the cache paragraph appended to every briefing
 // (default or custom) so an override can never suppress it. It names
-// the actual cache path/mode selected for this launch, the OMAC_CACHE_*
+// the actual cache paths/mode selected for this launch, the OMAC_CACHE_*
 // selectors, every tool-specific variable omac injects, and explains
 // that hardcoded host cache locations are denied by the sandbox.
-func CacheGuidance(dir string, mode toolcache.Mode) string {
-	env := toolcache.Environment(dir, mode)
+//
+// buildDir is the per-workdir build-cache scope (OMAC_CACHE_DIR); xdgDir is
+// the harness's own XDG cache scope (OMAC_XDG_CACHE_DIR), which is shared
+// across workdirs. When they are equal (ephemeral mode) the split is invisible.
+func CacheGuidance(buildDir, xdgDir string, mode toolcache.Mode) string {
+	if xdgDir == "" {
+		xdgDir = buildDir
+	}
+	env := toolcache.EnvironmentSplit(buildDir, xdgDir, mode)
 	keys := make([]string, 0, len(env))
 	for k := range env {
 		keys = append(keys, k)
@@ -46,9 +53,10 @@ func CacheGuidance(dir string, mode toolcache.Mode) string {
 	sort.Strings(keys)
 	var b strings.Builder
 	fmt.Fprintf(&b, "\n## Tool cache\n\n")
-	fmt.Fprintf(&b, "omac redirects every tool's cache into a sandbox-granted directory: `%s` (mode `%s`). ", dir, mode)
-	fmt.Fprintf(&b, "The selector variables `OMAC_CACHE_DIR` and `OMAC_CACHE_MODE` name this directory and mode; ")
-	fmt.Fprintf(&b, "the tool-specific variables below all point underneath `OMAC_CACHE_DIR`:\n\n")
+	fmt.Fprintf(&b, "omac redirects every tool's cache into a sandbox-granted directory: `%s` (mode `%s`). ", buildDir, mode)
+	fmt.Fprintf(&b, "The selector variables `OMAC_CACHE_DIR` and `OMAC_CACHE_MODE` name the build-cache directory and mode; ")
+	fmt.Fprintf(&b, "the harness's own cache (`XDG_CACHE_HOME`) is kept in `OMAC_XDG_CACHE_DIR`, shared across workdirs. ")
+	fmt.Fprintf(&b, "Write through the variables below rather than any host path:\n\n")
 	for _, k := range keys {
 		fmt.Fprintf(&b, "- `%s` → `%s`\n", k, env[k])
 	}

--- a/internal/sandboxbrief/sandboxbrief_test.go
+++ b/internal/sandboxbrief/sandboxbrief_test.go
@@ -9,11 +9,12 @@ import (
 
 func TestCacheGuidanceNamesPathModeAndAllVars(t *testing.T) {
 	const dir = "/sandbox/cache/dir"
-	got := CacheGuidance(dir, toolcache.ModePersistent)
+	got := CacheGuidance(dir, dir, toolcache.ModePersistent)
 	for _, want := range []string{
 		dir,
 		"persistent",
 		"OMAC_CACHE_DIR",
+		"OMAC_XDG_CACHE_DIR",
 		"OMAC_CACHE_MODE",
 		"XDG_CACHE_HOME",
 		"GOCACHE",
@@ -32,7 +33,7 @@ func TestCacheGuidanceNamesPathModeAndAllVars(t *testing.T) {
 }
 
 func TestCacheGuidanceExplainsHardcodedHostCachesDenied(t *testing.T) {
-	got := CacheGuidance("/c", toolcache.ModeEphemeral)
+	got := CacheGuidance("/c", "/c", toolcache.ModeEphemeral)
 	if !strings.Contains(strings.ToLower(got), "denied") {
 		t.Errorf("CacheGuidance should explain hardcoded host caches are denied;\ngot:\n%s", got)
 	}

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -198,27 +198,48 @@ func injectedToolCacheEnv(grants *Grants, getenv func(string) string) (map[strin
 		return nil, fmt.Errorf("invalid OMAC_CACHE_MODE %q", getenv("OMAC_CACHE_MODE"))
 	}
 
-	cacheDir, err := canonicalCachePath(dir)
+	cacheDir, err := grantedCacheDir(grants, "OMAC_CACHE_DIR", dir)
 	if err != nil {
-		return nil, fmt.Errorf("resolve OMAC_CACHE_DIR: %w", err)
+		return nil, err
 	}
-	info, err := os.Stat(cacheDir)
+	// The harness XDG cache is a separate writable grant. It is absent for
+	// ephemeral launches (single scope) and for launchers that predate the
+	// split; fall back to the build-cache dir so XDG stays inside a grant.
+	xdgDir := cacheDir
+	if raw := getenv("OMAC_XDG_CACHE_DIR"); raw != "" {
+		xdgDir, err = grantedCacheDir(grants, "OMAC_XDG_CACHE_DIR", raw)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return toolcache.EnvironmentSplit(cacheDir, xdgDir, mode), nil
+}
+
+// grantedCacheDir canonicalizes a launcher-provided cache directory and
+// returns it only when it is an exact writable grant. This prevents inherited
+// cache paths from bypassing the profile's filesystem allowlist.
+func grantedCacheDir(grants *Grants, name, raw string) (string, error) {
+	dir, err := canonicalCachePath(raw)
 	if err != nil {
-		return nil, fmt.Errorf("stat OMAC_CACHE_DIR: %w", err)
+		return "", fmt.Errorf("resolve %s: %w", name, err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("stat %s: %w", name, err)
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("OMAC_CACHE_DIR %q is not a directory", dir)
+		return "", fmt.Errorf("%s %q is not a directory", name, raw)
 	}
 	for _, allowed := range grants.AllowPaths {
 		allowedDir, err := canonicalCachePath(allowed)
 		if err != nil {
-			return nil, fmt.Errorf("resolve writable grant %q: %w", allowed, err)
+			return "", fmt.Errorf("resolve writable grant %q: %w", allowed, err)
 		}
-		if cacheDir == allowedDir {
-			return toolcache.Environment(cacheDir, mode), nil
+		if dir == allowedDir {
+			return dir, nil
 		}
 	}
-	return nil, fmt.Errorf("OMAC_CACHE_DIR %q does not match an exact writable grant", dir)
+	return "", fmt.Errorf("%s %q does not match an exact writable grant", name, raw)
 }
 
 // canonicalCachePath compares cleaned absolute paths and resolves symlinks for

--- a/internal/toolcache/cache.go
+++ b/internal/toolcache/cache.go
@@ -22,6 +22,12 @@ type Domain string
 const (
 	DomainWorkdir Domain = "workdir"
 	DomainServe   Domain = "serve"
+	// DomainHarness keys a cache scope by harness identity, not workdir. The
+	// harness's own XDG cache holds config-declared plugins — user state, like
+	// the already-global ~/.config/<harness> — so sharing it across workdirs
+	// avoids a per-project registry re-fetch without weakening build-cache
+	// isolation (which stays per-workdir).
+	DomainHarness Domain = "harness"
 )
 
 type Scope struct {
@@ -61,11 +67,48 @@ func DescribePersistent(domain Domain, path string) (Scope, error) {
 	}, nil
 }
 
+// DescribeHarness returns the persistent, cross-workdir cache scope for a
+// harness, keyed by harness name instead of a workdir path. It does not touch
+// the filesystem. The digest inputs never include a path, so the same harness
+// resolves to the same scope from every directory.
+func DescribeHarness(harness string) (Scope, error) {
+	if harness == "" {
+		return Scope{}, errors.New("harness name is empty")
+	}
+	identity := "v1:harness:" + harness
+	digest := sha256.Sum256([]byte(identity))
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return Scope{}, err
+	}
+	return Scope{
+		Domain:   DomainHarness,
+		Mode:     ModePersistent,
+		Identity: identity,
+		Digest:   hex.EncodeToString(digest[:]),
+		Dir:      filepath.Join(home, ".cache", "omac", hex.EncodeToString(digest[:])),
+	}, nil
+}
+
+// PrepareHarness creates and locks the harness-scoped persistent cache,
+// mirroring PreparePersistent for the workdir/serve domains.
+func PrepareHarness(harness string) (*Scope, error) {
+	scope, err := DescribeHarness(harness)
+	if err != nil {
+		return nil, err
+	}
+	return prepareScope(scope)
+}
+
 func PreparePersistent(domain Domain, path string) (*Scope, error) {
 	scope, err := DescribePersistent(domain, path)
 	if err != nil {
 		return nil, err
 	}
+	return prepareScope(scope)
+}
+
+func prepareScope(scope Scope) (*Scope, error) {
 	lock, err := acquireLock(filepath.Dir(scope.Dir), scope.Digest, syscall.LOCK_SH)
 	if err != nil {
 		return nil, err
@@ -89,16 +132,29 @@ func PrepareEphemeral(sandboxTmp string) (*Scope, error) {
 	}, nil
 }
 
+// Environment returns the cache redirects for a single-scope launch where the
+// harness XDG cache and the tool-specific build caches share one directory
+// (ephemeral mode, and diagnostics such as provenance).
 func Environment(dir string, mode Mode) map[string]string {
+	return EnvironmentSplit(dir, dir, mode)
+}
+
+// EnvironmentSplit returns the cache redirects when the harness's own XDG
+// cache lives in a different scope from the build caches. buildDir backs the
+// per-workdir build caches (Go/npm/pip/Cargo, OMAC_CACHE_DIR); xdgDir backs
+// XDG_CACHE_HOME (OMAC_XDG_CACHE_DIR), which the sandbox re-exec grant-checks
+// independently.
+func EnvironmentSplit(buildDir, xdgDir string, mode Mode) map[string]string {
 	return map[string]string{
-		"XDG_CACHE_HOME":   filepath.Join(dir, "xdg"),
-		"GOCACHE":          filepath.Join(dir, "go-build"),
-		"GOMODCACHE":       filepath.Join(dir, "go-mod"),
-		"NPM_CONFIG_CACHE": filepath.Join(dir, "npm"),
-		"PIP_CACHE_DIR":    filepath.Join(dir, "pip"),
-		"CARGO_HOME":       filepath.Join(dir, "cargo"),
-		"OMAC_CACHE_DIR":   dir,
-		"OMAC_CACHE_MODE":  string(mode),
+		"XDG_CACHE_HOME":     filepath.Join(xdgDir, "xdg"),
+		"GOCACHE":            filepath.Join(buildDir, "go-build"),
+		"GOMODCACHE":         filepath.Join(buildDir, "go-mod"),
+		"NPM_CONFIG_CACHE":   filepath.Join(buildDir, "npm"),
+		"PIP_CACHE_DIR":      filepath.Join(buildDir, "pip"),
+		"CARGO_HOME":         filepath.Join(buildDir, "cargo"),
+		"OMAC_CACHE_DIR":     buildDir,
+		"OMAC_XDG_CACHE_DIR": xdgDir,
+		"OMAC_CACHE_MODE":    string(mode),
 	}
 }
 

--- a/internal/toolcache/cache_test.go
+++ b/internal/toolcache/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -183,20 +184,62 @@ func TestEnvironment(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dir := filepath.Join(t.TempDir(), "cache")
 			want := map[string]string{
-				"XDG_CACHE_HOME":   filepath.Join(dir, "xdg"),
-				"GOCACHE":          filepath.Join(dir, "go-build"),
-				"GOMODCACHE":       filepath.Join(dir, "go-mod"),
-				"NPM_CONFIG_CACHE": filepath.Join(dir, "npm"),
-				"PIP_CACHE_DIR":    filepath.Join(dir, "pip"),
-				"CARGO_HOME":       filepath.Join(dir, "cargo"),
-				"OMAC_CACHE_DIR":   dir,
-				"OMAC_CACHE_MODE":  string(test.mode),
+				"XDG_CACHE_HOME":     filepath.Join(dir, "xdg"),
+				"GOCACHE":            filepath.Join(dir, "go-build"),
+				"GOMODCACHE":         filepath.Join(dir, "go-mod"),
+				"NPM_CONFIG_CACHE":   filepath.Join(dir, "npm"),
+				"PIP_CACHE_DIR":      filepath.Join(dir, "pip"),
+				"CARGO_HOME":         filepath.Join(dir, "cargo"),
+				"OMAC_CACHE_DIR":     dir,
+				"OMAC_XDG_CACHE_DIR": dir,
+				"OMAC_CACHE_MODE":    string(test.mode),
 			}
 
 			if got := Environment(dir, test.mode); !maps.Equal(got, want) {
 				t.Errorf("Environment() = %#v, want %#v", got, want)
 			}
 		})
+	}
+}
+
+// TestEnvironmentSplitSeparatesXDGFromBuildCaches asserts that the harness
+// XDG cache and the tool build caches resolve under their own scope
+// directories, so a harness's plugins persist across workdirs while build
+// artifacts stay isolated per workdir.
+func TestEnvironmentSplitSeparatesXDGFromBuildCaches(t *testing.T) {
+	buildDir := filepath.Join(t.TempDir(), "build")
+	xdgDir := filepath.Join(t.TempDir(), "xdg-scope")
+	env := EnvironmentSplit(buildDir, xdgDir, ModePersistent)
+	if got, want := env["XDG_CACHE_HOME"], filepath.Join(xdgDir, "xdg"); got != want {
+		t.Errorf("XDG_CACHE_HOME = %q; want %q", got, want)
+	}
+	if got, want := env["OMAC_XDG_CACHE_DIR"], xdgDir; got != want {
+		t.Errorf("OMAC_XDG_CACHE_DIR = %q; want %q", got, want)
+	}
+	for _, name := range []string{"GOCACHE", "GOMODCACHE", "NPM_CONFIG_CACHE", "PIP_CACHE_DIR", "CARGO_HOME"} {
+		if !strings.HasPrefix(env[name], buildDir) {
+			t.Errorf("%s = %q; want it under build scope %q", name, env[name], buildDir)
+		}
+	}
+	if env["OMAC_CACHE_DIR"] != buildDir {
+		t.Errorf("OMAC_CACHE_DIR = %q; want %q", env["OMAC_CACHE_DIR"], buildDir)
+	}
+}
+
+// TestDescribeHarnessIsWorkdirIndependent asserts a harness scope is keyed by
+// name only (workdir-independent) and distinct from a workdir scope.
+func TestDescribeHarnessIsWorkdirIndependent(t *testing.T) {
+	a, _ := DescribeHarness("opencode")
+	if a.Domain != DomainHarness {
+		t.Errorf("domain = %q, want %q", a.Domain, DomainHarness)
+	}
+	other, _ := DescribeHarness("claude-code")
+	wd, _ := DescribePersistent(DomainWorkdir, t.TempDir())
+	if a.Digest == other.Digest || a.Digest == wd.Digest {
+		t.Errorf("harness digest %q collides with another harness/workdir scope", a.Digest)
+	}
+	if _, err := DescribeHarness(""); err == nil {
+		t.Error("DescribeHarness accepted an empty harness name")
 	}
 }
 


### PR DESCRIPTION
## What

Fixes #143. Splits the persistent tool cache into two scopes so a harness's own plugins/extensions install once and persist across workdirs, while project build caches stay isolated per workdir.

- **Per-workdir build scope** (`OMAC_CACHE_DIR`): `GOCACHE`, `GOMODCACHE`, `NPM_CONFIG_CACHE`, `PIP_CACHE_DIR`, `CARGO_HOME` — unchanged, still isolated per project.
- **Per-harness XDG scope** (`OMAC_XDG_CACHE_DIR`, `toolcache.DomainHarness`): `XDG_CACHE_HOME` — keyed by harness name, shared across all workdirs.

## Why

XDG-aware harnesses resolve their cache root to `$XDG_CACHE_HOME/<harness>` and install config-declared plugins under `$XDG_CACHE_HOME/<harness>/packages`. Because #104 scopes `XDG_CACHE_HOME` per-workdir, every new project directory starts with a cold harness cache.

The baseline effect (always present) is a **redundant re-fetch**: the harness re-downloads its own user-configured plugins from their registry on the first launch in each new workdir, and the copy under the pre-upgrade `~/.cache/<harness>` is orphaned (a grant #104 also removed). This is not about running offline — the harness needs network for the model regardless; the point is that user-controlled state that should install once is re-fetched per project.

That re-fetch becomes an **outright failure** only when it can't complete inside the sandbox: a non-interactive / `serve` launch or prompt timeout (default `network.mode: filtered`, `network_prompt.on_unavailable: deny`), a VPN-gated registry, or a locally-placed (non-registry) plugin that is never re-fetched. The original "plugin stopped working after the upgrade" report is one of those conditional cases.

The harness's plugin cache is user-config state, not untrusted project output, so per-workdir isolation gives no security benefit (the #26 threat model is build/tool caches). It also mirrors the harness's other dirs — `~/.local/share/<harness>` and `~/.config/<harness>` are already global and not remapped.

## Security posture — what of #104's hardening is kept vs relaxed

**Kept:**
- No broad host-cache grants: `~/.cache`, `~/Library/Caches`, `~/go` stay ungranted; the removed harness-global grants (`~/.cache/opencode`, …) are **not** restored. The harness scope is still an isolated `~/.cache/omac/<hash>` dir.
- Per-workdir isolation of build/tool caches (`GOCACHE`/`GOMODCACHE`/`NPM_CONFIG_CACHE`/`PIP_CACHE_DIR`/`CARGO_HOME`) — the security-critical part where untrusted project code writes. They have explicit overrides so tools do not fall back to `XDG_CACHE_HOME`.
- Injected env still overrides host-inherited values (hostile `GOCACHE`/`CARGO_HOME` replaced), and the sandbox re-exec grant-checks **both** cache dirs (`grantedCacheDir`) so neither bypasses the filesystem allowlist.
- `--ephemeral-cache` collapses both scopes to a per-launch temp dir (full isolation); `~/.rustup`/`~/.cargo/bin` stay read-only.

**Relaxed (deliberate):**
- `XDG_CACHE_HOME` is now shared across a user's workdirs for a given harness. Intended writer: the harness's own plugin cache (user-controlled). Residual surface: any *other* XDG-aware tool a project invokes that writes under `$XDG_CACHE_HOME` and lacks a dedicated redirect would share that entry across the same user's same-harness projects — a narrow cross-project surface per-workdir XDG previously closed.
- Not narrowed to `$XDG_CACHE_HOME/<harness>` only, because OpenCode derives its whole cache root from `XDG_CACHE_HOME` with no env to relocate just its subtree (all-or-nothing on that variable).

## How

- `internal/toolcache`: add `DomainHarness`, `DescribeHarness`/`PrepareHarness`, split `Environment` into `EnvironmentSplit(buildDir, xdgDir, mode)` (adds `OMAC_XDG_CACHE_DIR`).
- `internal/cli/start.go`, `serve.go`: prepare both scopes, grant both leaves read+write, inject `OMAC_XDG_CACHE_DIR` alongside `OMAC_CACHE_DIR`.
- `internal/sandboxrun/run.go`: re-derive and grant-check both dirs independently on the sandbox re-exec (factored into `grantedCacheDir`).
- `internal/sandboxbrief`, `provenance.go`: reflect the split in the agent briefing and diagnostics.
- `--ephemeral-cache` and `--no-sandbox` behaviour unchanged: both scopes collapse to the single per-launch dir (or none).
- Does not migrate the orphaned pre-upgrade `~/.cache/<harness>` contents: the plugin is re-fetched once into the new stable scope, then reused.
- Docs: `NONO_SANDBOX.md` and the cache-isolation design doc updated.

## Verification

- **Unit** (`internal/toolcache`, `internal/cli`, `internal/sandboxbrief`): harness scope is workdir-independent and distinct from workdir/serve domains; `EnvironmentSplit` routes XDG vs build caches to their own scopes; serve holds/clears both scope locks.
- **e2e** (`internal/e2e`, bubblewrap host): new `TestE2ECacheHarnessXDGSharedAcrossWorkdirs` — a marker under `$XDG_CACHE_HOME` in project A is readable from project B (shared harness scope) while `OMAC_CACHE_DIR` differs (build cache still isolated). The `-run '^TestE2ECache'` suite passes except `TestE2ECacheTools`, which fails identically on the base commit due to a host Python-3.14 `sysconfig` path (unrelated; passes in CI). `-tags=e2e_fast` passes.
- **Before/after** with real pre-fix vs fixed binaries at OpenCode's actual plugin path: before, `XDG_CACHE_HOME` differs per workdir and the plugin is lost in project B; after, it is shared and the plugin persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
