### PR TITLE
fix(session): resume the session this run created, not a sibling

### DIFF
--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/session"
@@ -471,29 +472,125 @@ func TestContinueHintToken(t *testing.T) {
 }
 
 func TestHintSessionID(t *testing.T) {
+	seen := func(ids ...string) map[string]struct{} {
+		m := map[string]struct{}{}
+		for _, id := range ids {
+			m[id] = struct{}{}
+		}
+		return m
+	}
 	cases := []struct {
-		name     string
-		sessions []session.Session
-		wantID   string
-		wantOK   bool
+		name      string
+		sessions  []session.Session
+		resumedID string
+		prior     map[string]struct{}
+		wantID    string
+		wantOK    bool
 	}{
-		{"empty", nil, "", false},
-		{"leading-empty-id", []session.Session{{ID: ""}}, "", false},
+		{name: "empty", wantID: "", wantOK: false},
+		{name: "leading-empty-id", sessions: []session.Session{{ID: ""}}, wantID: "", wantOK: false},
 		{
-			// session.List returns newest-first, so the hint must advertise
-			// the first entry — never a later one.
-			name:     "picks-first-newest",
+			// No prior snapshot and no resume: fall back to newest (index 0).
+			name:     "fresh-no-prior-picks-newest",
 			sessions: []session.Session{{ID: "ses_new"}, {ID: "ses_old"}},
 			wantID:   "ses_new",
 			wantOK:   true,
 		},
+		{
+			// #141: the newest session is a sibling that existed before launch;
+			// advertise the session this run created (absent from prior),
+			// even though it is not index 0.
+			name:     "skips-sibling-picks-new-session",
+			sessions: []session.Session{{ID: "ses_sibling"}, {ID: "ses_ours"}, {ID: "ses_old"}},
+			prior:    seen("ses_sibling", "ses_old"),
+			wantID:   "ses_ours",
+			wantOK:   true,
+		},
+		{
+			// Every session predates launch (bare continue reused a session, or
+			// the harness persisted nothing new): fall back to newest.
+			name:     "all-known-falls-back-to-newest",
+			sessions: []session.Session{{ID: "ses_a"}, {ID: "ses_b"}},
+			prior:    seen("ses_a", "ses_b"),
+			wantID:   "ses_a",
+			wantOK:   true,
+		},
+		{
+			// A known resume id wins outright — the list and snapshot are moot.
+			name:      "resumed-id-wins",
+			sessions:  []session.Session{{ID: "ses_sibling"}},
+			resumedID: "ses_resumed",
+			prior:     seen("ses_sibling"),
+			wantID:    "ses_resumed",
+			wantOK:    true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			id, ok := hintSessionID(tc.sessions)
+			id, ok := hintSessionID(tc.sessions, tc.resumedID, tc.prior)
 			if id != tc.wantID || ok != tc.wantOK {
 				t.Errorf("hintSessionID = (%q, %v), want (%q, %v)", id, ok, tc.wantID, tc.wantOK)
 			}
 		})
+	}
+}
+
+// encodeClaudeProjectDir mirrors Claude Code's project-dir naming (every
+// non-alphanumeric rune → '-'). Duplicated here as test scaffolding so the
+// integrated hint test can place fixtures where the session package looks.
+func encodeClaudeProjectDir(path string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return r
+		}
+		return '-'
+	}, path)
+}
+
+func writeClaudeSessionFile(t *testing.T, home, workdir, id, ts string) {
+	t.Helper()
+	dir := filepath.Join(home, "projects", encodeClaudeProjectDir(workdir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := fmt.Sprintf(`{"type":"user","cwd":%q,"timestamp":%q,"message":{"content":"hi"}}`, workdir, ts)
+	if err := os.WriteFile(filepath.Join(dir, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestContinueHintSkipsSiblingSession reproduces #141 end-to-end against a real
+// on-disk Claude session store (the harness-agnostic snapshot path): a sibling
+// session is active in the workdir when our run starts and stays the
+// most-recently-updated row, yet the hint must advertise the session this run
+// created — not the sibling.
+func TestContinueHintSkipsSiblingSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CLAUDE_HOME", home)
+	h, ok := config.LookupHarness("claude-code")
+	if !ok {
+		t.Fatal("claude-code harness not registered")
+	}
+	const wd = "/home/u/proj"
+
+	// A sibling session already exists before our run — captured in the snapshot.
+	writeClaudeSessionFile(t, home, wd, "sibling-0000", "2026-01-01T10:00:00Z")
+	prior := session.KnownIDs(h, wd)
+
+	// Our run creates a new session; the sibling is then touched again, so it
+	// remains the newest row when the hint is computed at exit.
+	writeClaudeSessionFile(t, home, wd, "ours-1111", "2026-01-01T10:01:00Z")
+	writeClaudeSessionFile(t, home, wd, "sibling-0000", "2026-01-01T10:02:00Z")
+
+	sessions, err := session.List(h, wd)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sessions) == 0 || sessions[0].ID != "sibling-0000" {
+		t.Fatalf("precondition: newest row should be the sibling, got %+v", sessions)
+	}
+	id, ok := hintSessionID(sessions, "", prior)
+	if !ok || id != "ours-1111" {
+		t.Errorf("hint = (%q, %v), want (\"ours-1111\", true) — sibling must be skipped", id, ok)
 	}
 }

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -52,6 +52,9 @@ func runResume(args []string, env *Env) int {
 		return ExitOK // cancelled, or non-interactive stdin
 	}
 
+	// Record the picked id so the post-exit continue hint advertises this exact
+	// session rather than whichever sibling was most-recently-updated (#141).
+	opts.sessionID = sessions[idx].ID
 	opts.innerArgs = buildResumeInnerArgs(h.Session, sessions[idx].ID, opts.innerArgs)
 	return runLaunch(env, opts)
 }

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -903,13 +903,21 @@ func runLaunch(env *Env, opts launchOpts) int {
 	auditor.Emit(audit.SessionStart(env.Version, harness.Name, profName, sandboxBackend))
 	auditor.Emit(audit.InnerExec(argv, profName, sandboxed))
 
+	// Snapshot the sessions that already exist so the post-exit hint can tell
+	// the session this run creates apart from a sibling session active in the
+	// same workdir (issue #141). Skipped when no hint would be shown anyway.
+	var priorSessions map[string]struct{}
+	if harness.Session != nil && len(harness.Session.ContinueArgs) > 0 {
+		priorSessions = session.KnownIDs(harness, env.Workdir)
+	}
+
 	code, err := sandbox.ExecWithReady(argv, extra, nil)
 	auditor.Emit(audit.SessionStop(code))
 	if err != nil {
 		fmt.Fprintln(env.Stderr, prefix+": exec:", err)
 		return ExitSandboxAbnormal
 	}
-	printContinueHint(env, harness)
+	printContinueHint(env, harness, opts.sessionID, priorSessions)
 	return code
 }
 
@@ -947,7 +955,12 @@ func continueHintToken(h config.Harness) string {
 // session strategy yields no sessions → no hint (never an error, never
 // blocks). Reuses session.List — the same path `omac resume` takes — so the
 // hint only appears when continue would actually find a session.
-func printContinueHint(env *Env, harness config.Harness) {
+//
+// resumedID is the session this run is known to have re-entered (omac continue
+// -s / omac resume), or "" for a fresh session. prior is the set of session
+// ids that existed before launch (see hintSessionID for how both steer the
+// selection).
+func printContinueHint(env *Env, harness config.Harness, resumedID string, prior map[string]struct{}) {
 	if harness.Session == nil || len(harness.Session.ContinueArgs) == 0 {
 		return
 	}
@@ -969,7 +982,7 @@ func printContinueHint(env *Env, harness config.Harness) {
 		if r.err != nil {
 			return
 		}
-		id, ok := hintSessionID(r.sessions)
+		id, ok := hintSessionID(r.sessions, resumedID, prior)
 		if !ok {
 			return
 		}
@@ -980,12 +993,32 @@ func printContinueHint(env *Env, harness config.Harness) {
 	}
 }
 
-// hintSessionID picks the session id to advertise in the continue hint: the
-// most-recently-updated session, which session.List guarantees at index 0.
-// It returns ok=false when there is nothing resumable (empty list, or a
-// leading entry with no id). Kept as a pure function so this selection is
-// unit-testable without printContinueHint's goroutine and timeout.
-func hintSessionID(sessions []session.Session) (string, bool) {
+// hintSessionID picks the session id to advertise in the continue hint.
+//
+// When this run resumed a known session (omac continue -s / omac resume),
+// resumedID is advertised verbatim — it is exactly the session that ran.
+// Otherwise the run created a fresh session: the most-recent session absent
+// from prior (the snapshot of ids taken before launch) is that new session, so
+// a sibling session that stayed active in the same workdir is never advertised
+// (issue #141). When nothing is new — the snapshot was unavailable, or the
+// harness reused an id — it falls back to the most-recent session, preserving
+// the previous best-effort behavior.
+//
+// sessions is newest-first, as session.List guarantees. Returns ok=false only
+// when there is nothing resumable. Kept pure so the selection is unit-testable
+// without printContinueHint's goroutine and timeout.
+func hintSessionID(sessions []session.Session, resumedID string, prior map[string]struct{}) (string, bool) {
+	if resumedID != "" {
+		return resumedID, true
+	}
+	for _, s := range sessions {
+		if s.ID == "" {
+			continue
+		}
+		if _, seen := prior[s.ID]; !seen {
+			return s.ID, true
+		}
+	}
 	if len(sessions) == 0 || sessions[0].ID == "" {
 		return "", false
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -82,6 +82,54 @@ func list(h config.Harness, workdir string, run runner, claudeRoot, ocDBPath, co
 	}
 }
 
+// KnownIDs returns the set of session IDs that already exist for workdir
+// before a run begins. The continue-hint logic snapshots this set just before
+// launching the harness; after the harness exits, any id absent from the
+// snapshot is the session this run created, so a sibling session that stayed
+// active in the same workdir is never mistaken for "this" session (see
+// cli.printContinueHint and issue #141).
+//
+// It is a cheap, best-effort snapshot: identifiers are enumerated without the
+// full parse List performs, and any error yields an empty (never nil) set.
+// Returning a superset is safe for the caller, which only uses the set to
+// exclude pre-existing ids, so per-session cwd verification is skipped where it
+// would otherwise force a parse.
+func KnownIDs(h config.Harness, workdir string) map[string]struct{} {
+	ids := map[string]struct{}{}
+	if h.Session == nil {
+		return ids
+	}
+	workdir = filepath.Clean(workdir)
+	if h.Session.ListKind == config.SessionListClaudeFiles {
+		// Claude session ids ARE the <uuid>.jsonl filenames under the workdir's
+		// encoded project dir, so they enumerate without opening a single file.
+		root := claudeProjectsRoot(h)
+		if root == "" {
+			return ids
+		}
+		entries, err := os.ReadDir(filepath.Join(root, encodeProjectDir(workdir)))
+		if err != nil {
+			return ids
+		}
+		for _, e := range entries {
+			if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+				continue
+			}
+			ids[strings.TrimSuffix(e.Name(), ".jsonl")] = struct{}{}
+		}
+		return ids
+	}
+	// Other backends' List paths are already cheap (a single DB query, or a
+	// first-line read per file); reuse List and keep only the ids.
+	sessions, _ := List(h, workdir)
+	for _, s := range sessions {
+		if s.ID != "" {
+			ids[s.ID] = struct{}{}
+		}
+	}
+	return ids
+}
+
 // sortNewestFirst orders sessions by When descending (unknown times sink to
 // the end), with ID as a stable tiebreaker.
 func sortNewestFirst(s []Session) {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -531,3 +531,53 @@ func TestListPiEmptyRootIsEmpty(t *testing.T) {
 		t.Errorf("empty root should yield nil, got %+v", got)
 	}
 }
+
+func claudeHarness(t *testing.T) config.Harness {
+	t.Helper()
+	h, ok := config.LookupHarness("claude-code")
+	if !ok {
+		t.Fatal("claude-code harness not registered")
+	}
+	return h
+}
+
+func TestKnownIDsClaudeEnumeratesFilenames(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CLAUDE_HOME", home)
+	root := filepath.Join(home, "projects")
+	const wd = "/home/u/proj"
+
+	writeClaudeFixture(t, root, wd, "aaaa-1111", []string{
+		`{"type":"user","cwd":"/home/u/proj","message":{"content":"x"}}`,
+	})
+	// Encoding collision: cwd differs, so List would exclude it — but KnownIDs
+	// deliberately returns a superset (no per-file parse), so it is included.
+	writeClaudeFixture(t, root, wd, "bbbb-2222", []string{
+		`{"type":"user","cwd":"/home/u/different","message":{"content":"y"}}`,
+	})
+
+	got := KnownIDs(claudeHarness(t), wd)
+	for _, want := range []string{"aaaa-1111", "bbbb-2222"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("KnownIDs missing %q; got %v", want, got)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("KnownIDs size = %d, want 2: %v", len(got), got)
+	}
+}
+
+func TestKnownIDsClaudeMissingDirIsEmpty(t *testing.T) {
+	t.Setenv("CLAUDE_HOME", t.TempDir()) // no projects/ subtree written
+	got := KnownIDs(claudeHarness(t), "/home/u/proj")
+	if got == nil || len(got) != 0 {
+		t.Errorf("missing project dir should yield an empty (non-nil) set, got %v", got)
+	}
+}
+
+func TestKnownIDsUnsupportedHarnessIsEmpty(t *testing.T) {
+	got := KnownIDs(config.Harness{}, "/home/u/proj")
+	if got == nil || len(got) != 0 {
+		t.Errorf("nil-session harness should yield an empty (non-nil) set, got %v", got)
+	}
+}


### PR DESCRIPTION
## What

The post-exit `To resume this session: omac continue -s <id>` hint could advertise the **wrong** session when a second omac session runs in the same workdir — it pointed at whichever session was most-recently-updated, not the one that just exited. Fixes #141.

## Why

`printContinueHint` selected `sessions[0]` — the newest-updated session for the workdir. With two concurrent sessions in one workdir, a still-active *sibling* takes that slot, so the hint resumes the sibling instead of the session you were in.

The earlier fix #142 (`parent_id IS NULL`) only excluded opencode **sub-agent children**. A top-level **sibling** still slips through, and the Claude backend has no such filter at all — so #141 was not actually fixed.

## How

Determine *this* run's session instead of guessing the newest:

- **`session.KnownIDs`** snapshots the existing session ids just before launch. After exit, the hint advertises the most-recent id **absent** from that snapshot — the session this run created. A concurrently-active sibling was already in the snapshot, so it is never picked.
- When the run resumed a **known** session (`omac continue -s` / `omac resume`), that id is advertised verbatim — `resume.go` now records the picked id.
- Falls back to the most-recent session when nothing is new (snapshot unavailable, or the harness reused an id), preserving prior best-effort behavior.

Harness-agnostic: `KnownIDs` enumerates Claude ids from filenames without a parse, and reuses the (already cheap) `List` path for opencode/codex/copilot/pi — so **all** harnesses are fixed, not just opencode.

The `parent_id IS NULL` filter from #142 is intentionally kept: it lives in the shared `session.List`, still excludes sub-agents from the resume picker, and complements this fix (a fresh run's own sub-agent children are also "new", so the filter keeps them out of the hint's candidate list).

## Verification

- `go build ./...` and `go vet` clean.
- Unit tests for `hintSessionID` (sibling-skip, resume-wins, fallback, empty) and `KnownIDs` (Claude enumeration incl. superset, missing dir, unsupported harness).
- **`TestContinueHintSkipsSiblingSession`** — end-to-end reproduction of #141 against a real on-disk Claude session store: sibling active before launch → snapshot → our session created → sibling touched again to become newest → hint correctly advertises our session.
- All `internal/session` and `internal/cli` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)