### PR TITLE
fix(e2e): make cacheHostRootDenied a host-side leak check, not a write probe

### DIFF
--- a/.opencode/skills/self-audit/scripts/audit.sh
+++ b/.opencode/skills/self-audit/scripts/audit.sh
@@ -232,9 +232,9 @@ echo ""
 echo "=== PROBE: cache ==="
 # Cache isolation probe (Tasks 1-10). Verifies the sandbox redirected
 # every tool cache to OMAC_CACHE_DIR (injected by omac via the trusted
-# re-injection path, bypassing the allow_vars filter) and that the
-# host-global cache roots (~/.cache, ~/Library/Caches) are denied so
-# the agent cannot escape the scoped cache.
+# re-injection path, bypassing the allow_vars filter) and that a write
+# aimed at the host-global cache roots (~/.cache, ~/Library/Caches) never
+# reaches the real host filesystem (asserted host-side; see issue #149).
 #
 # The allow_vars fixture intentionally lists only OMAC_* for cache
 # names (see allowance.go), so the non-OMAC_* tool mappings
@@ -266,20 +266,24 @@ else
         echo "CACHE_MARKER_WRITE_FAILED: $(cat /tmp/audit-cache-write.txt)"
     fi
 fi
-echo "--- host-global cache roots must be denied (write) ---"
-# ~/.cache and ~/Library/Caches are NOT granted by DefaultProfile
-# (Tasks 1-10 removed them). A write attempt must fail; a success is a
-# security boundary violation the test asserts on.
+echo "--- host cache root: write attempt (authoritative check is host-side) ---"
+# Drop a marker into the string path $HOME/.cache and $HOME/Library/Caches.
+# A successful write here is NOT itself a breach: inside the sandbox these
+# paths are throwaway tmpfs mount-point parents bubblewrap auto-creates to
+# host the scoped tool-cache bind (~/.cache/omac/<digest>), isolated from the
+# host. The harness verifies host-side (assertCacheHostRootDenied) that this
+# marker never lands in the real host cache root; the write result below is
+# informational only. See issue #149.
 host_cache="$HOME/.cache"
-( echo "pwn" > "$host_cache/audit-host-marker.txt" ) 2>/tmp/audit-host-cache.txt \
-    && echo "HOST_CACHE_WRITABLE: SECURITY VIOLATION ($host_cache)" \
-    || echo "HOST_CACHE_DENIED: $(cat /tmp/audit-host-cache.txt)"
+( echo "omac-host-cache-probe" > "$host_cache/audit-host-marker.txt" ) 2>/tmp/audit-host-cache.txt \
+    && echo "HOST_CACHE_WRITE_ATTEMPTED: $host_cache/audit-host-marker.txt" \
+    || echo "HOST_CACHE_WRITE_REFUSED: $(cat /tmp/audit-host-cache.txt)"
 if [ -d "$HOME/Library/Caches" ]; then
-    ( echo "pwn" > "$HOME/Library/Caches/audit-host-marker.txt" ) 2>/tmp/audit-host-caches.txt \
-        && echo "HOST_LIBRARY_CACHES_WRITABLE: SECURITY VIOLATION" \
-        || echo "HOST_LIBRARY_CACHES_DENIED: $(cat /tmp/audit-host-caches.txt)"
+    ( echo "omac-host-cache-probe" > "$HOME/Library/Caches/audit-host-marker.txt" ) 2>/tmp/audit-host-caches.txt \
+        && echo "HOST_LIBRARY_CACHES_WRITE_ATTEMPTED: $HOME/Library/Caches/audit-host-marker.txt" \
+        || echo "HOST_LIBRARY_CACHES_WRITE_REFUSED: $(cat /tmp/audit-host-caches.txt)"
 else
-    echo "HOST_LIBRARY_CACHES_DENIED: ~/Library/Caches does not exist"
+    echo "HOST_LIBRARY_CACHES_ABSENT: ~/Library/Caches does not exist"
 fi
 # Clean up the scratch files used to capture inner-command stderr so
 # they don't accumulate across runs. The denial messages have already

--- a/internal/e2e/cachehostroot.go
+++ b/internal/e2e/cachehostroot.go
@@ -1,0 +1,38 @@
+//go:build e2e || e2e_fast
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// hostCacheProbeMarker is the filename the self-audit cache probe writes into
+// $HOME/.cache (and $HOME/Library/Caches) from inside the sandbox. The harness
+// checks host-side that it never lands in the real cache roots — see
+// hostCacheLeak and assertCacheHostRootDenied.
+const hostCacheProbeMarker = "audit-host-marker.txt"
+
+// hostCacheLeak reports whether the self-audit probe marker leaked into one of
+// home's real cache roots (~/.cache or ~/Library/Caches), returning the leaked
+// path when found.
+//
+// It deliberately ignores the scoped ~/.cache/omac/<digest> subtree: the probe
+// writes to the cache ROOT, and only that root is the security boundary under
+// test (issue #149). A successful in-sandbox write to the string path
+// $HOME/.cache is not itself a breach — on Linux that path is a throwaway
+// tmpfs mount-point parent bubblewrap auto-creates to host the scoped
+// tool-cache bind — so this host-side presence check, not the probe's write
+// result, is authoritative.
+func hostCacheLeak(home string) (string, bool) {
+	for _, root := range []string{
+		filepath.Join(home, ".cache"),
+		filepath.Join(home, "Library", "Caches"),
+	} {
+		leaked := filepath.Join(root, hostCacheProbeMarker)
+		if _, err := os.Stat(leaked); err == nil {
+			return leaked, true
+		}
+	}
+	return "", false
+}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -281,7 +281,7 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 		assertFilesystemWriteDenied(t, stdout)
 		assertSymlinkEscapeDenied(t, stdout)
 		assertNetworkDenied(t, stdout, spec.NetDenyDomain)
-		assertCacheHostRootDenied(t, stdout)
+		assertCacheHostRootDenied(t, home, stdout)
 	} else {
 		// A --no-sandbox harness (e.g. codex on macOS) has no sandbox to
 		// enforce the negative properties, so we can't assert they hold.
@@ -1191,33 +1191,37 @@ func assertCacheIsolation(t *testing.T, output string) {
 	t.Logf("PASS: cache isolation — OMAC_CACHE_DIR injected, tool mappings re-injected, marker round-tripped")
 }
 
-// assertCacheHostRootDenied verifies the host-global cache roots
-// (~/.cache, ~/Library/Caches) are NOT writable from inside the sandbox.
-// This is the negative half of the cache isolation contract: only the
-// scoped OMAC_CACHE_DIR may be writable.
-func assertCacheHostRootDenied(t *testing.T, output string) {
+// assertCacheHostRootDenied verifies the host's real cache roots (home's
+// ~/.cache and ~/Library/Caches) did NOT receive the self-audit probe's write.
+//
+// The probe writes the string path "$HOME/.cache/audit-host-marker.txt" from
+// inside the sandbox. A successful write there is NOT a violation by itself:
+// on Linux that path is a throwaway tmpfs mount-point parent bubblewrap
+// auto-creates to host the scoped tool-cache bind (~/.cache/omac/<digest>),
+// isolated from the host. The real security property is that the write never
+// reaches the host cache root — checked authoritatively host-side via
+// hostCacheLeak, not by parsing the probe's in-sandbox write result. See
+// issue #149 (this replaced a write-success check that false-positived on
+// every run).
+func assertCacheHostRootDenied(t *testing.T, home, output string) {
 	t.Helper()
 	if !strings.Contains(output, "=== PROBE: cache ===") {
 		// Cache probe didn't run at all — handled by assertCacheIsolation.
 		t.Logf("SKIP: cache host-root denial — cache probe not in output")
 		return
 	}
-	if strings.Contains(output, "HOST_CACHE_WRITABLE: SECURITY VIOLATION") {
-		failWithClassification(t, "cacheHostRootDenied", fmSandboxFail,
-			output+": host ~/.cache is writable (cache isolation broken)")
-		return
-	}
-	if strings.Contains(output, "HOST_LIBRARY_CACHES_WRITABLE: SECURITY VIOLATION") {
-		failWithClassification(t, "cacheHostRootDenied", fmSandboxFail,
-			output+": host ~/Library/Caches is writable (cache isolation broken)")
-		return
-	}
-	if !strings.Contains(output, "HOST_CACHE_DENIED:") {
+	if !strings.Contains(output, "HOST_CACHE_WRITE_ATTEMPTED") &&
+		!strings.Contains(output, "HOST_CACHE_WRITE_REFUSED") {
 		failWithClassification(t, "cacheHostRootDenied", fmAgentPartial,
-			output+": host ~/.cache denial marker missing")
+			output+": host cache probe line missing (audit output truncated?)")
 		return
 	}
-	t.Logf("PASS: cache host-root denial — ~/.cache and ~/Library/Caches not writable from sandbox")
+	if leaked, ok := hostCacheLeak(home); ok {
+		failWithClassification(t, "cacheHostRootDenied", fmSandboxFail,
+			output+": probe marker leaked to host cache root "+leaked+" (cache isolation broken)")
+		return
+	}
+	t.Logf("PASS: cache host-root denial — probe write did not reach host ~/.cache or ~/Library/Caches")
 }
 
 // logExecProbeResults logs the exec probe results without asserting

--- a/internal/e2e/security_assertions_test.go
+++ b/internal/e2e/security_assertions_test.go
@@ -2,7 +2,45 @@
 
 package e2e
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHostCacheLeak covers the host-side check backing
+// assertCacheHostRootDenied (issue #149): a probe marker inside the scoped
+// ~/.cache/omac/<digest> subtree is expected and must NOT count as a leak,
+// while a marker at the cache ROOT is a genuine host-cache escape.
+func TestHostCacheLeak(t *testing.T) {
+	home := t.TempDir()
+
+	// The scoped cache subtree is created by omac at launch; a marker there is
+	// the intended, isolated write and must not be flagged.
+	scoped := filepath.Join(home, ".cache", "omac", "deadbeef")
+	if err := os.MkdirAll(scoped, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scoped, hostCacheProbeMarker), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if leaked, ok := hostCacheLeak(home); ok {
+		t.Fatalf("marker in scoped subtree must not be a leak, got %q", leaked)
+	}
+
+	// A marker at the cache ROOT is a real leak.
+	rootMarker := filepath.Join(home, ".cache", hostCacheProbeMarker)
+	if err := os.WriteFile(rootMarker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	leaked, ok := hostCacheLeak(home)
+	if !ok {
+		t.Fatal("marker at the cache root must be reported as a leak")
+	}
+	if leaked != rootMarker {
+		t.Errorf("leaked path = %q, want %q", leaked, rootMarker)
+	}
+}
 
 // These tests exercise, against synthetic probe output (no live
 // agent/sandbox), the exact marker-absence checks that back


### PR DESCRIPTION
## What

Fix the `cacheHostRootDenied` e2e assertion, which has failed `SANDBOX_FAIL` on **every** scheduled `main` run since it was introduced (`26899a1`). It was a **false-positive**, not a real sandbox gap. Fixes #149.

## Why

The assertion keyed off the self-audit probe writing successfully to the string path `$HOME/.cache` *inside the sandbox*. But that isn't the host cache: on Linux, bubblewrap auto-creates `$HOME/.cache` as a throwaway **tmpfs mount-point parent** to host the scoped tool-cache bind (`~/.cache/omac/<digest>`), and leaves it writable. The write succeeds against tmpfs and never touches the host — so the premise "write succeeded ⇒ host cache writable" is false whenever a scoped cache subdir is bound underneath, i.e. the default persistent-cache path. The assertion could only ever pass in the accidental case where nothing was bound under `$HOME`.

Empirically reproduced (see #149): the in-sandbox write succeeds yet leaves **no file on the host**; only writes to the genuinely-bound scoped subdir persist. `TestDefaultProfileIsolatesToolCaches` already proves `DefaultProfile` grants no access to `~/.cache`.

## How

Test the real property **host-side** instead of parsing the probe's in-sandbox write result:

- **`hostCacheLeak(home)`** — pure, unit-tested helper: after the run, checks that the probe marker did **not** land in `home`'s real cache roots (`~/.cache`, `~/Library/Caches`), deliberately ignoring the intended scoped `~/.cache/omac/<digest>` subtree. Backend-agnostic (bwrap *and* seatbelt); fails only on a genuine leak. Lives in an `e2e || e2e_fast` file so the fast PR gate covers it.
- **`assertCacheHostRootDenied(t, home, output)`** — delegates to `hostCacheLeak`; keeps the probe-ran gate plus an `AGENT_PARTIAL` gate for truncated audit output.
- **self-audit probe** — still drops the marker as bait, but reports the write neutrally (`HOST_CACHE_WRITE_ATTEMPTED`/`REFUSED`) instead of the misleading `SECURITY VIOLATION`; the host-side check is authoritative.

No sandbox behavior changes — host cache isolation was already intact.

## Verification

- `go vet -tags=e2e` and `-tags=e2e_fast` clean.
- New `TestHostCacheLeak` passes under both tags (marker in scoped subtree ≠ leak; marker at cache root = leak).
- `TestDefaultProfileIsolatesToolCaches` still green; `bash -n audit.sh` OK.
- Full live e2e (`E2E: full`) can't be run from here, but this changes only test/probe logic; the assertion now passes on the (already-isolated) sandbox and would still fail a real host-cache leak.

## Notes

Orthogonal to #143 (a real per-workdir cold-cache functional regression in the same subsystem). This is purely a test-probe correctness fix and is needed regardless of #143's outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)