### PR TITLE
feat(cache): make per-workdir cache isolation configurable

### DIFF
--- a/docs/MULTI_DIR_DESKTOP.md
+++ b/docs/MULTI_DIR_DESKTOP.md
@@ -440,20 +440,21 @@ global skills (the shared baseline available to every project). Per-dir
 skills are added lazily (§5.2).
 
 > **Tool-cache scope under `serve`.** omac prepares a single
-> persistent tool-cache scope for the whole `omac serve` process,
-> keyed on the launch workdir identity (`v1:serve:<canonical launch
-> workdir>`), and injects `OMAC_CACHE_DIR` / `OMAC_CACHE_MODE` plus the
-> six tool redirects (`XDG_CACHE_HOME`, `GOCACHE`, `GOMODCACHE`,
+> persistent tool-cache scope for the whole `omac serve` process and
+> injects `OMAC_CACHE_DIR` / `OMAC_CACHE_MODE` plus the six tool
+> redirects (`XDG_CACHE_HOME`, `GOCACHE`, `GOMODCACHE`,
 > `NPM_CONFIG_CACHE`, `PIP_CACHE_DIR`, `CARGO_HOME`) into the shared
-> sandbox. All served directories therefore **share one cache
-> directory** — this is the Desktop path and is strictly weaker
-> isolation than per-workdir `omac start` (which keys the cache on the
-> workdir identity). It is an explicit, documented consequence of
-> Decision #2 (one shared sandbox). `omac serve --workdir <dir>`
-> pre-activates a single directory and keys the cache on that dir's
-> workdir identity instead; `omac serve --ephemeral-cache` uses a
-> per-launch temp cache removed on exit. `omac start` (TUI, one
-> directory) keeps the per-workdir persistent cache scope unchanged.
+> sandbox. The scope is chosen by `cache.scope` (§9.1), defaulting to
+> `global` — one cache shared by every workdir on the machine, which is
+> also what all served directories share here. Because one serve process
+> runs one shared sandbox, per-workdir isolation only applies to `omac
+> serve --workdir <dir>` (or `--cache-scope workdir` with `--workdir`),
+> which keys the cache on that dir's workdir identity. Without `--workdir`,
+> `--cache-scope workdir` falls back to a per-launch serve-scope cache
+> (`v1:serve:<canonical launch workdir>`). `omac serve --ephemeral-cache`
+> uses a per-launch temp cache removed on exit. This shared default is an
+> explicit consequence of Decision #2 (one shared sandbox); set
+> `cache.scope: workdir` (with `--workdir`) to opt into isolation.
 
 ### 5.2 Lazy activation (the core new behavior)
 

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/toolcache"
 )
 
@@ -61,13 +62,38 @@ func runCacheClear(args []string, env *Env) int {
 		return ExitOK
 	}
 
-	result, err := toolcache.ClearWorkdir(env.Workdir)
+	result, err := clearActiveScope(env.Workdir)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac cache clear:", err)
 		return ExitIOError
 	}
 	renderClearResult(env, result)
 	return ExitOK
+}
+
+// clearActiveScope removes the persistent cache scope the current config
+// resolves to (global/config/workdir), so `omac cache clear` targets the
+// cache actually in use rather than always the per-workdir one.
+func clearActiveScope(workdir string) (toolcache.ClearResult, error) {
+	lc, cfgPath, err := config.LoadLauncher(workdir)
+	if err != nil {
+		return toolcache.ClearResult{}, err
+	}
+	scope, err := lc.Cache.Resolve()
+	if err != nil {
+		return toolcache.ClearResult{}, err
+	}
+	switch scope {
+	case config.CacheScopeWorkdir:
+		return toolcache.ClearWorkdir(workdir)
+	case config.CacheScopeConfig:
+		if cfgPath != "" {
+			return toolcache.ClearConfig(cfgPath)
+		}
+		return toolcache.ClearShared()
+	default:
+		return toolcache.ClearShared()
+	}
 }
 
 func renderClearResult(env *Env, r toolcache.ClearResult) {
@@ -82,7 +108,8 @@ func printCacheUsage(env *Env) {
 	fmt.Fprintln(env.Stderr, `omac cache — manage the tool cache
 
 Usage:
-  omac cache clear           Remove the current workdir's cache scope.
+  omac cache clear           Remove the active cache scope (global, config, or
+                             workdir, per the launcher config's cache.scope).
   omac cache clear --all     Remove every inactive cache scope (destructive).
 
 A scope is reported as:

--- a/internal/cli/cache_scope_test.go
+++ b/internal/cli/cache_scope_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+func TestResolveCacheScope(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		cfg      config.CacheScope
+		override string
+		want     config.CacheScope
+		wantErr  bool
+	}{
+		{name: "default global", want: config.CacheScopeGlobal},
+		{name: "config value honored", cfg: config.CacheScopeWorkdir, want: config.CacheScopeWorkdir},
+		{name: "flag overrides config", cfg: config.CacheScopeWorkdir, override: "global", want: config.CacheScopeGlobal},
+		{name: "flag config scope", override: "config", want: config.CacheScopeConfig},
+		{name: "invalid flag errors", override: "bogus", wantErr: true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := resolveCacheScope(config.CacheConfig{Scope: c.cfg}, c.override)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got scope %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveCacheScope: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("scope = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/cli/cache_test.go
+++ b/internal/cli/cache_test.go
@@ -9,6 +9,21 @@ import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/toolcache"
 )
 
+// writeWorkdirScopeConfig writes a launcher config in workdir that selects
+// the per-workdir cache scope, so `omac cache clear` targets the workdir
+// scope rather than the default shared one.
+func writeWorkdirScopeConfig(t *testing.T, workdir string) {
+	t.Helper()
+	dir := filepath.Join(workdir, ".opencode")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir .opencode: %v", err)
+	}
+	cfg := filepath.Join(dir, "oh-my-agentic-coder.yaml")
+	if err := os.WriteFile(cfg, []byte("cache:\n  scope: workdir\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
 // stageActiveScope prepares a workdir cache scope, leaves it open
 // (so its shared lock is held), and returns the marker file path and
 // a closer the test must defer.
@@ -50,6 +65,7 @@ func stageInactiveScope(t *testing.T, workdir string) (marker, dir string) {
 func TestRunCacheClearCurrent(t *testing.T) {
 	isolateHome(t)
 	wd := t.TempDir()
+	writeWorkdirScopeConfig(t, wd)
 	marker, dir := stageInactiveScope(t, wd)
 
 	env, read := captureEnv(t, wd)
@@ -75,6 +91,7 @@ func TestRunCacheClearCurrent(t *testing.T) {
 func TestRunCacheClearCurrentActive(t *testing.T) {
 	isolateHome(t)
 	wd := t.TempDir()
+	writeWorkdirScopeConfig(t, wd)
 	marker := stageActiveScope(t, wd)
 
 	env, read := captureEnv(t, wd)

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -114,7 +114,7 @@ func TestLaunchCachePersistentAndEphemeral(t *testing.T) {
 	workdir := t.TempDir()
 	sandboxTmp := t.TempDir()
 
-	scope, err := prepareLaunchCache(true, false, workdir, sandboxTmp)
+	scope, err := prepareLaunchCache(true, false, config.CacheScopeGlobal, workdir, "", sandboxTmp)
 	if err != nil {
 		t.Fatalf("no-sandbox cache: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestLaunchCachePersistentAndEphemeral(t *testing.T) {
 		t.Errorf("no-sandbox scope = %#v, want nil", scope)
 	}
 
-	ephemeral, err := prepareLaunchCache(false, true, workdir, sandboxTmp)
+	ephemeral, err := prepareLaunchCache(false, true, config.CacheScopeGlobal, workdir, "", sandboxTmp)
 	if err != nil {
 		t.Fatalf("ephemeral cache: %v", err)
 	}
@@ -136,7 +136,21 @@ func TestLaunchCachePersistentAndEphemeral(t *testing.T) {
 		t.Errorf("persistent cache root exists or stat failed: %v", err)
 	}
 
-	persistent, err := prepareLaunchCache(false, false, workdir, sandboxTmp)
+	// Default global scope resolves to the shared domain.
+	shared, err := prepareLaunchCache(false, false, config.CacheScopeGlobal, workdir, "", sandboxTmp)
+	if err != nil {
+		t.Fatalf("shared cache: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := shared.Close(); err != nil {
+			t.Errorf("close shared cache: %v", err)
+		}
+	})
+	if shared.Domain != toolcache.DomainShared {
+		t.Errorf("shared domain = %q, want %q", shared.Domain, toolcache.DomainShared)
+	}
+
+	persistent, err := prepareLaunchCache(false, false, config.CacheScopeWorkdir, workdir, "", sandboxTmp)
 	if err != nil {
 		t.Fatalf("persistent cache: %v", err)
 	}
@@ -183,9 +197,9 @@ func TestLaunchCacheInjectsSelectedScope(t *testing.T) {
 				}
 				return
 			}
-			cleared, err := toolcache.ClearWorkdir(capture.workdir)
+			cleared, err := toolcache.ClearShared()
 			if err != nil {
-				t.Fatalf("clear workdir cache: %v", err)
+				t.Fatalf("clear shared cache: %v", err)
 			}
 			if cleared.Status != toolcache.ClearRemoved {
 				t.Errorf("clear status = %q, want %q (launch should close the scope)", cleared.Status, toolcache.ClearRemoved)

--- a/internal/cli/provenance.go
+++ b/internal/cli/provenance.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/netprompt"
 	"github.com/tngtech/oh-my-agentic-coder/internal/profileaudit"
 	"github.com/tngtech/oh-my-agentic-coder/internal/registry"
@@ -123,8 +124,16 @@ func buildProvenanceView(workdir, profileRef string) (*provenanceView, error) {
 	// --- Skills ---
 	view.Skills = buildSkillsView(workdir)
 
-	// --- Cache (default persistent scope for this workdir) ---
-	cv, err := buildCacheView(workdir)
+	// --- Cache (persistent scope this workdir would resolve to) ---
+	lc, cfgPath, err := config.LoadLauncher(workdir)
+	if err != nil {
+		return nil, fmt.Errorf("cache: %w", err)
+	}
+	cacheScope, err := lc.Cache.Resolve()
+	if err != nil {
+		return nil, fmt.Errorf("cache: %w", err)
+	}
+	cv, err := buildCacheView(cacheScope, workdir, cfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("cache: %w", err)
 	}
@@ -133,13 +142,28 @@ func buildProvenanceView(workdir, profileRef string) (*provenanceView, error) {
 	return view, nil
 }
 
-// buildCacheView describes the default persistent cache scope for the
-// given workdir via toolcache.DescribePersistent — which does NOT create
-// the directory. It always reports the default workdir scope, not a live
-// ephemeral or serve-process scope. An error from DescribePersistent
-// (e.g. HOME unset) is returned to the caller rather than swallowed.
-func buildCacheView(workdir string) (cacheView, error) {
-	scope, err := toolcache.DescribePersistent(toolcache.DomainWorkdir, workdir)
+// buildCacheView describes the persistent cache scope the given workdir
+// resolves to via the Describe* helpers — which do NOT create the directory.
+// It reports the config-resolved scope (global/config/workdir), not a live
+// ephemeral or serve-process scope. An error from the describe call (e.g.
+// HOME unset) is returned to the caller rather than swallowed.
+func buildCacheView(cacheScope config.CacheScope, workdir, cfgPath string) (cacheView, error) {
+	var (
+		scope toolcache.Scope
+		err   error
+	)
+	switch cacheScope {
+	case config.CacheScopeWorkdir:
+		scope, err = toolcache.DescribePersistent(toolcache.DomainWorkdir, workdir)
+	case config.CacheScopeConfig:
+		if cfgPath != "" {
+			scope, err = toolcache.DescribePersistent(toolcache.DomainConfig, cfgPath)
+		} else {
+			scope, err = toolcache.DescribeShared()
+		}
+	default:
+		scope, err = toolcache.DescribeShared()
+	}
 	if err != nil {
 		return cacheView{}, err
 	}

--- a/internal/cli/provenance_test.go
+++ b/internal/cli/provenance_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/toolcache"
 )
 
@@ -469,6 +470,8 @@ func TestBuildProvenanceView_CacheSection(t *testing.T) {
 	os.MkdirAll(profDir, 0o755)
 	profPath := filepath.Join(profDir, "default.json")
 	os.WriteFile(profPath, []byte(`{"meta":{"name":"default"},"workdir":{"access":"readwrite"}}`), 0o644)
+	// Select the per-workdir scope so provenance reports it (default is global).
+	os.WriteFile(filepath.Join(profDir, "oh-my-agentic-coder.yaml"), []byte("cache:\n  scope: workdir\n"), 0o644)
 
 	view, err := buildProvenanceView(wd, profPath)
 	if err != nil {
@@ -567,8 +570,9 @@ func TestWriteProvenanceJSON_CacheSection(t *testing.T) {
 	if !ok {
 		t.Fatalf("JSON missing cache object; got %v", parsed)
 	}
-	if scope, _ := cache["scope"].(string); scope != string(toolcache.DomainWorkdir) {
-		t.Errorf("cache.scope = %q; want %q", scope, toolcache.DomainWorkdir)
+	// No config on disk => default global scope, backed by the shared domain.
+	if scope, _ := cache["scope"].(string); scope != string(toolcache.DomainShared) {
+		t.Errorf("cache.scope = %q; want %q", scope, toolcache.DomainShared)
 	}
 	if mode, _ := cache["mode"].(string); mode != string(toolcache.ModePersistent) {
 		t.Errorf("cache.mode = %q; want %q", mode, toolcache.ModePersistent)
@@ -614,7 +618,7 @@ func TestBuildCacheView_ErrorNotSwallowed(t *testing.T) {
 	wd := t.TempDir()
 	t.Setenv("HOME", "")
 
-	cv, err := buildCacheView(wd)
+	cv, err := buildCacheView(config.CacheScopeGlobal, wd, "")
 	if err == nil {
 		t.Fatalf("expected error from buildCacheView when HOME is unset; got %+v", cv)
 	}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -56,7 +56,8 @@ func runServe(args []string, env *Env) int {
 		innerCmdOverride = fs.String("inner", "", "Override inner_cmd's executable (default: opencode serve).")
 		noSandbox        = fs.Bool("no-sandbox", false, "Run the inner command directly, without a sandbox (debug only).")
 		noInner          = fs.Bool("no-inner", false, "Do not launch any inner command; run the control plane only (testing/headless).")
-		ephemeralCache   = fs.Bool("ephemeral-cache", false, "Use a per-launch cache instead of the persistent serve cache.")
+		ephemeralCache   = fs.Bool("ephemeral-cache", false, "Use a per-launch cache instead of the persistent cache.")
+		cacheScopeFlag   = fs.String("cache-scope", "", "Persistent cache scope: global, config, or workdir. Overrides config (default: global).")
 		verbose          = fs.Bool("verbose", false, "Verbose lifecycle logging.")
 		forDesktop       = fs.Bool("for-opencode-desktop", false, "Grant every project worktree from the local OpenCode state (Desktop projects) read+write in the sandbox.")
 		learn            = fs.Bool("learn", false, "Learn mode: do not restrict filesystem access; record folders used and offer to add them to the sandbox profile at session end.")
@@ -100,9 +101,15 @@ func runServe(args []string, env *Env) int {
 		fmt.Fprintln(env.Stderr, "omac serve: --ephemeral-cache cannot be used with --no-sandbox")
 		return ExitMisuse
 	}
+	if *cacheScopeFlag != "" {
+		if _, err := config.ValidateCacheScope(*cacheScopeFlag); err != nil {
+			fmt.Fprintln(env.Stderr, "omac serve:", err)
+			return ExitMisuse
+		}
+	}
 	innerArgs = append(fs.Args(), innerArgs...)
 
-	lc, _, err := config.LoadLauncher(env.Workdir)
+	lc, cfgPath, err := config.LoadLauncher(env.Workdir)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve: launcher config:", err)
 		return ExitConfigInvalid
@@ -218,7 +225,12 @@ func runServe(args []string, env *Env) int {
 		return ExitIOError
 	}
 	defer os.RemoveAll(sandboxTmp)
-	cacheScope, err := prepareServeCache(*noSandbox, *noInner, *ephemeralCache, *workdir, env.Workdir, sandboxTmp)
+	scope, err := resolveCacheScope(lc.Cache, *cacheScopeFlag)
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "omac serve: cache:", err)
+		return ExitConfigInvalid
+	}
+	cacheScope, err := prepareServeCache(*noSandbox, *noInner, *ephemeralCache, scope, *workdir, env.Workdir, cfgPath, sandboxTmp)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve: cache:", err)
 		return ExitIOError
@@ -1425,17 +1437,30 @@ func (s *serveServer) baseEnv() map[string]string {
 	return extra
 }
 
-func prepareServeCache(noSandbox, noInner, ephemeral bool, explicitWorkdir, launchWorkdir, sandboxTmp string) (*toolcache.Scope, error) {
+func prepareServeCache(noSandbox, noInner, ephemeral bool, scope config.CacheScope, explicitWorkdir, launchWorkdir, cfgPath, sandboxTmp string) (*toolcache.Scope, error) {
 	if noSandbox || noInner {
 		return nil, nil
 	}
 	if ephemeral {
 		return toolcache.PrepareEphemeral(sandboxTmp)
 	}
-	if explicitWorkdir != "" {
-		return toolcache.PreparePersistent(toolcache.DomainWorkdir, explicitWorkdir)
+	switch scope {
+	case config.CacheScopeWorkdir:
+		// Per-workdir isolation only maps to a single served directory; a
+		// multi-dir serve shares one sandbox, so fall back to the per-launch
+		// serve cache when no --workdir is pinned.
+		if explicitWorkdir != "" {
+			return toolcache.PreparePersistent(toolcache.DomainWorkdir, explicitWorkdir)
+		}
+		return toolcache.PreparePersistent(toolcache.DomainServe, launchWorkdir)
+	case config.CacheScopeConfig:
+		if cfgPath != "" {
+			return toolcache.PreparePersistent(toolcache.DomainConfig, cfgPath)
+		}
+		return toolcache.PrepareShared()
+	default:
+		return toolcache.PrepareShared()
 	}
-	return toolcache.PreparePersistent(toolcache.DomainServe, launchWorkdir)
 }
 
 // facadeMounts returns the set of facade mount segments to advertise to the

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -594,11 +594,21 @@ func TestPrepareServeCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("canonical explicit workdir: %v", err)
 	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("cache:\n  scope: config\n"), 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	canonicalCfg, err := filepath.EvalSymlinks(cfgPath)
+	if err != nil {
+		t.Fatalf("canonical cfg: %v", err)
+	}
 
 	for _, c := range []struct {
 		name                          string
 		noSandbox, noInner, ephemeral bool
+		scope                         config.CacheScope
 		explicitWorkdir               string
+		cfgPath                       string
 		wantNil                       bool
 		wantDomain                    toolcache.Domain
 		wantMode                      toolcache.Mode
@@ -607,12 +617,15 @@ func TestPrepareServeCache(t *testing.T) {
 	}{
 		{name: "no inner skips cache", noInner: true, wantNil: true},
 		{name: "no sandbox skips cache", noSandbox: true, wantNil: true},
-		{name: "single workdir", explicitWorkdir: explicitWorkdir, wantDomain: toolcache.DomainWorkdir, wantMode: toolcache.ModePersistent, wantCanonical: canonicalExplicit},
-		{name: "desktop shared serve cache", wantDomain: toolcache.DomainServe, wantMode: toolcache.ModePersistent, wantCanonical: canonicalLaunch},
+		{name: "global default shares one cache", scope: config.CacheScopeGlobal, wantDomain: toolcache.DomainShared, wantMode: toolcache.ModePersistent},
+		{name: "config scope keys on config path", scope: config.CacheScopeConfig, cfgPath: cfgPath, wantDomain: toolcache.DomainConfig, wantMode: toolcache.ModePersistent, wantCanonical: canonicalCfg},
+		{name: "config scope without file falls back to shared", scope: config.CacheScopeConfig, wantDomain: toolcache.DomainShared, wantMode: toolcache.ModePersistent},
+		{name: "workdir scope, single workdir", scope: config.CacheScopeWorkdir, explicitWorkdir: explicitWorkdir, wantDomain: toolcache.DomainWorkdir, wantMode: toolcache.ModePersistent, wantCanonical: canonicalExplicit},
+		{name: "workdir scope, multi-dir serve cache", scope: config.CacheScopeWorkdir, wantDomain: toolcache.DomainServe, wantMode: toolcache.ModePersistent, wantCanonical: canonicalLaunch},
 		{name: "ephemeral cache", ephemeral: true, explicitWorkdir: explicitWorkdir, wantMode: toolcache.ModeEphemeral, wantPath: filepath.Join(sandboxTmp, "cache")},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			scope, err := prepareServeCache(c.noSandbox, c.noInner, c.ephemeral, c.explicitWorkdir, launchWorkdir, sandboxTmp)
+			scope, err := prepareServeCache(c.noSandbox, c.noInner, c.ephemeral, c.scope, c.explicitWorkdir, launchWorkdir, c.cfgPath, sandboxTmp)
 			if err != nil {
 				t.Fatalf("prepareServeCache: %v", err)
 			}
@@ -734,7 +747,7 @@ func TestRunServeRetainsCacheLockAndAllowsOnlyScope(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	scope, err := toolcache.DescribePersistent(toolcache.DomainServe, workdir)
+	scope, err := toolcache.DescribeShared()
 	if err != nil {
 		t.Fatalf("describe serve cache: %v", err)
 	}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -45,6 +45,7 @@ type launchOpts struct {
 	innerCmdOverride   string
 	noSandbox          bool
 	ephemeralCache     bool
+	cacheScope         string
 	keepRunning        bool
 	acceptSkillChanges bool
 	skipSecretPattern  bool
@@ -74,7 +75,8 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 		profile            = fs.String("sandbox", "", "Name of a sandbox profile from the launcher config.")
 		innerCmdOverride   = fs.String("inner", "", "Override inner_cmd's executable.")
 		noSandbox          = fs.Bool("no-sandbox", false, "Run inner command directly, without a sandbox (debug only).")
-		ephemeralCache     = fs.Bool("ephemeral-cache", false, "Use a per-launch cache instead of the persistent workdir cache.")
+		ephemeralCache     = fs.Bool("ephemeral-cache", false, "Use a per-launch cache instead of the persistent cache.")
+		cacheScope         = fs.String("cache-scope", "", "Persistent cache scope: global, config, or workdir. Overrides config (default: global).")
 		keepRunning        = fs.Bool("keep-running", false, "Do not stop sidecars when the inner command exits.")
 		acceptSkillChanges = fs.Bool("accept-skill-changes", false, "Tolerate bundle_hash drift in registered skills (proceed even if the on-disk skill differs from what was registered).")
 		skipSecretPattern  = fs.Bool("skip-secret-pattern", false, "Do not enforce a secret's pattern against an env_passthrough-supplied value (escape hatch for an outdated pattern; the raw value is still passed through).")
@@ -123,6 +125,12 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 		fmt.Fprintf(env.Stderr, "omac %s: --ephemeral-cache cannot be used with --no-sandbox\n", cmdName)
 		return launchOpts{}, false
 	}
+	if *cacheScope != "" {
+		if _, err := config.ValidateCacheScope(*cacheScope); err != nil {
+			fmt.Fprintf(env.Stderr, "omac %s: %v\n", cmdName, err)
+			return launchOpts{}, false
+		}
+	}
 	innerArgs = append(fs.Args(), innerArgs...)
 	return launchOpts{
 		label:              cmdName,
@@ -131,6 +139,7 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 		innerCmdOverride:   *innerCmdOverride,
 		noSandbox:          *noSandbox,
 		ephemeralCache:     *ephemeralCache,
+		cacheScope:         *cacheScope,
 		keepRunning:        *keepRunning,
 		acceptSkillChanges: *acceptSkillChanges,
 		skipSecretPattern:  *skipSecretPattern,
@@ -641,7 +650,12 @@ func runLaunch(env *Env, opts launchOpts) int {
 	if verbose {
 		fmt.Fprintf(env.Stderr, "[verbose] sandbox TMPDIR: %s\n", sandboxTmp)
 	}
-	cacheScope, err := prepareLaunchCache(noSandbox, opts.ephemeralCache, env.Workdir, sandboxTmp)
+	scope, err := resolveCacheScope(lc.Cache, opts.cacheScope)
+	if err != nil {
+		fmt.Fprintln(env.Stderr, prefix+": cache:", err)
+		return ExitConfigInvalid
+	}
+	cacheScope, err := prepareLaunchCache(noSandbox, opts.ephemeralCache, scope, env.Workdir, cfgPath, sandboxTmp)
 	if err != nil {
 		if opts.ephemeralCache {
 			fmt.Fprintln(env.Stderr, prefix+": cache:", err)
@@ -921,14 +935,33 @@ func runLaunch(env *Env, opts launchOpts) int {
 	return code
 }
 
-func prepareLaunchCache(noSandbox, ephemeral bool, workdir, sandboxTmp string) (*toolcache.Scope, error) {
+func prepareLaunchCache(noSandbox, ephemeral bool, scope config.CacheScope, workdir, cfgPath, sandboxTmp string) (*toolcache.Scope, error) {
 	if noSandbox {
 		return nil, nil
 	}
 	if ephemeral {
 		return toolcache.PrepareEphemeral(sandboxTmp)
 	}
-	return toolcache.PreparePersistent(toolcache.DomainWorkdir, workdir)
+	switch scope {
+	case config.CacheScopeWorkdir:
+		return toolcache.PreparePersistent(toolcache.DomainWorkdir, workdir)
+	case config.CacheScopeConfig:
+		if cfgPath != "" {
+			return toolcache.PreparePersistent(toolcache.DomainConfig, cfgPath)
+		}
+		return toolcache.PrepareShared()
+	default:
+		return toolcache.PrepareShared()
+	}
+}
+
+// resolveCacheScope merges the config's cache scope with an optional
+// --cache-scope flag override (precedence: flag > config > default global).
+func resolveCacheScope(cfg config.CacheConfig, override string) (config.CacheScope, error) {
+	if override != "" {
+		return config.ValidateCacheScope(override)
+	}
+	return cfg.Resolve()
 }
 
 // continueHintToken returns the harness token to embed in the post-exit

--- a/internal/config/launcher.go
+++ b/internal/config/launcher.go
@@ -20,6 +20,49 @@ type LauncherConfig struct {
 	Sandbox SandboxConfig `yaml:"sandbox" json:"sandbox"`
 	Facade  FacadeConfig  `yaml:"facade"  json:"facade"`
 	Audit   AuditConfig   `yaml:"audit"   json:"audit"`
+	Cache   CacheConfig   `yaml:"cache"   json:"cache"`
+}
+
+// CacheScope selects how the persistent tool cache is partitioned.
+type CacheScope string
+
+const (
+	// CacheScopeGlobal shares one cache across every workdir and config.
+	CacheScopeGlobal CacheScope = "global"
+	// CacheScopeConfig shares one cache across all workdirs governed by the
+	// same launcher config file (falls back to global when none is on disk).
+	CacheScopeConfig CacheScope = "config"
+	// CacheScopeWorkdir gives each workdir its own isolated cache.
+	CacheScopeWorkdir CacheScope = "workdir"
+)
+
+// CacheConfig controls the tool cache scope (see internal/toolcache).
+//
+// Scope defaults to "global": every workdir shares one persistent cache. The
+// zero value (unset in YAML) resolves to global via Resolve, so no default
+// backfill is needed.
+type CacheConfig struct {
+	Scope CacheScope `yaml:"scope" json:"scope"`
+}
+
+// Resolve returns the effective scope, treating unset as global, and errors
+// on an unrecognized value.
+func (c CacheConfig) Resolve() (CacheScope, error) {
+	if c.Scope == "" {
+		return CacheScopeGlobal, nil
+	}
+	return ValidateCacheScope(string(c.Scope))
+}
+
+// ValidateCacheScope normalizes and validates a scope string (from config or
+// the --cache-scope flag).
+func ValidateCacheScope(s string) (CacheScope, error) {
+	switch CacheScope(s) {
+	case CacheScopeGlobal, CacheScopeConfig, CacheScopeWorkdir:
+		return CacheScope(s), nil
+	default:
+		return "", fmt.Errorf("invalid cache scope %q (want global, config, or workdir)", s)
+	}
 }
 
 // AuditConfig controls the security audit trail (see internal/audit).
@@ -263,6 +306,7 @@ func defaultLauncherConfigFor(h Harness) LauncherConfig {
 			Syslog:  false,
 			Strict:  false,
 		},
+		Cache: CacheConfig{Scope: CacheScopeGlobal},
 	}
 }
 
@@ -297,6 +341,9 @@ func LoadLauncher(workdir string) (LauncherConfig, string, error) {
 			return LauncherConfig{}, "", fmt.Errorf("parse %s: %w", p, err)
 		}
 		lc = mergeDefaults(lc)
+		if _, err := lc.Cache.Resolve(); err != nil {
+			return LauncherConfig{}, "", fmt.Errorf("parse %s: %w", p, err)
+		}
 		return lc, p, nil
 	}
 	return DefaultLauncherConfig(), "", nil

--- a/internal/config/launcher_cache_test.go
+++ b/internal/config/launcher_cache_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCacheConfigResolveDefaultsToGlobal(t *testing.T) {
+	scope, err := CacheConfig{}.Resolve()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if scope != CacheScopeGlobal {
+		t.Errorf("scope = %q, want %q", scope, CacheScopeGlobal)
+	}
+	if got := DefaultLauncherConfig().Cache.Scope; got != CacheScopeGlobal {
+		t.Errorf("default cache scope = %q, want %q", got, CacheScopeGlobal)
+	}
+}
+
+func TestValidateCacheScope(t *testing.T) {
+	for _, s := range []string{"global", "config", "workdir"} {
+		if _, err := ValidateCacheScope(s); err != nil {
+			t.Errorf("ValidateCacheScope(%q) = %v, want nil", s, err)
+		}
+	}
+	if _, err := ValidateCacheScope("bogus"); err == nil {
+		t.Errorf("ValidateCacheScope(bogus) = nil, want error")
+	}
+}
+
+func TestLoadLauncherCacheScope(t *testing.T) {
+	dir := t.TempDir()
+	ocDir := filepath.Join(dir, ".opencode")
+	if err := os.MkdirAll(ocDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ocDir, "oh-my-agentic-coder.yaml"),
+		[]byte("cache:\n  scope: workdir\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lc, _, err := LoadLauncher(dir)
+	if err != nil {
+		t.Fatalf("LoadLauncher: %v", err)
+	}
+	if lc.Cache.Scope != CacheScopeWorkdir {
+		t.Errorf("scope = %q, want %q", lc.Cache.Scope, CacheScopeWorkdir)
+	}
+}
+
+func TestLoadLauncherRejectsInvalidCacheScope(t *testing.T) {
+	dir := t.TempDir()
+	ocDir := filepath.Join(dir, ".opencode")
+	if err := os.MkdirAll(ocDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ocDir, "oh-my-agentic-coder.yaml"),
+		[]byte("cache:\n  scope: nonsense\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadLauncher(dir); err == nil {
+		t.Fatalf("LoadLauncher accepted invalid cache scope")
+	}
+}

--- a/internal/e2e/cache_isolation_test.go
+++ b/internal/e2e/cache_isolation_test.go
@@ -241,6 +241,21 @@ func writeCacheTestProfile(t *testing.T, home string, extraRead, extraAllow []st
 	}
 }
 
+// writeLauncherCacheScope writes a minimal launcher config that pins the
+// persistent cache scope for a workdir, so omac subcommands run with
+// cmd.Dir=workdir (provenance, cache clear) resolve that scope.
+func writeLauncherCacheScope(t *testing.T, workdir, scope string) {
+	t.Helper()
+	cfgDir := filepath.Join(workdir, ".opencode")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "cache:\n  scope: " + scope + "\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, "oh-my-agentic-coder.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func commandOutput(t *testing.T, name string, args ...string) string {
 	t.Helper()
 	out, err := exec.Command(name, args...).Output()
@@ -785,14 +800,17 @@ func TestE2ECacheMainAndLinkedWorktreesAreIsolated(t *testing.T) {
 	writeCacheTestProfile(t, home, nil, nil, 0)
 	omacBin := buildOmac(t)
 
+	// Per-workdir isolation is opt-in since the default scope became
+	// global; --cache-scope workdir keys the cache on each worktree path.
+	workdirScope := []string{"--cache-scope", "workdir"}
 	marker := "main-worktree-cache-marker"
-	out, code := runOmacShell(t, omacBin, home, repoRoot, nil,
+	out, code := runOmacShell(t, omacBin, home, repoRoot, workdirScope,
 		"/bin/sh", "-c", "echo "+marker+" > \"$OMAC_CACHE_DIR/probe.txt\" && echo WROTE_MAIN")
 	if code != 0 {
 		t.Fatalf("main worktree launch failed (exit %d): %s", code, out)
 	}
 
-	out, code = runOmacShell(t, omacBin, home, linkedDir, nil,
+	out, code = runOmacShell(t, omacBin, home, linkedDir, workdirScope,
 		"/bin/sh", "-c", "cat \"$OMAC_CACHE_DIR/probe.txt\" 2>&1 || echo NOT_FOUND")
 	if code != 0 {
 		t.Fatalf("linked worktree launch failed (exit %d): %s", code, out)
@@ -855,7 +873,11 @@ func TestE2ECacheServeScopes(t *testing.T) {
 	writeCacheTestProfile(t, home, nil, nil, 0)
 	omacBin := buildOmac(t)
 
-	out, code := runOmacServeShell(t, omacBin, home, workdir, nil,
+	// Under workdir scope, a multi-dir serve (no --workdir) falls back to a
+	// serve-scoped cache while start keys on the workdir, so the two differ.
+	// The default global scope would collapse both onto the shared cache.
+	workdirScope := []string{"--cache-scope", "workdir"}
+	out, code := runOmacServeShell(t, omacBin, home, workdir, workdirScope,
 		"/bin/sh", "-c", "echo SERVE_CACHE=$OMAC_CACHE_DIR")
 	if code != 0 {
 		t.Fatalf("serve launch failed (exit %d): %s", code, out)
@@ -865,7 +887,7 @@ func TestE2ECacheServeScopes(t *testing.T) {
 	}
 
 	// Start mode uses a workdir-scoped cache; serve uses serve-scoped.
-	startOut, _ := runOmacShell(t, omacBin, home, workdir, nil,
+	startOut, _ := runOmacShell(t, omacBin, home, workdir, workdirScope,
 		"/bin/sh", "-c", "echo START_CACHE=$OMAC_CACHE_DIR")
 	if !strings.Contains(startOut, "START_CACHE=") {
 		t.Errorf("start did not expose OMAC_CACHE_DIR: %s", startOut)
@@ -887,6 +909,10 @@ func TestE2ECacheActiveScopeCannotBeCleared(t *testing.T) {
 	home := cacheTestHome(t)
 	workdir := t.TempDir()
 	writeCacheTestProfile(t, home, nil, nil, 0)
+	// Pin workdir scope so provenance, `cache clear`, and the hold-lock
+	// helper (which uses DomainWorkdir) all resolve the same leaf; the
+	// default global scope would key clear on the shared cache instead.
+	writeLauncherCacheScope(t, workdir, "workdir")
 	omacBin := buildOmac(t)
 
 	// Prepare the persistent scope so the cache root + leaf exist on

--- a/internal/toolcache/cache.go
+++ b/internal/toolcache/cache.go
@@ -22,6 +22,12 @@ type Domain string
 const (
 	DomainWorkdir Domain = "workdir"
 	DomainServe   Domain = "serve"
+	// DomainShared is a single persistent cache reused across every workdir.
+	// It backs the default "global" cache scope.
+	DomainShared Domain = "shared"
+	// DomainConfig keys the cache on a launcher config file path, so all
+	// workdirs governed by that config share one cache ("config" scope).
+	DomainConfig Domain = "config"
 )
 
 type Scope struct {
@@ -43,14 +49,21 @@ func DescribePersistent(domain Domain, path string) (Scope, error) {
 	if err != nil {
 		return Scope{}, err
 	}
+	return describe(domain, "v1:"+string(domain)+":"+canonical, canonical)
+}
 
-	identity := "v1:" + string(domain) + ":" + canonical
+// DescribeShared returns the single shared persistent scope, independent of
+// any workdir. Its identity is a constant so all callers resolve to one dir.
+func DescribeShared() (Scope, error) {
+	return describe(DomainShared, "v1:"+string(DomainShared), "")
+}
+
+func describe(domain Domain, identity, canonical string) (Scope, error) {
 	digest := sha256.Sum256([]byte(identity))
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return Scope{}, err
 	}
-
 	return Scope{
 		Domain:        domain,
 		Mode:          ModePersistent,
@@ -66,6 +79,19 @@ func PreparePersistent(domain Domain, path string) (*Scope, error) {
 	if err != nil {
 		return nil, err
 	}
+	return prepare(scope)
+}
+
+// PrepareShared locks and prepares the single shared persistent scope.
+func PrepareShared() (*Scope, error) {
+	scope, err := DescribeShared()
+	if err != nil {
+		return nil, err
+	}
+	return prepare(scope)
+}
+
+func prepare(scope Scope) (*Scope, error) {
 	lock, err := acquireLock(filepath.Dir(scope.Dir), scope.Digest, syscall.LOCK_SH)
 	if err != nil {
 		return nil, err

--- a/internal/toolcache/clear.go
+++ b/internal/toolcache/clear.go
@@ -56,6 +56,22 @@ func ClearWorkdir(path string) (ClearResult, error) {
 	return clearScope(filepath.Dir(scope.Dir), scope.Digest, scope.Dir)
 }
 
+func ClearShared() (ClearResult, error) {
+	scope, err := DescribeShared()
+	if err != nil {
+		return ClearResult{}, err
+	}
+	return clearScope(filepath.Dir(scope.Dir), scope.Digest, scope.Dir)
+}
+
+func ClearConfig(cfgPath string) (ClearResult, error) {
+	scope, err := DescribePersistent(DomainConfig, cfgPath)
+	if err != nil {
+		return ClearResult{}, err
+	}
+	return clearScope(filepath.Dir(scope.Dir), scope.Digest, scope.Dir)
+}
+
 func ClearAll() ([]ClearResult, error) {
 	root, err := persistentRoot()
 	if err != nil {

--- a/internal/toolcache/shared_test.go
+++ b/internal/toolcache/shared_test.go
@@ -1,0 +1,60 @@
+package toolcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDescribeSharedIsWorkdirIndependent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	a, err := DescribeShared()
+	if err != nil {
+		t.Fatalf("DescribeShared: %v", err)
+	}
+	b, err := DescribeShared()
+	if err != nil {
+		t.Fatalf("DescribeShared: %v", err)
+	}
+	if a.Dir != b.Dir {
+		t.Errorf("shared dir not stable: %q vs %q", a.Dir, b.Dir)
+	}
+	if a.Domain != DomainShared {
+		t.Errorf("domain = %q, want %q", a.Domain, DomainShared)
+	}
+	if a.CanonicalPath != "" {
+		t.Errorf("shared scope should have no canonical path, got %q", a.CanonicalPath)
+	}
+}
+
+func TestDomainConfigKeysOnPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfgA := filepath.Join(t.TempDir(), "config.yaml")
+	cfgB := filepath.Join(t.TempDir(), "config.yaml")
+	for _, p := range []string{cfgA, cfgB} {
+		if err := os.WriteFile(p, []byte("cache:\n  scope: config\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	a, err := DescribePersistent(DomainConfig, cfgA)
+	if err != nil {
+		t.Fatalf("describe cfgA: %v", err)
+	}
+	b, err := DescribePersistent(DomainConfig, cfgB)
+	if err != nil {
+		t.Fatalf("describe cfgB: %v", err)
+	}
+	if a.Dir == b.Dir {
+		t.Errorf("distinct config paths share a cache dir: %q", a.Dir)
+	}
+
+	shared, err := DescribeShared()
+	if err != nil {
+		t.Fatalf("DescribeShared: %v", err)
+	}
+	if a.Dir == shared.Dir {
+		t.Errorf("config scope collided with shared scope: %q", a.Dir)
+	}
+}

--- a/oh-my-agentic-coder.md
+++ b/oh-my-agentic-coder.md
@@ -490,58 +490,68 @@ environment allowlist.
 
 ### 9.1 Cache modes and trust domains
 
-The cache scope is selected at launch from the launch command and the
-workdir identity (the canonical absolute path after symlink
-resolution):
+The persistent cache scope is selected by the `cache.scope` config key
+(overridable per launch with `--cache-scope`). It defaults to `global`:
+one shared cache for every workdir, mirroring a normal dev box's single
+`~/.cache`. Two narrower scopes trade sharing for isolation.
 
-| Launch | Scope identity | Mode | Path |
-| --- | --- | --- | --- |
-| `omac start` (default) | `v1:workdir:<canonical workdir>` | `persistent` | `~/.cache/omac/<sha256(identity)>` |
-| `omac start --ephemeral-cache` | per-launch sandbox temp dir | `ephemeral` | `$TMPDIR/omac-sandbox-tmp-*/cache` (removed on exit) |
-| `omac serve` (no `--workdir`) | `v1:serve:<canonical launch workdir>` | `persistent` | `~/.cache/omac/<sha256(identity)>` — shared Desktop serve cache |
-| `omac serve --workdir <dir>` | `v1:workdir:<canonical <dir>>` | `persistent` | as `omac start` from that dir |
-| `omac serve --ephemeral-cache` | per-launch sandbox temp dir | `ephemeral` | removed on exit |
-| `omac start --no-sandbox` / `omac serve --no-sandbox` | none | — | no cache scope prepared |
+| `cache.scope` | Scope identity | Shared across |
+| --- | --- | --- |
+| `global` (default) | `v1:shared` | all workdirs and all configs |
+| `config` | `v1:config:<canonical config path>` | all workdirs governed by the same launcher config file |
+| `workdir` | `v1:workdir:<canonical workdir>` | that one workdir only |
 
-- **Persistent (default).** The same workdir reuses the same cache
-  directory across launches, so incremental builds survive. The scope
-  identity is the canonical workdir path, **not** the bare directory
-  name, so `~/work/acme` and `~/clients/acme` are distinct scopes.
-  Because identity follows the resolved path, the main worktree and a
-  linked worktree of the same repository have distinct cache scopes.
-- **Accepted same-domain poisoning.** Two paths that resolve to the
-  same canonical absolute path share a scope; omac does not try to
-  distinguish them.
-- **`--ephemeral-cache`.** A fresh directory under the per-launch
-  sandbox temp dir, removed on exit. Use it for a clean-room build or
-  when persistent-scope setup fails (e.g. an unsafe `~/.cache/omac`
-  symlink); omac's failure hint names the flag. Cannot be combined
-  with `--no-sandbox` (no sandbox to grant the temp dir).
-- **`--no-sandbox`.** Disables the entire omac sandbox. No cache
-  scope is prepared and no `OMAC_CACHE_*` / tool redirects are
-  injected. Normal `OMAC_*` transport variables and the per-launch
-  `TMPDIR` remain available to the inner command.
-- **Single-directory `omac serve`.** `omac serve --workdir <dir>`
-  pre-activates that one directory at cold start; its cache scope is
-  the workdir-scope identity, not the shared serve scope.
-- **Shared multi-directory `omac serve` cache.** Without `--workdir`,
-  all directories served by one `omac serve` process share the single
-  serve-scope cache directory. This is the Desktop path: many
-  projects reuse one cache. It is strictly weaker isolation than
-  per-workdir `omac start` and is an explicit, documented consequence
-  of the shared-sandbox decision. Use `--ephemeral-cache` or
-  `omac serve --workdir` per project to opt back into per-directory
-  isolation.
+All persistent scopes resolve to `~/.cache/omac/<sha256(identity)>`. The
+launch command and flags then map onto the chosen scope:
+
+| Launch | Persistent scope | Mode |
+| --- | --- | --- |
+| `omac start` / `omac serve` (default) | `global` → `v1:shared` | `persistent` |
+| `--cache-scope config` (with a config on disk) | `v1:config:<config path>` | `persistent` |
+| `--cache-scope workdir` (`omac start`, `omac serve --workdir`) | `v1:workdir:<canonical workdir>` | `persistent` |
+| `omac serve --cache-scope workdir` (no `--workdir`) | `v1:serve:<canonical launch workdir>` | `persistent` |
+| `--ephemeral-cache` | per-launch sandbox temp dir (removed on exit) | `ephemeral` |
+| `--no-sandbox` | none — no scope prepared | — |
+
+- **`global` (default).** One cache shared by everything. Cheapest, and
+  what most developers already expect; tool caches (Go, npm, cargo, pip)
+  are concurrency-safe, so parallel launches sharing it is fine.
+- **`config`.** All workdirs that load the same launcher config file
+  share a cache, keyed on the config file's canonical path. Falls back
+  to `global` when no config file is on disk (compiled-in defaults).
+  Good for a team config that governs many project directories.
+- **`workdir`.** Each workdir gets its own cache, keyed on the canonical
+  workdir path (**not** the bare directory name), so `~/work/acme` and
+  `~/clients/acme` are distinct, as are the main worktree and a linked
+  worktree of the same repository. This is the strongest isolation.
+- **Accepted same-domain poisoning.** Two paths that resolve to the same
+  canonical absolute path share a scope; omac does not distinguish them.
+- **`--ephemeral-cache`.** A fresh directory under the per-launch sandbox
+  temp dir, removed on exit. Use it for a clean-room build or when
+  persistent-scope setup fails (e.g. an unsafe `~/.cache/omac` symlink);
+  omac's failure hint names the flag. Cannot be combined with
+  `--no-sandbox` (no sandbox to grant the temp dir).
+- **`--no-sandbox`.** Disables the entire omac sandbox. No cache scope is
+  prepared and no `OMAC_CACHE_*` / tool redirects are injected. Normal
+  `OMAC_*` transport variables and the per-launch `TMPDIR` remain
+  available to the inner command.
+- **Multi-directory `omac serve`.** Because one serve process shares a
+  single sandbox across every activated directory, per-workdir isolation
+  only applies to `omac serve --workdir <dir>`. Under `--cache-scope
+  workdir` without `--workdir`, the process falls back to a per-launch
+  serve-scope cache (`v1:serve:<canonical launch workdir>`); `global` and
+  `config` behave as above.
 
 ### 9.2 Cleaning up cache scopes
 
 ```text
-omac cache clear           # Remove the current workdir's cache scope.
+omac cache clear           # Remove the active cache scope (per cache.scope).
 omac cache clear --all     # Remove every inactive cache scope (destructive).
 ```
 
-`omac cache clear` removes the current workdir's persistent cache
-scope; `omac cache clear --all` walks every scope under
+`omac cache clear` removes the persistent cache scope the current
+config resolves to (`global`, `config`, or `workdir`);
+`omac cache clear --all` walks every scope under
 `~/.cache/omac` and removes the inactive ones. Each scope is reported
 as `removed`, `active` (lock held by a running launch, left intact),
 or `skipped` (unsafe, missing, or replaced between open and remove).
@@ -1033,6 +1043,14 @@ facade:
   idle_timeout_secs: 300
   max_body_bytes: 10485760
   base_env_passthrough: [PATH, HOME, USER, LANG, LC_ALL, LC_CTYPE, TMPDIR]
+
+cache:
+  # Persistent tool-cache partitioning (§9.1). One of:
+  #   global  — one cache for every workdir (default)
+  #   config  — one cache per launcher config file
+  #   workdir — a separate cache per workdir
+  # Overridable per launch with --cache-scope.
+  scope: global
 ```
 
 > Historical note: this example shows the `--env` flag for completeness with how nono profiles were originally written. Current `omac` versions inject `OMAC_*` into the runtime's process environment instead (nono propagates parent env to the inner process by default). The reference profile in `internal/config/launcher.go` is authoritative.


### PR DESCRIPTION
## What
Adds a three-way `cache.scope` launcher-config key that controls how the persistent tool cache is partitioned, **defaulting to `global`** — one shared cache across every workdir (no per-workdir isolation). Per-workdir isolation becomes opt-in.

| `cache.scope` | Cache shared across | Identity |
| --- | --- | --- |
| `global` *(default)* | all workdirs & configs | `v1:shared` |
| `config` | all workdirs under the same launcher config file | `v1:config:<config path>` |
| `workdir` | that one workdir | `v1:workdir:<workdir>` (previous default) |

```yaml
# .opencode/oh-my-agentic-coder.yaml
cache:
  scope: workdir   # opt into per-workdir isolation
```
Per-launch override: `omac start --cache-scope workdir` (precedence flag > config > default).

## Why
A single shared cache matches how a normal dev box works (one `~/.cache`), and the redirected tool caches (Go, npm, cargo, pip) are concurrency-safe, so sharing across launches is fine. The previous behavior keyed a separate cache on every workdir path by default; this made isolation opt-in and lets a team config turn it on for all its projects at once.

## How
- **`internal/config/launcher.go`** — `CacheConfig{ Scope CacheScope }` with `Resolve()` / `ValidateCacheScope()`; validated at load; default documented in `DefaultLauncherConfig`.
- **`internal/toolcache`** — `DomainShared` / `DomainConfig`, `DescribeShared` / `PrepareShared`, `ClearShared` / `ClearConfig`; shared prepare/describe helper.
- **`internal/cli/{start,serve}.go`** — selectors switch on the resolved scope; new `--cache-scope` flag overrides config. Multi-dir `serve` without `--workdir` keeps its per-launch serve cache under `workdir` scope (one serve process = one sandbox).
- **`provenance` & `omac cache clear`** — resolve the same scope, so they report/clear the cache actually in use.
- Docs: `oh-my-agentic-coder.md` §9.1/§9.2/§14.1, `docs/MULTI_DIR_DESKTOP.md`.

## Verification
- `go build ./...` clean; `gofmt` clean.
- New/updated tests pass in `internal/{toolcache,config,cli}`: scope resolution & flag precedence, shared/config domain keying, and updated start/serve/provenance/clear behavior for the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)