### PR TITLE
fix(session): take opencode's session id from the plugin, don't enumerate on start

### DIFF
--- a/.opencode/plugins/omac-multidir.ts
+++ b/.opencode/plugins/omac-multidir.ts
@@ -93,6 +93,9 @@ export const OmacMultiDirPlugin: Plugin = async ({ client, directory, worktree }
   // directories we've already issued an activate for (dedupe; omac itself is
   // idempotent, but this avoids needless round-trips).
   const activated = new Set<string>()
+  // Session ids already reported to omac (see the session.* handler), so the
+  // report fires once per session rather than on every session.updated.
+  const reportedSessions = new Set<string>()
 
   function enabled(): boolean {
     return typeof controlBase === "string" && controlBase.length > 0
@@ -259,6 +262,12 @@ export const OmacMultiDirPlugin: Plugin = async ({ client, directory, worktree }
           if (id && dir) {
             sessionDir.set(id, dir)
             await activate(dir)
+            if (!reportedSessions.has(id)) {
+              reportedSessions.add(id)
+              // Tell omac which session this run created, so its post-exit
+              // "resume" hint is exact — no `opencode session list` needed.
+              void controlPost("/__omac__/session", { session: id })
+            }
           }
           break
         }

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -926,7 +926,11 @@ func runLaunch(env *Env, opts launchOpts) int {
 	selfReportsSession := harness.Session != nil && harness.Session.ListKind == config.SessionListOpenCodeCLI
 	var priorSessions map[string]struct{}
 	if harness.Session != nil && len(harness.Session.ContinueArgs) > 0 && !selfReportsSession {
-		priorSessions = session.KnownIDs(harness, env.Workdir)
+		// Bounded: the snapshot only sharpens the resume hint, so it must never
+		// delay the inner launch. `omac start` waits at most hintTimeout for it.
+		priorSessions = boundedKnownIDs(func() map[string]struct{} {
+			return session.KnownIDs(harness, env.Workdir)
+		}, hintTimeout)
 	}
 
 	code, err := sandbox.ExecWithReady(argv, extra, nil)
@@ -1079,6 +1083,25 @@ func hintSessionID(sessions []session.Session, resumedID string, prior map[strin
 // the harness's session list. opencode shells out to its CLI; 2s is plenty
 // on a warm cache and a sane ceiling for the pathological slow case.
 const hintTimeout = 2 * time.Second
+
+// boundedKnownIDs runs the prior-session enumeration but never waits longer
+// than d for it. The snapshot only sharpens the post-exit resume hint (#145),
+// so a slow or stuck session store must never stall the inner launch: on
+// timeout we return an empty snapshot and carry on (best-effort, matching
+// printContinueHint). This is the structural guarantee that `omac start` never
+// waits indefinitely on session listing — the regression guard for the
+// opencode-session-list hang. enumerate is injected so the bound is testable
+// without real session I/O.
+func boundedKnownIDs(enumerate func() map[string]struct{}, d time.Duration) map[string]struct{} {
+	ch := make(chan map[string]struct{}, 1)
+	go func() { ch <- enumerate() }()
+	select {
+	case ids := <-ch:
+		return ids
+	case <-time.After(d):
+		return nil
+	}
+}
 
 // secretFromEnv returns the host value that will satisfy a keychain-absent
 // secret at runtime, if any. It returns ok=true only when the secret is

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -917,11 +917,15 @@ func runLaunch(env *Env, opts launchOpts) int {
 	auditor.Emit(audit.SessionStart(env.Version, harness.Name, profName, sandboxBackend))
 	auditor.Emit(audit.InnerExec(argv, profName, sandboxed))
 
-	// Snapshot the sessions that already exist so the post-exit hint can tell
-	// the session this run creates apart from a sibling session active in the
-	// same workdir (issue #141). Skipped when no hint would be shown anyway.
+	// The post-exit hint needs the id of the session this run created. opencode
+	// self-reports it via the control plane (the omac plugin POSTs
+	// /__omac__/session), so the pre-exec enumeration is skipped for it:
+	// `opencode session list` runs before the inner launches and can block
+	// indefinitely. Other harnesses enumerate here — cheap on-disk reads — to
+	// tell a fresh session apart from a sibling active in the same workdir (#145).
+	selfReportsSession := harness.Session != nil && harness.Session.ListKind == config.SessionListOpenCodeCLI
 	var priorSessions map[string]struct{}
-	if harness.Session != nil && len(harness.Session.ContinueArgs) > 0 {
+	if harness.Session != nil && len(harness.Session.ContinueArgs) > 0 && !selfReportsSession {
 		priorSessions = session.KnownIDs(harness, env.Workdir)
 	}
 
@@ -931,7 +935,11 @@ func runLaunch(env *Env, opts launchOpts) int {
 		fmt.Fprintln(env.Stderr, prefix+": exec:", err)
 		return ExitSandboxAbnormal
 	}
-	printContinueHint(env, harness, opts.sessionID, priorSessions)
+	resumed := opts.sessionID
+	if resumed == "" && selfReportsSession {
+		resumed = reloader.reportedSession()
+	}
+	printContinueHint(env, harness, resumed, priorSessions)
 	return code
 }
 
@@ -995,6 +1003,15 @@ func continueHintToken(h config.Harness) string {
 // selection).
 func printContinueHint(env *Env, harness config.Harness, resumedID string, prior map[string]struct{}) {
 	if harness.Session == nil || len(harness.Session.ContinueArgs) == 0 {
+		return
+	}
+	// When the session that ran is already known — an explicit resume, or a
+	// harness that self-reported its id via the control plane — advertise it
+	// directly. No enumeration needed (and for opencode none is attempted, so a
+	// slow/blocking `session list` never runs).
+	if resumedID != "" {
+		fmt.Fprintf(env.Stderr, "\nTo resume this session: omac continue%s -s %s\n",
+			continueHintToken(harness), resumedID)
 		return
 	}
 	// session.List may shell out to the harness CLI (opencode: ~500ms) or

--- a/internal/cli/start_hint_test.go
+++ b/internal/cli/start_hint_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBoundedKnownIDsNeverWaitsIndefinitely is the regression guard for the
+// opencode session-list hang: the pre-exec session snapshot must never block
+// the inner launch, no matter how slow (or stuck) the enumeration is. If
+// someone reintroduces an unbounded wait on this path, this test hangs the
+// package deadline instead of shipping.
+func TestBoundedKnownIDsNeverWaitsIndefinitely(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block) // release the never-returning goroutine when the test ends
+
+	start := time.Now()
+	got := boundedKnownIDs(func() map[string]struct{} {
+		<-block // simulate an enumeration that never returns (the #145 hang)
+		return map[string]struct{}{"unreachable": {}}
+	}, 50*time.Millisecond)
+
+	if got != nil {
+		t.Errorf("want nil snapshot on timeout, got %v", got)
+	}
+	if waited := time.Since(start); waited > 2*time.Second {
+		t.Fatalf("boundedKnownIDs waited %v — it must not wait indefinitely", waited)
+	}
+}
+
+// TestBoundedKnownIDsReturnsSnapshotWhenFast confirms the bound is transparent
+// when enumeration completes in time: the snapshot is returned unchanged.
+func TestBoundedKnownIDsReturnsSnapshotWhenFast(t *testing.T) {
+	want := map[string]struct{}{"ses_a": {}, "ses_b": {}}
+	got := boundedKnownIDs(func() map[string]struct{} { return want }, 2*time.Second)
+	if len(got) != len(want) {
+		t.Fatalf("want the enumerated snapshot %v, got %v", want, got)
+	}
+	for id := range want {
+		if _, ok := got[id]; !ok {
+			t.Errorf("snapshot dropped id %q", id)
+		}
+	}
+}

--- a/internal/cli/start_reload.go
+++ b/internal/cli/start_reload.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -38,8 +39,9 @@ type startReloader struct {
 	tcpPort int
 	verbose bool
 
-	mu      sync.Mutex
-	mounted map[string]string // skill name -> mount, for skills mounted on the facade
+	mu          sync.Mutex
+	mounted     map[string]string // skill name -> mount, for skills mounted on the facade
+	lastSession string            // most-recent session id the harness plugin reported (see handleSession)
 }
 
 // startControlPlane binds a loopback control-plane HTTP server for start and
@@ -62,6 +64,9 @@ func startControlPlane(r *startReloader) (controlURL string, closeFn func(), ok 
 	mux.HandleFunc("/__omac__/activate", r.handleActivate)
 	mux.HandleFunc("/__omac__/deactivate", r.handleActivate) // no-op deactivate, same response
 	mux.HandleFunc("/__omac__/reload-global", r.handleReloadGlobalStart)
+	// The harness plugin reports the id of the session it created here, so the
+	// post-exit "resume" hint is exact without enumerating sessions.
+	mux.HandleFunc("/__omac__/session", r.handleSession)
 	srv := &http.Server{Handler: mux}
 	go func() {
 		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -90,6 +95,35 @@ func (r *startReloader) isMounted(name string) bool {
 	_, ok := r.mounted[name]
 	r.mu.Unlock()
 	return ok
+}
+
+// handleSession records the session id the harness plugin reports for this
+// run (opencode posts it on session.created). Best-effort: a malformed or
+// empty body is ignored. The recorded id feeds the post-exit continue hint,
+// replacing the need to enumerate sessions to guess which one this run created.
+func (r *startReloader) handleSession(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "POST only"})
+		return
+	}
+	var body struct {
+		Session string `json:"session"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err == nil && body.Session != "" {
+		r.mu.Lock()
+		r.lastSession = body.Session
+		r.mu.Unlock()
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+// reportedSession returns the last session id reported via handleSession, or
+// "" if the plugin never reported one (control plane down, or a harness with
+// no such plugin).
+func (r *startReloader) reportedSession() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastSession
 }
 
 func (r *startReloader) handleDirs(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cli/start_reload_test.go
+++ b/internal/cli/start_reload_test.go
@@ -90,6 +90,40 @@ func TestStartReloaderActivateNot404(t *testing.T) {
 	}
 }
 
+func TestStartReloaderSessionReport(t *testing.T) {
+	r := newStartReloaderForTest(t)
+	mux := r.startTestMux()
+	if r.reportedSession() != "" {
+		t.Fatal("no session should be reported yet")
+	}
+
+	post := func(body string) int {
+		req := httptest.NewRequest("POST", "/__omac__/session", stringReader(body))
+		req.Header.Set("content-type", "application/json")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if code := post(`{"session":"ses_abc"}`); code != 200 {
+		t.Fatalf("session report status=%d, want 200", code)
+	}
+	if got := r.reportedSession(); got != "ses_abc" {
+		t.Errorf("reportedSession=%q, want ses_abc", got)
+	}
+	// Last report wins (a run may touch more than one session).
+	post(`{"session":"ses_def"}`)
+	if got := r.reportedSession(); got != "ses_def" {
+		t.Errorf("reportedSession=%q, want ses_def", got)
+	}
+	// An empty/malformed report must not clobber a known id.
+	post(`{"session":""}`)
+	post(`not json`)
+	if got := r.reportedSession(); got != "ses_def" {
+		t.Errorf("empty/bad report clobbered id: %q", got)
+	}
+}
+
 // startTestMux builds the same routes startControlPlane wires, for testing.
 func (r *startReloader) startTestMux() *http.ServeMux {
 	m := http.NewServeMux()
@@ -98,6 +132,7 @@ func (r *startReloader) startTestMux() *http.ServeMux {
 	m.HandleFunc("/__omac__/activate", r.handleActivate)
 	m.HandleFunc("/__omac__/deactivate", r.handleActivate)
 	m.HandleFunc("/__omac__/reload-global", r.handleReloadGlobalStart)
+	m.HandleFunc("/__omac__/session", r.handleSession)
 	return m
 }
 

--- a/internal/plugin/assets/omac-multidir.ts
+++ b/internal/plugin/assets/omac-multidir.ts
@@ -93,6 +93,9 @@ export const OmacMultiDirPlugin: Plugin = async ({ client, directory, worktree }
   // directories we've already issued an activate for (dedupe; omac itself is
   // idempotent, but this avoids needless round-trips).
   const activated = new Set<string>()
+  // Session ids already reported to omac (see the session.* handler), so the
+  // report fires once per session rather than on every session.updated.
+  const reportedSessions = new Set<string>()
 
   function enabled(): boolean {
     return typeof controlBase === "string" && controlBase.length > 0
@@ -259,6 +262,12 @@ export const OmacMultiDirPlugin: Plugin = async ({ client, directory, worktree }
           if (id && dir) {
             sessionDir.set(id, dir)
             await activate(dir)
+            if (!reportedSessions.has(id)) {
+              reportedSessions.add(id)
+              // Tell omac which session this run created, so its post-exit
+              // "resume" hint is exact — no `opencode session list` needed.
+              void controlPost("/__omac__/session", { session: id })
+            }
           }
           break
         }


### PR DESCRIPTION
## What
`omac start` no longer runs `session.KnownIDs` (→ `opencode session list`) before launching the inner command for opencode. Instead, the omac OpenCode plugin reports the id of the session it creates to the control plane (`POST /__omac__/session`), and `start` uses that reported id for the post-exit *"To resume this session"* hint. `printContinueHint` now advertises a known id (an explicit resume, or the plugin-reported id) **directly, without enumerating sessions**.

## Why
#145 added a pre-exec `KnownIDs` snapshot so the hint advertises the session *this* run created rather than a sibling active in the same workdir. For opencode that snapshot shells out to `opencode session list --format json` via `exec.Command(...).Output()` **with no timeout**.

In a fresh `$HOME` (no `~/.local/share/opencode/opencode.db`) the fast DB path bails and it *always* takes that CLI fallback — which does not return (its stdout pipe never reaches EOF; the process lingers). So `omac start` blocks in `Waitid` **indefinitely, before the inner ever launches**. Released 0.5.1 has no such pre-exec call, so this is a regression introduced with #145.

opencode already hands us the session id via the plugin, so enumerating to *guess* it is both fragile (depends on `opencode.db` existing + schema) and hang-prone.

### Repro (before)
```
omac start opencode --no-sandbox --inner=<any cmd>   # in a fresh HOME
# → provisions the facade, logs "sandbox argv: …", then hangs forever
#   (goroutine blocked in session.KnownIDs → listOpenCodeCLI → exec Waitid)
```

## How
- **Plugin** (`omac-multidir.ts`): on `session.created`/`updated`, report the new session id once, reusing the existing control-plane channel — no new dependency, no new round-trips per keystroke.
- **Control plane** (`start_reload.go`): record the reported id (`/__omac__/session` → `reportedSession()`).
- **start.go**: skip the pre-exec enumeration for the self-reporting harness (`SessionListOpenCodeCLI`) and advertise the reported id; keep the cheap on-disk snapshot for the others (claude/codex/copilot), so #145's sibling-disambiguation is preserved for them. `printContinueHint` short-circuits when the id is already known — so for opencode **no `session list` runs at all**, pre- or post-exec.

## Verification
- New unit test for the `/__omac__/session` handler + `reportedSession()` (last-write-wins; empty/malformed reports ignored).
- `go build ./...`, `go vet`, and `internal/{cli,session,config,plugin}` tests pass; `gofmt` clean.
- The repro above now runs the inner and exits `0` in ~2s instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Regression guard (never wait indefinitely)

Beyond removing opencode's specific hang, the pre-exec snapshot is now **structurally time-bounded** (`boundedKnownIDs`, capped at `hintTimeout`): no session enumeration on the path to launching the inner can block indefinitely, for any harness or future lister. `TestBoundedKnownIDsNeverWaitsIndefinitely` fails (hits the package deadline) if an unbounded wait is ever reintroduced.