### PR TITLE
test(e2e): forward per-harness auth env into non-audit sandbox profile

### DIFF
--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -1348,6 +1348,17 @@ func writeSandboxProfile(t *testing.T, home string, h harnessConfig, spec *Allow
 	// exercises Task 3's trusted re-injection of the cache env.
 	if spec != nil && len(spec.EnvAllowVars) > 0 {
 		profile.Environment = sandboxprofile.Environment{AllowVars: spec.EnvAllowVars}
+	} else if h.EnvVarsForAllow != nil {
+		// Non-audit path (echo-rest LLM leg, launch/serve probes): the
+		// compiled-in DefaultAllowVars deliberately omits harness
+		// provider-auth vars (#111), so append this harness's auth
+		// allow-list. Without it the sandbox strips the token an env-auth
+		// harness reads from the process env (codex/copilot →
+		// "Missing SKAINET_TOKEN" / "No authentication found"); file-auth
+		// harnesses (opencode/claude-code) are unaffected either way.
+		profile.Environment.AllowVars = append(
+			append([]string{}, profile.Environment.AllowVars...),
+			h.EnvVarsForAllow()...)
 	}
 
 	profDir := filepath.Join(home, ".config", "omac", "sandbox-profiles")
@@ -1361,12 +1372,8 @@ func writeSandboxProfile(t *testing.T, home string, h harnessConfig, spec *Allow
 	if err := os.WriteFile(filepath.Join(profDir, "default.json"), data, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	allowVarsCount := 0
-	if spec != nil {
-		allowVarsCount = len(spec.EnvAllowVars)
-	}
 	t.Logf("sandbox profile written (derived from DefaultProfile) with %d allow_domain entries, %d allow_vars",
-		len(allowDomains), allowVarsCount)
+		len(allowDomains), len(profile.Environment.AllowVars))
 }
 
 // extractHost parses a URL string and returns the hostname.


### PR DESCRIPTION
## What

Test-only fix so the e2e harness-compatibility legs forward each harness's own auth secret into the sandbox. Fixes the `E2E: drift` failures for **codex** (`Missing environment variable: SKAINET_TOKEN`) and **copilot** (`No authentication information found`).

## Why

Since **#111** (`fix(sandbox): ship default env allowlist; strip ambient host env`), the compiled-in `DefaultAllowVars` ships a restrictive allowlist that **deliberately omits provider-auth vars**, and `FilterEnv` strips anything not listed.

`writeSandboxProfile` only appended the per-harness auth allow-list on the **security-audit** path (`spec != nil`, via `allowance.go`). The **echo-rest LLM leg** (`TestE2EEchoRest`) and the launch/serve probes pass `spec == nil`, so the default profile stripped the token before the harness saw it. This splits exactly by auth mechanism:

| Harness | Auth | Result before fix |
|---|---|---|
| opencode | `auth.json` file | ✅ unaffected |
| claude-code | written config | ✅ unaffected |
| **codex** | reads token from **process env** | ❌ stripped |
| **copilot** | env-based auth | ❌ stripped |

The last green drift run was 2026-07-18; #111 merged 2026-07-20, which is why it surfaced only on the next dispatch. No production or default-profile change is warranted — the default's restrictiveness is intended; the e2e fixture just needs to allow the secret it already puts in omac's env.

## How

On the `spec == nil` path in `writeSandboxProfile`, append `h.EnvVarsForAllow()` to the default profile's `allow_vars` — the same per-harness allow-list the audit path already uses (`allowance.go:117`). Guarded on `h.EnvVarsForAllow != nil`. Log line now reports the real merged count.

Only the e2e test fixture's profile is widened, and only by each harness's declared auth vars.

## Verification

- `gofmt -l` clean; `go vet -tags e2e ./internal/e2e/` clean; package compiles.
- Mechanism proven locally against the built sandbox (no harness/model needed): with `SKAINET_TOKEN` absent from `allow_vars` the token is empty inside the sandbox; with it present the token reaches the inner process.
- `E2E: drift` dispatched on this branch to confirm codex/copilot end-to-end (link in comments).

Note: **pi**'s separate `sandbox profile "builtin" not found` failure is unrelated to auth and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
