### PR TITLE
fix(sandbox): resolve harness binary behind an `env` wrapper so bun/npm installs work

### DIFF
--- a/internal/sandboxprofile/resolve.go
+++ b/internal/sandboxprofile/resolve.go
@@ -28,9 +28,15 @@ func DefaultProfile() *Profile {
 			Read: []string{
 				"~/.gitconfig",
 				"~/.gitignore_global",
+				// Generic version-manager / toolchain bin dirs, so tools the
+				// agent shells out to (node, cargo, ...) are reachable. The
+				// active harness's OWN binary dir is NOT listed here: it is
+				// resolved and granted per-launch, install-method agnostically,
+				// by sandboxrun.resolveInnerBinaryDirs (handles bun/npm/mise/
+				// asdf shims + their symlink targets). Do not re-add a specific
+				// harness package path here.
 				"~/.nvm",
 				"~/.bun/bin",
-				"~/.bun/install/global/node_modules/opencode-ai",
 				"~/.cargo/bin",
 				"~/.rustup",
 				"~/go/bin",

--- a/internal/sandboxrun/backend_linux_test.go
+++ b/internal/sandboxrun/backend_linux_test.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
 )
 
 func TestResolveInnerBinaryDirs(t *testing.T) {
@@ -94,6 +96,54 @@ func TestResolveInnerBinaryDirs(t *testing.T) {
 	for _, want := range []string{shimDir, realDir} {
 		if !slices.Contains(got, want) {
 			t.Errorf("env-wrapped dirs = %v, missing wrapped-command dir %q", got, want)
+		}
+	}
+}
+
+// TestBuildChildArgvGrantsEnvWrappedHarnessDir is the end-to-end wiring
+// guard: it proves the env-unwrapped harness directory reaches the actual
+// bwrap --ro-bind mounts, not just resolveInnerBinaryDirs in isolation.
+// Regression target: a profile that wraps the inner command in
+// `env NAME=VALUE ... <harness>` (tng-default) must still mount the
+// harness's own directory, or a bun/npm-installed harness fails to exec.
+func TestBuildChildArgvGrantsEnvWrappedHarnessDir(t *testing.T) {
+	requireBwrap(t)
+
+	// Shim in one dir, symlink target ("harness") in a different subtree,
+	// mirroring bun (~/.bun/bin/opencode -> …/opencode-ai/bin/opencode.exe).
+	root := t.TempDir()
+	realDir := filepath.Join(root, "pkg", "bin")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realBin := filepath.Join(realDir, "harness.real")
+	if err := os.WriteFile(realBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shimDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(shimDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shim := filepath.Join(shimDir, "harness")
+	if err := os.Symlink(realBin, shim); err != nil {
+		t.Fatal(err)
+	}
+
+	// ModeOpen + env-only enforcement keeps BuildChildArgv off the Landlock
+	// ABI gate so the test runs on any kernel with a functional bwrap.
+	g := &Grants{
+		Workdir:     root,
+		NetworkMode: sandboxprofile.ModeOpen,
+		Enforcement: sandboxprofile.EnforceEnvOnly,
+	}
+	argv, err := BuildChildArgv(g, []string{"env", "FOO=bar", "BAR=baz", shim})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(argv, " ")
+	for _, dir := range []string{shimDir, realDir} {
+		if !strings.Contains(joined, "--ro-bind "+dir+" "+dir) {
+			t.Errorf("bwrap argv missing --ro-bind for env-wrapped harness dir %q\nargv: %s", dir, joined)
 		}
 	}
 }

--- a/internal/sandboxrun/backend_linux_test.go
+++ b/internal/sandboxrun/backend_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -82,6 +83,42 @@ func TestResolveInnerBinaryDirs(t *testing.T) {
 	wantPlain := append([]string{plainDir}, interpDirs...)
 	if got := resolveInnerBinaryDirs([]string{plainBin}); !reflect.DeepEqual(got, wantPlain) {
 		t.Errorf("plain binary dirs = %v, want %v", got, wantPlain)
+	}
+
+	// An `env NAME=VALUE ... <cmd>` wrapper (as a sandbox profile may use to
+	// set NPM_CONFIG_* before launch) must not hide the harness: the wrapped
+	// command's dirs must still be granted, or a bun/npm-installed opencode
+	// fails to exec inside the sandbox. Grant the shim via PATH lookup.
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+"/usr/bin:/bin")
+	got := resolveInnerBinaryDirs([]string{"env", "FOO=bar", "BAR=baz", "opencode"})
+	for _, want := range []string{shimDir, realDir} {
+		if !slices.Contains(got, want) {
+			t.Errorf("env-wrapped dirs = %v, missing wrapped-command dir %q", got, want)
+		}
+	}
+}
+
+func TestUnwrapEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"no wrapper", []string{"opencode", "--version"}, []string{"opencode", "--version"}},
+		{"env + assignments", []string{"env", "A=1", "B=2", "opencode", "-x"}, []string{"opencode", "-x"}},
+		{"env no assignments", []string{"env", "opencode"}, []string{"opencode"}},
+		{"absolute env path", []string{"/usr/bin/env", "A=1", "claude"}, []string{"claude"}},
+		{"nested env", []string{"env", "A=1", "env", "B=2", "codex"}, []string{"codex"}},
+		{"env flag left in place", []string{"env", "-i", "opencode"}, []string{"-i", "opencode"}},
+		{"bare env", []string{"env"}, []string{"env"}},
+		{"empty", nil, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := unwrapEnv(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("unwrapEnv(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/sandboxrun/resolve_binary.go
+++ b/internal/sandboxrun/resolve_binary.go
@@ -22,12 +22,29 @@ import (
 //     #!/usr/bin/env node), the interpreter's directory too — so the
 //     kernel can exec the script inside the sandbox.
 //
+// When the inner command is wrapped in an `env NAME=VALUE ... <cmd>` prefix
+// (a sandbox profile may do this to set NPM_CONFIG_* etc. before launching
+// the harness), the wrapped <cmd> is resolved and granted in addition to
+// `env` itself — otherwise only `env`'s own directory would be granted and
+// the harness (e.g. a bun/npm-installed opencode) would fail to exec.
+//
 // Returns nil when the command cannot be found or resolved.
 func resolveInnerBinaryDirs(innerArgv []string) []string {
-	if len(innerArgv) == 0 || innerArgv[0] == "" {
+	dirs := resolveCommandBinaryDirs(innerArgv)
+	if cmd := unwrapEnv(innerArgv); len(cmd) > 0 && cmd[0] != innerArgv[0] {
+		dirs = append(dirs, resolveCommandBinaryDirs(cmd)...)
+	}
+	return dirs
+}
+
+// resolveCommandBinaryDirs is the core resolution for a single command argv
+// (no env-wrapper handling): PATH-entry dir, symlink-resolved real dir, and
+// shebang interpreter dirs. Returns nil when argv is empty or unresolvable.
+func resolveCommandBinaryDirs(argv []string) []string {
+	if len(argv) == 0 || argv[0] == "" {
 		return nil
 	}
-	resolved, err := exec.LookPath(innerArgv[0])
+	resolved, err := exec.LookPath(argv[0])
 	if err != nil {
 		return nil
 	}
@@ -46,6 +63,30 @@ func resolveInnerBinaryDirs(innerArgv []string) []string {
 		}
 	}
 	return dirs
+}
+
+// unwrapEnv strips a leading `env NAME=VALUE ...` wrapper and returns the
+// argv that begins with the real command. It skips `env` and any following
+// NAME=VALUE assignment tokens; the first non-assignment token is the
+// command. `env` flags (e.g. -i, -u) are not used by omac's profiles and are
+// left in place, so an argv like `env -i cmd` yields `-i cmd` — which fails
+// to resolve and is safely ignored by the caller. Returns argv unchanged when
+// there is no env wrapper.
+func unwrapEnv(argv []string) []string {
+	for len(argv) >= 2 && filepath.Base(argv[0]) == "env" {
+		i := 1
+		for i < len(argv) && isEnvAssignment(argv[i]) {
+			i++
+		}
+		argv = argv[i:]
+	}
+	return argv
+}
+
+// isEnvAssignment reports whether tok is a NAME=VALUE assignment (not a flag).
+func isEnvAssignment(tok string) bool {
+	eq := strings.IndexByte(tok, '=')
+	return eq > 0 && !strings.HasPrefix(tok, "-")
 }
 
 // resolveInnerBinaryPath resolves the inner command's executable to its


### PR DESCRIPTION
Closes #164

## What

Teaches the dynamic harness-binary resolver (`sandboxrun.resolveInnerBinaryDirs`) to see through a leading `env NAME=VALUE … <harness>` wrapper and grant the **wrapped** command's directories, not just `env`'s. Also drops the now-redundant hardcoded read entry `~/.bun/install/global/node_modules/opencode-ai` from the default profile.

## Why

`resolveInnerBinaryDirs` inspected only `innerArgv[0]` to decide which dirs to mount so the harness is reachable inside the sandbox. The `tng-default` profile (generated by `install.sh`) wraps the inner command to set npm config:

```
… -- env NPM_CONFIG_USERCONFIG=… npm_config_cache=… opencode --version
```

So `argv[0]` is `env` — the resolver granted `/usr/bin` and **never** the harness's own directory. A bun/npm-installed opencode (`~/.bun/bin/opencode` → `…/opencode-ai/bin/opencode.exe`) then failed to exec inside the sandbox:

```
env: 'opencode': No such file or directory      (exit 127)
```

This is the "bin-installed opencode doesn't work out of the box" report. The resolver already handled bun/npm/mise/asdf shims via `LookPath` + `EvalSymlinks` — it just never ran on the command hidden behind `env`.

The hardcoded `opencode-ai` read entry is removed because the resolver now robustly grants the active harness's dir per-launch; baking one harness's npm package path into a security-sensitive default is unnecessary. Generic toolchain bin dirs (`~/.bun/bin`, `~/.nvm`, `~/.cargo/bin`, `~/go/bin`) stay — they serve tools the agent shells out to.

## How

- `resolveInnerBinaryDirs` → resolves `innerArgv[0]` **and**, when an `env` wrapper is present, the unwrapped command; extracted the single-command core into `resolveCommandBinaryDirs`.
- `unwrapEnv` skips `env` + `NAME=VALUE` tokens to find the real command (env flags are not used by omac profiles and are left in place → safely unresolved).
- Removed `resolve.go` read entry + comment guarding against re-adding harness package paths.

## Verification

Empirical, with a **real** bun install (`opencode-ai` 1.17.12) and a **bun-only** PATH (no `~/.opencode/bin`):

| Scenario | Before | After |
|---|---|---|
| `omac start opencode` under `tng-default` (env-wrapped) profile | ❌ exit 127 | ✅ exit 0 (`1.17.12`) |
| `omac sandbox run -- env FOO=bar opencode --version`, profile grants no bun paths | ❌ exit 127 | ✅ exit 0 |
| `omac sandbox run -- opencode --version` (no wrapper) | ✅ | ✅ (unchanged) |

Negative control (resolver disabled, recompiled) fails with *"not found in the sandbox filesystem"* naming `…/opencode-ai/bin/opencode.exe`, confirming the resolver is what grants it.

Tests: `go build ./...`, `go vet`, and `go test ./internal/sandboxrun/... ./internal/sandboxprofile/...` all pass. Added `TestUnwrapEnv` and an env-wrapper assertion in `TestResolveInnerBinaryDirs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)