### PR TITLE
docs: fix documentation drift in resume/continue flags and ConfigHome

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,7 +909,7 @@ omac [--workdir <dir>] <subcommand> [flags] [args]
 
    continue     Like `start`, but continue the most recent session for this
                 workdir (appends the harness's continue flag: opencode/claude
-                `--continue`, codex `resume`, copilot `--continue`, pi `-c`).
+                `--continue`, codex `resume --last`, copilot `--continue`, pi `-c`).
                 Pass `-s`/`--session <id>` to target a specific session
                 (opencode `--session <id>`, claude `--resume <id>`, codex
                 `resume <id>`, copilot `--session-id <id>`, pi `--session <id>`).
@@ -923,9 +923,10 @@ omac [--workdir <dir>] <subcommand> [flags] [args]
                `--resume <id>`, codex `resume <id>`, copilot
                `--session-id <id>`, pi `--session <id>`). Sessions come from
                the harness's own store (opencode `session list`; Claude Code's
-               ~/.claude/projects files; codex `codex session list`; copilot
-               `copilot session list`; pi's ~/.pi/agent/sessions/ JSONL
-               files). Non-interactive stdin prints the list and exits.
+               ~/.claude/projects files; codex's ~/.codex/sessions/ rollout
+               files; copilot's ~/.copilot/session-store.db; pi's
+               ~/.pi/agent/sessions/ JSONL files). Non-interactive stdin
+               prints the list and exits.
                Accepts the same flags as `start` and an optional [harness].
 
   doctor       Sanity checks: config, registry, binaries, secrets, sandbox.

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -511,7 +511,7 @@ func (h Harness) WorkdirSkillsDir() string {
 
 // ConfigHome returns the harness's full config home directory, honoring
 // the HomeEnv override. For UserConfigHome harnesses (claude, codex,
-// copilot), this is $HOME/<UserConfigHome> by default. For XDG harnesses
+// copilot, pi), this is $HOME/<UserConfigHome> by default. For XDG harnesses
 // (opencode), this is $XDG_CONFIG_HOME/<base> or ~/.config/<base> by
 // default. When HomeEnv is set and non-empty, its value replaces the
 // default entirely. Returns "" when no home can be resolved.


### PR DESCRIPTION
## What
Fixes three factual documentation drifts — points where the docs describe behaviour the code no longer implements. Surfaced by the doc-drift audit job (added in #166) and verified by hand.

## Why
Each is a concrete claim a reader would act on and be misled by: a wrong CLI flag, wrong session-discovery mechanism, and an incomplete docstring enumeration.

## How
- **README `omac continue`** — codex's continue flag is `resume --last`, not `resume`.
  Code: `internal/config/harness.go:303` (`ContinueArgs: []string{"resume", "--last"}`), asserted by `internal/config/harness_test.go:573`.
- **README `omac resume`** — codex/copilot sessions are read directly from their on-disk stores (`~/.codex/sessions/` rollout files; `~/.copilot/session-store.db`), not via `codex session list` / `copilot session list` CLIs.
  Code: `internal/session/session.go` (`listCodex`, `listCopilot`). The new wording also matches README's own earlier §117-120 description.
- **`ConfigHome` docstring** — pi was omitted from the "UserConfigHome harnesses" list; pi sets `UserConfigHome: ".pi/agent"`.
  Code: `internal/config/harness.go:373`.

## Verification
- `go build ./internal/config/` passes (comment-only change there).
- Each fix traced to the exact code line quoted above.
- Doc-only + one docstring; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)