### PR TITLE
fix(sandbox): grant operational env defaults regardless of profile; add deny_vars

### DIFF
--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -143,6 +143,38 @@ sandbox:
 > arbitrary `OMAC_*` variables in the host env expecting them to stay out of
 > the sandbox.
 >
+> **Defaults on by default; remove with `deny_vars`.** Every profile — empty
+> or restrictive, including custom ones like `tng-default.json` — is granted
+> the full operational default set (`sandboxprofile.DefaultAllowVars()`)
+> *automatically* via `EffectiveAllowVars`, so vars like `COLORTERM` never
+> need to be hand-carried into each profile. `allow_vars` then adds anything
+> extra (e.g. the harness's auth vars); `deny_vars` removes anything the
+> profile does not want:
+> - **`allow_vars`** — extra grants on top of the defaults. `["*"]` grants
+>   every non-blocklisted var.
+> - **`deny_vars`** — patterns to drop (same exact / trailing-`*` matching as
+>   `allow_vars`). It is applied **last** — after the allowlist *and* after
+>   omac's injected overlay — so it wins over `allow_vars`, over `["*"]`, and
+>   over injected vars. A profile can therefore drop even an injected var such
+>   as `HTTP_PROXY` or a tool-cache path. That is deliberately powerful:
+>   denying the proxy or cache injections can break networking or cache
+>   isolation, so it is the profile author's explicit call.
+>
+> Because the defaults are merged in, `allow_vars` is **additive only** — a
+> profile cannot express "narrower than the defaults" by listing fewer
+> entries; use `deny_vars` for that.
+>
+> `sandboxprofile.BaseAllowVars()` (`OMAC_*`, `HOME`, `PATH`, `PWD`, `TMPDIR`,
+> `LANG`, `LC_*`, `TERM`, `COLORTERM`) is the operational minimum. Denying a
+> base var is **allowed** (deny always wins) but is almost never intended, so
+> the launch path prints a warning and `omac doctor` reports it. The remaining
+> defaults (`SHELL`, `USER`, `LOGNAME`, `TZ`, `EDITOR`, `VISUAL`,
+> `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `NPM_CONFIG_PREFIX`)
+> are the removable convenience tier — dropping those is silent.
+>
+> `omac provenance` shows the defaults as `builtin (default)`, the profile's
+> `allow_vars` additions under the profile source, and `deny_vars` as `deny`.
+>
 > **Empty `allow_vars` — fail-closed at launch.** If a sandbox profile has an
 > empty `environment.allow_vars` (e.g. an existing `default.json` with
 > `"environment": {}`, or a hand-authored profile), `omac start` / `omac serve`
@@ -181,10 +213,12 @@ sandbox:
 > every third-party provider key into the sandbox, so a user relying on an
 > env-based provider key lists it in `allow_vars` themselves (opencode's primary
 > `auth.json` login, in its granted dirs, is unaffected). Auto-forwarding is
-> skipped entirely for the empty (misconfigured) case. A direct
-> `omac sandbox run --profile X` invocation — not via `start`/`serve` — still
-> treats an empty `allow_vars` as inherit-all; the fail-closed seeding happens
-> in the `start`/`serve` launch path.
+> skipped entirely for the empty (misconfigured) case.
+>
+> A direct `omac sandbox run --profile X` invocation — not via
+> `start`/`serve` — is fail-closed too: `EffectiveAllowVars` resolves an empty
+> `allow_vars` to the operational defaults at the enforcement point, so no
+> entry point inherits the ambient environment.
 
 For successfully inspectable built-in `{{self}} sandbox run` profiles,
 `omac doctor` warns when a profile re-introduces a broad read/write

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -169,8 +169,11 @@ sandbox:
 > base var is **allowed** (deny always wins) but is almost never intended, so
 > the launch path prints a warning and `omac doctor` reports it. The remaining
 > defaults (`SHELL`, `USER`, `LOGNAME`, `TZ`, `EDITOR`, `VISUAL`,
-> `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `NPM_CONFIG_PREFIX`)
-> are the removable convenience tier — dropping those is silent.
+> `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `NPM_CONFIG_PREFIX`,
+> `DISPLAY`) are the removable convenience tier — dropping those is silent.
+> `DISPLAY` is only the X11 server address: a GUI still needs the filesystem
+> policy to expose the X11 socket (and `XAUTHORITY` on a cookie-protected
+> server), so deny it in headless or hardened profiles.
 >
 > `omac provenance` shows the defaults as `builtin (default)`, the profile's
 > `allow_vars` additions under the profile source, and `deny_vars` as `deny`.
@@ -183,9 +186,9 @@ sandbox:
 > `sandboxprofile.DefaultAllowVars()`: `HOME`, `PATH`, `PWD`, `TMPDIR`, `LANG`,
 > `LC_*`, `TERM`, `COLORTERM`, `SHELL`, `USER`, `LOGNAME`, `TZ`, `EDITOR`,
 > `VISUAL`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`,
-> `NPM_CONFIG_PREFIX`, `OMAC_*`. Note this is **not** a blanket `XDG_*`
-> prefix: `XDG_CACHE_HOME` is deliberately absent, because omac sets it
-> itself to the isolated tool-cache scope.
+> `NPM_CONFIG_PREFIX`, `DISPLAY`, `OMAC_*`. Note this is **not** a blanket
+> `XDG_*` prefix: `XDG_CACHE_HOME` is deliberately absent, because omac sets
+> it itself to the isolated tool-cache scope.
 >
 > Everything else is **stripped** — secrets, *and* provider-auth vars.
 > omac deliberately does **not** auto-forward the harness's auth variables for

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -221,7 +221,9 @@ sandbox:
 > A direct `omac sandbox run --profile X` invocation — not via
 > `start`/`serve` — is fail-closed too: `EffectiveAllowVars` resolves an empty
 > `allow_vars` to the operational defaults at the enforcement point, so no
-> entry point inherits the ambient environment.
+> entry point inherits the ambient environment. It warns there rather than
+> pausing; `start`/`serve` warn and pause in their own launch path, then seed
+> the defaults as `--allow-env` flags, so a seeded launch does not warn twice.
 
 For successfully inspectable built-in `{{self}} sandbox run` profiles,
 `omac doctor` warns when a profile re-introduces a broad read/write

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -304,6 +304,15 @@ func doctorSandboxProfileWarnings(env *Env, lc config.LauncherConfig) {
 			fmt.Fprintln(env.Stdout, `                      sandboxprofile.DefaultAllowVars), or set allow_vars: ["*"] to forward`)
 			fmt.Fprintln(env.Stdout, "                      every ambient var (minus the danger blocklist).")
 		}
+		if denied := sandboxprofile.DeniedBaseVars(p.Environment.DenyVars); len(denied) > 0 {
+			fmt.Fprintf(env.Stdout, "  [warn] sandbox profile %q denies operational base var(s): %s\n", profName, strings.Join(denied, ", "))
+			fmt.Fprintln(env.Stdout, "         impact:      deny_vars wins over everything (allowlist, \"*\", and omac's injected")
+			fmt.Fprintln(env.Stdout, "                      overlay), so these are stripped. They are the operational minimum a")
+			fmt.Fprintln(env.Stdout, "                      sandboxed harness needs (HOME/PATH/TERM/…); removing them will likely")
+			fmt.Fprintln(env.Stdout, "                      break it.")
+			fmt.Fprintln(env.Stdout, "         remediation: drop these entries from environment.deny_vars unless the removal is")
+			fmt.Fprintln(env.Stdout, "                      deliberate.")
+		}
 		warns := profileGrantWarnings(p)
 		// Cargo-specific presence warning (mode-000 sentinel files).
 		warns = append(warns, cargoSentinelWarnings()...)

--- a/internal/cli/provenance.go
+++ b/internal/cli/provenance.go
@@ -263,16 +263,43 @@ func buildEnvironmentView(profile *sandboxprofile.Profile, profPath, workdir str
 	for _, p := range prefixes {
 		ev.Entries = append(ev.Entries, provEntry{Entry: p + "*", Action: "deny", Source: "blocklist"})
 	}
-	if len(profile.Environment.AllowVars) == 0 {
-		ev.Entries = append(ev.Entries, provEntry{
-			Entry:  "(no allowlist — all non-blocklisted vars pass)",
-			Action: "allow",
-			Source: "default",
-		})
-	} else {
-		for _, v := range profile.Environment.AllowVars {
-			ev.Entries = append(ev.Entries, provEntry{Entry: v, Action: "allow", Source: profSrc})
+	wildcard := false
+	for _, v := range profile.Environment.AllowVars {
+		if v == "*" {
+			wildcard = true
+			break
 		}
+	}
+	if wildcard {
+		ev.Entries = append(ev.Entries, provEntry{Entry: "*", Action: "allow", Source: profSrc})
+		return ev
+	}
+	if len(profile.Environment.AllowVars) == 0 {
+		// Empty is NOT inherit-all: it fails closed to the operational
+		// minimum (sandboxprofile.EffectiveAllowVars).
+		for _, v := range sandboxprofile.DefaultAllowVars() {
+			ev.Entries = append(ev.Entries, provEntry{Entry: v, Action: "allow", Source: "builtin (empty→minimum)"})
+		}
+		return ev
+	}
+	// Restrictive list: the full DefaultAllowVars is granted by default
+	// (see sandboxprofile.EffectiveAllowVars), so show those as the
+	// always-on defaults and the profile's own additions separately.
+	def := map[string]bool{}
+	for _, v := range sandboxprofile.DefaultAllowVars() {
+		def[v] = true
+		ev.Entries = append(ev.Entries, provEntry{Entry: v, Action: "allow", Source: "builtin (default)"})
+	}
+	for _, v := range profile.Environment.AllowVars {
+		if def[v] {
+			continue
+		}
+		ev.Entries = append(ev.Entries, provEntry{Entry: v, Action: "allow", Source: profSrc})
+	}
+	// deny_vars is applied last and wins over everything (allowlist, "*",
+	// injected overlay), so render it after the allow entries.
+	for _, v := range profile.Environment.DenyVars {
+		ev.Entries = append(ev.Entries, provEntry{Entry: v, Action: "deny", Source: profSrc})
 	}
 	return ev
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -670,6 +670,11 @@ var emptyAllowVarsWarnDelay = 2 * time.Second
 // credentials into the sandbox to paper over it. It warns that this differs
 // from the old inherit-everything behavior and pauses so the message is seen.
 func forwardHarnessEnv(env *Env, argv []string, harness config.Harness, prof config.SandboxProfile, profName string) []string {
+	if denied := sandboxProfileDeniedBaseVars(prof); len(denied) > 0 {
+		fmt.Fprintf(env.Stderr, "omac: sandbox profile %q denies operational base var(s): %s.\n", profName, strings.Join(denied, ", "))
+		fmt.Fprintln(env.Stderr, "      deny_vars wins over everything, so these are stripped even though the harness")
+		fmt.Fprintln(env.Stderr, `      needs them to run. Remove them from deny_vars unless intended ("omac doctor").`)
+	}
 	if empty, ok := sandboxProfileAllowVarsEmpty(prof); ok && empty {
 		fmt.Fprintf(env.Stderr, "omac: sandbox profile %q has an empty environment.allow_vars.\n", profName)
 		fmt.Fprintln(env.Stderr, "      Forwarding only the operational minimum (HOME, PATH, TERM, locale, …).")
@@ -698,6 +703,22 @@ func sandboxProfileAllowVarsEmpty(prof config.SandboxProfile) (empty bool, ok bo
 		return false, false
 	}
 	return len(sp.Environment.AllowVars) == 0, true
+}
+
+// sandboxProfileDeniedBaseVars returns the operational base vars that the
+// native sandbox profile's deny_vars would strip (see
+// sandboxprofile.DeniedBaseVars). It returns nil for non-native or
+// unresolvable profiles.
+func sandboxProfileDeniedBaseVars(prof config.SandboxProfile) []string {
+	ref, isNative := inspectBuiltinProfileRef(prof.Command)
+	if !isNative {
+		return nil
+	}
+	sp, _, err := sandboxprofile.ResolveReadOnly(ref)
+	if err != nil {
+		return nil
+	}
+	return sandboxprofile.DeniedBaseVars(sp.Environment.DenyVars)
 }
 
 // injectSandboxEnvAllow splices --allow-env flags for each harness-declared

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os/exec"
@@ -141,6 +142,16 @@ func ensureOpenCodePlugin(env *Env, harness config.Harness) {
 	// overwrite) and Unchanged covers the silent common path.
 	res, err := plugin.InstallMultiDirIn(dir, false)
 	if err != nil {
+		var conflict *plugin.ConflictError
+		if errors.As(err, &conflict) {
+			// The common post-upgrade case: a stale/edited copy differs from
+			// the embedded plugin. A plain re-install hits the same guard, so
+			// point at the actual remedy (overwrite, or delete + relaunch).
+			fmt.Fprintf(env.Stderr, "[warn] an existing, differing %s is at %s; the sandbox briefing won't appear in OpenCode until it is refreshed.\n", plugin.MultiDirFileName, conflict.Path)
+			fmt.Fprintln(env.Stderr, "       Overwrite it:  omac plugin install opencode-desktop --global --force")
+			fmt.Fprintf(env.Stderr, "       Or delete %s and relaunch (omac reprovisions it automatically).\n", conflict.Path)
+			return
+		}
 		fmt.Fprintf(env.Stderr, "[warn] could not provision the omac OpenCode plugin (%v); the sandbox briefing won't appear in OpenCode. Install it with: omac plugin install opencode-desktop --global\n", err)
 		return
 	}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -82,6 +82,18 @@ func isMultiDirInstalledIn(dir string) (bool, error) {
 	return false, err
 }
 
+// ConflictError is returned by the install routines when a differing
+// plugin file already exists and force was not set. It carries the path
+// so callers can tell the user exactly what to overwrite or delete,
+// rather than suggesting a command that would hit the same guard again.
+type ConflictError struct {
+	Path string
+}
+
+func (e *ConflictError) Error() string {
+	return fmt.Sprintf("a different %s already exists at %s; re-run with --force to overwrite", MultiDirFileName, e.Path)
+}
+
 // InstallResult describes what an install call did, for friendly output.
 type InstallResult struct {
 	// Path is the absolute file path the plugin was written to.
@@ -127,9 +139,7 @@ func installMultiDirIn(dir string, force bool) (InstallResult, error) {
 			return InstallResult{Path: dest, Unchanged: true}, nil
 		}
 		if !force {
-			return InstallResult{Path: dest}, fmt.Errorf(
-				"a different %s already exists at %s; re-run with --force to overwrite",
-				MultiDirFileName, dest)
+			return InstallResult{Path: dest}, &ConflictError{Path: dest}
 		}
 		overwrote = true
 	} else if !os.IsNotExist(err) {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,8 +79,16 @@ func TestInstallRefusesToClobberWithoutForce(t *testing.T) {
 	if err := os.WriteFile(dest, []byte("// local edits\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := InstallMultiDir(wd, bridge, false); err == nil {
+	_, err := InstallMultiDir(wd, bridge, false)
+	if err == nil {
 		t.Fatal("expected refusal to overwrite a differing file without --force")
+	}
+	var conflict *ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected *ConflictError, got %T: %v", err, err)
+	}
+	if conflict.Path != dest {
+		t.Errorf("ConflictError.Path = %q, want %q", conflict.Path, dest)
 	}
 	// With force it overwrites.
 	res, err := InstallMultiDir(wd, bridge, true)

--- a/internal/profileaudit/check.go
+++ b/internal/profileaudit/check.go
@@ -26,12 +26,18 @@ func Check(profile *sandboxprofile.Profile) []Finding {
 	return findings
 }
 
-// checkEnvironment flags an empty env allowlist. With no allow_vars the
-// sandbox inherits every ambient variable except the danger blocklist —
-// credentials, capability pointers, proxy settings — contradicting the
-// "no host env unless explicitly forwarded" trust model (issue #102).
-// MEDIUM: it is a real leak but affects only the launching shell's own
-// environment, not an on-disk secret.
+// checkEnvironment flags an empty env allowlist. An empty allow_vars no
+// longer inherits the ambient environment: sandboxprofile.EffectiveAllowVars
+// resolves it to the operational defaults, and every launch path enforces
+// that, so the "no host env unless explicitly forwarded" trust model
+// (issue #102) holds. What remains is a misconfiguration — the profile
+// forwards nothing the harness needs beyond HOME/PATH/locale, so the
+// harness starts and then cannot authenticate.
+//
+// MEDIUM on functional impact, not exposure: an empty allowlist is
+// fail-closed, so there is nothing to leak, but a silently unauthenticated
+// harness is more than cosmetic. Only HIGH gates the exit code
+// (see ExitCode), so this stays advisory either way.
 func checkEnvironment(profile *sandboxprofile.Profile) []Finding {
 	if len(profile.Environment.AllowVars) > 0 {
 		return nil
@@ -41,7 +47,7 @@ func checkEnvironment(profile *sandboxprofile.Profile) []Finding {
 		Category: CatEnvironment,
 		Field:    "environment.allow_vars",
 		Value:    "(empty)",
-		Message:  "empty allowlist inherits all ambient env vars except the danger blocklist; add an explicit allow_vars list",
+		Message:  `fails closed to the operational defaults, so the harness starts but cannot authenticate; add the vars it needs to allow_vars, or ["*"] to inherit every non-blocklisted var`,
 	}}
 }
 

--- a/internal/profileaudit/check_test.go
+++ b/internal/profileaudit/check_test.go
@@ -26,6 +26,9 @@ func TestCheck_EmptyProfileNoFindings(t *testing.T) {
 	}
 }
 
+// TestCheck_EmptyAllowVarsIsMedium pins the finding at MEDIUM. The severity
+// rests on functional impact (an unauthenticated harness), not exposure —
+// see TestCheck_EmptyAllowVarsIsFailClosed for why there is nothing to leak.
 func TestCheck_EmptyAllowVarsIsMedium(t *testing.T) {
 	p := cleanProfile()
 	p.Environment.AllowVars = nil
@@ -41,6 +44,35 @@ func TestCheck_EmptyAllowVarsIsMedium(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("empty allow_vars should produce an environment finding; got %+v", findings)
+	}
+}
+
+// TestCheck_EmptyAllowVarsIsFailClosed pins the behavior the finding's
+// message describes: an empty allow_vars resolves to the operational
+// defaults, it does NOT inherit the ambient environment. The message said
+// the opposite for a while after the enforcement layer changed, leaving
+// `omac provenance --check` contradicting `omac doctor`. Asserting the
+// resolved policy rather than the prose keeps the two from drifting again.
+func TestCheck_EmptyAllowVarsIsFailClosed(t *testing.T) {
+	effective := sandboxprofile.EffectiveAllowVars(nil)
+	if len(effective) == 0 {
+		t.Fatal("EffectiveAllowVars(nil) is empty — an empty allow_vars would inherit every ambient var, and the finding's message is wrong")
+	}
+	want := sandboxprofile.DefaultAllowVars()
+	if len(effective) != len(want) {
+		t.Fatalf("EffectiveAllowVars(nil) = %v, want DefaultAllowVars %v", effective, want)
+	}
+	for i := range want {
+		if effective[i] != want[i] {
+			t.Errorf("EffectiveAllowVars(nil)[%d] = %q, want %q", i, effective[i], want[i])
+		}
+	}
+	// A secret on the ambient env must not survive the resolved allowlist.
+	got := sandboxprofile.FilterEnv([]string{"HOME=/h", "AWS_SECRET_ACCESS_KEY=zzz"}, effective, nil, nil)
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "AWS_SECRET_ACCESS_KEY=") {
+			t.Errorf("empty allow_vars leaked %q; the finding's fail-closed framing is wrong", kv)
+		}
 	}
 }
 

--- a/internal/sandboxprofile/env.go
+++ b/internal/sandboxprofile/env.go
@@ -41,13 +41,13 @@ var dangerousEnvPrefixes = []string{
 	"OP_SESSION_",
 }
 
-// DefaultAllowVars is the minimal set of environment variables the
-// sandboxed runtime needs to function. It is compiled into
-// DefaultProfile so the scaffolded default.json ships an explicit
-// allowlist rather than the implicit "inherit everything" behaviour of
-// an empty list. Harness-specific auth variables (e.g. the LLM provider
-// token) are NOT here — they are merged in per-harness at launch via
-// Harness.SandboxEnvAllow (mirroring how SandboxDirs are injected).
+// BaseAllowVars is the always-on tier of the env allowlist: the
+// operational minimum a sandboxed process needs to run at all and which
+// is never desirable to withhold. EffectiveAllowVars merges these into
+// every restrictive profile's allow_vars, so a profile author cannot
+// accidentally strip them (COLORTERM was the motivating gap — issue
+// #139). A profile can ADD to the allowlist; it cannot subtract from
+// this base. All entries are non-secret.
 //
 // Entries are exact names or trailing-* prefixes (see envVarAllowed).
 // Injected variables (HTTP(S)_PROXY, OMAC_* skill bases) bypass the
@@ -55,13 +55,8 @@ var dangerousEnvPrefixes = []string{
 // is listed too because omac sets several OMAC_* vars in its own process
 // environment before exec (see internal/cli/start.go), and those reach
 // the child through inheritance rather than the injected overlay.
-//
-// USER/LOGNAME (default identity for git/npm/ssh — also forwarded to the
-// facade via FacadeConfig.BaseEnvPassthrough), TZ (date formatting),
-// EDITOR/VISUAL (harnesses that shell out to an editor), and COLORTERM
-// (truecolor capability hint, paired with TERM) round out the
-// operational minimum; all are non-secret.
-func DefaultAllowVars() []string {
+// COLORTERM is the truecolor-capability hint, paired with TERM.
+func BaseAllowVars() []string {
 	return []string{
 		"OMAC_*",
 		"HOME",
@@ -72,6 +67,18 @@ func DefaultAllowVars() []string {
 		"LC_*",
 		"TERM",
 		"COLORTERM",
+	}
+}
+
+// convenienceAllowVars is the removable tier scaffolded into default.json
+// on top of BaseAllowVars. Unlike the base, a profile MAY omit these:
+// USER/LOGNAME (default identity for git/npm/ssh — also forwarded to the
+// facade via FacadeConfig.BaseEnvPassthrough), TZ (date formatting),
+// EDITOR/VISUAL (harnesses that shell out to an editor), SHELL, the
+// XDG_*_HOME config/data/state dirs, and NPM_CONFIG_PREFIX. All are
+// non-secret.
+func convenienceAllowVars() []string {
+	return []string{
 		"SHELL",
 		"USER",
 		"LOGNAME",
@@ -83,6 +90,85 @@ func DefaultAllowVars() []string {
 		"XDG_STATE_HOME",
 		"NPM_CONFIG_PREFIX",
 	}
+}
+
+// DefaultAllowVars is the full allowlist compiled into DefaultProfile and
+// scaffolded into default.json: the always-on BaseAllowVars followed by
+// the removable convenience vars. Harness-specific auth variables (e.g.
+// the LLM provider token) are NOT here — they are merged in per-harness
+// at launch via Harness.SandboxEnvAllow (mirroring how SandboxDirs are
+// injected).
+func DefaultAllowVars() []string {
+	return append(BaseAllowVars(), convenienceAllowVars()...)
+}
+
+// EffectiveAllowVars returns the allow_vars actually granted for a
+// profile — the allow side only; removals are applied separately by
+// FilterEnv via deny_vars (see FilterEnv and EnvVarMatches).
+//
+//   - an explicit "*" wildcard means "grant every non-blocklisted var"
+//     and is returned unchanged — the only sanctioned inherit-all opt-in;
+//   - an EMPTY list is NOT inherit-all. Since #102/#111 an empty allow_vars
+//     is a misconfiguration that resolves to the operational defaults
+//     (DefaultAllowVars), never the pre-#102 inherit-everything. cmd/serve
+//     and cmd/start already seed this at launch; resolving it here too
+//     closes the gap for a bare `omac sandbox run` against an empty
+//     profile, so the policy holds regardless of entry point;
+//   - a non-empty list has the full DefaultAllowVars merged in, so every
+//     operational default (base + convenience) is granted by default
+//     regardless of what the profile itself lists (COLORTERM was the
+//     motivating gap — issue #139). A profile removes a default it does
+//     not want with deny_vars, not by omitting it here.
+//
+// The returned slice is a fresh copy — default entries first, then the
+// profile's own additions with duplicates removed — so callers may retain
+// or mutate it without touching the profile.
+func EffectiveAllowVars(profileAllow []string) []string {
+	for _, v := range profileAllow {
+		if v == "*" {
+			return profileAllow
+		}
+	}
+	if len(profileAllow) == 0 {
+		return DefaultAllowVars()
+	}
+	defs := DefaultAllowVars()
+	seen := make(map[string]bool, len(defs)+len(profileAllow))
+	out := make([]string, 0, len(defs)+len(profileAllow))
+	for _, v := range defs {
+		seen[v] = true
+		out = append(out, v)
+	}
+	for _, v := range profileAllow {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// DeniedBaseVars returns the BaseAllowVars entries that denyVars would
+// remove. Denying a base var is permitted (deny_vars always wins — see
+// FilterEnv) but is almost never intended: the base is the operational
+// minimum a sandboxed process needs to run. Callers (launch path, doctor)
+// use this to warn rather than block. Matching is pattern-overlap so a
+// prefix deny (e.g. "LC_*", or a bare "*") flags the base entries it
+// shadows.
+func DeniedBaseVars(denyVars []string) []string {
+	if len(denyVars) == 0 {
+		return nil
+	}
+	var out []string
+	for _, b := range BaseAllowVars() {
+		for _, d := range denyVars {
+			if patternsOverlap(d, b) {
+				out = append(out, b)
+				break
+			}
+		}
+	}
+	return out
 }
 
 // IsDangerousEnvVar reports whether key is on the always-drop blocklist.
@@ -114,13 +200,12 @@ func DangerousEnvBlocklist() (exact []string, prefixes []string) {
 	return exact, prefixes
 }
 
-// envVarAllowed checks key against the allow_vars list (exact names or
-// trailing-* prefixes). An empty list allows everything.
-func envVarAllowed(key string, allowVars []string) bool {
-	if len(allowVars) == 0 {
-		return true
-	}
-	for _, pat := range allowVars {
+// EnvVarMatches reports whether key matches any pattern in pats. Each
+// pattern is an exact name ("HOME") or a trailing-* prefix ("OMAC_*",
+// matched from the key start); a bare "*" matches everything. An empty
+// pats list matches nothing.
+func EnvVarMatches(key string, pats []string) bool {
+	for _, pat := range pats {
 		if pat == "*" {
 			return true
 		}
@@ -137,14 +222,54 @@ func envVarAllowed(key string, allowVars []string) bool {
 	return false
 }
 
+// patternsOverlap reports whether two allow/deny patterns can match a
+// common key. Used by DeniedBaseVars to detect a deny that shadows a
+// base entry even when either side is a trailing-* prefix.
+func patternsOverlap(a, b string) bool {
+	if a == "*" || b == "*" {
+		return true
+	}
+	aStar := strings.HasSuffix(a, "*")
+	bStar := strings.HasSuffix(b, "*")
+	switch {
+	case aStar && bStar:
+		pa, pb := a[:len(a)-1], b[:len(b)-1]
+		return strings.HasPrefix(pa, pb) || strings.HasPrefix(pb, pa)
+	case aStar:
+		return strings.HasPrefix(b, a[:len(a)-1])
+	case bStar:
+		return strings.HasPrefix(a, b[:len(b)-1])
+	default:
+		return a == b
+	}
+}
+
+// envVarAllowed checks key against the allow_vars list. An empty list
+// allows everything (the low-level inherit-all primitive; the policy
+// layer in EffectiveAllowVars never hands FilterEnv an empty list).
+func envVarAllowed(key string, allowVars []string) bool {
+	if len(allowVars) == 0 {
+		return true
+	}
+	return EnvVarMatches(key, allowVars)
+}
+
 // FilterEnv builds the child environment from scratch:
-//  1. drop blocklisted vars,
+//  1. drop the hardcoded danger blocklist,
 //  2. apply the optional allow_vars allowlist,
-//  3. overlay injected vars (which bypass both filters and win over
-//     inherited values).
+//  3. overlay injected vars (which win over inherited values),
+//  4. LAST, drop everything matching denyVars.
+//
+// deny_vars is applied last, over the whole result, so it wins over the
+// allowlist, over "*", AND over the injected overlay: a profile can drop
+// an injected var (e.g. HTTP_PROXY or a tool-cache path) just as it drops
+// an inherited one. This is deliberately powerful — denying the proxy or
+// cache injections can break networking or cache isolation — so it is the
+// profile author's explicit choice (the launch path and `omac doctor`
+// warn when deny_vars removes a base operational var; see DeniedBaseVars).
 //
 // environ entries are "KEY=VALUE" as from os.Environ().
-func FilterEnv(environ []string, allowVars []string, injected map[string]string) []string {
+func FilterEnv(environ []string, allowVars, denyVars []string, injected map[string]string) []string {
 	out := make([]string, 0, len(environ)+len(injected))
 	for _, kv := range environ {
 		eq := strings.IndexByte(kv, '=')
@@ -166,5 +291,16 @@ func FilterEnv(environ []string, allowVars []string, injected map[string]string)
 	for k, v := range injected {
 		out = append(out, k+"="+v)
 	}
-	return out
+	if len(denyVars) == 0 {
+		return out
+	}
+	kept := out[:0]
+	for _, kv := range out {
+		eq := strings.IndexByte(kv, '=')
+		if eq > 0 && EnvVarMatches(kv[:eq], denyVars) {
+			continue
+		}
+		kept = append(kept, kv)
+	}
+	return kept
 }

--- a/internal/sandboxprofile/env.go
+++ b/internal/sandboxprofile/env.go
@@ -75,8 +75,14 @@ func BaseAllowVars() []string {
 // USER/LOGNAME (default identity for git/npm/ssh — also forwarded to the
 // facade via FacadeConfig.BaseEnvPassthrough), TZ (date formatting),
 // EDITOR/VISUAL (harnesses that shell out to an editor), SHELL, the
-// XDG_*_HOME config/data/state dirs, and NPM_CONFIG_PREFIX. All are
-// non-secret.
+// XDG_*_HOME config/data/state dirs, NPM_CONFIG_PREFIX, and DISPLAY. All
+// are non-secret.
+//
+// DISPLAY is the X11 server address, for harnesses that open a GUI (a
+// browser, a graphical diff/editor). It is only an address: reaching the
+// server still requires the filesystem policy to expose the X11 socket
+// and, on a cookie-protected server, XAUTHORITY — neither is granted
+// here. A headless or hardened profile drops it with deny_vars.
 func convenienceAllowVars() []string {
 	return []string{
 		"SHELL",
@@ -89,6 +95,7 @@ func convenienceAllowVars() []string {
 		"XDG_DATA_HOME",
 		"XDG_STATE_HOME",
 		"NPM_CONFIG_PREFIX",
+		"DISPLAY",
 	}
 }
 

--- a/internal/sandboxprofile/profile.go
+++ b/internal/sandboxprofile/profile.go
@@ -256,6 +256,15 @@ type Environment struct {
 	// Empty/absent means every variable passes (minus the always-on
 	// danger blocklist, which wins over any allow entry).
 	AllowVars []string `json:"allow_vars,omitempty"`
+
+	// DenyVars lists env-var patterns to drop, using the same exact/
+	// trailing-* matching as AllowVars. It is applied LAST — after the
+	// allowlist and after omac's injected overlay — so it wins over
+	// allow_vars, over "*", and over injected vars (a profile can drop
+	// e.g. the injected HTTP_PROXY or a tool-cache path). Denying a base
+	// operational var (see BaseAllowVars) is permitted but flagged by the
+	// launch path and `omac doctor`, since it is rarely intended.
+	DenyVars []string `json:"deny_vars,omitempty"`
 }
 
 // Parse decodes and validates a profile, rejecting unknown fields.
@@ -341,6 +350,11 @@ func (p *Profile) Validate() error {
 	for _, v := range p.Environment.AllowVars {
 		if strings.TrimSpace(v) == "" {
 			return fmt.Errorf("sandbox profile: environment.allow_vars contains an empty entry")
+		}
+	}
+	for _, v := range p.Environment.DenyVars {
+		if strings.TrimSpace(v) == "" {
+			return fmt.Errorf("sandbox profile: environment.deny_vars contains an empty entry")
 		}
 	}
 	for _, d := range p.Filesystem.Deny {

--- a/internal/sandboxprofile/profile_test.go
+++ b/internal/sandboxprofile/profile_test.go
@@ -807,6 +807,7 @@ func TestDefaultAllowVarsGoldenList(t *testing.T) {
 		"XDG_DATA_HOME",
 		"XDG_STATE_HOME",
 		"NPM_CONFIG_PREFIX",
+		"DISPLAY",
 	}
 	got := DefaultAllowVars()
 	if len(got) != len(want) {

--- a/internal/sandboxprofile/profile_test.go
+++ b/internal/sandboxprofile/profile_test.go
@@ -96,6 +96,7 @@ func TestParseValidationErrors(t *testing.T) {
 		`{"network": {"listen_port": [70000]}}`,
 		`{"network": {"network_prompt": {"on_unavailable": "ask"}}}`,
 		`{"environment": {"allow_vars": [" "]}}`,
+		`{"environment": {"deny_vars": [" "]}}`,        // empty deny_vars entry
 		`{"filesystem": {"deny": [" "]}}`,              // empty deny entry
 		`{"filesystem": {"deny": ["[a-"]}}`,            // malformed basename glob
 		`{"network": {"proxy_injection": ["python"]}}`, // unsupported tool
@@ -115,6 +116,19 @@ func TestProxyInjection(t *testing.T) {
 	want := []string{ProxyInjectJVM, ProxyInjectNode}
 	if !slices.Equal(p.Network.ProxyInjection, want) {
 		t.Errorf("proxy_injection = %v, want %v", p.Network.ProxyInjection, want)
+	}
+}
+
+func TestParseDenyVars(t *testing.T) {
+	p, err := Parse([]byte(`{"environment": {"allow_vars": ["SKAINET_TOKEN"], "deny_vars": ["XDG_*", "HTTP_PROXY"]}}`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(p.Environment.DenyVars) != 2 || p.Environment.DenyVars[0] != "XDG_*" || p.Environment.DenyVars[1] != "HTTP_PROXY" {
+		t.Errorf("deny_vars = %v, want [XDG_* HTTP_PROXY]", p.Environment.DenyVars)
+	}
+	if len(p.Environment.AllowVars) != 1 || p.Environment.AllowVars[0] != "SKAINET_TOKEN" {
+		t.Errorf("allow_vars = %v, want [SKAINET_TOKEN]", p.Environment.AllowVars)
 	}
 }
 
@@ -643,7 +657,7 @@ func TestFilterEnv(t *testing.T) {
 	injected := map[string]string{"HTTP_PROXY": "http://omac:tok@127.0.0.1:9"}
 
 	// With allowlist.
-	got := FilterEnv(environ, []string{"HOME", "PATH", "OMAC_*"}, injected)
+	got := FilterEnv(environ, []string{"HOME", "PATH", "OMAC_*"}, nil, injected)
 	want := map[string]string{
 		"HOME":       "/home/u",
 		"PATH":       "/usr/bin",
@@ -661,7 +675,7 @@ func TestFilterEnv(t *testing.T) {
 	}
 
 	// Without allowlist: everything but the blocklist passes.
-	got = FilterEnv(environ, nil, nil)
+	got = FilterEnv(environ, nil, nil, nil)
 	gotMap = envMap(got)
 	if _, ok := gotMap["AWS_SECRET_ACCESS_KEY"]; !ok {
 		t.Error("no allowlist: AWS var should pass")
@@ -673,7 +687,7 @@ func TestFilterEnv(t *testing.T) {
 	}
 
 	// Blocklist beats allowlist.
-	got = FilterEnv(environ, []string{"NODE_OPTIONS"}, nil)
+	got = FilterEnv(environ, []string{"NODE_OPTIONS"}, nil, nil)
 	if len(got) != 0 {
 		t.Errorf("blocklist must beat allowlist: %v", got)
 	}
@@ -681,7 +695,7 @@ func TestFilterEnv(t *testing.T) {
 	// Inverse of the no-allowlist case: with the default allowlist an
 	// ambient secret that is neither injected nor listed must be stripped
 	// (issue #102 — ambient env leak). HOME/PATH still pass.
-	got = FilterEnv(environ, DefaultAllowVars(), nil)
+	got = FilterEnv(environ, DefaultAllowVars(), nil, nil)
 	gotMap = envMap(got)
 	if _, ok := gotMap["AWS_SECRET_ACCESS_KEY"]; ok {
 		t.Error("default allowlist: ambient secret AWS_SECRET_ACCESS_KEY must be stripped")
@@ -744,7 +758,7 @@ func TestFilterEnvMergedLaunchEnv(t *testing.T) {
 		"OMAC_GATE":  "1",
 	}
 
-	got := envMap(FilterEnv(environ, allow, injected))
+	got := envMap(FilterEnv(environ, allow, nil, injected))
 	want := map[string]string{
 		"HOME":              "/home/u",
 		"PATH":              "/usr/bin",
@@ -802,6 +816,160 @@ func TestDefaultAllowVarsGoldenList(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("DefaultAllowVars()[%d] = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestBaseAllowVarsGoldenList(t *testing.T) {
+	want := []string{
+		"OMAC_*",
+		"HOME",
+		"PATH",
+		"PWD",
+		"TMPDIR",
+		"LANG",
+		"LC_*",
+		"TERM",
+		"COLORTERM",
+	}
+	got := BaseAllowVars()
+	if len(got) != len(want) {
+		t.Fatalf("BaseAllowVars() has %d entries, want %d:\n got  %v\n want %v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("BaseAllowVars()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	// DefaultAllowVars must lead with the full base (the scaffolded
+	// default.json is base + convenience, in that order).
+	def := DefaultAllowVars()
+	for i, v := range want {
+		if def[i] != v {
+			t.Errorf("DefaultAllowVars()[%d] = %q, want base var %q", i, def[i], v)
+		}
+	}
+}
+
+func TestEffectiveAllowVars(t *testing.T) {
+	// Empty fails closed to the operational minimum — NOT inherit-all
+	// (issue #102/#111). It must equal DefaultAllowVars.
+	got0 := EffectiveAllowVars(nil)
+	def := DefaultAllowVars()
+	if len(got0) != len(def) {
+		t.Fatalf("EffectiveAllowVars(nil) = %v, want DefaultAllowVars %v", got0, def)
+	}
+	for i := range def {
+		if got0[i] != def[i] {
+			t.Errorf("EffectiveAllowVars(nil)[%d] = %q, want %q", i, got0[i], def[i])
+		}
+	}
+	// A "*" wildcard is the only inherit-all opt-in; returned unchanged.
+	if got := EffectiveAllowVars([]string{"*"}); len(got) != 1 || got[0] != "*" {
+		t.Errorf("EffectiveAllowVars([*]) = %v, want [*]", got)
+	}
+	// "*" wins even alongside other entries (still inherit-all).
+	if got := EffectiveAllowVars([]string{"FOO", "*"}); len(got) != 2 {
+		t.Errorf("EffectiveAllowVars([FOO,*]) = %v, want the list unchanged", got)
+	}
+	// A restrictive list (the tng-default.json / #139 case) gets the FULL
+	// DefaultAllowVars merged in — base AND convenience — defaults first.
+	got := EffectiveAllowVars([]string{"SKAINET_TOKEN", "TERM"})
+	set := map[string]bool{}
+	for _, v := range got {
+		set[v] = true
+	}
+	for _, v := range DefaultAllowVars() {
+		if !set[v] {
+			t.Errorf("EffectiveAllowVars omitted default var %q: %v", v, got)
+		}
+	}
+	if !set["SKAINET_TOKEN"] {
+		t.Errorf("EffectiveAllowVars dropped the profile's own var: %v", got)
+	}
+	// TERM appears once (dedup) and defaults lead.
+	term := 0
+	for _, v := range got {
+		if v == "TERM" {
+			term++
+		}
+	}
+	if term != 1 {
+		t.Errorf("EffectiveAllowVars duplicated TERM (%d times): %v", term, got)
+	}
+	for i := range def {
+		if got[i] != def[i] {
+			t.Errorf("EffectiveAllowVars[%d] = %q, want default var %q (defaults must lead)", i, got[i], def[i])
+		}
+	}
+	// The input slice is not mutated.
+	in := []string{"FOO"}
+	_ = EffectiveAllowVars(in)
+	if len(in) != 1 || in[0] != "FOO" {
+		t.Errorf("EffectiveAllowVars mutated its input: %v", in)
+	}
+}
+
+func TestFilterEnvDenyVars(t *testing.T) {
+	environ := []string{
+		"HOME=/home/u",
+		"EDITOR=vim",
+		"XDG_CONFIG_HOME=/home/u/.config",
+		"AWS_SECRET_ACCESS_KEY=oops",
+		"HTTP_PROXY=http://stale:1",
+	}
+	injected := map[string]string{
+		"HTTP_PROXY": "http://omac:tok@127.0.0.1:9",
+		"OMAC_BASE":  "http://127.0.0.1:1/x",
+	}
+
+	// deny beats the allowlist: EDITOR/XDG_CONFIG_HOME are granted (via "*")
+	// but denied, so they are stripped.
+	got := envMap(FilterEnv(environ, []string{"*"}, []string{"EDITOR", "XDG_*"}, injected))
+	if _, ok := got["EDITOR"]; ok {
+		t.Error("deny_vars must strip EDITOR even under a '*' allowlist")
+	}
+	if _, ok := got["XDG_CONFIG_HOME"]; ok {
+		t.Error("deny_vars prefix XDG_* must strip XDG_CONFIG_HOME")
+	}
+	if got["HOME"] != "/home/u" {
+		t.Error("HOME should survive: not denied")
+	}
+
+	// deny beats the injected overlay: a profile can drop an injected var.
+	got = envMap(FilterEnv(environ, []string{"HOME"}, []string{"HTTP_PROXY", "OMAC_*"}, injected))
+	if _, ok := got["HTTP_PROXY"]; ok {
+		t.Error("deny_vars must strip the injected HTTP_PROXY (deny is applied last)")
+	}
+	if _, ok := got["OMAC_BASE"]; ok {
+		t.Error("deny_vars prefix OMAC_* must strip the injected OMAC_BASE")
+	}
+
+	// nil deny_vars is a no-op (equivalent to the pre-deny behaviour).
+	got = envMap(FilterEnv(environ, []string{"HOME", "EDITOR"}, nil, nil))
+	if got["EDITOR"] != "vim" {
+		t.Error("nil deny_vars must not strip anything")
+	}
+}
+
+func TestDeniedBaseVars(t *testing.T) {
+	if got := DeniedBaseVars(nil); got != nil {
+		t.Errorf("DeniedBaseVars(nil) = %v, want nil", got)
+	}
+	// Exact base var.
+	if got := DeniedBaseVars([]string{"TERM"}); len(got) != 1 || got[0] != "TERM" {
+		t.Errorf("DeniedBaseVars([TERM]) = %v, want [TERM]", got)
+	}
+	// A convenience var is not a base var — not flagged.
+	if got := DeniedBaseVars([]string{"EDITOR"}); len(got) != 0 {
+		t.Errorf("DeniedBaseVars([EDITOR]) = %v, want none (EDITOR is convenience)", got)
+	}
+	// A prefix deny that overlaps a base prefix entry (LC_*) is flagged.
+	if got := DeniedBaseVars([]string{"LC_ALL"}); len(got) != 1 || got[0] != "LC_*" {
+		t.Errorf("DeniedBaseVars([LC_ALL]) = %v, want [LC_*]", got)
+	}
+	// A bare "*" deny shadows every base var.
+	if got := DeniedBaseVars([]string{"*"}); len(got) != len(BaseAllowVars()) {
+		t.Errorf("DeniedBaseVars([*]) flagged %d base vars, want %d", len(got), len(BaseAllowVars()))
 	}
 }
 

--- a/internal/sandboxrun/proxyinject_integration_linux_test.go
+++ b/internal/sandboxrun/proxyinject_integration_linux_test.go
@@ -199,7 +199,7 @@ func runToolThroughProxy(t *testing.T, omac string, proxy *netproxy.Server, inje
 	}
 
 	cmd := exec.Command(argv[0], argv[1:]...)
-	cmd.Env = sandboxprofile.FilterEnv(append(ambientPoison, os.Environ()...), nil, injected)
+	cmd.Env = sandboxprofile.FilterEnv(append(ambientPoison, os.Environ()...), nil, nil, injected)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
@@ -365,7 +365,7 @@ func TestEnvLayeringDropsBlocklistAndOverlays(t *testing.T) {
 	proxy, _ := startHermeticProxy(t)
 	injected := injectedEnv(t, proxy)
 
-	env := sandboxprofile.FilterEnv(append(ambientPoison, os.Environ()...), nil, injected)
+	env := sandboxprofile.FilterEnv(append(ambientPoison, os.Environ()...), nil, nil, injected)
 
 	// Blocklist: JAVA_TOOL_OPTIONS is on dangerousEnvExact and must be absent.
 	for _, kv := range env {

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -200,7 +200,7 @@ func Run(opts Options) int {
 	// user where runtime diagnostics will land.
 	diag.AnnouncePath()
 
-	env := sandboxprofile.FilterEnv(os.Environ(), merged.Environment.AllowVars, injected)
+	env := sandboxprofile.FilterEnv(os.Environ(), sandboxprofile.EffectiveAllowVars(merged.Environment.AllowVars), merged.Environment.DenyVars, injected)
 	var onReady func(int)
 	if recorder != nil {
 		onReady = recorder.Start

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -30,6 +30,31 @@ type Options struct {
 	Stderr  io.Writer
 }
 
+// warnEmptyAllowVars warns when the merged profile carries no env
+// allowlist. An empty allow_vars is a misconfiguration rather than an
+// inherit-all request: EffectiveAllowVars resolves it to the operational
+// defaults, so ambient secrets and provider-auth vars are stripped and a
+// harness launched this way cannot authenticate.
+//
+// allowVars must be the profile list AFTER flag merge. `omac start` and
+// `omac serve` warn in their own layer and seed the defaults via
+// --allow-env, which lands here as a non-empty list — so a seeded launch
+// stays quiet and does not warn twice. What this covers is a direct
+// `omac sandbox run` against an empty profile, whose fail-closed behavior
+// otherwise has no warning surface at all. Sitting at the enforcement
+// point also covers profiles the launcher layer cannot inspect (its
+// warnings are gated on the `{{self}} sandbox run` command shape).
+func warnEmptyAllowVars(stderr io.Writer, allowVars []string) {
+	if len(allowVars) > 0 {
+		return
+	}
+	fmt.Fprintln(stderr, "omac sandbox: warning: empty environment.allow_vars — forwarding only the")
+	fmt.Fprintln(stderr, "  operational defaults (HOME, PATH, TERM, locale, …). Every other ambient var,")
+	fmt.Fprintln(stderr, "  including provider tokens, is stripped: a harness started this way will not")
+	fmt.Fprintln(stderr, "  authenticate. Add what it needs to allow_vars, pass --allow-env <name>, or set")
+	fmt.Fprintln(stderr, `  allow_vars: ["*"] to inherit every non-blocklisted var.`)
+}
+
 // Run is the `omac sandbox run` supervisor: resolve profile + flags,
 // start the filtering proxy, launch the sandboxed child, forward
 // signals, propagate the exit code, tear everything down. Returns the
@@ -62,6 +87,7 @@ func Run(opts Options) int {
 	if err := merged.Validate(); err != nil {
 		return fail("%v", err)
 	}
+	warnEmptyAllowVars(stderr, merged.Environment.AllowVars)
 
 	grants, err := ResolveGrants(merged, opts.Workdir, diag.Writer())
 	if err != nil {

--- a/internal/sandboxrun/run_test.go
+++ b/internal/sandboxrun/run_test.go
@@ -145,7 +145,7 @@ func TestCacheEnvSurvivesAllowVars(t *testing.T) {
 		"HOME=/home/test",
 		"GOCACHE=/hostile/go-build",
 		"CARGO_HOME=/hostile/cargo",
-	}, []string{"HOME"}, injected)
+	}, []string{"HOME"}, nil, injected)
 	gotMap := envMap(got)
 	if len(gotMap) != len(injected)+1 {
 		t.Fatalf("environment = %v, want HOME plus all injected cache values", gotMap)

--- a/internal/sandboxrun/run_test.go
+++ b/internal/sandboxrun/run_test.go
@@ -167,3 +167,50 @@ func envMap(env []string) map[string]string {
 	}
 	return result
 }
+
+// TestWarnEmptyAllowVars covers the warning on the `omac sandbox run` path.
+// The empty-allow_vars fail-closed behavior lands only on this entry point
+// (omac start/serve already seed the defaults in their own layer), and it
+// previously had no warning surface here.
+func TestWarnEmptyAllowVars(t *testing.T) {
+	t.Run("empty list warns", func(t *testing.T) {
+		var buf strings.Builder
+		warnEmptyAllowVars(&buf, nil)
+		got := buf.String()
+		if got == "" {
+			t.Fatal("empty allow_vars produced no warning")
+		}
+		for _, want := range []string{"empty environment.allow_vars", "will not", "authenticate", "--allow-env"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("warning lacks %q:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("non-empty list is quiet", func(t *testing.T) {
+		var buf strings.Builder
+		warnEmptyAllowVars(&buf, []string{"HOME"})
+		if buf.String() != "" {
+			t.Errorf("non-empty allow_vars warned: %s", buf.String())
+		}
+	})
+
+	// A start/serve-seeded launch reaches Run as --allow-env flags over an
+	// empty profile. Merge folds those into allow_vars, so the inner run
+	// must stay quiet rather than repeat the warning the launcher already
+	// printed. Asserted through Merge (not a literal list) so the two
+	// layers cannot drift apart.
+	t.Run("seeded via --allow-env is quiet", func(t *testing.T) {
+		empty := &sandboxprofile.Profile{Meta: sandboxprofile.Meta{Name: "empty"}}
+		flags := &sandboxprofile.Flags{AllowEnv: sandboxprofile.DefaultAllowVars()}
+		merged, _ := sandboxprofile.Merge(empty, flags)
+		if len(merged.Environment.AllowVars) == 0 {
+			t.Fatal("Merge dropped --allow-env entries; a seeded launch would warn twice")
+		}
+		var buf strings.Builder
+		warnEmptyAllowVars(&buf, merged.Environment.AllowVars)
+		if buf.String() != "" {
+			t.Errorf("seeded launch warned: %s", buf.String())
+		}
+	})
+}


### PR DESCRIPTION
**Issue:** Closes #168

## What
- Every sandbox profile is granted the full operational default set (`DefaultAllowVars()`) automatically; `allow_vars` adds extras on top. Custom profiles (e.g. `tng-default.json`) no longer need to hand-carry `COLORTERM`/`EDITOR`/`XDG_*`/… (the #139 gap, fully closed).
- New `environment.deny_vars` opt-out, applied **last** — wins over `allow_vars`, `"*"`, and omac's injected overlay.
- Empty `allow_vars` now fails closed to the operational minimum at the enforcement layer, not just at launch.
- Clearer, actionable OpenCode multidir-plugin conflict warning.

## Why
Adding `COLORTERM` to `DefaultAllowVars()` (#139) only fixed the scaffolded `default.json`. A named profile from disk is authoritative — `loadFile → Parse` (`internal/sandboxprofile/resolve.go`) returns it verbatim with **no merge** — so `tng-default.json` dropped `COLORTERM` again. Separately, `FilterEnv` treated empty `allow_vars` as inherit-all, so a bare `omac sandbox run` against an empty profile leaked the whole ambient env (the pre-#102 behavior on that entry point). And the plugin warning suggested a command that repeated the failure it was reporting.

## How
- `sandboxprofile/env.go`: `EffectiveAllowVars` = `"*"` → as-is; empty → `DefaultAllowVars()`; else `DefaultAllowVars() ∪ allow_vars`. `FilterEnv` gains a `denyVars` param applied as a final pass over inherited **and** injected env (shared `EnvVarMatches`). `DeniedBaseVars` detects base-var denials.
- `sandboxprofile/profile.go`: `Environment.DenyVars` field + validation.
- `sandboxrun/run.go`: single enforcement point passes `EffectiveAllowVars(...)` + `DenyVars`.
- `cli/serve.go` (covers `start`+`serve`): warns when `deny_vars` removes a base var. `cli/doctor.go`: reports the same. `cli/provenance.go`: `builtin (default)` / `deny` rows.
- `cli/setup.go` + `plugin/plugin.go`: typed `ConflictError{Path}`; auto-provision suggests `--force`/delete with the exact path.

## Verification
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` (non-e2e) — all pass, incl. new `TestEffectiveAllowVars`, `TestFilterEnvDenyVars`, `TestDeniedBaseVars`, `TestParseDenyVars`, and the strengthened plugin conflict test.

## Follow-up
Two behavior changes worth flagging for reviewers:
1. Empty `allow_vars` now fails closed for a bare `omac sandbox run` (previously inherit-all). `["*"]` remains the explicit inherit-all opt-in.
2. `deny_vars` can strip injected vars (proxy/cache) — deliberately powerful; denying a base operational var is allowed but warned. The TNG install routine that generates `tng-default.json` can now drop its redundant operational-var list.