### PR TITLE
Feature/codewhale harness

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        harness: [opencode, claude-code, codex, copilot, pi]
+        harness: [opencode, claude-code, codex, copilot, pi, codewhale]
         # Two omac versions: main (built from source) and release (the latest
         # published binary — what users actually run). The contract stage is
         # identical across both (it's compiled from source), but launch + llm
@@ -62,9 +62,13 @@ jobs:
         omac: [main, release]
         exclude:
           # codex's Rust HTTP client is incompatible with the macOS Seatbelt
-          # sandbox (see e2e.yml / issue #48).
+          # sandbox (see e2e.yml / issue #48). codewhale is excluded on macOS
+          # by analogy (also a Rust CLI with its own HTTP client) — unverified,
+          # re-test and drop if it works.
           - os: macos-latest
             harness: codex
+          - os: macos-latest
+            harness: codewhale
     runs-on: ${{ matrix.os }}
     concurrency:
       group: e2e-smoke-${{ matrix.os }}-${{ matrix.harness }}-${{ matrix.omac }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,10 @@ on:
         description: 'Pinned pi package spec. Overrides internal/e2e/versions.go for THIS RUN ONLY (the file itself is untouched); ignored if "use latest" is checked'
         type: string
         default: '@earendil-works/pi-coding-agent@0.80.6'
+      codewhale_version:
+        description: 'Pinned codewhale package spec. Overrides internal/e2e/versions.go for THIS RUN ONLY (the file itself is untouched); ignored if "use latest" is checked'
+        type: string
+        default: 'codewhale@0.9.1'
   schedule:
     - cron: '0 8 * * 6' # Saturdays 10:00 CEST
 
@@ -51,15 +55,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        harness: [opencode, claude-code, codex, copilot, pi]
+        harness: [opencode, claude-code, codex, copilot, pi, codewhale]
         # codex on macOS is excluded — its Rust HTTP client is incompatible
         # with the macOS Seatbelt sandbox (stream disconnected mid-completion,
         # even with network=open). `omac start codex` on macOS fails loud;
         # --no-sandbox would disable the entire omac sandbox, leaving nothing
         # to assert against. See issue #48.
+        #
+        # codewhale on macOS is excluded by analogy: it too is a Rust CLI with
+        # its own HTTP client (the codex failure class). This is precautionary
+        # and UNVERIFIED for codewhale — re-test on macOS and drop this exclude
+        # (and the matching ones in internal/e2e) if it works.
         exclude:
           - os: macos-latest
             harness: codex
+          - os: macos-latest
+            harness: codewhale
     runs-on: ${{ matrix.os }}
     concurrency:
       group: e2e-${{ matrix.os }}-${{ matrix.harness }}
@@ -82,6 +93,7 @@ jobs:
       E2E_VERSION_CODEX: ${{ github.event.inputs.codex_version }}
       E2E_VERSION_COPILOT: ${{ github.event.inputs.copilot_version }}
       E2E_VERSION_PI: ${{ github.event.inputs.pi_version }}
+      E2E_VERSION_CODEWHALE: ${{ github.event.inputs.codewhale_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CREATING_A_SKILL.md
+++ b/CREATING_A_SKILL.md
@@ -48,6 +48,8 @@ which harness is chosen:
   - Codex → `.codex/skills` (+ `~/.codex/skills`)
   - Copilot → `.copilot/skills` (+ `~/.copilot/skills`)
   - Pi → `.pi/skills` (+ `~/.pi/agent/skills`)
+  - CodeWhale → `.agents/skills` (+ `~/.codewhale/skills`) — CodeWhale reads the
+    shared workspace dir, not a `.codewhale/skills`, so it owns the shared base
   - **Shared** → `.agents/skills` (+ `~/.config/agents/skills`), in scope for
     every harness.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ omac register <skill>
 
 # 5. Launch — default sandbox (Seatbelt/bwrap) + default harness (opencode)
 #    (omac's built-in skills are auto-provisioned on launch; no extra step)
-#    Harness options: opencode (oc), claude (cc), codex (cx), copilot (co), pi
+#    Harness options: opencode (oc), claude (cc), codex (cx), copilot (co), pi, codewhale (cw)
 omac start
 ```
 
@@ -62,12 +62,13 @@ omac start claude     # Claude Code
 omac start codex      # OpenAI Codex CLI
 omac start copilot    # GitHub Copilot CLI
 omac start pi         # Pi (pi.dev)
+omac start codewhale  # CodeWhale (bring-your-own-model)
 omac serve claude     # multi-directory server, Claude Code harness
 ```
 
 Supported harnesses (and aliases): `opencode` (`oc`), `claude-code`
-(`claude`, `cc`), `codex` (`cx`), `copilot` (`co`), `pi`. Omitting the
-token defaults to `opencode`. An unknown token is rejected with the list
+(`claude`, `cc`), `codex` (`cx`), `copilot` (`co`), `pi`, `codewhale`
+(`cw`). Omitting the token defaults to `opencode`. An unknown token is rejected with the list
 of supported names. Inner arguments that happen to be barewords go after
 `--` (e.g. `omac start claude -- --model sonnet`).
 
@@ -104,7 +105,7 @@ omac resume claude     # ...with Claude Code
 `omac continue` re-enters the most recent session for this folder. Pass
 `-s`/`--session <id>` to target a specific session non-interactively
 (opencode `--session <id>`, claude `--resume <id>`, codex `resume <id>`,
-copilot `--session-id <id>`, pi `--session <id>`). After the inner command
+copilot `--session-id <id>`, pi `--session <id>`, codewhale `--resume <id>`). After the inner command
 exits, omac prints a one-line hint with the most recent session id:
 
 ```

--- a/docs/HARNESS_COMPAT.md
+++ b/docs/HARNESS_COMPAT.md
@@ -1,6 +1,6 @@
 # Harness compatibility tracking
 
-omac supports several inner harnesses (opencode, claude-code, codex, copilot, pi).
+omac supports several inner harnesses (opencode, claude-code, codex, copilot, pi, codewhale).
 A harness release can silently break omac by renaming a CLI flag, moving a
 subcommand, or changing a config schema. The weekly
 [`E2E: drift` workflow](../.github/workflows/e2e-smoke.yml) (also manually
@@ -16,7 +16,9 @@ from source) and `release` (the latest published binary, i.e. what users run):
 | `llm` | A **single lightweight** agent turn (echo-rest) — confirms the model auth/proxy path and sidecar facade. Run for every harness, claude-code included. The heavy multi-probe security-audit stays in the pinned weekly `E2E: full`. | yes |
 
 `✅` pass · `❌` fail · `➖` not run / not applicable. The matrix is
-`harness × os × omac{main,release}` (codex/macOS excluded), and rows are sorted
+`harness × os × omac{main,release}` (codex and codewhale excluded on macOS —
+both are Rust CLIs with the Seatbelt-incompatible HTTP-client class; codewhale
+by analogy, unverified), and rows are sorted
 newest-first, then grouped by omac version, OS, and harness.
 
 ## Where the record lives

--- a/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
+++ b/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
@@ -48,6 +48,8 @@ which harness is chosen:
   - Codex → `.codex/skills` (+ `~/.codex/skills`)
   - Copilot → `.copilot/skills` (+ `~/.copilot/skills`)
   - Pi → `.pi/skills` (+ `~/.pi/agent/skills`)
+  - CodeWhale → `.agents/skills` (+ `~/.codewhale/skills`) — CodeWhale reads the
+    shared workspace dir, not a `.codewhale/skills`, so it owns the shared base
   - **Shared** → `.agents/skills` (+ `~/.config/agents/skills`), in scope for
     every harness.
 

--- a/internal/cli/briefing.go
+++ b/internal/cli/briefing.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxbrief"
 	"github.com/tngtech/oh-my-agentic-coder/internal/toolcache"
@@ -34,4 +37,21 @@ func briefingInjection(noSandbox bool, inner []string, harness config.Harness, o
 	}
 	text += sandboxbrief.CacheGuidance(dir, mode)
 	return text, true
+}
+
+// removeBriefingFile deletes a workdir briefing file written by a harness's
+// BriefingFileFunc (e.g. codewhale's .codewhale/rules/omac-sandbox-briefing.md)
+// and best-effort prunes the parent directories omac may have created for it.
+// All operations are best-effort: os.Remove only removes empty directories, so
+// a user's own files under .codewhale/rules or .codewhale are never touched.
+func removeBriefingFile(path string) {
+	if path == "" {
+		return
+	}
+	_ = os.Remove(path)
+	// Prune up to two now-empty parents (e.g. .codewhale/rules, then
+	// .codewhale). os.Remove fails on a non-empty dir, so this is safe.
+	dir := filepath.Dir(path)
+	_ = os.Remove(dir)
+	_ = os.Remove(filepath.Dir(dir))
 }

--- a/internal/cli/briefing.go
+++ b/internal/cli/briefing.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxbrief"
@@ -54,4 +55,47 @@ func removeBriefingFile(path string) {
 	dir := filepath.Dir(path)
 	_ = os.Remove(dir)
 	_ = os.Remove(filepath.Dir(dir))
+}
+
+// gitExcludeBriefing makes git ignore a workdir briefing file written by a
+// harness's BriefingFileFunc, by appending its workdir-relative path to
+// <workdir>/.git/info/exclude. Without this, an agent whose own workflow runs
+// `git add -A && git commit` would stage and commit the briefing (and a later
+// removeBriefingFile then leaves a staged deletion of a now-tracked file).
+//
+// .git/info/exclude is the repo-local, never-committed ignore list — this
+// touches neither the user's .gitignore nor the index. It is written BEFORE
+// the agent launches, so the entry persists even if omac is SIGKILLed (which
+// the deferred removeBriefingFile would miss): the leftover file stays
+// git-ignored until the next run overwrites and cleans it. Idempotent and
+// best-effort — a no-op when workdir is not a standard git worktree.
+func gitExcludeBriefing(workdir, relPath string) {
+	if workdir == "" || relPath == "" {
+		return
+	}
+	// A linked worktree/submodule stores .git as a file pointing elsewhere;
+	// resolving its info/exclude is nontrivial, so only handle a real .git dir.
+	gitDir := filepath.Join(workdir, ".git")
+	if fi, err := os.Stat(gitDir); err != nil || !fi.IsDir() {
+		return
+	}
+	infoDir := filepath.Join(gitDir, "info")
+	if err := os.MkdirAll(infoDir, 0o755); err != nil {
+		return
+	}
+	excludePath := filepath.Join(infoDir, "exclude")
+	rel := filepath.ToSlash(relPath)
+	if data, err := os.ReadFile(excludePath); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if strings.TrimSpace(line) == rel {
+				return // already excluded
+			}
+		}
+	}
+	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.WriteString(rel + "\n")
 }

--- a/internal/cli/briefing_test.go
+++ b/internal/cli/briefing_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -114,4 +115,91 @@ func TestEnsureOpenCodePluginSkipsNonOpenCode(t *testing.T) {
 	defer f.Close()
 	env := &Env{Stderr: f}
 	ensureOpenCodePlugin(env, h) // must simply return for a non-opencode harness
+}
+
+func TestGitExcludeBriefingAppendsAndIsIdempotent(t *testing.T) {
+	wd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wd, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rel := filepath.Join(".codewhale", "rules", "omac-sandbox-briefing.md")
+
+	gitExcludeBriefing(wd, rel)
+	gitExcludeBriefing(wd, rel) // second call must not duplicate
+
+	excludePath := filepath.Join(wd, ".git", "info", "exclude")
+	data, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("exclude not written: %v", err)
+	}
+	want := filepath.ToSlash(rel)
+	n := strings.Count(string(data), want)
+	if n != 1 {
+		t.Errorf("exclude contains %d copies of %q, want exactly 1:\n%s", n, want, data)
+	}
+}
+
+func TestGitExcludeBriefingNoOpWithoutGitDir(t *testing.T) {
+	wd := t.TempDir() // no .git
+	gitExcludeBriefing(wd, ".codewhale/rules/omac-sandbox-briefing.md")
+	if _, err := os.Stat(filepath.Join(wd, ".git")); !os.IsNotExist(err) {
+		t.Errorf("gitExcludeBriefing must not create .git when absent (err=%v)", err)
+	}
+}
+
+// TestGitExcludeBriefingPreservesExistingEntries ensures a user's own
+// .git/info/exclude content is not clobbered.
+func TestGitExcludeBriefingPreservesExistingEntries(t *testing.T) {
+	wd := t.TempDir()
+	infoDir := filepath.Join(wd, ".git", "info")
+	if err := os.MkdirAll(infoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(infoDir, "exclude"), []byte("*.tmp\nbuild/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitExcludeBriefing(wd, ".codewhale/rules/omac-sandbox-briefing.md")
+	data, err := os.ReadFile(filepath.Join(infoDir, "exclude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	for _, want := range []string{"*.tmp", "build/", ".codewhale/rules/omac-sandbox-briefing.md"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("exclude missing %q:\n%s", want, s)
+		}
+	}
+}
+
+func TestRemoveBriefingFilePrunesEmptyDirsOnly(t *testing.T) {
+	wd := t.TempDir()
+	rulesDir := filepath.Join(wd, ".codewhale", "rules")
+	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(rulesDir, "omac-sandbox-briefing.md")
+	if err := os.WriteFile(path, []byte("BRIEF"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	removeBriefingFile(path)
+	// File and the now-empty .codewhale/rules + .codewhale dirs are gone.
+	if _, err := os.Stat(filepath.Join(wd, ".codewhale")); !os.IsNotExist(err) {
+		t.Errorf(".codewhale should be pruned when empty (err=%v)", err)
+	}
+
+	// A non-empty .codewhale (user content) must survive.
+	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("BRIEF"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	keep := filepath.Join(wd, ".codewhale", "constitution.json")
+	if err := os.WriteFile(keep, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	removeBriefingFile(path)
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("user file under .codewhale must survive: %v", err)
+	}
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -413,6 +413,15 @@ func runServe(args []string, env *Env) int {
 				extra[k] = v
 			}
 		}
+		// File-based briefing delivery (codewhale) writes into the workdir;
+		// remove it when serve exits. See start.go for the rationale.
+		if harness.BriefingFileFunc != nil {
+			if rel, werr := harness.BriefingFileFunc(briefingText, env.Workdir); werr != nil {
+				fmt.Fprintln(env.Stderr, "omac serve: briefing file:", werr)
+			} else if rel != "" {
+				defer removeBriefingFile(filepath.Join(env.Workdir, rel))
+			}
+		}
 	}
 
 	var argv []string

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -419,6 +419,7 @@ func runServe(args []string, env *Env) int {
 			if rel, werr := harness.BriefingFileFunc(briefingText, env.Workdir); werr != nil {
 				fmt.Fprintln(env.Stderr, "omac serve: briefing file:", werr)
 			} else if rel != "" {
+				gitExcludeBriefing(env.Workdir, rel)
 				defer removeBriefingFile(filepath.Join(env.Workdir, rel))
 			}
 		}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -898,6 +898,9 @@ func runLaunch(env *Env, opts launchOpts) int {
 			if rel, werr := harness.BriefingFileFunc(briefingText, env.Workdir); werr != nil {
 				fmt.Fprintln(env.Stderr, prefix+": briefing file:", werr)
 			} else if rel != "" {
+				// Keep git from committing the briefing (persists across a
+				// SIGKILL); remove the file itself on a clean exit.
+				gitExcludeBriefing(env.Workdir, rel)
 				defer removeBriefingFile(filepath.Join(env.Workdir, rel))
 			}
 		}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -891,6 +891,16 @@ func runLaunch(env *Env, opts launchOpts) int {
 				extra[k] = v
 			}
 		}
+		// Harnesses that load always-on context only from files in the
+		// workspace tree (codewhale) get the briefing written into the workdir;
+		// omac removes it (and any empty dirs it created) when the run exits.
+		if harness.BriefingFileFunc != nil {
+			if rel, werr := harness.BriefingFileFunc(briefingText, env.Workdir); werr != nil {
+				fmt.Fprintln(env.Stderr, prefix+": briefing file:", werr)
+			} else if rel != "" {
+				defer removeBriefingFile(filepath.Join(env.Workdir, rel))
+			}
+		}
 	}
 
 	// Now that the supervisor, facade, and control plane exist, give the

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -92,6 +92,22 @@ type Harness struct {
 	// leaves this nil.
 	BriefingEnvFunc func(briefing, tmpDir string) map[string]string
 
+	// BriefingFileFunc delivers the briefing by writing a file into the
+	// workdir, for harnesses that (a) expose no system-prompt flag or env
+	// pointer and (b) load always-on context only from files in the
+	// workspace tree. It returns the workdir-relative path it wrote (so the
+	// launcher can remove it on exit) and any error. A nil func means this
+	// mechanism is unused.
+	//   - CodeWhale: writes .codewhale/rules/omac-sandbox-briefing.md, which
+	//     CodeWhale loads additively and unconditionally into every session.
+	//     (Its first-found .codewhale/instructions.md would be shadowed by any
+	//     AGENTS.md/CLAUDE.md; the rules dir is not — see project_context.rs.)
+	// Unlike BriefingEnvFunc's tmpDir (ephemeral, env-pointed), this writes
+	// into the persistent workdir because CodeWhale reads instruction/rules
+	// files only from the workspace tree; omac removes the file when the run
+	// exits (internal/cli.removeBriefingFile).
+	BriefingFileFunc func(briefing, workdir string) (relPath string, err error)
+
 	// SandboxDirs are directories the selected harness needs at runtime
 	// for configuration, authentication, state, and session storage.
 	// omac grants them read+write only for that selected harness.
@@ -392,6 +408,67 @@ func harnessRegistry() []Harness {
 			// system prompt.
 			SystemContextArgs:    nil,
 			BriefingEnvFunc:      nil,
+			NeedsPluginBootstrap: false,
+		},
+		{
+			Name:    "codewhale",
+			Aliases: []string{"cw"},
+			// CodeWhale CLI executable is `codewhale` (Rust; npm package
+			// "codewhale"). Headless runs use `codewhale exec "<prompt>"`.
+			InnerCmd: []string{"codewhale"},
+			// CodeWhale's `web` mode is a browser client, not a headless API
+			// daemon in the mold of `opencode serve`; under `omac serve` it
+			// runs as-is.
+			ServerLaunch: nil,
+			// CodeWhale has no omac bridge plugin; the briefing is delivered
+			// as a rules file (BriefingFileFunc), not a plugin.
+			BridgeDir:  "",
+			SkillsBase: "codewhale",
+			// CodeWhale's config home is ~/.codewhale (not ~/.config/codewhale),
+			// overridable via CODEWHALE_HOME. config.toml, state.db (the SQLite
+			// session store), secrets/secrets.json, and constitution.json all
+			// live under it (crates/config, crates/secrets, crates/state).
+			UserConfigHome: ".codewhale",
+			HomeEnv:        "CODEWHALE_HOME",
+			// ~/.codewhale holds configuration, auth secrets, and sessions.
+			SandboxDirs: []string{"~/.codewhale"},
+			// CodeWhale is multi-provider (DeepSeek/OpenAI/Anthropic/OpenRouter/
+			// Moonshot/… reading a different *_API_KEY per configured provider).
+			// Like opencode and pi, omac must NOT blindly forward a grab-bag of
+			// third-party keys regardless of which provider is configured: the
+			// user declares the specific key their setup uses in the profile's
+			// environment.allow_vars. So this stays empty.
+			SandboxEnvAllow: nil,
+			Session: &HarnessSession{
+				// `codewhale --continue` reopens the most recent session for
+				// this workdir; `codewhale --resume <id>` resumes a specific one.
+				ContinueArgs:   []string{"--continue"},
+				ResumeByIDArgs: func(id string) []string { return []string{"--resume", id} },
+				// Enumerating CodeWhale's SQLite state.db is not modeled yet, so
+				// `omac resume` with no id reports listing unsupported;
+				// `omac continue` and `omac resume <id>` work via the flags above.
+				ListKind: SessionListNone,
+			},
+			// CodeWhale exposes no system-prompt CLI flag and no env pointer to
+			// an instructions dir; it loads always-on context only from files in
+			// the workspace tree. The first-found project-instructions file
+			// (.codewhale/instructions.md) is shadowed by any AGENTS.md/CLAUDE.md,
+			// but every .md under .codewhale/rules/ is loaded additively and
+			// unconditionally (crates/tui/src/project_context.rs), so omac writes
+			// the briefing there.
+			SystemContextArgs: nil,
+			BriefingEnvFunc:   nil,
+			BriefingFileFunc: func(briefing, workdir string) (string, error) {
+				rel := filepath.Join(".codewhale", "rules", "omac-sandbox-briefing.md")
+				dst := filepath.Join(workdir, rel)
+				if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+					return "", err
+				}
+				if err := os.WriteFile(dst, []byte(briefing), 0o644); err != nil {
+					return "", err
+				}
+				return rel, nil
+			},
 			NeedsPluginBootstrap: false,
 		},
 	}

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -166,6 +166,9 @@ const (
 	// SessionListPi lists by reading Pi's session store (JSONL files under
 	// ~/.pi/agent/sessions/).
 	SessionListPi
+	// SessionListCodewhale lists by reading CodeWhale's SQLite session store
+	// (~/.codewhale/state.db, the `threads` table).
+	SessionListCodewhale
 )
 
 // HarnessSession encodes the harness-specific knowledge `omac continue` and
@@ -444,10 +447,10 @@ func harnessRegistry() []Harness {
 				// this workdir; `codewhale --resume <id>` resumes a specific one.
 				ContinueArgs:   []string{"--continue"},
 				ResumeByIDArgs: func(id string) []string { return []string{"--resume", id} },
-				// Enumerating CodeWhale's SQLite state.db is not modeled yet, so
-				// `omac resume` with no id reports listing unsupported;
-				// `omac continue` and `omac resume <id>` work via the flags above.
-				ListKind: SessionListNone,
+				// `omac resume` enumerates CodeWhale's SQLite session store
+				// (~/.codewhale/state.db, the `threads` table); see
+				// session.listCodewhale.
+				ListKind: SessionListCodewhale,
 			},
 			// CodeWhale exposes no system-prompt CLI flag and no env pointer to
 			// an instructions dir; it loads always-on context only from files in

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -425,8 +425,15 @@ func harnessRegistry() []Harness {
 			ServerLaunch: nil,
 			// CodeWhale has no omac bridge plugin; the briefing is delivered
 			// as a rules file (BriefingFileFunc), not a plugin.
-			BridgeDir:  "",
-			SkillsBase: "codewhale",
+			BridgeDir: "",
+			// CodeWhale loads workspace-local skills only from `.agents/skills`
+			// or `./skills` (docs/CONFIGURATION.md) — NOT a workspace
+			// `.codewhale/skills`. Owning the shared "agents" base is therefore
+			// correct: WorkdirSkillsDir() becomes `.agents/skills` (where
+			// CodeWhale actually looks), while ConfigHome()/GlobalSkillsDir()
+			// still resolve to ~/.codewhale[/skills] via UserConfigHome below
+			// (CodeWhale reads ~/.codewhale/skills as its global skills dir).
+			SkillsBase: SharedSkillsBase,
 			// CodeWhale's config home is ~/.codewhale (not ~/.config/codewhale),
 			// overridable via CODEWHALE_HOME. config.toml, state.db (the SQLite
 			// session store), secrets/secrets.json, and constitution.json all
@@ -444,9 +451,13 @@ func harnessRegistry() []Harness {
 			SandboxEnvAllow: nil,
 			Session: &HarnessSession{
 				// `codewhale --continue` reopens the most recent session for
-				// this workdir; `codewhale --resume <id>` resumes a specific one.
+				// this workdir (--continue is a top-level flag). Resuming a
+				// specific id is the top-level `resume <id>` SUBCOMMAND, not a
+				// flag: `codewhale --resume <id>` is rejected ("unexpected
+				// argument"); `--resume`/`--session-id` are exec-only. So this
+				// mirrors codex's `resume <id>` shape, not claude's `--resume`.
 				ContinueArgs:   []string{"--continue"},
-				ResumeByIDArgs: func(id string) []string { return []string{"--resume", id} },
+				ResumeByIDArgs: func(id string) []string { return []string{"resume", id} },
 				// `omac resume` enumerates CodeWhale's SQLite session store
 				// (~/.codewhale/state.db, the `threads` table); see
 				// session.listCodewhale.

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -135,7 +135,7 @@ func TestServerLaunchListenPort(t *testing.T) {
 	if oc.ServerLaunch.AuthEnvVar != "OPENCODE_SERVER_PASSWORD" {
 		t.Errorf("opencode ServerLaunch.AuthEnvVar = %q, want OPENCODE_SERVER_PASSWORD", oc.ServerLaunch.AuthEnvVar)
 	}
-	for _, name := range []string{"claude-code", "codex", "copilot", "pi"} {
+	for _, name := range []string{"claude-code", "codex", "copilot", "pi", "codewhale"} {
 		h, _ := LookupHarness(name)
 		if h.ServerLaunch != nil {
 			t.Errorf("%s unexpectedly declares a ServerLaunch (%+v)", name, h.ServerLaunch)
@@ -216,7 +216,7 @@ func TestHarnessSandboxEnvAllowIsSafe(t *testing.T) {
 // auth declares the specific key in the profile's allow_vars, so omac does not
 // blindly push every third-party key into the sandbox.
 func TestHarnessAuthForwardPolicy(t *testing.T) {
-	multiProvider := map[string]bool{"opencode": true, "pi": true}
+	multiProvider := map[string]bool{"opencode": true, "pi": true, "codewhale": true}
 	for _, h := range AllHarnesses() {
 		if multiProvider[h.Name] {
 			if len(h.SandboxEnvAllow) != 0 {
@@ -838,5 +838,136 @@ func TestPiSystemContextArgsNil(t *testing.T) {
 	}
 	if h.BriefingEnvFunc != nil {
 		t.Error("pi BriefingEnvFunc should be nil (briefing via OMAC_SANDBOX_BRIEFING + TS extension)")
+	}
+}
+
+// --- CodeWhale harness descriptor --------------------------------------------
+
+func TestLookupCodewhaleHarness(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantName string
+		wantOK   bool
+	}{
+		{"codewhale", "codewhale", true},
+		{"CodeWhale", "codewhale", true},
+		{"cw", "codewhale", true},
+		{"CW", "codewhale", true},
+	}
+	for _, c := range cases {
+		h, ok := LookupHarness(c.in)
+		if ok != c.wantOK {
+			t.Errorf("LookupHarness(%q) ok=%v, want %v", c.in, ok, c.wantOK)
+			continue
+		}
+		if ok && h.Name != c.wantName {
+			t.Errorf("LookupHarness(%q) name=%q, want %q", c.in, h.Name, c.wantName)
+		}
+	}
+}
+
+func TestCodewhaleHarnessDescriptor(t *testing.T) {
+	h, ok := LookupHarness("codewhale")
+	if !ok {
+		t.Fatal("codewhale harness not registered")
+	}
+	if !reflect.DeepEqual(h.InnerCmd, []string{"codewhale"}) {
+		t.Errorf("codewhale InnerCmd = %v, want [codewhale]", h.InnerCmd)
+	}
+	if h.ServerLaunch != nil {
+		t.Errorf("codewhale ServerLaunch = %v, want nil", h.ServerLaunch)
+	}
+	if h.SkillsBase != "codewhale" {
+		t.Errorf("codewhale SkillsBase = %q, want codewhale", h.SkillsBase)
+	}
+	if h.UserConfigHome != ".codewhale" {
+		t.Errorf("codewhale UserConfigHome = %q, want .codewhale", h.UserConfigHome)
+	}
+	if h.HomeEnv != "CODEWHALE_HOME" {
+		t.Errorf("codewhale HomeEnv = %q, want CODEWHALE_HOME", h.HomeEnv)
+	}
+	if !reflect.DeepEqual(h.SandboxDirs, []string{"~/.codewhale"}) {
+		t.Errorf("codewhale SandboxDirs = %v, want [~/.codewhale]", h.SandboxDirs)
+	}
+	// Multi-provider: omac auto-forwards no provider keys (see
+	// TestHarnessAuthForwardPolicy).
+	if len(h.SandboxEnvAllow) != 0 {
+		t.Errorf("codewhale SandboxEnvAllow = %v, want empty (multi-provider)", h.SandboxEnvAllow)
+	}
+}
+
+func TestCodewhaleSessionMetadata(t *testing.T) {
+	h, ok := LookupHarness("codewhale")
+	if !ok {
+		t.Fatal("codewhale harness not registered")
+	}
+	if h.Session == nil {
+		t.Fatal("codewhale Session is nil, want session metadata")
+	}
+	if !reflect.DeepEqual(h.Session.ContinueArgs, []string{"--continue"}) {
+		t.Errorf("codewhale ContinueArgs = %v, want [--continue]", h.Session.ContinueArgs)
+	}
+	if got := h.Session.ResumeByIDArgs("abc123"); !reflect.DeepEqual(got, []string{"--resume", "abc123"}) {
+		t.Errorf("codewhale ResumeByIDArgs = %v, want [--resume abc123]", got)
+	}
+	// Session enumeration (SQLite state.db) is not modeled yet: listing is
+	// unsupported, but --continue / --resume <id> work via the flags above.
+	if h.Session.ListKind != SessionListNone {
+		t.Errorf("codewhale ListKind = %v, want SessionListNone", h.Session.ListKind)
+	}
+}
+
+func TestCodewhaleConfigHome(t *testing.T) {
+	h, _ := LookupHarness("codewhale")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(home, ".codewhale"); h.ConfigHome() != want {
+		t.Errorf("codewhale ConfigHome() = %q, want %q", h.ConfigHome(), want)
+	}
+}
+
+func TestCodewhaleConfigHomeEnvOverride(t *testing.T) {
+	h, _ := LookupHarness("codewhale")
+	t.Setenv("CODEWHALE_HOME", "/custom/codewhale")
+	if got := h.ConfigHome(); got != "/custom/codewhale" {
+		t.Errorf("codewhale ConfigHome() with CODEWHALE_HOME set = %q, want /custom/codewhale", got)
+	}
+}
+
+// TestCodewhaleBriefingFileFunc verifies the file-based briefing delivery:
+// it writes .codewhale/rules/omac-sandbox-briefing.md (loaded additively and
+// unconditionally by CodeWhale, unlike the shadowable .codewhale/instructions.md)
+// and returns that workdir-relative path so the launcher can clean it up.
+func TestCodewhaleBriefingFileFunc(t *testing.T) {
+	h, ok := LookupHarness("codewhale")
+	if !ok {
+		t.Fatal("codewhale harness not registered")
+	}
+	if h.SystemContextArgs != nil {
+		t.Error("codewhale SystemContextArgs should be nil (no system-prompt flag exists)")
+	}
+	if h.BriefingEnvFunc != nil {
+		t.Error("codewhale BriefingEnvFunc should be nil (briefing via a rules file)")
+	}
+	if h.BriefingFileFunc == nil {
+		t.Fatal("codewhale BriefingFileFunc is nil; want a workdir file writer")
+	}
+	workdir := t.TempDir()
+	rel, err := h.BriefingFileFunc("BRIEF", workdir)
+	if err != nil {
+		t.Fatalf("BriefingFileFunc error: %v", err)
+	}
+	want := filepath.Join(".codewhale", "rules", "omac-sandbox-briefing.md")
+	if rel != want {
+		t.Errorf("BriefingFileFunc rel = %q, want %q", rel, want)
+	}
+	data, err := os.ReadFile(filepath.Join(workdir, rel))
+	if err != nil {
+		t.Fatalf("briefing file not written: %v", err)
+	}
+	if string(data) != "BRIEF" {
+		t.Errorf("briefing file = %q, want %q", string(data), "BRIEF")
 	}
 }

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -877,8 +877,13 @@ func TestCodewhaleHarnessDescriptor(t *testing.T) {
 	if h.ServerLaunch != nil {
 		t.Errorf("codewhale ServerLaunch = %v, want nil", h.ServerLaunch)
 	}
-	if h.SkillsBase != "codewhale" {
-		t.Errorf("codewhale SkillsBase = %q, want codewhale", h.SkillsBase)
+	// CodeWhale owns the shared "agents" base, not a "codewhale" base:
+	// CodeWhale reads workspace .agents/skills, not .codewhale/skills.
+	if h.SkillsBase != SharedSkillsBase {
+		t.Errorf("codewhale SkillsBase = %q, want %q", h.SkillsBase, SharedSkillsBase)
+	}
+	if got := h.WorkdirSkillsDir(); got != ".agents/skills" {
+		t.Errorf("codewhale WorkdirSkillsDir = %q, want .agents/skills", got)
 	}
 	if h.UserConfigHome != ".codewhale" {
 		t.Errorf("codewhale UserConfigHome = %q, want .codewhale", h.UserConfigHome)
@@ -907,8 +912,9 @@ func TestCodewhaleSessionMetadata(t *testing.T) {
 	if !reflect.DeepEqual(h.Session.ContinueArgs, []string{"--continue"}) {
 		t.Errorf("codewhale ContinueArgs = %v, want [--continue]", h.Session.ContinueArgs)
 	}
-	if got := h.Session.ResumeByIDArgs("abc123"); !reflect.DeepEqual(got, []string{"--resume", "abc123"}) {
-		t.Errorf("codewhale ResumeByIDArgs = %v, want [--resume abc123]", got)
+	// resume is a top-level subcommand, not a --resume flag (see descriptor).
+	if got := h.Session.ResumeByIDArgs("abc123"); !reflect.DeepEqual(got, []string{"resume", "abc123"}) {
+		t.Errorf("codewhale ResumeByIDArgs = %v, want [resume abc123]", got)
 	}
 	if h.Session.ListKind != SessionListCodewhale {
 		t.Errorf("codewhale ListKind = %v, want SessionListCodewhale", h.Session.ListKind)

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -910,10 +910,8 @@ func TestCodewhaleSessionMetadata(t *testing.T) {
 	if got := h.Session.ResumeByIDArgs("abc123"); !reflect.DeepEqual(got, []string{"--resume", "abc123"}) {
 		t.Errorf("codewhale ResumeByIDArgs = %v, want [--resume abc123]", got)
 	}
-	// Session enumeration (SQLite state.db) is not modeled yet: listing is
-	// unsupported, but --continue / --resume <id> work via the flags above.
-	if h.Session.ListKind != SessionListNone {
-		t.Errorf("codewhale ListKind = %v, want SessionListNone", h.Session.ListKind)
+	if h.Session.ListKind != SessionListCodewhale {
+		t.Errorf("codewhale ListKind = %v, want SessionListCodewhale", h.Session.ListKind)
 	}
 }
 

--- a/internal/e2e/contract_test.go
+++ b/internal/e2e/contract_test.go
@@ -36,11 +36,12 @@ func TestDeriveContractKnownTokens(t *testing.T) {
 		"codex":       {"exec", "-m", "--dangerously-bypass-approvals-and-sandbox", "-c", "resume", "--last"},
 		"copilot":     {"-p", "--model", "--allow-all-tools", "--continue", "--session-id"},
 		"pi":          {"-p", "--provider", "--model", "-c", "--session"},
+		"codewhale":   {"exec", "--auto", "--continue", "resume"},
 	}
 	for name, tokens := range want {
 		c, ok := deriveContract(name)
 		if !ok {
-			// codex is excluded on darwin; skip rather than fail host-dependently.
+			// codex/codewhale are excluded on darwin; skip rather than fail host-dependently.
 			t.Logf("%s: not eligible on this host, skipping", name)
 			continue
 		}
@@ -148,6 +149,7 @@ func TestHarnessHasServerMode(t *testing.T) {
 		"codex":       false,
 		"copilot":     false,
 		"pi":          false,
+		"codewhale":   false,
 		"nonexistent": false,
 	}
 	for name, want := range cases {

--- a/internal/e2e/harnesses.go
+++ b/internal/e2e/harnesses.go
@@ -654,10 +654,12 @@ func piConfig() harnessConfig {
 // `--auto` enables tool-backed agent mode with auto-approvals (crates/cli/
 // src/lib.rs:252,259) — required so the agent can call the echo-rest skill,
 // write files, and git-commit. config.toml pins approval_policy = "never"
-// and sandbox_mode = "danger-full-access" so CodeWhale neither prompts nor
+// and sandbox_mode = "external-sandbox" so CodeWhale neither prompts nor
 // applies its OWN inner OS sandbox inside omac's bwrap/Seatbelt sandbox.
 // `[update] check_for_updates = false` suppresses the startup version check
-// so no fixed release host is contacted.
+// so no fixed release host is contacted. The token binds via [providers.openai]
+// api_key_env = "OPENAI_API_KEY": CodeWhale refuses an ambient key on a custom
+// base_url unless it is bound explicitly.
 //
 // Sandbox deviations: none expected — the model host (SKAINET_INTERNAL) is
 // allowed by the base profile and the update check is disabled. This has NOT
@@ -696,16 +698,27 @@ func codewhaleConfig() harnessConfig {
 			if err := os.MkdirAll(cwDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
-			// The API key is NOT written here — it comes from OPENAI_API_KEY in
-			// the process env (see EnvVars), keeping the token off disk.
+			// The API key is NOT written here — api_key_env binds it to the
+			// OPENAI_API_KEY process env var (see EnvVars), keeping the token
+			// off disk. This explicit binding is REQUIRED: CodeWhale refuses to
+			// send an ambient OPENAI_API_KEY to a custom (non-default) base_url
+			// ("Custom endpoint credentials … must be bound explicitly"), so
+			// api_key_env is what lets the auth path reach the gateway.
+			//
+			// sandbox_mode = "external-sandbox": CodeWhale runs inside omac's
+			// bwrap sandbox, so it must not apply its own inner OS isolation;
+			// "external-sandbox" is the semantically exact value for that (an
+			// external sandbox is already in force). approval_policy = "never"
+			// auto-approves tool actions for the non-interactive run.
 			configToml := `provider = "openai"
 default_text_model = "` + modelIDs["codewhale"] + `"
 approval_policy = "never"
-sandbox_mode = "danger-full-access"
+sandbox_mode = "external-sandbox"
 
 [providers.openai]
 base_url = "` + baseURL + `"
 path_suffix = "/chat/completions"
+api_key_env = "OPENAI_API_KEY"
 
 [update]
 check_for_updates = false
@@ -725,9 +738,13 @@ check_for_updates = false
 		},
 		Sandbox: SandboxConfig{}, // no deviations expected — see the doc comment (unverified live)
 		RunArgs: func(prompt string) []string {
-			// Global flags (--model) MUST precede the `exec` subcommand; the
-			// `--auto` tool-mode flag is an exec passthrough and follows it.
-			return []string{"--model", modelIDs["codewhale"], "exec", "--auto", prompt}
+			// `exec` leads so the contract deriver captures it as a subcommand
+			// (flagsAndSub only treats a LEADING positional as the subcommand;
+			// a preceding `--model <val>` would hide `exec` and its --model
+			// value would be misread). The model comes from config.toml's
+			// default_text_model instead. `--auto` = tool-backed agent mode
+			// with auto-approvals (required for the echo-rest tool call).
+			return []string{"exec", "--auto", prompt}
 		},
 		SkillsBase: ".agents",
 		EnvVarsForAllow: func() []string {

--- a/internal/e2e/harnesses.go
+++ b/internal/e2e/harnesses.go
@@ -117,11 +117,16 @@ func allHarnesses() []harnessConfig {
 		codexConfig(),
 		copilotConfig(),
 		piConfig(),
+		codewhaleConfig(),
 	}
 	if runtime.GOOS == "darwin" {
+		// codex and codewhale are excluded on darwin — both are Rust CLIs
+		// whose HTTP clients are (codex: confirmed; codewhale: by analogy,
+		// unverified — see codewhaleConfig) incompatible with the macOS
+		// Seatbelt sandbox. See issue #48.
 		out := all[:0]
 		for _, h := range all {
-			if h.Name != "codex" {
+			if h.Name != "codex" && h.Name != "codewhale" {
 				out = append(out, h)
 			}
 		}
@@ -623,6 +628,113 @@ func piConfig() harnessConfig {
 		},
 		ExpectVisibleEnv: func() []string {
 			return []string{"SKAINET_TOKEN=", "OMAC_"}
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// codewhale
+// ---------------------------------------------------------------------------
+
+// codewhale is a Rust CLI (npm package "codewhale") that is multi-provider.
+// For this test it runs against the internal SKAINET gateway via CodeWhale's
+// generic OpenAI-compatible route: config.example.toml documents
+// `provider = "openai"` + a `[providers.openai]` table for "generic
+// OpenAI-compatible gateways" (config.example.toml:354). We point that
+// provider's base_url at SKAINET_INTERNAL and set path_suffix = "/chat/
+// completions" so requests go to <base>/chat/completions — the same shape
+// opencode's @ai-sdk/openai-compatible client uses against this gateway.
+//
+// Env vars: OPENAI_API_KEY carries the bearer token. CodeWhale's openai
+// provider reads it from the process env (crates/config/src/provider.rs:546),
+// so — like codex's env_key and pi's $ENV_VAR indirection — the raw token is
+// never written to disk. SKAINET_TOKEN also propagates via os.Environ().
+//
+// Headless execution: `codewhale exec` alone is a one-shot model response;
+// `--auto` enables tool-backed agent mode with auto-approvals (crates/cli/
+// src/lib.rs:252,259) — required so the agent can call the echo-rest skill,
+// write files, and git-commit. config.toml pins approval_policy = "never"
+// and sandbox_mode = "danger-full-access" so CodeWhale neither prompts nor
+// applies its OWN inner OS sandbox inside omac's bwrap/Seatbelt sandbox.
+// `[update] check_for_updates = false` suppresses the startup version check
+// so no fixed release host is contacted.
+//
+// Sandbox deviations: none expected — the model host (SKAINET_INTERNAL) is
+// allowed by the base profile and the update check is disabled. This has NOT
+// been verified against a live gateway run (unlike opencode/pi, which were);
+// treat ExtraAllowDomains as provisional if a real run surfaces a startup host.
+//
+// macOS: excluded from allHarnesses() by analogy with codex — CodeWhale is
+// Rust with its own HTTP client, the same class that makes codex's client
+// disconnect mid-stream under macOS Seatbelt (issue #48). This is a
+// precaution, NOT a verified CodeWhale failure; re-test on macOS and drop the
+// exclusion (here, in expectedHarnessNames, and in e2e.yml) if it works.
+//
+// SkillsBase is ".agents", not ".codewhale": CodeWhale loads workspace-local
+// skills from `.agents/skills` or `./skills` (CONFIGURATION.md:1490), and
+// does NOT read a workspace `.codewhale/skills`. The e2e installs the skill
+// into <workdir>/<SkillsBase>/skills, so it must target a dir CodeWhale reads.
+//
+// Files written:
+//   - ~/.codewhale/config.toml — provider, model, approvals, sandbox, update
+func codewhaleConfig() harnessConfig {
+	return harnessConfig{
+		Name:       "codewhale",
+		BinaryName: "codewhale",
+		InstallCmd: []string{"npm", "install", "-g", pinnedPackage("codewhale")},
+		ProviderSetup: func(t *testing.T, home string) {
+			token := os.Getenv("SKAINET_TOKEN")
+			if token == "" {
+				t.Fatal("SKAINET_TOKEN not set")
+			}
+			baseURL := os.Getenv("SKAINET_INTERNAL")
+			if baseURL == "" {
+				t.Fatal("SKAINET_INTERNAL not set (CI secret for the model provider URL)")
+			}
+			t.Logf("codewhale provider: baseURL=%s tokenLen=%d", baseURL, len(token))
+			cwDir := filepath.Join(home, ".codewhale")
+			if err := os.MkdirAll(cwDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			// The API key is NOT written here — it comes from OPENAI_API_KEY in
+			// the process env (see EnvVars), keeping the token off disk.
+			configToml := `provider = "openai"
+default_text_model = "` + modelIDs["codewhale"] + `"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[providers.openai]
+base_url = "` + baseURL + `"
+path_suffix = "/chat/completions"
+
+[update]
+check_for_updates = false
+`
+			if err := os.WriteFile(filepath.Join(cwDir, "config.toml"), []byte(configToml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("config.toml written to %s", cwDir)
+		},
+		EnvVars: func(t *testing.T) []string {
+			token := os.Getenv("SKAINET_TOKEN")
+			if token == "" {
+				t.Fatal("SKAINET_TOKEN not set")
+			}
+			// CodeWhale's openai provider reads OPENAI_API_KEY from the env.
+			return []string{"OPENAI_API_KEY=" + token}
+		},
+		Sandbox: SandboxConfig{}, // no deviations expected — see the doc comment (unverified live)
+		RunArgs: func(prompt string) []string {
+			// Global flags (--model) MUST precede the `exec` subcommand; the
+			// `--auto` tool-mode flag is an exec passthrough and follows it.
+			return []string{"--model", modelIDs["codewhale"], "exec", "--auto", prompt}
+		},
+		SkillsBase: ".agents",
+		EnvVarsForAllow: func() []string {
+			return []string{"OPENAI_API_KEY"}
+		},
+		ExpectVisibleEnv: func() []string {
+			return []string{"OPENAI_API_KEY=", "OMAC_"}
 		},
 	}
 }

--- a/internal/e2e/harnesses_test.go
+++ b/internal/e2e/harnesses_test.go
@@ -8,23 +8,24 @@ import (
 )
 
 // expectedHarnessNames is allHarnesses' expected content for the current
-// GOOS: codex is excluded on darwin (see allHarnesses; its Rust HTTP client
-// is incompatible with the macOS Seatbelt sandbox — issue #48).
+// GOOS: codex and codewhale are excluded on darwin (see allHarnesses; both
+// are Rust CLIs whose HTTP clients are — codex confirmed, codewhale by
+// analogy — incompatible with the macOS Seatbelt sandbox, issue #48).
 func expectedHarnessNames() []string {
-	names := []string{"opencode", "claude-code", "codex", "copilot", "pi"}
+	names := []string{"opencode", "claude-code", "codex", "copilot", "pi", "codewhale"}
 	if runtime.GOOS != "darwin" {
 		return names
 	}
 	out := names[:0:0]
 	for _, n := range names {
-		if n != "codex" {
+		if n != "codex" && n != "codewhale" {
 			out = append(out, n)
 		}
 	}
 	return out
 }
 
-func TestAllHarnessesReturnsFour(t *testing.T) {
+func TestAllHarnessesMatchesExpectedCount(t *testing.T) {
 	hs := allHarnesses()
 	want := len(expectedHarnessNames())
 	if len(hs) != want {

--- a/internal/e2e/versions.go
+++ b/internal/e2e/versions.go
@@ -17,6 +17,7 @@ var harnessVersions = map[string]string{
 	"codex":       "@openai/codex@0.142.5",
 	"copilot":     "@github/copilot@1.0.68",
 	"pi":          "@earendil-works/pi-coding-agent@0.80.6",
+	"codewhale":   "codewhale@0.9.1",
 }
 
 // versionEnvVar maps a harness name to the env var that can override its
@@ -30,6 +31,7 @@ var versionEnvVar = map[string]string{
 	"codex":       "E2E_VERSION_CODEX",
 	"copilot":     "E2E_VERSION_COPILOT",
 	"pi":          "E2E_VERSION_PI",
+	"codewhale":   "E2E_VERSION_CODEWHALE",
 }
 
 // Model identifiers per harness.
@@ -39,6 +41,7 @@ var modelIDs = map[string]string{
 	"codex":       "zai-org/GLM-5.2",
 	"copilot":     "zai-org/GLM-5.2",
 	"pi":          "zai-org/GLM-5.2",
+	"codewhale":   "zai-org/GLM-5.2",
 }
 
 // pinnedPackage returns the package spec for a harness.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -54,14 +54,14 @@ func execRunner(name string, args ...string) ([]byte, error) {
 // List returns harness's prior sessions for workdir, most-recent first.
 // workdir SHOULD be absolute; it is cleaned before comparison.
 func List(h config.Harness, workdir string) ([]Session, error) {
-	return list(h, workdir, execRunner, claudeProjectsRoot(h), opencodeDBPath(), codexSessionsRoot(h), copilotDBPath(h), copilotStateDir(h), piSessionsRoot(h))
+	return list(h, workdir, execRunner, claudeProjectsRoot(h), opencodeDBPath(), codexSessionsRoot(h), copilotDBPath(h), copilotStateDir(h), piSessionsRoot(h), codewhaleDBPath(h))
 }
 
 // list is the testable core: callers inject the command runner, the Claude
 // projects root, the opencode SQLite db path, the codex sessions root, the
 // copilot SQLite db path, the copilot session-state dir (yaml fallback),
 // and the pi sessions root.
-func list(h config.Harness, workdir string, run runner, claudeRoot, ocDBPath, codexRoot, copilotDB, copilotState, piRoot string) ([]Session, error) {
+func list(h config.Harness, workdir string, run runner, claudeRoot, ocDBPath, codexRoot, copilotDB, copilotState, piRoot, codewhaleDB string) ([]Session, error) {
 	if h.Session == nil {
 		return nil, ErrUnsupported
 	}
@@ -77,6 +77,8 @@ func list(h config.Harness, workdir string, run runner, claudeRoot, ocDBPath, co
 		return listCopilot(workdir, copilotDB, copilotState), nil
 	case config.SessionListPi:
 		return listPi(workdir, piRoot), nil
+	case config.SessionListCodewhale:
+		return listCodewhale(workdir, codewhaleDB), nil
 	default:
 		return nil, ErrUnsupported
 	}
@@ -838,4 +840,122 @@ func listPi(workdir, piRoot string) []Session {
 // import encoding/json directly for one-off parsing.
 func jsonUnmarshal(data []byte, v any) error {
 	return json.Unmarshal(data, v)
+}
+
+// --- CodeWhale backend ------------------------------------------------------
+
+// codewhaleDBPath returns CodeWhale's SQLite session store
+// (~/.codewhale/state.db), honoring CODEWHALE_HOME via ConfigHome(). Returns
+// "" when no config home resolves.
+func codewhaleDBPath(h config.Harness) string {
+	home := h.ConfigHome()
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, "state.db")
+}
+
+// listCodewhale reads CodeWhale sessions for workdir from state.db. CodeWhale
+// stores one row per conversation in the `threads` table, with the workspace
+// path in `cwd`, a picker label in `title` (nullable) / `preview` (NOT NULL),
+// an `archived` flag, and `updated_at` in epoch SECONDS (Utc::now().timestamp()
+// — see CodeWhale crates/state/src/lib.rs). We open the db read-only so a live
+// CodeWhale session is never blocked, schema-gate the optional columns so a
+// future schema drift degrades instead of breaking, filter to this workdir,
+// drop archived threads, and order newest-first. Best-effort: any error
+// (missing db, locked, unrecognized schema) yields nil, never a hard failure.
+func listCodewhale(workdir, dbPath string) []Session {
+	if dbPath == "" {
+		return nil
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil
+	}
+	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout=500"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil
+	}
+	defer db.Close()
+	cols := tableColumns(db, "threads")
+	if !cols["id"] {
+		return nil
+	}
+	// Picker label: first non-empty of title, preview, id.
+	label := "id"
+	switch {
+	case cols["title"] && cols["preview"]:
+		label = "COALESCE(NULLIF(title, ''), NULLIF(preview, ''), id)"
+	case cols["title"]:
+		label = "COALESCE(NULLIF(title, ''), id)"
+	case cols["preview"]:
+		label = "COALESCE(NULLIF(preview, ''), id)"
+	}
+	cwdSel := "''"
+	if cols["cwd"] {
+		cwdSel = "COALESCE(cwd, '')"
+	}
+	updatedSel, orderBy := "0", "rowid DESC"
+	if cols["updated_at"] {
+		updatedSel, orderBy = "updated_at", "updated_at DESC"
+	}
+	where := ""
+	if cols["archived"] {
+		where = "WHERE archived = 0 "
+	}
+	q := "SELECT id, " + label + " AS label, " + cwdSel + " AS cwd, " + updatedSel + " AS updated_at " +
+		"FROM threads " + where + "ORDER BY " + orderBy + " LIMIT 100"
+	rows, err := db.Query(q)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var sessions []Session
+	for rows.Next() {
+		var id, title, cwd string
+		var updated sql.NullInt64
+		if err := rows.Scan(&id, &title, &cwd, &updated); err != nil {
+			continue
+		}
+		if id == "" {
+			continue
+		}
+		if cwd != "" && filepath.Clean(cwd) != workdir {
+			continue
+		}
+		var when time.Time
+		if updated.Valid && updated.Int64 > 0 {
+			when = time.Unix(updated.Int64, 0)
+		}
+		if title == "" {
+			title = id
+		}
+		sessions = append(sessions, Session{ID: id, Title: title, When: when})
+	}
+	if len(sessions) == 0 {
+		return nil
+	}
+	return sessions
+}
+
+// tableColumns returns the set of column names on the given table, read via
+// PRAGMA table_info. The table name is a trusted literal (never user input),
+// so string interpolation here is safe. Returns an empty set on any error.
+func tableColumns(db *sql.DB, table string) map[string]bool {
+	set := map[string]bool{}
+	rows, err := db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		return set
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, ctype string
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return set
+		}
+		set[name] = true
+	}
+	return set
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -590,44 +590,19 @@ func listCopilotDB(workdir, dbPath string) []Session {
 	}
 	defer db.Close()
 	// Schema-gate: verify the sessions table has the expected columns.
-	cols, err := db.Query("PRAGMA table_info(sessions)")
-	if err != nil {
-		return nil
-	}
-	hasID, hasCWD, hasSummary, hasUpdated := false, false, false, false
-	for cols.Next() {
-		var cid int
-		var name, ctype string
-		var notnull, pk int
-		var dflt sql.NullString
-		if err := cols.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
-			cols.Close()
-			return nil
-		}
-		switch name {
-		case "id":
-			hasID = true
-		case "cwd":
-			hasCWD = true
-		case "summary":
-			hasSummary = true
-		case "updated_at":
-			hasUpdated = true
-		}
-	}
-	cols.Close()
-	if !hasID || !hasCWD {
+	cols := tableColumns(db, "sessions")
+	if !cols["id"] || !cols["cwd"] {
 		return nil
 	}
 	// Build query based on available columns.
 	idCol := "id"
 	cwdCol := "cwd"
 	summaryCol := "id"
-	if hasSummary {
+	if cols["summary"] {
 		summaryCol = "summary"
 	}
 	updatedCol := ""
-	if hasUpdated {
+	if cols["updated_at"] {
 		updatedCol = "updated_at"
 	}
 	q := "SELECT " + idCol + ", " + summaryCol + ", COALESCE(" + cwdCol + ", '') AS cwd"

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"database/sql"
 	"errors"
 	"os"
 	"os/exec"
@@ -23,12 +24,12 @@ func opencodeHarness(t *testing.T) config.Harness {
 
 func TestListUnsupported(t *testing.T) {
 	// Harness with no Session block.
-	if _, err := list(config.Harness{}, "/w", nil, "", "", "", "", "", ""); !errors.Is(err, ErrUnsupported) {
+	if _, err := list(config.Harness{}, "/w", nil, "", "", "", "", "", "", ""); !errors.Is(err, ErrUnsupported) {
 		t.Errorf("nil Session: err = %v, want ErrUnsupported", err)
 	}
 	// Harness whose Session declares no listing strategy.
 	h := config.Harness{Session: &config.HarnessSession{ListKind: config.SessionListNone}}
-	if _, err := list(h, "/w", nil, "", "", "", "", "", ""); !errors.Is(err, ErrUnsupported) {
+	if _, err := list(h, "/w", nil, "", "", "", "", "", "", ""); !errors.Is(err, ErrUnsupported) {
 		t.Errorf("SessionListNone: err = %v, want ErrUnsupported", err)
 	}
 }
@@ -42,7 +43,7 @@ func TestListOpenCodeParseAndFilter(t *testing.T) {
 			{"id":"ses_other","title":"elsewhere","updated":3000,"directory":"/home/u/other"}
 		]`), nil
 	}
-	got, err := list(opencodeHarness(t), wd, run, "", "", "", "", "", "")
+	got, err := list(opencodeHarness(t), wd, run, "", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -59,7 +60,7 @@ func TestListOpenCodeParseAndFilter(t *testing.T) {
 
 func TestListOpenCodeCLIFailureIsEmpty(t *testing.T) {
 	run := func(name string, args ...string) ([]byte, error) { return nil, errors.New("not found") }
-	got, err := list(opencodeHarness(t), "/w", run, "", "", "", "", "", "")
+	got, err := list(opencodeHarness(t), "/w", run, "", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("CLI failure should not error, got %v", err)
 	}
@@ -256,14 +257,14 @@ func copilotHarness(t *testing.T) config.Harness {
 func TestListCodexDispatchesNotUnsupported(t *testing.T) {
 	// Even with empty paths, codex listing must NOT return ErrUnsupported —
 	// it dispatches to the codex backend (which returns nil best-effort).
-	_, err := list(codexHarness(t), "/w", nil, "", "", "", "", "", "")
+	_, err := list(codexHarness(t), "/w", nil, "", "", "", "", "", "", "")
 	if errors.Is(err, ErrUnsupported) {
 		t.Errorf("codex listing returned ErrUnsupported, want dispatch (err=%v)", err)
 	}
 }
 
 func TestListCopilotDispatchesNotUnsupported(t *testing.T) {
-	_, err := list(copilotHarness(t), "/w", nil, "", "", "", "", "", "")
+	_, err := list(copilotHarness(t), "/w", nil, "", "", "", "", "", "", "")
 	if errors.Is(err, ErrUnsupported) {
 		t.Errorf("copilot listing returned ErrUnsupported, want dispatch (err=%v)", err)
 	}
@@ -272,7 +273,7 @@ func TestListCopilotDispatchesNotUnsupported(t *testing.T) {
 func TestListCodexMissingStoreIsEmpty(t *testing.T) {
 	// No codex session store at the given root → nil, no error.
 	root := filepath.Join(t.TempDir(), "no-sessions-dir")
-	got, err := list(codexHarness(t), "/w", nil, "", "", root, "", "", "")
+	got, err := list(codexHarness(t), "/w", nil, "", "", root, "", "", "", "")
 	if err != nil {
 		t.Fatalf("codex missing store: err = %v, want nil", err)
 	}
@@ -284,7 +285,7 @@ func TestListCodexMissingStoreIsEmpty(t *testing.T) {
 func TestListCopilotMissingDBIsEmpty(t *testing.T) {
 	// No copilot session-store.db → nil, no error.
 	dbPath := filepath.Join(t.TempDir(), "nope.db")
-	got, err := list(copilotHarness(t), "/w", nil, "", "", "", dbPath, "", "")
+	got, err := list(copilotHarness(t), "/w", nil, "", "", "", dbPath, "", "", "")
 	if err != nil {
 		t.Fatalf("copilot missing db: err = %v, want nil", err)
 	}
@@ -429,7 +430,7 @@ func piHarness(t *testing.T) config.Harness {
 }
 
 func TestListPiDispatchesNotUnsupported(t *testing.T) {
-	_, err := list(piHarness(t), "/w", nil, "", "", "", "", "", "")
+	_, err := list(piHarness(t), "/w", nil, "", "", "", "", "", "", "")
 	if errors.Is(err, ErrUnsupported) {
 		t.Errorf("pi listing returned ErrUnsupported, want dispatch (err=%v)", err)
 	}
@@ -437,7 +438,7 @@ func TestListPiDispatchesNotUnsupported(t *testing.T) {
 
 func TestListPiMissingStoreIsEmpty(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "no-sessions-dir")
-	got, err := list(piHarness(t), "/w", nil, "", "", "", "", "", root)
+	got, err := list(piHarness(t), "/w", nil, "", "", "", "", "", root, "")
 	if err != nil {
 		t.Fatalf("pi missing store: err = %v, want nil", err)
 	}
@@ -504,6 +505,105 @@ func TestListPiMissingCwdIncluded(t *testing.T) {
 	}
 	if got[0].ID != "nocwd" {
 		t.Errorf("ID = %q, want 'nocwd'", got[0].ID)
+	}
+}
+
+// --- CodeWhale session listing ----------------------------------------------
+
+func codewhaleHarness(t *testing.T) config.Harness {
+	t.Helper()
+	h, ok := config.LookupHarness("codewhale")
+	if !ok {
+		t.Fatal("codewhale harness not registered")
+	}
+	return h
+}
+
+func TestListCodewhaleDispatchesNotUnsupported(t *testing.T) {
+	_, err := list(codewhaleHarness(t), "/w", nil, "", "", "", "", "", "", "")
+	if errors.Is(err, ErrUnsupported) {
+		t.Errorf("codewhale listing returned ErrUnsupported, want dispatch (err=%v)", err)
+	}
+}
+
+func TestListCodewhaleMissingDBIsEmpty(t *testing.T) {
+	if got := listCodewhale("/w", filepath.Join(t.TempDir(), "nope.db")); got != nil {
+		t.Errorf("missing db should yield nil, got %+v", got)
+	}
+}
+
+type cwThreadRow struct {
+	ID, Title, Preview string
+	Updated            int64 // epoch seconds
+	CWD                string
+	Archived           int
+}
+
+// createCodewhaleThreads writes a minimal state.db mirroring the subset of
+// CodeWhale's `threads` schema that listCodewhale reads. It uses the in-process
+// modernc.org/sqlite driver (registered by the session package), so the test
+// needs no external sqlite3 binary. A row with an empty Title is stored as SQL
+// NULL, exercising the title→preview label fallback.
+func createCodewhaleThreads(t *testing.T, dbPath string, rows []cwThreadRow) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE threads (
+		id TEXT PRIMARY KEY,
+		preview TEXT NOT NULL,
+		updated_at INTEGER NOT NULL,
+		cwd TEXT NOT NULL,
+		title TEXT,
+		archived INTEGER NOT NULL DEFAULT 0
+	)`); err != nil {
+		t.Fatalf("create threads: %v", err)
+	}
+	for _, r := range rows {
+		var title any
+		if r.Title != "" {
+			title = r.Title
+		} // else nil -> NULL
+		if _, err := db.Exec(
+			"INSERT INTO threads (id, preview, updated_at, cwd, title, archived) VALUES (?, ?, ?, ?, ?, ?)",
+			r.ID, r.Preview, r.Updated, r.CWD, title, r.Archived,
+		); err != nil {
+			t.Fatalf("insert %s: %v", r.ID, err)
+		}
+	}
+}
+
+func TestListCodewhaleParseAndFilter(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "state.db")
+	const wd = "/home/u/proj"
+	createCodewhaleThreads(t, db, []cwThreadRow{
+		{ID: "t_new", Title: "newest", Preview: "pv", Updated: 2000, CWD: wd},
+		// NULL title -> label falls back to preview.
+		{ID: "t_old", Title: "", Preview: "old preview", Updated: 1000, CWD: wd},
+		// Different workdir -> excluded.
+		{ID: "t_other", Title: "elsewhere", Preview: "pv", Updated: 3000, CWD: "/home/u/other"},
+		// Archived in this workdir, most recent -> must be excluded so it never
+		// becomes the "resume this session" id.
+		{ID: "t_arch", Title: "archived", Preview: "pv", Updated: 9000, CWD: wd, Archived: 1},
+	})
+	got := listCodewhale(wd, db)
+	if len(got) != 2 {
+		t.Fatalf("got %d sessions, want 2 (workdir + non-archived): %+v", len(got), got)
+	}
+	if got[0].ID != "t_new" || got[1].ID != "t_old" {
+		t.Errorf("order = [%s,%s], want newest-first [t_new,t_old]", got[0].ID, got[1].ID)
+	}
+	if got[0].Title != "newest" {
+		t.Errorf("t_new Title = %q, want %q", got[0].Title, "newest")
+	}
+	if got[1].Title != "old preview" {
+		t.Errorf("t_old Title = %q, want preview fallback %q", got[1].Title, "old preview")
+	}
+	// updated_at is epoch SECONDS (Utc::now().timestamp()).
+	if !got[0].When.Equal(time.Unix(2000, 0)) {
+		t.Errorf("t_new When = %v, want epoch-seconds 2000", got[0].When)
 	}
 }
 

--- a/openspec/changes/support-codewhale-harness/proposal.md
+++ b/openspec/changes/support-codewhale-harness/proposal.md
@@ -1,0 +1,89 @@
+## Summary
+
+Add CodeWhale (`codewhale`) as a supported harness in omac, following the
+same declarative pattern used for OpenCode, Claude Code, Codex, Copilot, and
+Pi — plus a new *file-based* briefing-delivery mechanism for harnesses that
+load always-on context only from workspace files.
+
+## Motivation
+
+omac's harness registry is built for extensibility: adding a new agentic
+coder is a matter of registering one descriptor, not editing call sites.
+CodeWhale (a Rust CLI, npm package `codewhale`, multi-provider — DeepSeek,
+OpenAI, Anthropic, OpenRouter, …) is a natural sixth harness. The Go core is
+already harness-agnostic, so the work is: register the descriptor, teach omac
+how CodeWhale enumerates sessions, and — because CodeWhale exposes neither a
+system-prompt flag (like Claude/Codex) nor a plugin/env hook (like OpenCode/
+Pi/Copilot) — add a delivery path that writes the sandbox briefing into a
+workspace file CodeWhale loads.
+
+## What Changes
+
+- Register the `codewhale` harness descriptor in `harnessRegistry()` (inner
+  command `codewhale`; config home `~/.codewhale` via `CODEWHALE_HOME`;
+  `--continue` / `resume <id>` session args; multi-provider, so no
+  auto-forwarded auth keys; `SkillsBase = SharedSkillsBase` because CodeWhale
+  reads workspace `.agents/skills`, not a `.codewhale/skills`).
+- Add a `BriefingFileFunc` field to `config.Harness`: a delivery mechanism
+  that writes the briefing into the workdir for harnesses that load context
+  only from the workspace tree. CodeWhale writes
+  `.codewhale/rules/omac-sandbox-briefing.md` — every `.md` under
+  `.codewhale/rules/` is loaded additively and unconditionally, unlike the
+  first-found `.codewhale/instructions.md` which any `AGENTS.md`/`CLAUDE.md`
+  shadows.
+- The launcher (`omac start` / `omac serve`) writes the briefing file before
+  exec, adds its path to `<workdir>/.git/info/exclude` (so an agent's own
+  `git add -A` never commits it; persists across SIGKILL), and removes the
+  file on clean exit.
+- Add a `SessionListCodewhale` enum value and `listCodewhale()` — CodeWhale
+  stores sessions in SQLite at `~/.codewhale/state.db` (the `threads` table);
+  the backend reads it read-only, filters by `cwd`, drops archived threads.
+
+## Capabilities
+
+### New Capabilities
+- `codewhale-harness`: A registered `codewhale` harness descriptor with
+  file-based briefing delivery and SQLite session listing.
+- `file-briefing-delivery`: `Harness.BriefingFileFunc` — a third briefing
+  mechanism alongside `SystemContextArgs` (flag) and `BriefingEnvFunc`
+  (env+tmp file), for harnesses that only read workspace instruction/rules
+  files. Also relevant to #171 (harnesses that position system text
+  themselves are immune to double-injection).
+
+### Modified Capabilities
+- `inner-harness`: The registry gains one new descriptor (`codewhale`), one
+  new `SessionListKind` value, and one new optional descriptor field
+  (`BriefingFileFunc`). The registry pattern and positional-subcommand UX are
+  unchanged.
+
+## Impact
+
+- **Code (Go):** `internal/config/harness.go` (descriptor + `BriefingFileFunc`
+  field + `SessionListCodewhale`), `internal/session/session.go`
+  (`listCodewhale()` + `codewhaleDBPath()` + dispatch + `tableColumns()`
+  helper), `internal/cli/briefing.go` + `start.go` + `serve.go`
+  (`BriefingFileFunc` wiring + `gitExcludeBriefing` + `removeBriefingFile`).
+- **Env/contract:** `OMAC_*` naming reused as-is.
+- **E2e tests:** new harness config in `internal/e2e/harnesses.go`
+  (`codewhaleConfig()`) + pinned version in `versions.go` + matrix wiring in
+  `.github/workflows/e2e.yml` and `e2e-smoke.yml`.
+- **Docs:** README.md harness list, docs/HARNESS_COMPAT.md, CREATING_A_SKILL.md
+  (+ its bundled copy).
+- **Backward compatibility:** omitting the harness still defaults to
+  `opencode`; existing layouts and harnesses keep working unchanged.
+
+## Scope
+
+In scope:
+- Harness descriptor + file-based briefing delivery for `codewhale`
+- SQLite session listing (`listCodewhale`)
+- E2e test config + pinned version + CI matrix
+- Documentation updates
+- Unit tests
+
+Deferred / not verified:
+- The macOS exclusion is precautionary (by analogy with codex's Rust
+  HTTP-client × Seatbelt incompatibility) and UNVERIFIED for codewhale — one
+  manual `E2E: drift` dispatch settles it.
+- The model-calling e2e tiers are source-derived, not yet confirmed against a
+  live gateway run.

--- a/openspec/changes/support-codewhale-harness/tasks.md
+++ b/openspec/changes/support-codewhale-harness/tasks.md
@@ -1,0 +1,44 @@
+## 1. Harness descriptor (Go core)
+
+- [x] 1.1 Add `codewhale` descriptor to `harnessRegistry()` (inner `codewhale`; config home `~/.codewhale` via `CODEWHALE_HOME`; `SkillsBase = SharedSkillsBase`; multi-provider → empty `SandboxEnvAllow`)
+- [x] 1.2 Add `BriefingFileFunc` field to `config.Harness` (workdir file-based briefing delivery)
+- [x] 1.3 Session args: `ContinueArgs = ["--continue"]`, `ResumeByIDArgs = ["resume", id]` (top-level `resume` subcommand, not a `--resume` flag)
+- [x] 1.4 Add `SessionListCodewhale` enum value
+
+## 2. Briefing delivery + git safety
+
+- [x] 2.1 CodeWhale `BriefingFileFunc` writes `.codewhale/rules/omac-sandbox-briefing.md`
+- [x] 2.2 Wire `BriefingFileFunc` into `start.go` and `serve.go` (write before exec, remove on exit)
+- [x] 2.3 `gitExcludeBriefing()` appends the path to `.git/info/exclude` (idempotent, SIGKILL-safe, preserves user entries)
+
+## 3. Session listing
+
+- [x] 3.1 Extend `list()` signature with `codewhaleDB string` parameter + dispatch case
+- [x] 3.2 Implement `listCodewhale()` (read-only SQLite `threads` query, cwd filter, drop archived, epoch-seconds `updated_at`)
+- [x] 3.3 Implement `codewhaleDBPath(h)` helper (`~/.codewhale/state.db`)
+- [x] 3.4 Extract `tableColumns()` schema-gate helper (also refactors `listCopilotDB`)
+
+## 4. E2e config
+
+- [x] 4.1 Add `codewhaleConfig()` to `internal/e2e/harnesses.go` (config.toml `provider="openai"` + gateway `base_url` + `path_suffix` + `api_key_env`; `exec --auto` RunArgs; `SkillsBase ".agents"`)
+- [x] 4.2 Add `codewhale` to `allHarnesses()` + darwin exclusion
+- [x] 4.3 Add pinned version, version-env, and model ID to `internal/e2e/versions.go`
+- [x] 4.4 Wire matrix + version dispatch input into `.github/workflows/e2e.yml` and `e2e-smoke.yml`
+
+## 5. Tests
+
+- [x] 5.1 Harness descriptor tests (lookup, fields, session metadata, config home, `WorkdirSkillsDir`)
+- [x] 5.2 `BriefingFileFunc` + `gitExcludeBriefing` + `removeBriefingFile` tests
+- [x] 5.3 Session listing tests (dispatch, missing-db, parse/filter against a temp `state.db`)
+- [x] 5.4 Contract tests (`TestDeriveContractKnownTokens`, `TestHarnessHasServerMode`)
+
+## 6. Documentation
+
+- [x] 6.1 Update `README.md` harness list (add codewhale)
+- [x] 6.2 Update `docs/HARNESS_COMPAT.md` (harness list + macOS-exclude note)
+- [x] 6.3 Update `CREATING_A_SKILL.md` skills-dirs section + its bundled copy
+
+## 7. Follow-ups (not in this change)
+
+- [ ] 7.1 Verify the macOS exclusion (manual `E2E: drift` dispatch) and drop it if CodeWhale works under Seatbelt
+- [ ] 7.2 Confirm the model-calling e2e tiers against a live gateway run


### PR DESCRIPTION
Add the codewhale harness.

There is a workaround for codewhale not having `--append-system-prompt` or similar: We had to add a special mounted codewhale rule.