### PR TITLE
feat(e2e,ci): make the model overridable per run and report it in the output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,12 @@ jobs:
           version: latest
           install-go: false
 
+      # Workflow `run:` bodies are shell that nothing else parses, so a quoting
+      # mistake ships and only surfaces the next time that job runs — days
+      # later for the weekly LLM workflows.
+      - name: Workflow shell syntax
+        run: python3 scripts/check-workflow-shell.py
+
   e2e-fast:
     # Model-free slice of the e2e suite (build tag `e2e_fast`): the security
     # regression tests that need no live LLM harness, API token, or OS
@@ -176,6 +182,12 @@ jobs:
       # it didn't use.
       - name: Check model resolver parity
         run: scripts/resolve-model_test.sh
+
+      # The gateway-probe paths (variant flip, tier priority, fallback,
+      # exhausted candidates) against a local stub gateway — the states that
+      # can't be produced on demand upstream. No credentials, no real network.
+      - name: Check model probe against a stub gateway
+        run: scripts/probe-model_test.sh
 
   cache-integration:
     name: Cache integration (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,13 @@ jobs:
       - name: Run model-free e2e tests
         run: go test -tags=e2e_fast -race -count=1 -timeout=5m ./internal/e2e/
 
+      # The shell counterpart of the model-resolution invariants the Go tests
+      # above cover: scripts/resolve-model.sh feeds the workflows' shell steps
+      # and must agree with modelID()/validateModel(), or a run reports a model
+      # it didn't use.
+      - name: Check model resolver parity
+        run: scripts/resolve-model_test.sh
+
   cache-integration:
     name: Cache integration (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/doc-drift.yml
+++ b/.github/workflows/doc-drift.yml
@@ -27,6 +27,14 @@ on:
         description: 'Wall-clock timeout for the audit agent, in seconds'
         type: string
         default: '2400'
+      model:
+        description: 'Model id for the audit agent, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go (zai-org/GLM-5.2)'
+        type: string
+        default: ''
+      context_limit:
+        description: 'Context window declared to the agent, in tokens. Leave empty for the 100000 default, which is safely under every pinned model'
+        type: string
+        default: ''
   schedule:
     # Mondays 06:00 UTC — weekly drift sweep.
     - cron: '0 6 * * 1'
@@ -51,9 +59,21 @@ jobs:
       SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
       E2E_VERSION_OPENCODE: ${{ github.event.inputs.opencode_version }}
       DRIFT_TIMEOUT_SECS: ${{ github.event.inputs.timeout_secs }}
+      # Read by scripts/resolve-model.sh (which doc-drift.sh consults) and by
+      # the provider config it writes. Both empty on schedule runs, so that run
+      # always uses the committed pin and the 100000 default.
+      E2E_MODEL: ${{ github.event.inputs.model }}
+      E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Resolve model
+        id: model
+        run: |
+          model=$(scripts/resolve-model.sh opencode)
+          echo "model=$model" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Model::${{ matrix.mode }} drift audit runs against $model"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -69,6 +89,8 @@ jobs:
         run: |
           {
             echo "## Doc drift — ${{ matrix.mode }}"
+            echo ""
+            echo "Model: \`${{ steps.model.outputs.model }}\`"
             echo ""
             echo '```markdown'
             cat "${{ runner.temp }}/doc-drift-logs/DRIFT_REPORT-${{ matrix.mode }}.md" 2>/dev/null \

--- a/.github/workflows/doc-drift.yml
+++ b/.github/workflows/doc-drift.yml
@@ -43,8 +43,41 @@ permissions:
   contents: read
 
 jobs:
+  # Front-loads model selection: the gateway serves one name variant at a time
+  # and flips without notice (#184). Probing once here means a renamed model
+  # fails in seconds rather than after a 40-minute audit.
+  model:
+    name: Resolve model
+    runs-on: ubuntu-latest
+    outputs:
+      gateway: ${{ steps.probe.outputs.model }}
+      fallback: ${{ steps.probe.outputs.fallback }}
+      candidates: ${{ steps.probe.outputs.candidates }}
+    env:
+      SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+      SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+      E2E_MODEL: ${{ github.event.inputs.model }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Probe the gateway
+        id: probe
+        run: scripts/probe-model.sh opencode --github-output
+      - name: Report the selection
+        run: |
+          {
+            echo "## Model selection"
+            echo ""
+            echo "Model: \`${{ steps.probe.outputs.model }}\` · probed: \`${{ steps.probe.outputs.candidates }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ steps.probe.outputs.fallback }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Fallback model in use** — the intended model is not served by the gateway." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   drift:
     name: ${{ matrix.mode }} drift
+    needs: model
     strategy:
       fail-fast: false
       matrix:
@@ -59,21 +92,14 @@ jobs:
       SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
       E2E_VERSION_OPENCODE: ${{ github.event.inputs.opencode_version }}
       DRIFT_TIMEOUT_SECS: ${{ github.event.inputs.timeout_secs }}
-      # Read by scripts/resolve-model.sh (which doc-drift.sh consults) and by
-      # the provider config it writes. Both empty on schedule runs, so that run
-      # always uses the committed pin and the 100000 default.
-      E2E_MODEL: ${{ github.event.inputs.model }}
+      # From the preflight job: the input, the gateway probe and the -TEE flip
+      # already applied. Only opencode is involved here, so the cross-harness
+      # var is the right one to set.
+      E2E_MODEL: ${{ needs.model.outputs.gateway }}
       E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Resolve model
-        id: model
-        run: |
-          model=$(scripts/resolve-model.sh opencode)
-          echo "model=$model" >> "$GITHUB_OUTPUT"
-          echo "::notice title=Model::${{ matrix.mode }} drift audit runs against $model"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -90,7 +116,7 @@ jobs:
           {
             echo "## Doc drift — ${{ matrix.mode }}"
             echo ""
-            echo "Model: \`${{ steps.model.outputs.model }}\`"
+            echo "Model: \`${{ needs.model.outputs.gateway }}\`"
             echo ""
             echo '```markdown'
             cat "${{ runner.temp }}/doc-drift-logs/DRIFT_REPORT-${{ matrix.mode }}.md" 2>/dev/null \

--- a/.github/workflows/e2e-readme-onboarding.yml
+++ b/.github/workflows/e2e-readme-onboarding.yml
@@ -23,6 +23,14 @@ on:
         description: 'Wall-clock timeout for the onboarding agent session, in seconds'
         type: string
         default: '1200'
+      model:
+        description: 'Model id for the onboarding agent, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go (zai-org/GLM-5.2)'
+        type: string
+        default: ''
+      context_limit:
+        description: 'Context window declared to the agent, in tokens. Leave empty for the 100000 default, which is safely under every pinned model'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -43,9 +51,21 @@ jobs:
       SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
       E2E_VERSION_OPENCODE: ${{ github.event.inputs.opencode_version }}
       E2E_ONBOARDING_TIMEOUT_SECS: ${{ github.event.inputs.timeout_secs }}
+      # Read by scripts/resolve-model.sh (which the onboarding script consults)
+      # and by the provider config it writes. This workflow is dispatch-only, so
+      # an empty input means the committed pin and the 100000 default.
+      E2E_MODEL: ${{ github.event.inputs.model }}
+      E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Resolve model
+        id: model
+        run: |
+          model=$(scripts/resolve-model.sh opencode)
+          echo "model=$model" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Model::onboarding agent runs against $model"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -60,6 +80,8 @@ jobs:
         if: always()
         run: |
           echo "## README onboarding (${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Model: \`${{ steps.model.outputs.model }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.run_onboarding.outcome }}" = "success" ]; then
             echo "**Result:** README was sufficient — doctor healthy, report written." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e-readme-onboarding.yml
+++ b/.github/workflows/e2e-readme-onboarding.yml
@@ -36,8 +36,41 @@ permissions:
   contents: read
 
 jobs:
+  # Front-loads model selection: the gateway serves one name variant at a time
+  # and flips without notice (#184). Probing once here means a renamed model
+  # fails in seconds rather than after a 20-minute agent session.
+  model:
+    name: Resolve model
+    runs-on: ubuntu-latest
+    outputs:
+      gateway: ${{ steps.probe.outputs.model }}
+      fallback: ${{ steps.probe.outputs.fallback }}
+      candidates: ${{ steps.probe.outputs.candidates }}
+    env:
+      SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+      SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+      E2E_MODEL: ${{ github.event.inputs.model }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Probe the gateway
+        id: probe
+        run: scripts/probe-model.sh opencode --github-output
+      - name: Report the selection
+        run: |
+          {
+            echo "## Model selection"
+            echo ""
+            echo "Model: \`${{ steps.probe.outputs.model }}\` · probed: \`${{ steps.probe.outputs.candidates }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ steps.probe.outputs.fallback }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Fallback model in use** — the intended model is not served by the gateway." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   readme-onboarding:
     name: README onboarding (${{ matrix.os }})
+    needs: model
     strategy:
       fail-fast: false
       matrix:
@@ -51,21 +84,14 @@ jobs:
       SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
       E2E_VERSION_OPENCODE: ${{ github.event.inputs.opencode_version }}
       E2E_ONBOARDING_TIMEOUT_SECS: ${{ github.event.inputs.timeout_secs }}
-      # Read by scripts/resolve-model.sh (which the onboarding script consults)
-      # and by the provider config it writes. This workflow is dispatch-only, so
-      # an empty input means the committed pin and the 100000 default.
-      E2E_MODEL: ${{ github.event.inputs.model }}
+      # From the preflight job: the input, the gateway probe and the -TEE flip
+      # already applied. Only opencode is involved here, so the cross-harness
+      # var is the right one to set.
+      E2E_MODEL: ${{ needs.model.outputs.gateway }}
       E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Resolve model
-        id: model
-        run: |
-          model=$(scripts/resolve-model.sh opencode)
-          echo "model=$model" >> "$GITHUB_OUTPUT"
-          echo "::notice title=Model::onboarding agent runs against $model"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -81,7 +107,7 @@ jobs:
         run: |
           echo "## README onboarding (${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Model: \`${{ steps.model.outputs.model }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Model: \`${{ needs.model.outputs.gateway }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.run_onboarding.outcome }}" = "success" ]; then
             echo "**Result:** README was sufficient — doctor healthy, report written." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -38,6 +38,18 @@ on:
         description: 'Install each harness''s latest release (drift detection). Uncheck to test the versions.go pins instead.'
         type: boolean
         default: true
+      model:
+        description: 'Model id for EVERY harness, for THIS RUN ONLY. Leave empty to use each harness''s pin in internal/e2e/versions.go (opencode/codex/copilot/pi: zai-org/GLM-5.2, claude-code: claude-sonnet-5)'
+        type: string
+        default: ''
+      claude_code_model:
+        description: 'Model id for claude-code only — it accepts sonnet or haiku models ONLY. Wins over "model"; leave empty to fall back to it, then to the versions.go pin'
+        type: string
+        default: ''
+      context_limit:
+        description: 'Context window declared to the harness, in tokens. Leave empty for the 100000 default, which is safely under every pinned model'
+        type: string
+        default: ''
   schedule:
     # Same slot as e2e.yml — Saturdays 08:00 UTC (10:00 CEST).
     - cron: '0 8 * * 6'
@@ -76,9 +88,22 @@ jobs:
       E2E_HARNESS: ${{ matrix.harness }}
       # Schedule runs always test latest (drift); dispatch honors the input.
       E2E_USE_LATEST: ${{ (github.event_name == 'schedule' || github.event.inputs.use_latest != 'false') && '1' || '' }}
+      # Model overrides for a manual run. All empty on schedule runs, so that
+      # run always resolves to the pins in internal/e2e/versions.go.
+      E2E_MODEL: ${{ github.event.inputs.model }}
+      E2E_MODEL_CLAUDE_CODE: ${{ github.event.inputs.claude_code_model }}
+      E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # Fails the leg immediately on a model the harness can't launch
+      # (claude-code accepts sonnet/haiku only), rather than after the install.
+      # The row's Model cell comes from the test's own OMAC_COMPAT line, not
+      # from here — see "Build compatibility row".
+      - name: Resolve model
+        run: |
+          echo "::notice title=Model::${{ matrix.harness }} runs against $(scripts/resolve-model.sh '${{ matrix.harness }}')"
 
       - name: Install bubblewrap (Linux only)
         if: runner.os == 'Linux'
@@ -203,6 +228,13 @@ jobs:
           version=$(grep -oE 'OMAC_COMPAT .*stage=contract .*' modelfree.log 2>/dev/null \
             | sed -E 's/.*version=([^ ]+).*/\1/' | head -1)
           [ -z "$version" ] && version="unknown"
+          # Model the test process actually resolved (compatLine's model= field),
+          # so an overridden run's row is attributable to the model that produced
+          # it. When the leg crashed before emitting any line, fall back to the
+          # resolver — same precedence, so the same answer the test would give.
+          model=$(grep -oE 'OMAC_COMPAT .*stage=contract .*' modelfree.log 2>/dev/null \
+            | sed -E 's/.*model=([^ ]+).*/\1/' | head -1)
+          [ -z "$model" ] && model=$(scripts/resolve-model.sh '${{ matrix.harness }}' || echo unknown)
           contract=$(stage_mark contract)
           launch=$(stage_mark launch)
           serve=$(stage_mark serve ➖)
@@ -212,7 +244,10 @@ jobs:
             *)       llm='➖' ;;  # not run (e.g. leg crashed earlier)
           esac
           date_utc=$(date -u +%Y-%m-%d)
-          row="| $date_utc | ${{ steps.omac.outputs.version }} | ${{ matrix.os }} | ${{ matrix.harness }} | $version | $contract | $launch | $serve | $llm |"
+          # Model is APPENDED, never inserted: the report job and the Slack
+          # fallback address the stage marks positionally ($7..$10), and rows
+          # already archived have no model cell.
+          row="| $date_utc | ${{ steps.omac.outputs.version }} | ${{ matrix.os }} | ${{ matrix.harness }} | $version | $contract | $launch | $serve | $llm | $model |"
           mkdir -p compat
           slug="${{ matrix.os }}-${{ matrix.harness }}-${{ matrix.omac }}"
           printf '%s\n' "$row" > "compat/$slug.row"
@@ -238,8 +273,8 @@ jobs:
           {
             echo "### ${{ matrix.harness }} / ${{ matrix.os }} / omac@${{ matrix.omac }}"
             echo ""
-            echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm |"
-            echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|"
+            echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm | Model |"
+            echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|---|"
             echo "$row"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -342,6 +377,9 @@ jobs:
         env:
           SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
           SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+          # The summariser is an LLM call too, so it follows the same override —
+          # this job has no matrix, so only the cross-harness input applies.
+          E2E_MODEL: ${{ github.event.inputs.model }}
         run: |
           # Each failing leg already wrote a self-contained .ctx file (header
           # with harness/OS/omac + failing stage, plus its own log excerpts), so
@@ -356,10 +394,8 @@ jobs:
             echo "SKAINET creds missing — skipping AI summary (Slack will fall back to the failing-row list)"
             exit 0
           fi
-          # Single source of truth for the model id: internal/e2e/versions.go.
-          model=$(awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' internal/e2e/versions.go \
-            | grep '"opencode"' | sed -E 's/.*:\s*"([^"]+)".*/\1/')
-          [ -z "$model" ] && model="zai-org/GLM-5.2"
+          # Single source of truth for the model id, override included.
+          model=$(scripts/resolve-model.sh opencode)
           ctx=$(head -c 6000 failure-context.txt)
           sys="You are a CI assistant for the omac project. In at most 3 short sentences, state exactly what went wrong in these harness compatibility logs: name the harness, OS, and the specific flag or error message when present. Use the failing stage(s) stated in each '=== ... ===' header verbatim — do NOT infer or rename the stage. Output only the summary: no preamble, no fixes, and no chain-of-thought or <think> tags."
           payload=$(jq -n --arg m "$model" --arg s "$sys" --arg u "$ctx" \
@@ -376,7 +412,10 @@ jobs:
           summary=$(printf '%s' "$summary" | perl -0777 -pe 's{<think>.*?</think>}{}gs; s/\A\s+//' 2>/dev/null || printf '%s' "$summary")
           if [ -n "$(printf '%s' "$summary" | tr -d '[:space:]')" ]; then
             printf '%s\n' "$summary" > failure-summary.txt
-            echo "AI summary:"; cat failure-summary.txt
+            # Credited downstream so a summary is never read as more (or less)
+            # authoritative than the model that wrote it warrants.
+            echo "model=$model" >> "$GITHUB_OUTPUT"
+            echo "AI summary (model: $model):"; cat failure-summary.txt
           else
             echo "no summary returned (resp head: $(printf '%s' "$resp" | head -c 300))"
           fi
@@ -394,6 +433,7 @@ jobs:
           FAIL_COUNT: ${{ steps.rows.outputs.fail_count }}
           TOTAL: ${{ steps.rows.outputs.total }}
           INFRA_ONLY: ${{ steps.reason.outputs.infra_only }}
+          SUMMARY_MODEL: ${{ steps.summary.outputs.model }}
         run: |
           title="Harness compatibility matrix"
           # One stable issue, any state: reopen if it was closed so it is always
@@ -444,13 +484,13 @@ jobs:
                 echo ""
               fi
               if [ -s failure-summary.txt ]; then
-                echo "**What went wrong** (SKAINET summary):"
+                echo "**What went wrong** (SKAINET summary, model \`$SUMMARY_MODEL\`):"
                 echo ""
                 sed 's/^/> /' failure-summary.txt
                 echo ""
               fi
-              echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm |"
-              echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|"
+              echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm | Model |"
+              echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|---|"
               cat failing.rows
               echo ""
               # Footer hint depends on the failing stage: the contract-drift
@@ -464,8 +504,8 @@ jobs:
             echo ""
             echo "## History (rolling 30 days)"
             echo ""
-            echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm |"
-            echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|"
+            echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm | Model |"
+            echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|---|"
             printf '%s\n' "$all"
           } > dashboard.md
           if [ -n "$num" ]; then
@@ -500,10 +540,21 @@ jobs:
               echo ""
               echo "Appended by omac's e2e-smoke workflow. Do not edit by hand."
               echo ""
-              echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm |"
-              echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|"
+              echo "| Timestamp (UTC) | omac | OS | Harness | Version | contract | launch | serve | llm | Model |"
+              echo "|---|---|---|---|---|:-:|:-:|:-:|:-:|---|"
               echo "<!-- COMPAT_TABLE_END -->"
             } > "$file"
+          fi
+          # Widen a pre-existing header to include the Model column, added after
+          # this archive was first written. Without this the appended rows carry
+          # a model cell the narrower header hides, so the permanent history
+          # would silently drop the very field it needs to stay attributable.
+          if grep -q '| llm |$' "$file"; then
+            sed -i.bak \
+              -e 's/| llm |$/| llm | Model |/' \
+              -e 's/^|---|---|---|---|---|:-:|:-:|:-:|:-:|$/|---|---|---|---|---|:-:|:-:|:-:|:-:|---|/' \
+              "$file"
+            rm -f "$file.bak"
           fi
           # Append this run's rows just above the end marker (chronological).
           awk -v rows="$(cat run.rows)" '/<!-- COMPAT_TABLE_END -->/{print rows} {print}' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
@@ -528,11 +579,18 @@ jobs:
           FAIL_COUNT: ${{ steps.rows.outputs.fail_count }}
           TOTAL: ${{ steps.rows.outputs.total }}
           INFRA_ONLY: ${{ steps.reason.outputs.infra_only }}
+          SUMMARY_MODEL: ${{ steps.summary.outputs.model }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "SLACK_WEBHOOK_URL not set — skipping Slack notification"
             exit 0
           fi
+          # The run's model(s), from the rows' Model column (field 11). Stated
+          # unconditionally: without it a reader assumes the committed pin, and
+          # a manual run against an override reads as a regression in the default.
+          models=$(awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/,"",$11); if ($11!="") print $11}' run.rows \
+            | sort -u | paste -sd',' - )
+          [ -z "$models" ] && models="unknown"
           # Posted on every run — green and red alike.
           if [ "$HAS_FAILURES" = "true" ]; then
             hdr=$(printf '🔴 omac harness compatibility: %s of %s combination(s) FAILED.' "$FAIL_COUNT" "$TOTAL")
@@ -560,12 +618,12 @@ jobs:
             fi
             # Append the SKAINET summary as extra colour when it produced one.
             if [ -s failure-summary.txt ] && [ -s failure-reason.txt ]; then
-              detail=$(printf '%s\n— summary: %s' "$detail" "$(tr '\n' ' ' < failure-summary.txt)")
+              detail=$(printf '%s\n— summary (%s): %s' "$detail" "${SUMMARY_MODEL:-unknown model}" "$(tr '\n' ' ' < failure-summary.txt)")
             fi
-            text=$(printf '%s\n%s\nDashboard: %s — Run: %s' \
-              "$hdr" "$detail" "$ISSUE_URL" "$RUN_URL")
+            text=$(printf '%s\n%s\nModel(s): %s\nDashboard: %s — Run: %s' \
+              "$hdr" "$detail" "$models" "$ISSUE_URL" "$RUN_URL")
           else
-            text="🟢 omac harness compatibility: all $TOTAL combination(s) green. Dashboard: $ISSUE_URL — Run: $RUN_URL"
+            text="🟢 omac harness compatibility: all $TOTAL combination(s) green. Model(s): $models. Dashboard: $ISSUE_URL — Run: $RUN_URL"
           fi
           # The Slack endpoint is a Workflow Builder webhook: its payload keys
           # must match the workflow's declared variables, which expect "message"

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -59,8 +59,55 @@ permissions:
   issues: write # report job maintains the tracking issue
 
 jobs:
+  # Front-loads model selection: the gateway serves one name variant at a time
+  # and flips without notice (#184), which reddened every non-opencode llm stage
+  # on 2026-07-29. Probing once here means a renamed model costs seconds instead
+  # of 18 legs, and the -TEE flip self-heals.
+  model:
+    name: Resolve model
+    runs-on: ubuntu-latest
+    outputs:
+      gateway: ${{ steps.probe.outputs.model }}
+      fallback: ${{ steps.probe.outputs.fallback }}
+      candidates: ${{ steps.probe.outputs.candidates }}
+      claude_code: ${{ steps.probe.outputs.claude_code }}
+    env:
+      SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+      SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+      E2E_MODEL: ${{ github.event.inputs.model }}
+      E2E_MODEL_CLAUDE_CODE: ${{ github.event.inputs.claude_code_model }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Probe the gateway
+        id: probe
+        run: |
+          scripts/probe-model.sh opencode --github-output
+          cc=$(E2E_MODEL= scripts/probe-model.sh claude-code)
+          echo "claude_code=$cc" >> "$GITHUB_OUTPUT"
+
+      - name: Report the selection
+        run: |
+          gateway='${{ steps.probe.outputs.model }}'
+          {
+            echo "## Model selection"
+            echo ""
+            echo "| Harness | Model |"
+            echo "|---|---|"
+            echo "| opencode, codex, copilot, pi | \`$gateway\` |"
+            echo "| claude-code | \`${{ steps.probe.outputs.claude_code }}\` |"
+            echo ""
+            echo "Probed: \`${{ steps.probe.outputs.candidates }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ steps.probe.outputs.fallback }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Fallback model in use** — \`$gateway\` is not the intended model." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   smoke:
     name: "${{ matrix.harness }} / ${{ matrix.os }} / omac@${{ matrix.omac }}"
+    needs: model
     strategy:
       fail-fast: false
       matrix:
@@ -88,19 +135,22 @@ jobs:
       E2E_HARNESS: ${{ matrix.harness }}
       # Schedule runs always test latest (drift); dispatch honors the input.
       E2E_USE_LATEST: ${{ (github.event_name == 'schedule' || github.event.inputs.use_latest != 'false') && '1' || '' }}
-      # Model overrides for a manual run. All empty on schedule runs, so that
-      # run always resolves to the pins in internal/e2e/versions.go.
-      E2E_MODEL: ${{ github.event.inputs.model }}
-      E2E_MODEL_CLAUDE_CODE: ${{ github.event.inputs.claude_code_model }}
+      # From the preflight job (input + gateway probe + -TEE flip applied). Set
+      # PER HARNESS, not via cross-harness E2E_MODEL: the probed value is a
+      # gateway model and claude-code is on another provider.
+      E2E_MODEL_OPENCODE: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_CODEX: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_COPILOT: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_PI: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_CLAUDE_CODE: ${{ needs.model.outputs.claude_code }}
       E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Fails the leg immediately on a model the harness can't launch
-      # (claude-code accepts sonnet/haiku only), rather than after the install.
-      # The row's Model cell comes from the test's own OMAC_COMPAT line, not
-      # from here — see "Build compatibility row".
+      # Selection already happened in the preflight job; this reports what this
+      # leg's harness resolved to. The row's Model cell comes from the test's own
+      # OMAC_COMPAT line, not from here — see "Build compatibility row".
       - name: Resolve model
         run: |
           echo "::notice title=Model::${{ matrix.harness }} runs against $(scripts/resolve-model.sh '${{ matrix.harness }}')"
@@ -312,7 +362,7 @@ jobs:
 
   report:
     name: Record & report
-    needs: smoke
+    needs: [model, smoke]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -377,9 +427,10 @@ jobs:
         env:
           SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
           SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
-          # The summariser is an LLM call too, so it follows the same override —
-          # this job has no matrix, so only the cross-harness input applies.
-          E2E_MODEL: ${{ github.event.inputs.model }}
+          # The summariser is an LLM call too, so it uses the model the preflight
+          # proved is served — re-resolving the pin here would 422 in exactly
+          # the situation the summary is most needed.
+          E2E_MODEL: ${{ needs.model.outputs.gateway }}
         run: |
           # Each failing leg already wrote a self-contained .ctx file (header
           # with harness/OS/omac + failing stage, plus its own log excerpts), so
@@ -434,6 +485,8 @@ jobs:
           TOTAL: ${{ steps.rows.outputs.total }}
           INFRA_ONLY: ${{ steps.reason.outputs.infra_only }}
           SUMMARY_MODEL: ${{ steps.summary.outputs.model }}
+          MODEL_FALLBACK: ${{ needs.model.outputs.fallback }}
+          GATEWAY_MODEL: ${{ needs.model.outputs.gateway }}
         run: |
           title="Harness compatibility matrix"
           # One stable issue, any state: reopen if it was closed so it is always
@@ -467,6 +520,10 @@ jobs:
             echo "$status — [run log]($RUN_URL). Updated in place by [\`e2e-smoke.yml\`]($WF_URL); rolling 30-day window (newest first, grouped by omac / OS / harness). Full permanent history is mirrored to a private archive repo."
             echo ""
             echo "\`✅\` pass · \`❌\` fail · \`➖\` not run"
+            if [ "$MODEL_FALLBACK" = "true" ]; then
+              echo ""
+              echo "> ⚠️ **This run used a fallback model** (\`$GATEWAY_MODEL\`): the intended model is not currently served by the gateway. Green rows below certify the fallback, not the intended model."
+            fi
             if [ "$HAS_FAILURES" = "true" ]; then
               echo ""
               echo "## Currently failing"
@@ -580,6 +637,7 @@ jobs:
           TOTAL: ${{ steps.rows.outputs.total }}
           INFRA_ONLY: ${{ steps.reason.outputs.infra_only }}
           SUMMARY_MODEL: ${{ steps.summary.outputs.model }}
+          MODEL_FALLBACK: ${{ needs.model.outputs.fallback }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "SLACK_WEBHOOK_URL not set — skipping Slack notification"
@@ -591,6 +649,9 @@ jobs:
           models=$(awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/,"",$11); if ($11!="") print $11}' run.rows \
             | sort -u | paste -sd',' - )
           [ -z "$models" ] && models="unknown"
+          if [ "${MODEL_FALLBACK:-}" = "true" ]; then
+            models="$models (FALLBACK — intended model not served)"
+          fi
           # Posted on every run — green and red alike.
           if [ "$HAS_FAILURES" = "true" ]; then
             hdr=$(printf '🔴 omac harness compatibility: %s of %s combination(s) FAILED.' "$FAIL_COUNT" "$TOTAL")

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,18 @@ on:
         description: 'Pinned pi package spec. Overrides internal/e2e/versions.go for THIS RUN ONLY (the file itself is untouched); ignored if "use latest" is checked'
         type: string
         default: '@earendil-works/pi-coding-agent@0.80.6'
+      model:
+        description: 'Model id for EVERY harness, for THIS RUN ONLY (e.g. zai-org/GLM-5.2). Leave empty to use each harness''s pin in internal/e2e/versions.go (opencode/codex/copilot/pi: zai-org/GLM-5.2, claude-code: claude-sonnet-5)'
+        type: string
+        default: ''
+      claude_code_model:
+        description: 'Model id for claude-code only — it accepts sonnet or haiku models ONLY, and bills a different provider than the SKAINET gateway the others use. Wins over "model"; leave empty to fall back to it, then to the versions.go pin'
+        type: string
+        default: ''
+      context_limit:
+        description: 'Context window declared to the harness, in tokens. Leave empty for the 100000 default, which is safely under every pinned model; raise it to exercise a larger model''s full window (declaring MORE than the model has overflows mid-run)'
+        type: string
+        default: ''
   schedule:
     - cron: '0 8 * * 6' # Saturdays 10:00 CEST
 
@@ -82,9 +94,33 @@ jobs:
       E2E_VERSION_CODEX: ${{ github.event.inputs.codex_version }}
       E2E_VERSION_COPILOT: ${{ github.event.inputs.copilot_version }}
       E2E_VERSION_PI: ${{ github.event.inputs.pi_version }}
+      # Model overrides for a manual run, so a different model can be tested
+      # without editing internal/e2e/versions.go. Both empty on schedule runs
+      # and whenever the inputs are left blank; modelID() then falls back to
+      # the pinned modelIDs map. E2E_MODEL_CLAUDE_CODE wins over E2E_MODEL for
+      # claude-code, which bills a different provider than the rest.
+      E2E_MODEL: ${{ github.event.inputs.model }}
+      E2E_MODEL_CLAUDE_CODE: ${{ github.event.inputs.claude_code_model }}
+      # Empty (and on schedule runs) → contextLimit()'s 100000 default.
+      E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # Resolved with the same precedence the Go tests apply (modelID() in
+      # internal/e2e/versions.go), so what the summary reports is what ran.
+      - name: Resolve model
+        id: model
+        run: |
+          # Fails fast on a model the harness can't launch (claude-code accepts
+          # sonnet/haiku only), before the ~15 min of installs below.
+          model=$(scripts/resolve-model.sh '${{ matrix.harness }}')
+          # Reported as the label rather than the number so the default has one
+          # definition (contextLimit() in internal/e2e/versions.go).
+          context="${E2E_CONTEXT_LIMIT:-versions.go default}"
+          echo "model=$model" >> "$GITHUB_OUTPUT"
+          echo "context=$context" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Model::${{ matrix.harness }} runs against $model (context: $context)"
 
       - name: Install bubblewrap (Linux only)
         if: runner.os == 'Linux'
@@ -179,7 +215,7 @@ jobs:
         if: steps.run_e2e.outcome == 'skipped'
         run: |
           echo "## E2E (${{ matrix.harness }} / ${{ matrix.os }}): SKIPPED" >> "$GITHUB_STEP_SUMMARY"
-          echo "skip_claude_code was set on this workflow_dispatch run." >> "$GITHUB_STEP_SUMMARY"
+          echo "skip_claude_code was set on this workflow_dispatch run (model would have been \`${{ steps.model.outputs.model }}\`)." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Failure classification summary
         if: always() && steps.run_e2e.outcome != 'skipped'
@@ -187,6 +223,8 @@ jobs:
           # Render a markdown table on the run-summary page so the failure
           # cause is visible by indicator without opening the full log.
           echo "## E2E failure classification (${{ matrix.harness }} / ${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Model: \`${{ steps.model.outputs.model }}\` · context: \`${{ steps.model.outputs.context }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Assertion | Mode | Reason |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----------|------|--------|" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,8 +57,62 @@ permissions:
   contents: read
 
 jobs:
+  # Front-loads model selection so a renamed or withdrawn model costs seconds
+  # instead of a whole matrix. The gateway serves one name variant at a time and
+  # flips without notice (#184); scripts/probe-model.sh asks GET /models what is
+  # advertised, then settles it with a 1-token chat probe, flipping the -TEE
+  # suffix and finally falling back to another family if it must.
+  model:
+    name: Resolve model
+    runs-on: ubuntu-latest
+    outputs:
+      gateway: ${{ steps.probe.outputs.model }}
+      fallback: ${{ steps.probe.outputs.fallback }}
+      candidates: ${{ steps.probe.outputs.candidates }}
+      claude_code: ${{ steps.probe.outputs.claude_code }}
+    env:
+      SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+      SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+      E2E_MODEL: ${{ github.event.inputs.model }}
+      E2E_MODEL_CLAUDE_CODE: ${{ github.event.inputs.claude_code_model }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Probe the gateway
+        id: probe
+        run: |
+          # The gateway harnesses (opencode/codex/copilot/pi) share one model,
+          # so one probe covers all four.
+          scripts/probe-model.sh opencode --github-output
+          # claude-code is resolved but never probed: it talks to
+          # ANTHROPIC_BASE_URL, not this gateway. Its own input wins; failing
+          # here (rather than in the matrix) keeps an unlaunchable model from
+          # burning an install first.
+          cc=$(E2E_MODEL= scripts/probe-model.sh claude-code)
+          echo "claude_code=$cc" >> "$GITHUB_OUTPUT"
+
+      - name: Report the selection
+        run: |
+          gateway='${{ steps.probe.outputs.model }}'
+          {
+            echo "## Model selection"
+            echo ""
+            echo "| Harness | Model |"
+            echo "|---|---|"
+            echo "| opencode, codex, copilot, pi | \`$gateway\` |"
+            echo "| claude-code | \`${{ steps.probe.outputs.claude_code }}\` |"
+            echo ""
+            echo "Probed: \`${{ steps.probe.outputs.candidates }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ steps.probe.outputs.fallback }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Fallback model in use.** The intended model is not served by the gateway, so these results are for \`$gateway\` and do NOT certify the intended one." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   e2e:
     name: "${{ matrix.harness }} / ${{ matrix.os }}"
+    needs: model
     strategy:
       fail-fast: false
       matrix:
@@ -94,26 +148,28 @@ jobs:
       E2E_VERSION_CODEX: ${{ github.event.inputs.codex_version }}
       E2E_VERSION_COPILOT: ${{ github.event.inputs.copilot_version }}
       E2E_VERSION_PI: ${{ github.event.inputs.pi_version }}
-      # Model overrides for a manual run, so a different model can be tested
-      # without editing internal/e2e/versions.go. Both empty on schedule runs
-      # and whenever the inputs are left blank; modelID() then falls back to
-      # the pinned modelIDs map. E2E_MODEL_CLAUDE_CODE wins over E2E_MODEL for
-      # claude-code, which bills a different provider than the rest.
-      E2E_MODEL: ${{ github.event.inputs.model }}
-      E2E_MODEL_CLAUDE_CODE: ${{ github.event.inputs.claude_code_model }}
+      # Models come from the preflight job, which already applied the `model`
+      # input, the gateway probe, and the -TEE variant flip. Set PER HARNESS
+      # rather than via cross-harness E2E_MODEL: the probed value is a gateway
+      # model, and handing it to claude-code — which is on another provider and
+      # launches sonnet/haiku only — would fail its legs on every run,
+      # scheduled ones included.
+      E2E_MODEL_OPENCODE: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_CODEX: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_COPILOT: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_PI: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_CLAUDE_CODE: ${{ needs.model.outputs.claude_code }}
       # Empty (and on schedule runs) → contextLimit()'s 100000 default.
       E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Resolved with the same precedence the Go tests apply (modelID() in
-      # internal/e2e/versions.go), so what the summary reports is what ran.
+      # Selection happened in the preflight job; this only resolves what this
+      # leg's harness ended up with (per-harness env, set above) and reports it.
       - name: Resolve model
         id: model
         run: |
-          # Fails fast on a model the harness can't launch (claude-code accepts
-          # sonnet/haiku only), before the ~15 min of installs below.
           model=$(scripts/resolve-model.sh '${{ matrix.harness }}')
           # Reported as the label rather than the number so the default has one
           # definition (contextLimit() in internal/e2e/versions.go).
@@ -225,6 +281,10 @@ jobs:
           echo "## E2E failure classification (${{ matrix.harness }} / ${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Model: \`${{ steps.model.outputs.model }}\` · context: \`${{ steps.model.outputs.context }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ needs.model.outputs.fallback }}' = 'true' ] && [ '${{ matrix.harness }}' != 'claude-code' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ Fallback model — the intended model is not served by the gateway, so this result does NOT certify it." >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Assertion | Mode | Reason |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----------|------|--------|" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
         type: boolean
         default: true
       model:
-        description: "Model id for the release-notes summarizer, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go (zai-org/GLM-5.2)"
+        description: "Model id for the release-notes summarizer, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go. Whatever is resolved still goes through the gateway probe, so the -TEE variant flip and the fallback chain apply"
         type: string
         default: ''
 
@@ -128,8 +128,8 @@ jobs:
           # into user-facing highlights. Absent -> deterministic commit bullets.
           SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
           SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
-          # Read by scripts/resolve-model.sh below. Empty on a tag push (the
-          # normal path), so a real release always summarizes with the pin.
+          # Read by scripts/probe-model.sh below. Empty on a tag push (the
+          # normal path), so a real release starts from the committed pin.
           E2E_MODEL: ${{ github.event.inputs.model }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
@@ -179,12 +179,15 @@ jobs:
             max=48000
             [ "${#commits}" -gt "$max" ] && commits=${commits: -max}
             if [ -n "$commits" ]; then
-              # Single source of truth for the model id, override included:
-              # the `model` input, else internal/e2e/versions.go's pin.
+              # probe-model.sh, not resolve-model.sh: the gateway serves one
+              # name variant at a time and flips without notice (#184), so the
+              # committed pin alone would 422 and silently drop the release
+              # notes back to raw commit bullets. The probe flips the -TEE
+              # suffix and falls back a family if it must.
               # `|| true` because a release must never fail on its optional
               # summarizer: an empty model leaves llm_json empty below and the
               # deterministic commit bullets take over.
-              model=$(scripts/resolve-model.sh opencode || true)
+              model=$(scripts/probe-model.sh opencode || true)
               sys="You are the release-notes editor for oh-my-agentic-coder (omac), a CLI that runs coding agents in a sandbox. Below are the raw git commit messages for one release. Rewrite them into concise, user-facing highlights grouped into features (new capabilities) and fixes (bugs resolved). Write for end users: state what they can now do and why it matters. IGNORE anything only project developers care about: PR/issue numbers like (#123), commit SHAs, author or co-author trailers, internal refactors, and test/ci/build/chore changes. Drop internal module and scope names. Merge related commits into one bullet. Output ONLY minified JSON of the form {\"features\":[\"...\"],\"fixes\":[\"...\"]} with at most 6 items per group, each under 140 characters and starting with a capital letter. Use an empty array for a group with nothing user-facing. No preamble, no explanation, no chain-of-thought, no <think> tags."
               req=$(jq -n --arg m "$model" --arg s "$sys" --arg u "$commits" \
                 '{model:$m,temperature:0.2,max_tokens:1500,messages:[{role:"system",content:$s},{role:"user",content:$u}]}')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
         description: "Dry run (snapshot, do not publish)"
         type: boolean
         default: true
+      model:
+        description: "Model id for the release-notes summarizer, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go (zai-org/GLM-5.2)"
+        type: string
+        default: ''
 
 permissions:
   contents: write   # required to create the GitHub Release
@@ -124,6 +128,9 @@ jobs:
           # into user-facing highlights. Absent -> deterministic commit bullets.
           SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
           SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+          # Read by scripts/resolve-model.sh below. Empty on a tag push (the
+          # normal path), so a real release always summarizes with the pin.
+          E2E_MODEL: ${{ github.event.inputs.model }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "SLACK_RELEASE_WEBHOOK not set — skipping Slack notification"
@@ -172,10 +179,12 @@ jobs:
             max=48000
             [ "${#commits}" -gt "$max" ] && commits=${commits: -max}
             if [ -n "$commits" ]; then
-              # Single source of truth for the model id: internal/e2e/versions.go.
-              model=$(awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' internal/e2e/versions.go \
-                | grep '"opencode"' | sed -E 's/.*:\s*"([^"]+)".*/\1/')
-              [ -z "$model" ] && model="zai-org/GLM-5.2"
+              # Single source of truth for the model id, override included:
+              # the `model` input, else internal/e2e/versions.go's pin.
+              # `|| true` because a release must never fail on its optional
+              # summarizer: an empty model leaves llm_json empty below and the
+              # deterministic commit bullets take over.
+              model=$(scripts/resolve-model.sh opencode || true)
               sys="You are the release-notes editor for oh-my-agentic-coder (omac), a CLI that runs coding agents in a sandbox. Below are the raw git commit messages for one release. Rewrite them into concise, user-facing highlights grouped into features (new capabilities) and fixes (bugs resolved). Write for end users: state what they can now do and why it matters. IGNORE anything only project developers care about: PR/issue numbers like (#123), commit SHAs, author or co-author trailers, internal refactors, and test/ci/build/chore changes. Drop internal module and scope names. Merge related commits into one bullet. Output ONLY minified JSON of the form {\"features\":[\"...\"],\"fixes\":[\"...\"]} with at most 6 items per group, each under 140 characters and starting with a capital letter. Use an empty array for a group with nothing user-facing. No preamble, no explanation, no chain-of-thought, no <think> tags."
               req=$(jq -n --arg m "$model" --arg s "$sys" --arg u "$commits" \
                 '{model:$m,temperature:0.2,max_tokens:1500,messages:[{role:"system",content:$s},{role:"user",content:$u}]}')

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,6 +28,10 @@ on:
         type: choice
         options: [quick, standard, deep]
         default: deep
+      model:
+        description: 'Model id for the strix agent, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go (zai-org/GLM-5.2). The -TEE fallback probe below applies to whatever is resolved here'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -50,6 +54,9 @@ jobs:
       LLM_API_BASE: ${{ secrets.SKAINET_EXTERNAL }}
       LLM_API_KEY: ${{ secrets.SKAINET_TOKEN }}
       GH_TOKEN: ${{ github.token }}
+      # Read by scripts/resolve-model.sh below; empty on the scheduled run, so
+      # that run always resolves to the committed pin.
+      E2E_MODEL: ${{ inputs.model }}
     steps:
       - name: Checkout target repo
         uses: actions/checkout@v4
@@ -123,15 +130,12 @@ jobs:
         id: model
         run: |
           set -euo pipefail
-          # Base model name: single source of truth is internal/e2e/versions.go's
-          # modelIDs map (opencode's entry -- the plain GLM-5.2 name, which is
-          # what opencode's own resolution uses) rather than duplicating it here.
-          base=$(awk '/^var modelIDs = map\[string\]string\{/{flag=1; next} /^\}/{flag=0} flag' \
-            target/internal/e2e/versions.go | grep '"opencode"' | sed -E 's/.*:\s*"([^"]+)".*/\1/')
-          if [ -z "$base" ]; then
-            echo "::error::could not resolve model from internal/e2e/versions.go"
-            exit 1
-          fi
+          # Base model name: resolved by the checked-out repo's own resolver, so
+          # the same precedence the e2e Go tests apply -- the `model` input, else
+          # internal/e2e/versions.go's modelIDs map (opencode's entry, the plain
+          # GLM-5.2 name that opencode's own resolution uses). The resolver reads
+          # versions.go relative to itself, so the target/ checkout path is fine.
+          base=$(target/scripts/resolve-model.sh opencode)
           # Harden against the gateway's raw /v1/chat/completions path only
           # serving one model-name variant at a time: unlike opencode, strix
           # calls that path directly, and it recently flipped from accepting the
@@ -157,6 +161,11 @@ jobs:
           fi
           echo "selected model: ${chosen}"
           echo "strix_llm=openai/${chosen}" >> "$GITHUB_OUTPUT"
+          echo "model=${chosen}" >> "$GITHUB_OUTPUT"
+          # Model names aren't findings -- safe on this public summary, and the
+          # counts below are only interpretable against the model that produced
+          # them (especially on a manual run against an override).
+          echo "::notice title=Model::strix scan runs against ${chosen}"
 
       - name: Run strix scan
         id: scan
@@ -229,7 +238,10 @@ jobs:
 
       - name: Public summary (counts only, no exploit detail)
         if: steps.scan.outcome == 'success'
-        run: cat step-summary.md >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          cat step-summary.md >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Model: \`${{ steps.model.outputs.model }}\` · scan mode: \`${{ inputs.scan_mode || 'deep' }}\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Stop context-compaction proxy
         if: always()

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -29,7 +29,7 @@ on:
         options: [quick, standard, deep]
         default: deep
       model:
-        description: 'Model id for the strix agent, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go (zai-org/GLM-5.2). The -TEE fallback probe below applies to whatever is resolved here'
+        description: 'Model id for the strix agent, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go. Whatever is resolved here still goes through the gateway probe, so the -TEE variant flip and the fallback chain apply'
         type: string
         default: ''
 
@@ -54,8 +54,8 @@ jobs:
       LLM_API_BASE: ${{ secrets.SKAINET_EXTERNAL }}
       LLM_API_KEY: ${{ secrets.SKAINET_TOKEN }}
       GH_TOKEN: ${{ github.token }}
-      # Read by scripts/resolve-model.sh below; empty on the scheduled run, so
-      # that run always resolves to the committed pin.
+      # Read by scripts/probe-model.sh below; empty on the scheduled run, so
+      # that run starts from the committed pin.
       E2E_MODEL: ${{ inputs.model }}
     steps:
       - name: Checkout target repo
@@ -130,38 +130,16 @@ jobs:
         id: model
         run: |
           set -euo pipefail
-          # Base model name: resolved by the checked-out repo's own resolver, so
-          # the same precedence the e2e Go tests apply -- the `model` input, else
-          # internal/e2e/versions.go's modelIDs map (opencode's entry, the plain
-          # GLM-5.2 name that opencode's own resolution uses). The resolver reads
-          # versions.go relative to itself, so the target/ checkout path is fine.
-          base=$(target/scripts/resolve-model.sh opencode)
-          # Harden against the gateway's raw /v1/chat/completions path only
-          # serving one model-name variant at a time: unlike opencode, strix
-          # calls that path directly, and it recently flipped from accepting the
-          # plain name to requiring the -TEE variant (422 model_unavailable).
-          # Probe the base name first, fall back to <base>-TEE, and use
-          # whichever the gateway currently accepts -- so a future flip in
-          # either direction self-heals. Model names aren't secret; the bearer
-          # in the header is and is never printed.
-          endpoint="${LLM_API_BASE%/}/chat/completions"
-          chosen=""
-          for candidate in "$base" "${base}-TEE"; do
-            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 \
-              -X POST "$endpoint" \
-              -H "authorization: Bearer ${LLM_API_KEY}" \
-              -H 'content-type: application/json' \
-              -d "{\"model\":\"${candidate}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":1}") || true
-            if [ "$code" = "200" ]; then chosen="$candidate"; break; fi
-            echo "model '${candidate}' not accepted (HTTP ${code}); trying next variant"
-          done
-          if [ -z "$chosen" ]; then
-            echo "::error::neither '${base}' nor '${base}-TEE' was accepted by the gateway -- check the model provider and SKAINET_TOKEN validity"
-            exit 1
-          fi
+          # This workflow's own base/-TEE probe used to live here inline. It is
+          # now target/scripts/probe-model.sh, shared with every other LLM
+          # workflow (#184): same bidirectional variant flip, plus a GET /models
+          # listing to order candidates and a configured fallback family. The
+          # resolver reads versions.go relative to itself, so the target/
+          # checkout path needs no extra wiring. Model names aren't secret; the
+          # bearer in the header is and is never printed.
+          chosen=$(target/scripts/probe-model.sh opencode --github-output)
           echo "selected model: ${chosen}"
           echo "strix_llm=openai/${chosen}" >> "$GITHUB_OUTPUT"
-          echo "model=${chosen}" >> "$GITHUB_OUTPUT"
           # Model names aren't findings -- safe on this public summary, and the
           # counts below are only interpretable against the model that produced
           # them (especially on a manual run against an override).
@@ -242,6 +220,10 @@ jobs:
           cat step-summary.md >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Model: \`${{ steps.model.outputs.model }}\` · scan mode: \`${{ inputs.scan_mode || 'deep' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ steps.model.outputs.fallback }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Fallback model** — the intended model is not served by the gateway, so this scan's coverage is not comparable to previous ones." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Stop context-compaction proxy
         if: always()

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -102,6 +102,68 @@ Actions notice, `meta.txt` in the uploaded e2e artifacts, the `model=` field on
 every `OMAC_COMPAT` line, the `Model` column of the compatibility matrix, and
 the header of the drift/onboarding report artifacts.
 
+### The gateway renames models; the probe absorbs it
+
+The SKAINET gateway serves **one name variant at a time** — the plain name or a
+`-TEE` suffixed one — and flips between them without notice. On 2026-07-29 it
+stopped accepting plain `zai-org/GLM-5.2` and every non-opencode `llm` stage
+went red about ten minutes into each leg (issue #184).
+
+So every LLM workflow now starts with a **preflight `Resolve model` job** that
+runs [`scripts/probe-model.sh`](../scripts/probe-model.sh) once and hands the
+result to the jobs that follow. A renamed model costs seconds instead of a whole
+matrix. The probe:
+
+1. asks `GET $base/models` what the gateway advertises, and
+2. settles it with a 1-token `POST $base/chat/completions` — the endpoint that
+   actually 422s, so the endpoint that gets asked. The listing only *orders*
+   candidates; it never excludes one, because a stale listing must not veto a
+   name that works.
+
+Candidates are tried in **priority tiers** — the resolved model and its variant
+flip first, then each fallback and its flip. The listing may reorder within a
+tier but never across tiers, so a backup is only ever reached after the primary
+has genuinely been refused. The flip is bidirectional, so pinning either variant
+survives the next flip in either direction.
+
+A non-200 from the probe means one of two very different things, and the probe
+keeps them apart:
+
+| Gateway says | Meaning | Probe does |
+|---|---|---|
+| `422` / `404` | it refuses this **name** | move to the next candidate — this is what the flip and the fallback are for |
+| `5xx` / `429` / no answer | it is **unwell**; says nothing about the name | retry the same name, then fail as a gateway-health problem — **never** fall back |
+
+That second row matters: on 2026-07-29 the gateway also answered `500 An internal
+error occurred while invoking the model. The model inference should recover
+automatically within a few minutes.` Treating that as "model missing" would
+silently swap model families over a 30-second cluster blip, changing what the run
+tested for no good reason.
+
+| Substitution | Reported how |
+|---|---|
+| variant flip (`X` → `X-TEE`) | quietly — same model, gateway naming quirk |
+| fallback family (`fallbackModels`) | `::warning::`, step summary, dashboard and Slack all say the results are **not** for the intended model |
+
+The fallback chain lives in `fallbackModels` (`internal/e2e/versions.go`) rather
+than a workflow input, because `e2e.yml` is at GitHub's 10-input cap;
+`E2E_MODEL_FALLBACK` overrides it for a one-off (comma- or space-separated).
+
+claude-code is never probed — it talks to `ANTHROPIC_BASE_URL`, not this
+gateway. For the same reason the preflight hands the probed model to the
+**per-harness** vars (`E2E_MODEL_OPENCODE` and friends) rather than to
+cross-harness `E2E_MODEL`: the probed value is a gateway model, and giving it to
+claude-code would fail its legs on every run.
+
+```bash
+scripts/probe-model.sh opencode      # what a gateway job would use, probed
+scripts/probe-model.sh claude-code   # resolved, never probed
+scripts/probe-model_test.sh          # stub-gateway coverage of every path
+```
+
+Without credentials on the env the probe is a pure passthrough, so local runs
+and model-free jobs need no network to name a model.
+
 ### Multi-directory serve mode (`omac serve`)
 
 End-to-end smoke test of the control plane, facade routing, per-workdir

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -60,6 +60,48 @@ socket) and skip automatically in environments where `connect(2)` to
 `127.0.0.1` or to a Unix socket is disallowed (e.g. a hardened sandbox).
 On a normal dev machine they all run.
 
+### Choosing the model for LLM-driven runs
+
+Every workflow that calls a model — `E2E: full`, `E2E: drift`,
+`E2E: onboarding`, `Doc drift`, `Security Scan`, and the release-notes
+summarizer — resolves its model id the same way, so a run can be pointed at a
+different model from the Actions **Run workflow** form without editing or
+pushing anything. Precedence, highest first:
+
+| Source | Scope |
+|--------|-------|
+| `E2E_MODEL_<HARNESS>` (`claude_code_model` input) | one harness |
+| `E2E_MODEL` (`model` input) | every harness in the run |
+| `modelIDs` in `internal/e2e/versions.go` | the committed pin (what scheduled runs use) |
+
+The two implementations of that precedence — `modelID()` in
+`internal/e2e/versions.go` for the Go tests and
+[`scripts/resolve-model.sh`](../scripts/resolve-model.sh) for the workflows'
+shell steps — are kept in parity by `scripts/resolve-model_test.sh`, which runs
+on every PR. Locally the same env vars work:
+
+```bash
+E2E_MODEL=vendor/some-model go test -tags=e2e -v ./internal/e2e/
+scripts/resolve-model.sh claude-code   # print what a harness would resolve to
+```
+
+Two constraints the resolver enforces up front, rather than letting them surface
+as an opaque harness failure ten minutes into a run:
+
+- **claude-code launches sonnet or haiku models only.** A cross-harness
+  `model` override therefore can't reach it; give it a `claude_code_model` of
+  its own (it bills a different provider than the SKAINET gateway anyway).
+- **The declared context window must not exceed the model's real one**, or the
+  run overflows mid-turn. It defaults to 100000 — safely under every pinned
+  model, and a smaller declared window only makes the harness compact earlier.
+  Raise it via the `context_limit` input / `E2E_CONTEXT_LIMIT` to exercise a
+  larger model's full window.
+
+Each run reports the model it resolved: the run's step summary and an
+Actions notice, `meta.txt` in the uploaded e2e artifacts, the `model=` field on
+every `OMAC_COMPAT` line, the `Model` column of the compatibility matrix, and
+the header of the drift/onboarding report artifacts.
+
 ### Multi-directory serve mode (`omac serve`)
 
 End-to-end smoke test of the control plane, facade routing, per-workdir

--- a/docs/HARNESS_COMPAT.md
+++ b/docs/HARNESS_COMPAT.md
@@ -19,6 +19,13 @@ from source) and `release` (the latest published binary, i.e. what users run):
 `harness × os × omac{main,release}` (codex/macOS excluded), and rows are sorted
 newest-first, then grouped by omac version, OS, and harness.
 
+Every row also records the **model** the leg resolved, taken from the test's own
+`OMAC_COMPAT` line. Scheduled runs always show the pin in
+`internal/e2e/versions.go`; a manual run can point the whole matrix at a
+different model via the `model` input, so a row stays attributable to the model
+that produced it — see
+[*Choosing the model for LLM-driven runs*](DEVELOP.md#choosing-the-model-for-llm-driven-runs).
+
 ## Where the record lives
 
 The matrix is **not** committed to this repo (no bot pushes to `main`):

--- a/internal/e2e/artifacts.go
+++ b/internal/e2e/artifacts.go
@@ -59,6 +59,7 @@ func writeSessionArtifacts(t *testing.T, h harnessConfig, testType string,
 	var meta strings.Builder
 	fmt.Fprintf(&meta, "harness: %s\n", h.Name)
 	fmt.Fprintf(&meta, "binary: %s\n", h.BinaryName)
+	fmt.Fprintf(&meta, "model: %s\n", modelID(h.Name))
 	fmt.Fprintf(&meta, "os: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 	fmt.Fprintf(&meta, "test_type: %s\n", testType)
 	fmt.Fprintf(&meta, "no_sandbox: %v\n", h.Sandbox.NoSandbox)

--- a/internal/e2e/contract.go
+++ b/internal/e2e/contract.go
@@ -183,15 +183,23 @@ func harnessHasServerMode(name string) bool {
 // compatLine renders the stable machine-readable line the smoke test prints so
 // the workflow can parse it into the compatibility matrix without re-deriving
 // anything. The date and omac version are stamped by the workflow (they are not
-// known to, or stable within, the test process). Example:
+// known to, or stable within, the test process). model is the run's resolved
+// model id (see modelID) — like version, a property of the run rather than of
+// the stage, so the model-free stages carry it too; it keeps a result
+// attributable to the model that produced it when an override changed it.
+// Example:
 //
-//	OMAC_COMPAT harness=claude-code version=2.1.197 os=linux stage=contract result=PASS
+//	OMAC_COMPAT harness=claude-code version=2.1.197 os=linux model=claude-sonnet-5 stage=contract result=PASS
 func compatLine(harness, version, goos, stage, result string) string {
 	if version == "" {
 		version = "unknown"
 	}
-	return fmt.Sprintf("OMAC_COMPAT harness=%s version=%s os=%s stage=%s result=%s",
-		harness, sanitizeField(version), goos, stage, result)
+	model := modelID(harness)
+	if model == "" {
+		model = "unknown"
+	}
+	return fmt.Sprintf("OMAC_COMPAT harness=%s version=%s os=%s model=%s stage=%s result=%s",
+		harness, sanitizeField(version), goos, sanitizeField(model), stage, result)
 }
 
 // sanitizeField collapses whitespace in a value so it stays on the single

--- a/internal/e2e/contract_test.go
+++ b/internal/e2e/contract_test.go
@@ -131,13 +131,18 @@ func TestCompatLine(t *testing.T) {
 	t.Setenv("E2E_MODEL", "")
 	t.Setenv("E2E_MODEL_CLAUDE_CODE", "")
 
+	// Built from modelIDs rather than the literal pin: this asserts that the
+	// line carries the resolved model, not what that model happens to be
+	// today — the pin moves whenever the gateway renames a variant (#184).
 	got := compatLine("claude-code", "2.1.197", "linux", "contract", "PASS")
-	want := "OMAC_COMPAT harness=claude-code version=2.1.197 os=linux model=claude-sonnet-5 stage=contract result=PASS"
+	want := "OMAC_COMPAT harness=claude-code version=2.1.197 os=linux model=" +
+		modelIDs["claude-code"] + " stage=contract result=PASS"
 	if got != want {
 		t.Fatalf("compatLine = %q, want %q", got, want)
 	}
 	if got, want := compatLine("pi", "", "linux", "llm", "FAIL"),
-		"OMAC_COMPAT harness=pi version=unknown os=linux model=zai-org/GLM-5.2 stage=llm result=FAIL"; got != want {
+		"OMAC_COMPAT harness=pi version=unknown os=linux model="+
+			modelIDs["pi"]+" stage=llm result=FAIL"; got != want {
 		t.Fatalf("empty-version compatLine = %q, want %q", got, want)
 	}
 

--- a/internal/e2e/contract_test.go
+++ b/internal/e2e/contract_test.go
@@ -128,13 +128,36 @@ func TestMissingTokens(t *testing.T) {
 }
 
 func TestCompatLine(t *testing.T) {
+	t.Setenv("E2E_MODEL", "")
+	t.Setenv("E2E_MODEL_CLAUDE_CODE", "")
+
 	got := compatLine("claude-code", "2.1.197", "linux", "contract", "PASS")
-	want := "OMAC_COMPAT harness=claude-code version=2.1.197 os=linux stage=contract result=PASS"
+	want := "OMAC_COMPAT harness=claude-code version=2.1.197 os=linux model=claude-sonnet-5 stage=contract result=PASS"
 	if got != want {
 		t.Fatalf("compatLine = %q, want %q", got, want)
 	}
-	if got := compatLine("pi", "", "linux", "llm", "FAIL"); got != "OMAC_COMPAT harness=pi version=unknown os=linux stage=llm result=FAIL" {
-		t.Fatalf("empty-version compatLine = %q", got)
+	if got, want := compatLine("pi", "", "linux", "llm", "FAIL"),
+		"OMAC_COMPAT harness=pi version=unknown os=linux model=zai-org/GLM-5.2 stage=llm result=FAIL"; got != want {
+		t.Fatalf("empty-version compatLine = %q, want %q", got, want)
+	}
+
+	// The model field must track the override the run actually used, otherwise
+	// the compatibility matrix attributes a result to the wrong model.
+	t.Setenv("E2E_MODEL", "vendor/candidate-1")
+	if got, want := compatLine("pi", "1.0", "linux", "llm", "PASS"),
+		"OMAC_COMPAT harness=pi version=1.0 os=linux model=vendor/candidate-1 stage=llm result=PASS"; got != want {
+		t.Fatalf("overridden-model compatLine = %q, want %q", got, want)
+	}
+
+	// An unknown harness has no pin; the field stays parseable rather than empty.
+	if got, want := compatLine("nope", "1.0", "linux", "llm", "FAIL"),
+		"OMAC_COMPAT harness=nope version=1.0 os=linux model=vendor/candidate-1 stage=llm result=FAIL"; got != want {
+		t.Fatalf("unknown-harness compatLine = %q, want %q", got, want)
+	}
+	t.Setenv("E2E_MODEL", "")
+	if got, want := compatLine("nope", "1.0", "linux", "llm", "FAIL"),
+		"OMAC_COMPAT harness=nope version=1.0 os=linux model=unknown stage=llm result=FAIL"; got != want {
+		t.Fatalf("unpinned-harness compatLine = %q, want %q", got, want)
 	}
 }
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -341,7 +341,7 @@ func installHarness(t *testing.T, h harnessConfig, home string) {
 	// bun→npm fallback applied when bun is unavailable under
 	// E2E_RECOVER_INSTALL (the omac sandbox blocks writes to ~/.bun).
 	installCmd := resolveInstallCmd(h)
-	t.Logf("installing %s: %v", h.Name, installCmd)
+	t.Logf("installing %s: %v (model: %s)", h.Name, installCmd, modelID(h.Name))
 	cmd := exec.Command(installCmd[0], installCmd[1:]...)
 	cmd.Env = env
 	installFailed := false

--- a/internal/e2e/harnesses.go
+++ b/internal/e2e/harnesses.go
@@ -229,11 +229,13 @@ func opencodeConfig() harnessConfig {
 							"baseURL": baseURL,
 						},
 						"models": map[string]any{
-							modelIDs["opencode"]: map[string]any{
-								"name": "GLM 5.2",
+							modelID("opencode"): map[string]any{
+								// Display name follows the id so an
+								// overridden model isn't mislabelled.
+								"name": modelID("opencode"),
 								"limit": map[string]any{
-									"context": 131072,
-									"output":  32000,
+									"context": contextLimit(),
+									"output":  outputLimit(),
 								},
 							},
 						},
@@ -259,7 +261,7 @@ func opencodeConfig() harnessConfig {
 			ExtraReadPaths: opencodeCWDReadPaths(),
 		},
 		RunArgs: func(prompt string) []string {
-			return []string{"run", "--print-logs", "-m", "model/" + modelIDs["opencode"], prompt}
+			return []string{"run", "--print-logs", "-m", "model/" + modelID("opencode"), prompt}
 		},
 		SkillsBase: ".opencode",
 		EnvVarsForAllow: func() []string {
@@ -330,6 +332,12 @@ func claudeCodeConfig() harnessConfig {
 			if os.Getenv("ANTHROPIC_BASE_URL") == "" {
 				t.Fatal("ANTHROPIC_BASE_URL not set (CI secret for the Anthropic proxy)")
 			}
+			// Fail here, not on an opaque claude-code startup error, when a
+			// cross-harness model override lands on the one harness that
+			// cannot run it.
+			if err := validateModel("claude-code", modelID("claude-code")); err != nil {
+				t.Fatal(err)
+			}
 			// Claude Code provider is configured via env vars set on the
 			// omac start subprocess (ANTHROPIC_AUTH_TOKEN +
 			// ANTHROPIC_BASE_URL). No file-based config needed.
@@ -351,7 +359,7 @@ func claudeCodeConfig() harnessConfig {
 		},
 		Sandbox: SandboxConfig{}, // no deviations — model host allowed by base profile
 		RunArgs: func(prompt string) []string {
-			return []string{"-p", prompt, "--model", modelIDs["claude-code"], "--dangerously-skip-permissions"}
+			return []string{"-p", prompt, "--model", modelID("claude-code"), "--dangerously-skip-permissions"}
 		},
 		SkillsBase: ".claude",
 		EnvVarsForAllow: func() []string {
@@ -403,7 +411,7 @@ func codexConfig() harnessConfig {
 			}
 			// config.toml: codex requires wire_api=responses (Responses API).
 			// The responses API (SKAINET_INTERNAL) supports /v1/responses with the configured model.
-			configToml := `model = "` + modelIDs["codex"] + `"
+			configToml := `model = "` + modelID("codex") + `"
 model_provider = "model"
 
 [model_providers.model]
@@ -434,7 +442,7 @@ http_headers = { "X-User-Agent" = "Codex", "X-Separate-Reasoning" = "1" }
 			NoSandbox: runtime.GOOS == "darwin",
 		},
 		RunArgs: func(prompt string) []string {
-			return []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "-m", modelIDs["codex"], prompt}
+			return []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "-m", modelID("codex"), prompt}
 		},
 		SkillsBase: ".codex",
 		EnvVarsForAllow: func() []string {
@@ -505,13 +513,13 @@ func copilotConfig() harnessConfig {
 				"COPILOT_PROVIDER_TYPE=openai",
 				"COPILOT_PROVIDER_BASE_URL=" + baseURL,
 				"COPILOT_PROVIDER_API_KEY=" + token,
-				"COPILOT_MODEL=" + modelIDs["copilot"],
+				"COPILOT_MODEL=" + modelID("copilot"),
 				"COPILOT_PROVIDER_WIRE_API=responses",
 			}
 		},
 		Sandbox: SandboxConfig{}, // no deviations — model host allowed by base profile
 		RunArgs: func(prompt string) []string {
-			return []string{"-p", prompt, "--model", modelIDs["copilot"], "--allow-all-tools"}
+			return []string{"-p", prompt, "--model", modelID("copilot"), "--allow-all-tools"}
 		},
 		SkillsBase: ".copilot",
 		EnvVarsForAllow: func() []string {
@@ -592,7 +600,7 @@ func piConfig() harnessConfig {
 							"X-Separate-Reasoning": "1",
 						},
 						"models": []map[string]any{
-							{"id": modelIDs["pi"]},
+							{"id": modelID("pi")},
 						},
 					},
 				},
@@ -615,7 +623,7 @@ func piConfig() harnessConfig {
 			// --dangerously-skip-permissions-equivalent flag is needed.
 			// --provider is required: pi defaults to "google" without it,
 			// which would silently ignore the "model" custom provider above.
-			return []string{"-p", prompt, "--provider", "model", "--model", modelIDs["pi"]}
+			return []string{"-p", prompt, "--provider", "model", "--model", modelID("pi")}
 		},
 		SkillsBase: ".pi",
 		EnvVarsForAllow: func() []string {

--- a/internal/e2e/versions.go
+++ b/internal/e2e/versions.go
@@ -2,7 +2,12 @@
 
 package e2e
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
 
 // Versions and model configuration for e2e tests.
 //
@@ -32,13 +37,106 @@ var versionEnvVar = map[string]string{
 	"pi":          "E2E_VERSION_PI",
 }
 
-// Model identifiers per harness.
+// Model identifiers per harness. Read through modelID(), never directly, so
+// a run's workflow_dispatch override is honoured.
 var modelIDs = map[string]string{
 	"opencode":    "zai-org/GLM-5.2",
 	"claude-code": "claude-sonnet-5",
 	"codex":       "zai-org/GLM-5.2",
 	"copilot":     "zai-org/GLM-5.2",
 	"pi":          "zai-org/GLM-5.2",
+}
+
+// modelEnvVar maps a harness name to the env var that overrides its model id
+// for a single run. Wired from the e2e workflow's workflow_dispatch
+// claude_code_model input (.github/workflows/e2e.yml); unset in the scheduled
+// run, so that run always uses the modelIDs map above.
+//
+// The cross-harness E2E_MODEL override applies to every harness at once and is
+// what the workflows' single `model` input sets; these per-harness vars exist
+// for claude-code, whose model comes from a different provider than the rest.
+var modelEnvVar = map[string]string{
+	"opencode":    "E2E_MODEL_OPENCODE",
+	"claude-code": "E2E_MODEL_CLAUDE_CODE",
+	"codex":       "E2E_MODEL_CODEX",
+	"copilot":     "E2E_MODEL_COPILOT",
+	"pi":          "E2E_MODEL_PI",
+}
+
+// crossHarnessModelEnvVar overrides the model for every harness at once. Kept
+// in sync with scripts/resolve-model.sh, which implements the same precedence
+// for the workflows' shell steps.
+const crossHarnessModelEnvVar = "E2E_MODEL"
+
+// modelID returns the model id a harness runs against. A per-harness
+// E2E_MODEL_<HARNESS> override wins, then the cross-harness E2E_MODEL, then
+// the pinned modelIDs map — so a single run can test a different model
+// without editing this file.
+func modelID(harness string) string {
+	if ev, ok := modelEnvVar[harness]; ok {
+		if v := os.Getenv(ev); v != "" {
+			return v
+		}
+	}
+	if v := os.Getenv(crossHarnessModelEnvVar); v != "" {
+		return v
+	}
+	return modelIDs[harness]
+}
+
+// Declared context/output window for the openai-compatible provider configs
+// the harnesses are handed (opencode's models entry; scripts/doc-drift.sh and
+// scripts/e2e-readme-onboarding.sh write the same block for their own agent).
+//
+// The default is deliberately conservative and model-independent: a declared
+// window LARGER than the model's real one overflows mid-run and 422s, while a
+// smaller one only makes the harness compact earlier. 100k sits under every
+// model in modelIDs, so a model override needs no matching limit override to
+// work — E2E_CONTEXT_LIMIT / E2E_OUTPUT_LIMIT are there to raise it for a
+// model whose window is worth exercising in full.
+const (
+	defaultContextLimit = 100_000
+	defaultOutputLimit  = 32_000
+)
+
+// contextLimit returns the context window to declare, honouring
+// E2E_CONTEXT_LIMIT. A non-numeric or non-positive value is ignored.
+func contextLimit() int { return envInt("E2E_CONTEXT_LIMIT", defaultContextLimit) }
+
+// outputLimit returns the output window to declare, honouring
+// E2E_OUTPUT_LIMIT. A non-numeric or non-positive value is ignored.
+func outputLimit() int { return envInt("E2E_OUTPUT_LIMIT", defaultOutputLimit) }
+
+func envInt(name string, fallback int) int {
+	v, err := strconv.Atoi(strings.TrimSpace(os.Getenv(name)))
+	if err != nil || v <= 0 {
+		return fallback
+	}
+	return v
+}
+
+// claudeCodeModelFamilies are the model families the claude-code CLI accepts
+// for --model. Anything else is rejected by claude-code itself with an opaque
+// startup error, so validateModel names the real cause instead.
+var claudeCodeModelFamilies = []string{"sonnet", "haiku"}
+
+// validateModel reports whether a resolved model can actually run on a
+// harness. Only claude-code constrains this: it is the one harness bound to a
+// single provider, and only that provider's sonnet/haiku tiers are launchable.
+// Kept in sync with the same check in scripts/resolve-model.sh, which fails a
+// workflow's model input before the run spends time installing anything.
+func validateModel(harness, model string) error {
+	if harness != "claude-code" {
+		return nil
+	}
+	for _, family := range claudeCodeModelFamilies {
+		if strings.Contains(strings.ToLower(model), family) {
+			return nil
+		}
+	}
+	return fmt.Errorf("claude-code cannot run model %q: it accepts only %s models "+
+		"(override it separately via E2E_MODEL_CLAUDE_CODE / the claude_code_model workflow input)",
+		model, strings.Join(claudeCodeModelFamilies, " or "))
 }
 
 // pinnedPackage returns the package spec for a harness.

--- a/internal/e2e/versions.go
+++ b/internal/e2e/versions.go
@@ -39,12 +39,107 @@ var versionEnvVar = map[string]string{
 
 // Model identifiers per harness. Read through modelID(), never directly, so
 // a run's workflow_dispatch override is honoured.
+//
+// The gateway serves one name variant at a time and flips between the plain
+// name and a "-TEE" suffixed one without notice — on 2026-07-29 it stopped
+// accepting plain "zai-org/GLM-5.2" and every non-opencode llm stage went red
+// (see issue #184). Pin whichever variant is currently served;
+// scripts/probe-model.sh flips to the other one automatically, so a future flip
+// in either direction self-heals rather than reddening the matrix.
 var modelIDs = map[string]string{
-	"opencode":    "zai-org/GLM-5.2",
+	"opencode":    "zai-org/GLM-5.2-TEE",
 	"claude-code": "claude-sonnet-5",
-	"codex":       "zai-org/GLM-5.2",
-	"copilot":     "zai-org/GLM-5.2",
-	"pi":          "zai-org/GLM-5.2",
+	"codex":       "zai-org/GLM-5.2-TEE",
+	"copilot":     "zai-org/GLM-5.2-TEE",
+	"pi":          "zai-org/GLM-5.2-TEE",
+}
+
+// fallbackModels are tried, in order, when neither name variant of the
+// resolved model is served by the gateway. A different family, deliberately:
+// the point is to keep a run interpretable when the primary model disappears
+// entirely, so it has to be something the gateway is likely to still serve.
+//
+// Not a workflow input — e2e.yml is already at GitHub's 10-input cap for
+// workflow_dispatch — but overridable for a one-off via E2E_MODEL_FALLBACK
+// (space- or comma-separated for several).
+//
+// Substituting one of these is NOT silent: unlike a variant flip (same model,
+// gateway naming quirk), running a different family makes a green matrix mean
+// something weaker, so probe-model.sh annotates it and the reported model shows
+// what actually ran.
+var fallbackModels = []string{"moonshotai/Kimi-K3"}
+
+// fallbackModelEnvVar overrides fallbackModels for a single run. Kept in sync
+// with scripts/probe-model.sh.
+const fallbackModelEnvVar = "E2E_MODEL_FALLBACK"
+
+// teeSuffix is the gateway's confidential-computing name variant. Appending or
+// stripping it is the whole of the "variant flip" — see modelCandidates.
+const teeSuffix = "-TEE"
+
+// modelCandidates returns the model names to try for a harness, in order: the
+// resolved model, its variant flip, then each fallback and its flip. The flip
+// is bidirectional so pinning either variant survives the gateway changing its
+// mind. Duplicates are dropped, so a fallback that equals the primary does not
+// double the probe cost.
+//
+// claude-code gets exactly one candidate: it talks to ANTHROPIC_BASE_URL, not
+// the gateway, so neither the variant flip nor a gateway fallback applies.
+func modelCandidates(harness string) []string {
+	primary := modelID(harness)
+	if harness == "claude-code" {
+		return []string{primary}
+	}
+	var out []string
+	seen := map[string]bool{}
+	add := func(m string) {
+		if m == "" || seen[m] {
+			return
+		}
+		seen[m] = true
+		out = append(out, m)
+	}
+	for _, m := range append([]string{primary}, configuredFallbacks()...) {
+		add(m)
+		add(flipTEE(m))
+	}
+	return out
+}
+
+// flipTEE returns the other name variant of a model: the plain name gains
+// "-TEE", a "-TEE" name loses it.
+func flipTEE(model string) string {
+	if model == "" {
+		return ""
+	}
+	if strings.HasSuffix(model, teeSuffix) {
+		return strings.TrimSuffix(model, teeSuffix)
+	}
+	return model + teeSuffix
+}
+
+// configuredFallbacks returns the fallback chain, honouring
+// E2E_MODEL_FALLBACK (comma- or space-separated).
+func configuredFallbacks() []string {
+	raw := os.Getenv(fallbackModelEnvVar)
+	if strings.TrimSpace(raw) == "" {
+		return fallbackModels
+	}
+	var out []string
+	for _, f := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		out = append(out, f)
+	}
+	return out
+}
+
+// isFallbackModel reports whether model is a cross-family substitution rather
+// than the primary or its variant flip — the case that must be reported
+// loudly. Used by the workflows via scripts/probe-model.sh.
+func isFallbackModel(harness, model string) bool {
+	primary := modelID(harness)
+	return model != primary && model != flipTEE(primary)
 }
 
 // modelEnvVar maps a harness name to the env var that overrides its model id

--- a/internal/e2e/versions_test.go
+++ b/internal/e2e/versions_test.go
@@ -58,6 +58,95 @@ func TestModelIDOverride(t *testing.T) {
 	}
 }
 
+// TestFlipTEE covers the gateway's one naming quirk: it serves the plain name
+// or the -TEE name, never both, and flips without notice (#184). The flip must
+// work in both directions so pinning either variant survives the next flip.
+func TestFlipTEE(t *testing.T) {
+	cases := map[string]string{
+		"zai-org/GLM-5.2":     "zai-org/GLM-5.2-TEE",
+		"zai-org/GLM-5.2-TEE": "zai-org/GLM-5.2",
+		"":                    "",
+	}
+	for in, want := range cases {
+		if got := flipTEE(in); got != want {
+			t.Errorf("flipTEE(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// Flipping twice is the identity — otherwise a candidate list could miss
+	// the variant the gateway actually serves.
+	for _, m := range []string{"a/b", "a/b-TEE"} {
+		if got := flipTEE(flipTEE(m)); got != m {
+			t.Errorf("flipTEE(flipTEE(%q)) = %q, want %q", m, got, m)
+		}
+	}
+}
+
+// TestModelCandidates locks the probe order: primary, its variant flip, then
+// each fallback and its flip — deduped, so a fallback equal to the primary
+// doesn't double the probe cost.
+func TestModelCandidates(t *testing.T) {
+	t.Setenv("E2E_MODEL", "")
+	t.Setenv("E2E_MODEL_CLAUDE_CODE", "")
+	t.Setenv("E2E_MODEL_FALLBACK", "")
+
+	got := modelCandidates("pi")
+	want := []string{
+		modelIDs["pi"], flipTEE(modelIDs["pi"]),
+		fallbackModels[0], flipTEE(fallbackModels[0]),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("modelCandidates(pi) = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("modelCandidates(pi) = %v, want %v", got, want)
+		}
+	}
+
+	// claude-code is on a different provider: no gateway flip, no gateway
+	// fallback — exactly one candidate, or a run could silently retarget the
+	// billed Anthropic account at a model it can't launch.
+	if got := modelCandidates("claude-code"); len(got) != 1 || got[0] != modelIDs["claude-code"] {
+		t.Errorf("modelCandidates(claude-code) = %v, want exactly [%s]", got, modelIDs["claude-code"])
+	}
+
+	// A fallback that equals the primary must not produce duplicates.
+	t.Setenv("E2E_MODEL", "solo/model")
+	t.Setenv("E2E_MODEL_FALLBACK", "solo/model")
+	if got, want := modelCandidates("pi"), []string{"solo/model", "solo/model-TEE"}; len(got) != len(want) {
+		t.Errorf("deduped candidates = %v, want %v", got, want)
+	}
+
+	// Multiple fallbacks, comma- and space-separated.
+	t.Setenv("E2E_MODEL", "primary/m")
+	t.Setenv("E2E_MODEL_FALLBACK", "a/one, b/two")
+	got = modelCandidates("pi")
+	want = []string{"primary/m", "primary/m-TEE", "a/one", "a/one-TEE", "b/two", "b/two-TEE"}
+	for i := range want {
+		if i >= len(got) || got[i] != want[i] {
+			t.Fatalf("multi-fallback candidates = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestIsFallbackModel guards the reporting distinction: a variant flip is the
+// same model and may substitute silently, a cross-family fallback may not.
+func TestIsFallbackModel(t *testing.T) {
+	t.Setenv("E2E_MODEL", "")
+	t.Setenv("E2E_MODEL_PI", "")
+	pin := modelIDs["pi"]
+
+	if isFallbackModel("pi", pin) {
+		t.Errorf("the primary itself must not be reported as a fallback")
+	}
+	if isFallbackModel("pi", flipTEE(pin)) {
+		t.Errorf("a variant flip of the primary must not be reported as a fallback")
+	}
+	if !isFallbackModel("pi", "moonshotai/Kimi-K3") {
+		t.Errorf("a different family must be reported as a fallback")
+	}
+}
+
 // TestValidateModel locks the one harness-model constraint that exists: the
 // claude-code CLI launches only sonnet/haiku, so a cross-harness override
 // landing on it must be named as such rather than surfacing as an opaque

--- a/internal/e2e/versions_test.go
+++ b/internal/e2e/versions_test.go
@@ -27,6 +27,118 @@ func TestPinnedPackageOverride(t *testing.T) {
 	}
 }
 
+// TestModelIDOverride covers the precedence between the pinned modelIDs map,
+// the cross-harness E2E_MODEL override (the workflows' single `model` input),
+// and a per-harness E2E_MODEL_<HARNESS> override.
+func TestModelIDOverride(t *testing.T) {
+	t.Setenv("E2E_MODEL", "")
+	t.Setenv("E2E_MODEL_OPENCODE", "")
+	t.Setenv("E2E_MODEL_CLAUDE_CODE", "")
+
+	if got, want := modelID("opencode"), modelIDs["opencode"]; got != want {
+		t.Errorf("with no override: modelID(opencode) = %q, want %q (pinned map)", got, want)
+	}
+
+	// The cross-harness override reaches every harness — including claude-code,
+	// which is exactly why claude_code_model exists as a separate input.
+	t.Setenv("E2E_MODEL", "vendor/candidate-1")
+	if got, want := modelID("opencode"), "vendor/candidate-1"; got != want {
+		t.Errorf("cross-harness override: modelID(opencode) = %q, want %q", got, want)
+	}
+	if got, want := modelID("claude-code"), "vendor/candidate-1"; got != want {
+		t.Errorf("cross-harness override: modelID(claude-code) = %q, want %q", got, want)
+	}
+
+	t.Setenv("E2E_MODEL_CLAUDE_CODE", "claude-haiku-4-5-20251001")
+	if got, want := modelID("claude-code"), "claude-haiku-4-5-20251001"; got != want {
+		t.Errorf("per-harness override should win: modelID(claude-code) = %q, want %q", got, want)
+	}
+	if got, want := modelID("opencode"), "vendor/candidate-1"; got != want {
+		t.Errorf("per-harness override must not leak: modelID(opencode) = %q, want %q", got, want)
+	}
+}
+
+// TestValidateModel locks the one harness-model constraint that exists: the
+// claude-code CLI launches only sonnet/haiku, so a cross-harness override
+// landing on it must be named as such rather than surfacing as an opaque
+// harness startup failure.
+func TestValidateModel(t *testing.T) {
+	for _, model := range []string{"claude-sonnet-5", "claude-haiku-4-5-20251001", "SONNET"} {
+		if err := validateModel("claude-code", model); err != nil {
+			t.Errorf("validateModel(claude-code, %q) = %v, want nil", model, err)
+		}
+	}
+	for _, model := range []string{"zai-org/GLM-5.2", "claude-opus-5", ""} {
+		if err := validateModel("claude-code", model); err == nil {
+			t.Errorf("validateModel(claude-code, %q) = nil, want an error", model)
+		}
+	}
+	// No other harness constrains its model — they all talk to the same
+	// openai-compatible gateway.
+	for _, h := range allHarnesses() {
+		if h.Name == "claude-code" {
+			continue
+		}
+		if err := validateModel(h.Name, "zai-org/GLM-5.2"); err != nil {
+			t.Errorf("validateModel(%s, GLM) = %v, want nil", h.Name, err)
+		}
+	}
+}
+
+// TestPinnedModelsAreLaunchable guards the committed pins against the same
+// constraint, so a modelIDs edit can't ship a claude-code model the CLI
+// refuses to start with.
+func TestPinnedModelsAreLaunchable(t *testing.T) {
+	for harness, model := range modelIDs {
+		if err := validateModel(harness, model); err != nil {
+			t.Errorf("pinned modelIDs[%q] = %q is not launchable: %v", harness, model, err)
+		}
+	}
+}
+
+// TestContextLimitOverride covers the declared-window defaults and their
+// overrides. A garbage value must fall back rather than declare a zero window.
+func TestContextLimitOverride(t *testing.T) {
+	t.Setenv("E2E_CONTEXT_LIMIT", "")
+	t.Setenv("E2E_OUTPUT_LIMIT", "")
+	if got, want := contextLimit(), defaultContextLimit; got != want {
+		t.Errorf("contextLimit() = %d, want %d", got, want)
+	}
+	if got, want := outputLimit(), defaultOutputLimit; got != want {
+		t.Errorf("outputLimit() = %d, want %d", got, want)
+	}
+
+	t.Setenv("E2E_CONTEXT_LIMIT", "202752")
+	t.Setenv("E2E_OUTPUT_LIMIT", "64000")
+	if got, want := contextLimit(), 202752; got != want {
+		t.Errorf("overridden contextLimit() = %d, want %d", got, want)
+	}
+	if got, want := outputLimit(), 64000; got != want {
+		t.Errorf("overridden outputLimit() = %d, want %d", got, want)
+	}
+
+	for _, bad := range []string{"not-a-number", "0", "-5"} {
+		t.Setenv("E2E_CONTEXT_LIMIT", bad)
+		if got, want := contextLimit(), defaultContextLimit; got != want {
+			t.Errorf("E2E_CONTEXT_LIMIT=%q: contextLimit() = %d, want the %d default", bad, got, want)
+		}
+	}
+}
+
+// TestModelEnvVarCompleteness is the model-side counterpart of
+// TestVersionEnvVarCompleteness: a harness registered without a modelIDs pin
+// or a per-harness override var can't be pointed at a different model.
+func TestModelEnvVarCompleteness(t *testing.T) {
+	for _, h := range allHarnesses() {
+		if _, ok := modelIDs[h.Name]; !ok {
+			t.Errorf("harness %q has no entry in modelIDs", h.Name)
+		}
+		if _, ok := modelEnvVar[h.Name]; !ok {
+			t.Errorf("harness %q has no entry in modelEnvVar", h.Name)
+		}
+	}
+}
+
 // TestVersionEnvVarCompleteness guards against a harness being registered
 // (allHarnesses(), harnessVersions) without also wiring its workflow_dispatch
 // override — the class of bug fixed for pi, which shipped with a pinned

--- a/scripts/check-workflow-shell.py
+++ b/scripts/check-workflow-shell.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Bash-syntax-check every `run:` block in .github/workflows/.
+
+A workflow's `run:` body is shell, but nothing in the normal edit loop parses it
+— a quoting mistake ships and only surfaces when that job next runs, which for
+the weekly LLM workflows can be days later. The specific trap this was written
+for: an escaped backtick inside a double-quoted string. `\\\\`` leaves a literal
+backslash and an UNESCAPED backtick, silently turning step-summary markdown into
+command substitution:
+
+    echo "Model: \\\\`$m\\\\`"   ->   bash: $m\\: command not found
+
+`${{ ... }}` expressions are replaced with a placeholder token before parsing:
+they are substituted by the Actions runner before the shell ever sees them, so
+leaving them in would produce false positives on every step.
+
+This checks syntax only — it is not a linter. actionlint (with shellcheck)
+covers style and semantics; this covers "does bash accept it at all", which is
+the part that turns into a broken job.
+
+Exit 0 when clean, 1 with a per-step report otherwise.
+"""
+import glob
+import re
+import subprocess
+import sys
+
+import yaml
+
+EXPR = re.compile(r"\$\{\{[^}]*\}\}")
+
+
+def check_file(path):
+    """Yield a diagnostic string for each run block bash rejects."""
+    try:
+        doc = yaml.safe_load(open(path)) or {}
+    except yaml.YAMLError as exc:
+        yield f"{path}: not parseable as YAML: {exc}"
+        return
+    for job_name, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        for index, step in enumerate(job.get("steps") or []):
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if not run:
+                continue
+            shell = step.get("shell", "bash")
+            if shell not in ("bash", "sh"):
+                continue  # pwsh/python steps are not ours to parse
+            script = EXPR.sub("EXPR", run)
+            proc = subprocess.run(
+                ["bash", "-n"], input=script, text=True, capture_output=True
+            )
+            if proc.returncode != 0:
+                name = step.get("name", "<unnamed>")
+                detail = (proc.stderr or "").strip().splitlines()
+                first = detail[0] if detail else "bash -n failed"
+                yield f"{path}: job '{job_name}' step {index} ('{name}'): {first}"
+
+
+def main():
+    paths = sys.argv[1:] or sorted(glob.glob(".github/workflows/*.yml"))
+    if not paths:
+        print("no workflow files found", file=sys.stderr)
+        return 1
+    problems = [p for path in paths for p in check_file(path)]
+    for problem in problems:
+        print(problem, file=sys.stderr)
+    if problems:
+        print(
+            f"\n{len(problems)} run block(s) are not valid bash", file=sys.stderr
+        )
+        return 1
+    print(f"{len(paths)} workflow file(s): all run blocks are valid bash")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/doc-drift.sh
+++ b/scripts/doc-drift.sh
@@ -16,7 +16,8 @@
 #   comments — inline code comments and docstrings vs. the code they annotate.
 #
 # Same driver as scripts/e2e-readme-onboarding.sh: headless opencode `run`
-# against the internal SKAINET gateway (GLM-5.2), deliberately NOT claude-code
+# against the internal SKAINET gateway (same model as the harness matrix — see
+# scripts/resolve-model.sh), deliberately NOT claude-code
 # (the one harness billed to a real external account). Unlike the onboarding
 # test the agent works INSIDE the real checkout — it needs to read the code to
 # judge the docs — but it is a read-only audit: it reports, it does not edit.
@@ -34,8 +35,11 @@
 #   SKAINET_TOKEN              model API key (required)
 #   SKAINET_INTERNAL          model provider base URL (required)
 #   E2E_VERSION_OPENCODE       override the pinned opencode package spec
-#   DRIFT_MODEL                override the model id (default: zai-org/GLM-5.2)
+#   DRIFT_MODEL                override the model id; else E2E_MODEL, else the
+#                             pin resolved by scripts/resolve-model.sh
 #   DRIFT_LOG_DIR              artifact output dir (default: /tmp/doc-drift-logs)
+#   E2E_CONTEXT_LIMIT          declared context window (default: 100000)
+#   E2E_OUTPUT_LIMIT           declared output window (default: 32000)
 #   DRIFT_TIMEOUT_SECS         agent wall-clock timeout in seconds (default: 2400)
 #   DRIFT_FOCUS                optional: narrow the audit to specific files/areas
 #                             (appended to the prompt; useful for manual runs)
@@ -45,9 +49,8 @@ set -euo pipefail
 # Keep in sync with internal/e2e/versions.go's "opencode" pin (duplicated
 # there too, per the existing e2e convention).
 DEFAULT_OPENCODE_VERSION="opencode-ai@1.17.12"
-DEFAULT_MODEL="zai-org/GLM-5.2"
 # 40 min: the full-repo two-pass audit (read docs, verify each claim against
-# code) is heavy, and GLM-5.2's per-step latency through the gateway adds up.
+# code) is heavy, and the model's per-step latency through the gateway adds up.
 # The agent writes its report incrementally, so a run cut short here still
 # yields a partial report rather than nothing.
 DEFAULT_TIMEOUT_SECS="2400"
@@ -56,7 +59,14 @@ REPO="$(cd "$(dirname "$0")/.." && pwd)"
 MODE="${DRIFT_MODE:-docs}"
 LOG_DIR="${DRIFT_LOG_DIR:-/tmp/doc-drift-logs}"
 OPENCODE_VERSION="${E2E_VERSION_OPENCODE:-$DEFAULT_OPENCODE_VERSION}"
-MODEL="${DRIFT_MODEL:-$DEFAULT_MODEL}"
+MODEL="${DRIFT_MODEL:-$("$(dirname "$0")/resolve-model.sh" opencode)}"
+# Declared context/output window for the provider config below. Defaults match
+# internal/e2e/versions.go's defaultContextLimit/defaultOutputLimit: a declared
+# window LARGER than the model's real one overflows mid-run, a smaller one only
+# compacts earlier, so 100k is the model-independent safe default. Raise via
+# E2E_CONTEXT_LIMIT to exercise a bigger model's full window.
+CONTEXT_LIMIT="${E2E_CONTEXT_LIMIT:-100000}"
+OUTPUT_LIMIT="${E2E_OUTPUT_LIMIT:-32000}"
 # Seconds, not a duration string — see run_with_timeout (BSD sleep on macOS
 # rejects unit suffixes and there is no `timeout` binary there).
 TIMEOUT_SECS="${DRIFT_TIMEOUT_SECS:-$DEFAULT_TIMEOUT_SECS}"
@@ -107,7 +117,7 @@ trap 'chmod -R u+w "$WORK" 2>/dev/null; rm -rf "$WORK"; rm -f "$REPORT_FILE"' EX
 echo "== Installing opencode CLI ($OPENCODE_VERSION) =="
 bun install -g "$OPENCODE_VERSION"
 
-echo "== Writing opencode provider config (SKAINET / GLM-5.2) =="
+echo "== Writing opencode provider config (SKAINET / $MODEL) =="
 mkdir -p "$DRIVER_HOME/.local/share/opencode" "$DRIVER_HOME/.config/opencode"
 cat > "$DRIVER_HOME/.local/share/opencode/auth.json" <<EOF
 {"model": {"type": "api", "key": "$SKAINET_TOKEN"}}
@@ -122,7 +132,7 @@ cat > "$DRIVER_HOME/.config/opencode/opencode.json" <<EOF
       "npm": "@ai-sdk/openai-compatible",
       "options": { "baseURL": "$SKAINET_INTERNAL" },
       "models": {
-        "$MODEL": { "name": "GLM 5.2", "limit": { "context": 131072, "output": 32000 } }
+        "$MODEL": { "name": "$MODEL", "limit": { "context": $CONTEXT_LIMIT, "output": $OUTPUT_LIMIT } }
       }
     }
   }
@@ -232,7 +242,7 @@ fi
 # Read the prompt back from a file (avoids bash 3.2's heredoc-in-\$() apostrophe bug).
 PROMPT="$(cat "$PROMPT_FILE")"
 
-echo "== Running doc-drift agent (mode=$MODE, timeout ${TIMEOUT_SECS}s) =="
+echo "== Running doc-drift agent (mode=$MODE, model=$MODEL, timeout ${TIMEOUT_SECS}s) =="
 cd "$REPO"
 set +e
 # Override HOME + all XDG dirs: GH runners preset XDG_*_HOME at the real
@@ -259,13 +269,18 @@ set -e
 echo "agent exit status: $agent_status"
 
 # Transcript is already written directly into $LOG_DIR. Copy the report out of
-# the checkout before the EXIT trap removes it.
+# the checkout before the EXIT trap removes it, stamping the run's provenance on
+# top. Stamped here rather than asked of the agent: a finding is only meaningful
+# against the model that produced it, and the model is not the agent's to report.
+{
+  echo "_Model: \`$MODEL\` · opencode \`$OPENCODE_VERSION\` · mode \`$MODE\`_"
+  echo ""
+} > "$LOG_DIR/DRIFT_REPORT-$MODE.md"
 if [ -f "$REPORT_FILE" ]; then
-  cp "$REPORT_FILE" "$LOG_DIR/DRIFT_REPORT-$MODE.md"
+  cat "$REPORT_FILE" >> "$LOG_DIR/DRIFT_REPORT-$MODE.md"
   report_present=1
 else
-  echo "agent did not write a report to $REPORT_FILE" \
-    | tee "$LOG_DIR/DRIFT_REPORT-$MODE.md"
+  echo "agent did not write a report to $REPORT_FILE" >> "$LOG_DIR/DRIFT_REPORT-$MODE.md"
   report_present=0
 fi
 

--- a/scripts/e2e-readme-onboarding.sh
+++ b/scripts/e2e-readme-onboarding.sh
@@ -16,7 +16,8 @@
 #
 # Driver: opencode (headless `run`, non-interactive by design — no
 # permission-bypass flag needed) against the internal SKAINET gateway,
-# same GLM-5.2 model used by the rest of the harness matrix. Deliberately
+# same model as the rest of the harness matrix (see
+# scripts/resolve-model.sh). Deliberately
 # NOT claude-code: this session is open-ended (real installs, retries) and
 # claude-code is the one harness billed against a real external Anthropic
 # account.
@@ -28,7 +29,10 @@
 #   SKAINET_TOKEN                 model API key (required)
 #   SKAINET_INTERNAL               model provider base URL (required)
 #   E2E_VERSION_OPENCODE           override the pinned opencode package spec
-#   E2E_ONBOARDING_MODEL           override the model id (default: zai-org/GLM-5.2)
+#   E2E_ONBOARDING_MODEL           override the model id; else E2E_MODEL, else
+#                                 the pin resolved by scripts/resolve-model.sh
+#   E2E_CONTEXT_LIMIT              declared context window (default: 100000)
+#   E2E_OUTPUT_LIMIT               declared output window (default: 32000)
 #   E2E_LOG_DIR                    artifact output dir (default: /tmp/e2e-readme-logs)
 #   E2E_README_REF                 git ref to extract README.md from (default: HEAD)
 #   E2E_ONBOARDING_TIMEOUT_SECS    agent wall-clock timeout in seconds (default: 1200)
@@ -43,14 +47,20 @@ set -euo pipefail
 # Keep this in sync with internal/e2e/versions.go's "opencode" pin
 # (duplicated there too, per existing e2e.yml convention).
 DEFAULT_OPENCODE_VERSION="opencode-ai@1.17.12"
-DEFAULT_MODEL="zai-org/GLM-5.2"
 DEFAULT_TIMEOUT_SECS="1200"
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 LOG_DIR="${E2E_LOG_DIR:-/tmp/e2e-readme-logs}"
 README_REF="${E2E_README_REF:-HEAD}"
 OPENCODE_VERSION="${E2E_VERSION_OPENCODE:-$DEFAULT_OPENCODE_VERSION}"
-MODEL="${E2E_ONBOARDING_MODEL:-$DEFAULT_MODEL}"
+MODEL="${E2E_ONBOARDING_MODEL:-$("$(dirname "$0")/resolve-model.sh" opencode)}"
+# Declared context/output window for the provider config below. Defaults match
+# internal/e2e/versions.go's defaultContextLimit/defaultOutputLimit: a declared
+# window LARGER than the model's real one overflows mid-run, a smaller one only
+# compacts earlier, so 100k is the model-independent safe default. Raise via
+# E2E_CONTEXT_LIMIT to exercise a bigger model's full window.
+CONTEXT_LIMIT="${E2E_CONTEXT_LIMIT:-100000}"
+OUTPUT_LIMIT="${E2E_OUTPUT_LIMIT:-32000}"
 # Seconds, not a duration string ("20m") — macOS ships only BSD sleep,
 # which (unlike GNU sleep) rejects unit suffixes, and has no `timeout`
 # binary at all. See run_with_timeout below.
@@ -109,7 +119,7 @@ git -C "$REPO" show "${README_REF}:README.md" > "$ONBOARD_DIR/README.md"
 echo "== Installing opencode CLI ($OPENCODE_VERSION) =="
 bun install -g "$OPENCODE_VERSION"
 
-echo "== Writing opencode provider config (SKAINET / GLM-5.2) =="
+echo "== Writing opencode provider config (SKAINET / $MODEL) =="
 mkdir -p "$DRIVER_HOME/.local/share/opencode" "$DRIVER_HOME/.config/opencode"
 cat > "$DRIVER_HOME/.local/share/opencode/auth.json" <<EOF
 {"model": {"type": "api", "key": "$SKAINET_TOKEN"}}
@@ -124,7 +134,7 @@ cat > "$DRIVER_HOME/.config/opencode/opencode.json" <<EOF
       "npm": "@ai-sdk/openai-compatible",
       "options": { "baseURL": "$SKAINET_INTERNAL" },
       "models": {
-        "$MODEL": { "name": "GLM 5.2", "limit": { "context": 131072, "output": 32000 } }
+        "$MODEL": { "name": "$MODEL", "limit": { "context": $CONTEXT_LIMIT, "output": $OUTPUT_LIMIT } }
       }
     }
   }
@@ -207,7 +217,7 @@ EOF
 # read sidesteps the bug entirely, regardless of body content.
 PROMPT="$(cat "$PROMPT_FILE")"
 
-echo "== Running onboarding agent (timeout ${TIMEOUT_SECS}s) =="
+echo "== Running onboarding agent (model=$MODEL, timeout ${TIMEOUT_SECS}s) =="
 cd "$ONBOARD_DIR"
 set +e
 # GH Actions runners preset XDG_CONFIG_HOME/XDG_DATA_HOME (pointing at the
@@ -258,11 +268,18 @@ fi
 echo "omac doctor exit ok: $doctor_ok"
 
 cp "$TRANSCRIPT_FILE" "$LOG_DIR/" 2>/dev/null || true
+# Stamp the run's provenance on top of the agent's report: a gap report is
+# only meaningful against the model that hit the gap, and the model is not the
+# agent's to report.
+{
+  echo "_Model: \`$MODEL\` · opencode \`$OPENCODE_VERSION\`_"
+  echo ""
+} > "$LOG_DIR/ONBOARDING_REPORT.md"
 if [ -f "$REPORT_FILE" ]; then
-  cp "$REPORT_FILE" "$LOG_DIR/"
+  cat "$REPORT_FILE" >> "$LOG_DIR/ONBOARDING_REPORT.md"
   report_present=1
 else
-  echo "agent did not write a report to $REPORT_FILE" | tee "$LOG_DIR/ONBOARDING_REPORT.md"
+  echo "agent did not write a report to $REPORT_FILE" >> "$LOG_DIR/ONBOARDING_REPORT.md"
   report_present=0
 fi
 

--- a/scripts/probe-model.sh
+++ b/scripts/probe-model.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# Pick a model the gateway will actually serve, and print it on stdout.
+#
+# The SKAINET gateway serves ONE name variant at a time — the plain name or a
+# "-TEE" suffixed one — and flips between them without notice. On 2026-07-29 it
+# stopped accepting plain "zai-org/GLM-5.2" and every non-opencode `llm` stage
+# went red about ten minutes into each leg (issue #184). This script front-loads
+# that discovery so a renamed model costs seconds, not a whole matrix, and
+# self-heals instead of failing.
+#
+# Candidate order (see modelCandidates() in internal/e2e/versions.go, which this
+# mirrors): the resolved model, its variant flip, then each configured fallback
+# and its flip. Duplicates dropped. The flip is bidirectional, so pinning either
+# variant survives the next flip in either direction.
+#
+# Two-stage selection:
+#   1. GET $base/models (OpenAI-compatible) lists what the gateway advertises.
+#      Candidates on that list are probed FIRST. The listing only orders the
+#      candidates — it never excludes one, because a stale or partial listing
+#      must not veto a name that actually works.
+#   2. A 1-token POST $base/chat/completions is the authority. First HTTP 200
+#      wins. This is what the gateway 422s on, so it is what gets asked.
+#
+# Usage:
+#   scripts/probe-model.sh [harness]              # default harness: opencode
+#   scripts/probe-model.sh [harness] --github-output
+#
+# --github-output additionally writes model= / fallback= / candidates= to
+# $GITHUB_OUTPUT so a workflow can consume the result without re-parsing stdout.
+#
+# Environment:
+#   SKAINET_INTERNAL | LLM_API_BASE | MODEL_PROBE_BASE   gateway base URL
+#   SKAINET_TOKEN    | LLM_API_KEY  | MODEL_PROBE_TOKEN  bearer token
+#   E2E_MODEL_FALLBACK   override the fallback chain (comma/space separated)
+#   E2E_MODEL[_<HARNESS>]  the model override itself — see resolve-model.sh
+#
+# Without credentials this is a pure passthrough: it prints what
+# resolve-model.sh resolved and exits 0. Model-free jobs and local runs must not
+# need network access to name a model.
+#
+# claude-code is never probed: it talks to ANTHROPIC_BASE_URL, not this gateway,
+# so its model is not on the listing and a gateway fallback would silently
+# retarget the billed Anthropic account.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+harness="opencode"
+github_output=0
+for arg in "$@"; do
+  case "$arg" in
+    --github-output) github_output=1 ;;
+    -*) echo "probe-model: unknown flag '$arg'" >&2; exit 2 ;;
+    *) harness="$arg" ;;
+  esac
+done
+
+base="${MODEL_PROBE_BASE:-${SKAINET_INTERNAL:-${LLM_API_BASE:-}}}"
+token="${MODEL_PROBE_TOKEN:-${SKAINET_TOKEN:-${LLM_API_KEY:-}}}"
+
+# The resolved model, before any gateway consideration. Not guarded with
+# `|| true`: an unresolvable model is a real misconfiguration and the caller
+# needs to see it, exactly as resolve-model.sh's own callers do.
+primary="$("$HERE/resolve-model.sh" "$harness")"
+
+emit() {
+  local model="$1" fallback="$2" tried="$3"
+  if [ "$github_output" = "1" ] && [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "model=$model"
+      echo "fallback=$fallback"
+      echo "candidates=$tried"
+    } >> "$GITHUB_OUTPUT"
+  fi
+  printf '%s\n' "$model"
+}
+
+# --- passthrough paths (no network) -----------------------------------------
+
+if [ "$harness" = "claude-code" ]; then
+  echo "probe-model: claude-code is on its own provider — not probing the gateway" >&2
+  emit "$primary" false "$primary"
+  exit 0
+fi
+
+if [ -z "$base" ] || [ -z "$token" ]; then
+  echo "probe-model: no gateway base URL / token on the env — using '$primary' unprobed" >&2
+  emit "$primary" false "$primary"
+  exit 0
+fi
+
+# --- candidate list ---------------------------------------------------------
+
+flip_tee() {
+  case "$1" in
+    "") printf '' ;;
+    *-TEE) printf '%s' "${1%-TEE}" ;;
+    *) printf '%s-TEE' "$1" ;;
+  esac
+}
+
+# Fallback chain: E2E_MODEL_FALLBACK, else fallbackModels in versions.go — the
+# single source of truth shared with the Go tests.
+fallbacks() {
+  if [ -n "${E2E_MODEL_FALLBACK:-}" ]; then
+    printf '%s' "$E2E_MODEL_FALLBACK" | tr ',\t\n' '   '
+    return
+  fi
+  local versions_go="${VERSIONS_GO:-$HERE/../internal/e2e/versions.go}"
+  [ -f "$versions_go" ] || return 0
+  awk '/^var fallbackModels = \[\]string\{/{ \
+         line=$0; sub(/.*\{/,"",line); sub(/\}.*/,"",line); print line; exit }' \
+    "$versions_go" | tr -d '"' | tr ',' ' '
+}
+
+# Candidates are grouped into PRIORITY TIERS, one per configured model: tier 0
+# is the primary and its variant flip, tier 1 the first fallback and its flip,
+# and so on. The listing may reorder within a tier but never across tiers —
+# a backup must only ever be reached after the primary has actually been
+# refused by chat/completions. Letting the listing promote a tier would silently
+# downgrade a run whenever the gateway under-advertises a working model, which
+# is the same failure mode as the advertised-but-broken case below.
+tiers=""   # newline-separated; each line is one tier's space-separated models
+seen_all=" "
+for m in "$primary" $(fallbacks); do
+  tier=""
+  for v in "$m" "$(flip_tee "$m")"; do
+    [ -z "$v" ] && continue
+    case "$seen_all" in *" $v "*) continue ;; esac
+    seen_all="$seen_all$v "
+    tier="${tier:+$tier }$v"
+  done
+  [ -n "$tier" ] && tiers="${tiers}${tier}
+"
+done
+
+# --- stage 1: what does the gateway advertise? ------------------------------
+
+served=""
+listing_ok=0
+if listing=$(curl -sS --max-time 30 "${base%/}/models" \
+      -H "authorization: Bearer $token" 2>/dev/null); then
+  # jq if available (it is on GH runners), else a grep fallback so the script
+  # still works on a bare machine.
+  if command -v jq >/dev/null 2>&1; then
+    served=$(printf '%s' "$listing" | jq -r '(.data // [])[]? | .id // empty' 2>/dev/null | tr '\n' ' ' || true)
+  else
+    served=$(printf '%s' "$listing" | grep -oE '"id"[[:space:]]*:[[:space:]]*"[^"]+"' \
+      | sed -E 's/.*"([^"]+)"$/\1/' | tr '\n' ' ' || true)
+  fi
+  [ -n "$(printf '%s' "$served" | tr -d '[:space:]')" ] && listing_ok=1
+fi
+if [ "$listing_ok" = "1" ]; then
+  echo "probe-model: gateway advertises: $served" >&2
+else
+  echo "probe-model: model listing unavailable — probing all candidates directly" >&2
+fi
+
+# Within each tier, advertised names go first; the listing orders, it never
+# excludes, and it never reorders across tiers.
+ordered=""
+while IFS= read -r tier; do
+  [ -z "$tier" ] && continue
+  if [ "$listing_ok" = "1" ]; then
+    for m in $tier; do
+      case " $served " in *" $m "*) ordered="${ordered:+$ordered }$m" ;; esac
+    done
+  fi
+  for m in $tier; do
+    case " $ordered " in *" $m "*) ;; *) ordered="${ordered:+$ordered }$m" ;; esac
+  done
+done <<EOF
+$tiers
+EOF
+
+# --- stage 2: chat/completions is the authority -----------------------------
+
+endpoint="${base%/}/chat/completions"
+tried=""
+inconclusive=""
+
+# A non-200 means one of two very different things, and conflating them is how a
+# 30-second GPU-cluster hiccup silently changes which model a run tested:
+#
+#   unavailable — the gateway refuses this NAME (422 model_unavailable, 404).
+#                 Move on; this is what the variant flip and fallback are for.
+#   transient   — the gateway is unwell (5xx, 429, connection failure). Says
+#                 nothing about the name. Retry it; never fall back on it.
+#
+# Observed in the wild: "500 An internal error occurred while invoking the
+# model. The model inference should recover automatically within a few minutes."
+classify_code() {
+  case "$1" in
+    200) printf 'ok' ;;
+    408|409|425|429|500|502|503|504|000) printf 'transient' ;;
+    *) printf 'unavailable' ;;
+  esac
+}
+
+probe_candidate() {
+  # Echoes "<verdict> <last-http-code>" for one candidate, retrying while
+  # transient. Both on stdout because this runs in a command substitution — a
+  # variable set here would not survive back to the caller.
+  local candidate="$1" attempt=1 max=3 code verdict
+  while :; do
+    code=$(curl -s -o /tmp/probe-model-resp.$$ -w '%{http_code}' --max-time 30 \
+      -X POST "$endpoint" \
+      -H "authorization: Bearer $token" \
+      -H 'content-type: application/json' \
+      -d "{\"model\":\"${candidate}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":1}" \
+      2>/dev/null) || code="000"
+    verdict=$(classify_code "$code")
+    [ "$verdict" != "transient" ] && break
+    if [ "$attempt" -ge "$max" ]; then break; fi
+    echo "probe-model: '$candidate' hit a transient gateway error (HTTP $code) — retrying ($((attempt + 1))/$max)" >&2
+    attempt=$((attempt + 1))
+    sleep $((attempt * 2))
+  done
+  printf '%s %s' "$verdict" "$code"
+}
+
+# Tier 0 — the intended model and its name variant. A TRANSIENT result here must
+# never let the loop reach a fallback: the gateway being briefly unwell says
+# nothing about the model, and silently swapping families over a 30-second blip
+# would change what the run tested for no good reason. Definitive
+# unavailability is the only thing a backup is for.
+primary_tier=" $primary $(flip_tee "$primary") "
+primary_transient=0
+
+for candidate in $ordered; do
+  case "$primary_tier" in
+    *" $candidate "*) ;;
+    *)
+      if [ "$primary_transient" = "1" ]; then
+        echo "::error title=Gateway unhealthy::'$primary' could not be verified — the gateway kept returning transient errors (last HTTP $code). NOT falling back to another model: a transient fault is no reason to change which model is under test. Re-run once the gateway recovers." >&2
+        exit 1
+      fi
+      ;;
+  esac
+  tried="${tried:+$tried,}$candidate"
+  read -r verdict code <<EOF
+$(probe_candidate "$candidate")
+EOF
+  if [ "$verdict" = "ok" ]; then
+    rm -f /tmp/probe-model-resp.$$
+    if [ "$candidate" = "$primary" ] || [ "$candidate" = "$(flip_tee "$primary")" ]; then
+      # Same model, gateway naming quirk — safe to substitute quietly.
+      [ "$candidate" != "$primary" ] && \
+        echo "probe-model: '$primary' not served; using name variant '$candidate'" >&2
+      emit "$candidate" false "$tried"
+    else
+      # A different family. A green run on this means something weaker than a
+      # green run on the intended model, so say so where CI will surface it.
+      echo "::warning title=Model fallback::'$primary' is not served by the gateway; fell back to '$candidate'. Results are for $candidate, NOT $primary." >&2
+      emit "$candidate" true "$tried"
+    fi
+    exit 0
+  fi
+  msg=$(sed -n 's/.*"message"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' /tmp/probe-model-resp.$$ 2>/dev/null | head -1)
+  rm -f /tmp/probe-model-resp.$$
+  if [ "$verdict" = "transient" ]; then
+    inconclusive="${inconclusive:+$inconclusive,}$candidate"
+    case "$primary_tier" in *" $candidate "*) primary_transient=1 ;; esac
+    echo "probe-model: '$candidate' inconclusive — gateway unwell (HTTP $code)${msg:+: $msg}" >&2
+  else
+    echo "probe-model: '$candidate' rejected (HTTP $code)${msg:+: $msg}" >&2
+  fi
+done
+
+if [ -n "$inconclusive" ]; then
+  # Distinguished from "the models are gone" so whoever reads the log knows to
+  # re-run rather than go hunting for a renamed model.
+  echo "::error title=Gateway unhealthy::could not verify any model — these were inconclusive (transient gateway errors, not name rejections): $inconclusive. Tried: $tried. Re-run once the gateway recovers." >&2
+  exit 1
+fi
+
+echo "::error title=No usable model::none of these models was accepted by the gateway: $tried" >&2
+[ "$listing_ok" = "1" ] && echo "probe-model: gateway advertises: $served" >&2
+echo "probe-model: check the model provider, SKAINET_TOKEN validity, and the pins in internal/e2e/versions.go" >&2
+exit 1

--- a/scripts/probe-model_test.sh
+++ b/scripts/probe-model_test.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# Tests for scripts/probe-model.sh against a stub gateway.
+#
+# A stub, not the real gateway: the whole point of the script is behaviour when
+# the gateway renames or drops a model, and those states can't be produced on
+# demand upstream. The stub reproduces exactly the two shapes that matter —
+# an OpenAI-style GET /models listing, and a POST /chat/completions that 422s
+# with "Requested model name ... is currently not available" for anything it
+# does not serve, which is what broke CI in #184.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+PROBE="$ROOT/scripts/probe-model.sh"
+TMP="$(mktemp -d)"
+STUB_PID=""
+cleanup() {
+  [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+failures=0
+fail() { printf 'FAIL: %s\n' "$*" >&2; failures=$((failures + 1)); }
+
+cat > "$TMP/stub.py" <<'PY'
+"""Stub gateway. STUB_LISTED / STUB_ACCEPTED are space-separated model ids.
+
+STUB_LIST_STATUS != 200 makes the listing endpoint fail, so the test can prove
+the listing never vetoes a model the chat endpoint accepts.
+"""
+import json, os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+LISTED = os.environ.get("STUB_LISTED", "").split()
+ACCEPTED = os.environ.get("STUB_ACCEPTED", "").split()
+LIST_STATUS = int(os.environ.get("STUB_LIST_STATUS", "200"))
+# Models that answer with a transient 500 rather than a name rejection — the
+# real "internal error occurred while invoking the model" case.
+TRANSIENT = os.environ.get("STUB_TRANSIENT", "").split()
+HITS = os.environ.get("STUB_HITS", "/tmp/stub-hits")
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _record(self, what):
+        with open(HITS, "a") as f:
+            f.write(what + "\n")
+
+    def _send(self, code, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        self._record("GET " + self.path)
+        if not self.path.endswith("/models"):
+            return self._send(404, {"error": "no such path"})
+        if LIST_STATUS != 200:
+            return self._send(LIST_STATUS, {"error": {"message": "listing down"}})
+        self._send(200, {"data": [{"id": m} for m in LISTED]})
+
+    def do_POST(self):
+        n = int(self.headers.get("content-length", 0))
+        req = json.loads(self.rfile.read(n) or b"{}")
+        model = req.get("model", "")
+        self._record("POST " + model)
+        if model in TRANSIENT:
+            return self._send(500, {"error": {"message":
+                "An internal error occurred while invoking the model. The model "
+                "inference should recover automatically within a few minutes."}})
+        if model in ACCEPTED:
+            return self._send(200, {"choices": [{"message": {"content": "ok"}}]})
+        self._send(422, {"error": {"message":
+            "Requested model name '%s' is currently not available. "
+            "Supported model names are: {%s}" % (model, ", ".join(repr(m) for m in LISTED))}})
+
+
+HTTPServer(("127.0.0.1", int(os.environ["STUB_PORT"])), H).serve_forever()
+PY
+
+PORT=8931
+HITS="$TMP/hits"
+
+start_stub() {
+  [ -n "$STUB_PID" ] && { kill "$STUB_PID" 2>/dev/null || true; wait "$STUB_PID" 2>/dev/null || true; }
+  : > "$HITS"
+  STUB_LISTED="$1" STUB_ACCEPTED="$2" STUB_LIST_STATUS="${3:-200}" \
+    STUB_TRANSIENT="${4:-}" \
+    STUB_PORT="$PORT" STUB_HITS="$HITS" python3 "$TMP/stub.py" &
+  STUB_PID=$!
+  local up=0 _
+  for _ in $(seq 1 40); do
+    if curl -s -o /dev/null "http://127.0.0.1:$PORT/models" 2>/dev/null; then up=1; break; fi
+    sleep 0.1
+  done
+  [ "$up" = "1" ] || { echo "stub did not come up" >&2; exit 1; }
+  # Discard the readiness request: the "did this run touch the network at all"
+  # assertions below must see only what the probe itself sent.
+  : > "$HITS"
+}
+
+# Runs the probe against the stub with a clean model env. VAR=value args become
+# env assignments; a bare arg is the harness.
+probe() {
+  local assignments=() args=() a
+  for a in "$@"; do
+    case "$a" in *=*) assignments+=("$a") ;; *) args+=("$a") ;; esac
+  done
+  env -u E2E_MODEL -u E2E_MODEL_OPENCODE -u E2E_MODEL_CLAUDE_CODE \
+      -u E2E_MODEL_CODEX -u E2E_MODEL_COPILOT -u E2E_MODEL_PI \
+      -u E2E_MODEL_FALLBACK -u LLM_API_BASE -u LLM_API_KEY -u GITHUB_OUTPUT \
+      -u SKAINET_TOKEN -u SKAINET_INTERNAL \
+      MODEL_PROBE_BASE="http://127.0.0.1:$PORT" MODEL_PROBE_TOKEN=stub-token \
+      ${assignments[@]+"${assignments[@]}"} \
+      "$PROBE" ${args[@]+"${args[@]}"}
+}
+
+PIN=$(awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' \
+  "$ROOT/internal/e2e/versions.go" | grep '"opencode"' | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/')
+case "$PIN" in
+  *-TEE) PIN_FLIP="${PIN%-TEE}" ;;
+  *)     PIN_FLIP="$PIN-TEE" ;;
+esac
+echo "committed pin: $PIN (variant: $PIN_FLIP)"
+
+# --- 1. the pin itself is served -------------------------------------------
+start_stub "$PIN" "$PIN"
+got=$(probe opencode 2>/dev/null || true)
+[ "$got" = "$PIN" ] || fail "pin served: got '$got', want '$PIN'"
+
+# --- 2. only the OTHER variant is served (the #184 breakage, both ways) -----
+start_stub "$PIN_FLIP" "$PIN_FLIP"
+got=$(probe opencode 2>/dev/null || true)
+[ "$got" = "$PIN_FLIP" ] || fail "variant flip: got '$got', want '$PIN_FLIP'"
+# A same-model variant flip must NOT be announced as a fallback.
+err=$(probe opencode 2>&1 >/dev/null || true)
+case "$err" in
+  *"title=Model fallback"*) fail "variant flip was mislabelled as a cross-model fallback" ;;
+esac
+
+# --- 3. neither variant served, fallback wins, loudly ----------------------
+start_stub "fb/model" "fb/model"
+out=$(probe E2E_MODEL_FALLBACK=fb/model opencode 2>"$TMP/err" || true)
+[ "$out" = "fb/model" ] || fail "fallback: got '$out', want 'fb/model'"
+grep -q "title=Model fallback" "$TMP/err" || fail "cross-model fallback was not announced with a warning"
+grep -q "NOT $PIN" "$TMP/err" || fail "fallback warning does not name the model that was intended"
+
+# --- 4. nothing usable -> loud failure, non-zero ---------------------------
+start_stub "other/thing" ""
+if out=$(probe E2E_MODEL_FALLBACK=fb/model opencode 2>"$TMP/err"); then
+  fail "no usable model: expected a non-zero exit, got '$out'"
+fi
+grep -q "title=No usable model" "$TMP/err" || fail "exhausted candidates did not emit an error annotation"
+grep -q "other/thing" "$TMP/err" || fail "failure diagnostic omits what the gateway does serve"
+
+# --- 5. listing endpoint down must not veto a working model ---------------
+start_stub "$PIN" "$PIN" 500
+got=$(probe opencode 2>/dev/null || true)
+[ "$got" = "$PIN" ] || fail "listing down: got '$got', want '$PIN' (chat probe must still decide)"
+
+# --- 6. advertised but rejected by chat -> chat is the authority -----------
+# The listing claims the pin, chat only accepts the variant. Picking from the
+# listing alone would strand the run on a model that 422s on every real call.
+start_stub "$PIN" "$PIN_FLIP"
+got=$(probe opencode 2>/dev/null || true)
+[ "$got" = "$PIN_FLIP" ] || fail "advertised-but-broken: got '$got', want '$PIN_FLIP'"
+
+# --- 6b. the listing must never promote a fallback over the primary ---------
+# The gateway under-advertises the primary but still serves it, while the
+# fallback is both advertised and served. Ordering by the listing alone would
+# jump straight to the backup and silently downgrade the run — the primary has
+# to be refused by chat before a backup is reachable.
+start_stub "fb/model" "$PIN fb/model"
+got=$(probe E2E_MODEL_FALLBACK=fb/model opencode 2>/dev/null || true)
+[ "$got" = "$PIN" ] || fail "listing promoted a fallback over a working primary: got '$got', want '$PIN'"
+grep -q "POST $PIN" "$HITS" || fail "the primary was never probed before falling back"
+
+# --- 7. claude-code is never probed ----------------------------------------
+start_stub "$PIN" "$PIN"
+got=$(probe claude-code 2>/dev/null || true)
+CC_PIN=$(awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' \
+  "$ROOT/internal/e2e/versions.go" | grep '"claude-code"' | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/')
+[ "$got" = "$CC_PIN" ] || fail "claude-code: got '$got', want '$CC_PIN'"
+if [ -s "$HITS" ]; then
+  fail "claude-code probed the gateway ($(tr '\n' ';' < "$HITS")) — it is on another provider"
+fi
+
+# --- 8. --github-output contract ------------------------------------------
+start_stub "fb/model" "fb/model"
+: > "$TMP/gh-out"
+probe GITHUB_OUTPUT="$TMP/gh-out" E2E_MODEL_FALLBACK=fb/model opencode --github-output >/dev/null 2>&1 || true
+grep -q '^model=fb/model$' "$TMP/gh-out" || fail "--github-output did not write model="
+grep -q '^fallback=true$' "$TMP/gh-out" || fail "--github-output did not flag the fallback"
+# candidates= is probe ORDER, not the logical candidate order: an advertised
+# model is tried first, so the chosen one can legitimately lead. Assert both the
+# intended model and the winner appear, not their positions.
+cands=$(sed -n 's/^candidates=//p' "$TMP/gh-out")
+case "$cands" in
+  *"$PIN"*) ;;
+  *) fail "--github-output candidates='$cands' omits the intended model '$PIN'" ;;
+esac
+case "$cands" in
+  *fb/model*) ;;
+  *) fail "--github-output candidates='$cands' omits the model actually used" ;;
+esac
+
+start_stub "$PIN" "$PIN"
+: > "$TMP/gh-out"
+probe GITHUB_OUTPUT="$TMP/gh-out" opencode --github-output >/dev/null 2>&1 || true
+grep -q '^fallback=false$' "$TMP/gh-out" || fail "a primary hit must report fallback=false"
+
+# --- 9. no creds -> passthrough, no network -------------------------------
+start_stub "$PIN" "$PIN"
+got=$(env -u SKAINET_TOKEN -u SKAINET_INTERNAL -u LLM_API_BASE -u LLM_API_KEY \
+       -u MODEL_PROBE_BASE -u MODEL_PROBE_TOKEN -u E2E_MODEL \
+       "$PROBE" opencode 2>/dev/null || true)
+[ "$got" = "$PIN" ] || fail "no creds: got '$got', want the unprobed pin '$PIN'"
+if [ -s "$HITS" ]; then
+  fail "credential-less run still hit the network ($(tr '\n' ';' < "$HITS"))"
+fi
+
+# --- 10. a transient primary must NOT trigger a fallback -------------------
+# Observed on 2026-07-29: the gateway answered 500 "internal error occurred
+# while invoking the model ... should recover automatically". That says nothing
+# about the model name, so swapping families over it would change what the run
+# tested for no reason. Must fail as infra, and must never emit the fallback.
+start_stub "$PIN fb/model" "fb/model" 200 "$PIN $PIN_FLIP"
+if out=$(probe E2E_MODEL_FALLBACK=fb/model opencode 2>"$TMP/err"); then
+  fail "transient primary: expected a non-zero exit, got '$out'"
+fi
+grep -q "title=Gateway unhealthy" "$TMP/err" || fail "a transient primary was not reported as a gateway-health problem"
+grep -q "title=Model fallback" "$TMP/err" && fail "a transient primary must not fall back to another family"
+# It must have retried rather than given up on the first 500.
+[ "$(grep -c "POST $PIN\$" "$HITS")" -ge 2 ] || fail "a transient result was not retried"
+
+# --- 11. a DEFINITIVELY unavailable primary still falls back ---------------
+# The distinction that makes case 10 safe: a name rejection is exactly what the
+# backup exists for, so this one must still substitute.
+start_stub "fb/model" "fb/model"
+out=$(probe E2E_MODEL_FALLBACK=fb/model opencode 2>"$TMP/err" || true)
+[ "$out" = "fb/model" ] || fail "unavailable primary should still fall back: got '$out'"
+grep -q "title=Model fallback" "$TMP/err" || fail "definitive unavailability did not announce the fallback"
+
+# --- 12. a transient blip that clears is not a failure ---------------------
+# Only the flip is transient; the primary is served. The primary is probed
+# first, so this must succeed without ever reaching the transient name.
+start_stub "$PIN" "$PIN" 200 "$PIN_FLIP"
+got=$(probe opencode 2>/dev/null || true)
+[ "$got" = "$PIN" ] || fail "served primary alongside a transient variant: got '$got', want '$PIN'"
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+echo "all probe-model.sh checks passed"

--- a/scripts/resolve-model.sh
+++ b/scripts/resolve-model.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Resolve the model id a CI step should use, and print it on stdout.
+#
+# Single source of truth for the shell side of the model configuration, the
+# counterpart of modelID() in internal/e2e/versions.go. Both apply the same
+# precedence, so a workflow's shell steps and its Go tests never disagree
+# about which model a run used:
+#
+#   1. E2E_MODEL_<HARNESS>  — per-harness override (harness upper-cased, '-'
+#                             → '_'), e.g. E2E_MODEL_CLAUDE_CODE
+#   2. E2E_MODEL            — cross-harness override; what the workflows'
+#                             single `model` workflow_dispatch input sets
+#   3. internal/e2e/versions.go's modelIDs map — the committed pin
+#
+# Usage:
+#   scripts/resolve-model.sh [harness]      # default harness: opencode
+#
+# The default matters: the workflows that summarise with an LLM (release
+# notes, drift summaries) and the strix security scan are not tied to a
+# harness — they all use opencode's entry, the plain gateway model name.
+#
+# Exits non-zero with a diagnostic on stderr when no model can be resolved,
+# so a caller under `set -e` fails loudly rather than sending an empty model
+# name to the gateway.
+
+set -euo pipefail
+
+harness="${1:-opencode}"
+
+# claude-code is the one harness bound to a single provider, and only that
+# provider's sonnet/haiku tiers are launchable — anything else is rejected by
+# the CLI with an opaque startup error. Reject it here instead, so a bad model
+# input fails a workflow in seconds rather than after the install and agent
+# turn. Mirrors validateModel() in internal/e2e/versions.go.
+reject_unlaunchable() {
+  local model="$1"
+  [ "$harness" = "claude-code" ] || return 0
+  case "$(printf '%s' "$model" | tr '[:upper:]' '[:lower:]')" in
+    *sonnet*|*haiku*) return 0 ;;
+  esac
+  echo "resolve-model: claude-code cannot run model '$model' — it accepts only sonnet or haiku models (override it separately via E2E_MODEL_CLAUDE_CODE / the claude_code_model workflow input)" >&2
+  exit 1
+}
+
+# 1. Per-harness override.
+# Two tr passes, not one combined set: mixing a character class with a literal
+# in a single SET1 is unspecified, and macOS ships BSD tr.
+per_harness_var="E2E_MODEL_$(printf '%s' "$harness" | tr '[:lower:]' '[:upper:]' | tr '-' '_')"
+per_harness="${!per_harness_var:-}"
+if [ -n "$per_harness" ]; then
+  reject_unlaunchable "$per_harness"
+  printf '%s\n' "$per_harness"
+  exit 0
+fi
+
+# 2. Cross-harness override.
+if [ -n "${E2E_MODEL:-}" ]; then
+  reject_unlaunchable "$E2E_MODEL"
+  printf '%s\n' "$E2E_MODEL"
+  exit 0
+fi
+
+# 3. The committed pin. VERSIONS_GO lets a caller whose checkout is not the
+# repo root point at the file (security-scan.yml checks out into target/).
+repo="$(cd "$(dirname "$0")/.." && pwd)"
+versions_go="${VERSIONS_GO:-$repo/internal/e2e/versions.go}"
+if [ ! -f "$versions_go" ]; then
+  echo "resolve-model: $versions_go not found (set VERSIONS_GO or pass an explicit model via E2E_MODEL)" >&2
+  exit 1
+fi
+pinned=$(awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' "$versions_go" \
+  | grep "\"$harness\"" \
+  | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/' \
+  | head -1)
+if [ -z "$pinned" ]; then
+  echo "resolve-model: no modelIDs entry for harness '$harness' in $versions_go" >&2
+  exit 1
+fi
+printf '%s\n' "$pinned"

--- a/scripts/resolve-model_test.sh
+++ b/scripts/resolve-model_test.sh
@@ -59,10 +59,23 @@ assert_rejected() {
 }
 
 # --- the committed pin (no override) ---------------------------------------
-assert_model "zai-org/GLM-5.2" "default harness is opencode"
-assert_model "zai-org/GLM-5.2" "explicit opencode" opencode
-assert_model "claude-sonnet-5" "claude-code pin" claude-code
-assert_model "zai-org/GLM-5.2" "pi pin" pi
+# Read from versions.go, never hardcoded: the pin moves whenever the gateway
+# renames a variant (#184), and this asserts the resolution mechanism, not which
+# model happens to be pinned today.
+pin_for() {
+  awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' \
+    "$ROOT/internal/e2e/versions.go" \
+    | grep "\"$1\"" | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/' | head -1
+}
+PIN_OPENCODE=$(pin_for opencode)
+PIN_CLAUDE=$(pin_for claude-code)
+PIN_PI=$(pin_for pi)
+[ -n "$PIN_OPENCODE" ] || fail "could not read the opencode pin out of versions.go"
+
+assert_model "$PIN_OPENCODE" "default harness is opencode"
+assert_model "$PIN_OPENCODE" "explicit opencode" opencode
+assert_model "$PIN_CLAUDE" "claude-code pin" claude-code
+assert_model "$PIN_PI" "pi pin" pi
 
 # --- precedence ------------------------------------------------------------
 assert_model "vendor/candidate-1" "cross-harness override" \
@@ -71,7 +84,7 @@ assert_model "claude-haiku-4-5" "per-harness override wins over cross-harness" \
   E2E_MODEL=vendor/candidate-1 E2E_MODEL_CLAUDE_CODE=claude-haiku-4-5 claude-code
 assert_model "vendor/candidate-1" "per-harness override must not leak to others" \
   E2E_MODEL=vendor/candidate-1 E2E_MODEL_CLAUDE_CODE=claude-haiku-4-5 opencode
-assert_model "zai-org/GLM-5.2" "an empty override falls through to the pin" \
+assert_model "$PIN_OPENCODE" "an empty override falls through to the pin" \
   E2E_MODEL= E2E_MODEL_OPENCODE= opencode
 
 # --- claude-code's launchable-model constraint -----------------------------

--- a/scripts/resolve-model_test.sh
+++ b/scripts/resolve-model_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Tests for scripts/resolve-model.sh.
+#
+# The point of these is parity: the resolver is the shell counterpart of
+# modelID()/validateModel() in internal/e2e/versions.go, and the two must agree
+# or a workflow's reported model won't be the one its Go tests ran. The
+# expectations below are the same ones TestModelIDOverride and TestValidateModel
+# assert on the Go side, plus the fallback that reads the pin out of
+# versions.go — the one behaviour that has no Go equivalent.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+RESOLVE="$ROOT/scripts/resolve-model.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+
+# Every case runs with a clean slate: the caller's own E2E_MODEL* must not leak
+# into an expectation about the committed pin. Args of the form VAR=value become
+# env assignments; anything else is passed through to the resolver, so a case
+# reads as `resolve E2E_MODEL=x claude-code` regardless of order.
+resolve() {
+  local assignments=() args=() a
+  for a in "$@"; do
+    case "$a" in
+      *=*) assignments+=("$a") ;;
+      *)   args+=("$a") ;;
+    esac
+  done
+  env -u E2E_MODEL -u E2E_MODEL_OPENCODE -u E2E_MODEL_CLAUDE_CODE \
+      -u E2E_MODEL_CODEX -u E2E_MODEL_COPILOT -u E2E_MODEL_PI \
+      -u VERSIONS_GO \
+      ${assignments[@]+"${assignments[@]}"} \
+      "$RESOLVE" ${args[@]+"${args[@]}"}
+}
+
+assert_model() {
+  local want="$1" desc="$2"; shift 2
+  local got
+  if ! got=$(resolve "$@" 2>&1); then
+    fail "$desc: exited non-zero: $got"
+    return
+  fi
+  [ "$got" = "$want" ] || fail "$desc: got '$got', want '$want'"
+}
+
+assert_rejected() {
+  local desc="$1"; shift
+  local got
+  if got=$(resolve "$@" 2>&1); then
+    fail "$desc: expected a non-zero exit, got '$got'"
+  fi
+}
+
+# --- the committed pin (no override) ---------------------------------------
+assert_model "zai-org/GLM-5.2" "default harness is opencode"
+assert_model "zai-org/GLM-5.2" "explicit opencode" opencode
+assert_model "claude-sonnet-5" "claude-code pin" claude-code
+assert_model "zai-org/GLM-5.2" "pi pin" pi
+
+# --- precedence ------------------------------------------------------------
+assert_model "vendor/candidate-1" "cross-harness override" \
+  E2E_MODEL=vendor/candidate-1 codex
+assert_model "claude-haiku-4-5" "per-harness override wins over cross-harness" \
+  E2E_MODEL=vendor/candidate-1 E2E_MODEL_CLAUDE_CODE=claude-haiku-4-5 claude-code
+assert_model "vendor/candidate-1" "per-harness override must not leak to others" \
+  E2E_MODEL=vendor/candidate-1 E2E_MODEL_CLAUDE_CODE=claude-haiku-4-5 opencode
+assert_model "zai-org/GLM-5.2" "an empty override falls through to the pin" \
+  E2E_MODEL= E2E_MODEL_OPENCODE= opencode
+
+# --- claude-code's launchable-model constraint -----------------------------
+assert_rejected "claude-code rejects a non-sonnet/haiku cross-harness override" \
+  E2E_MODEL=zai-org/GLM-5.2 claude-code
+assert_rejected "claude-code rejects a non-sonnet/haiku per-harness override" \
+  E2E_MODEL_CLAUDE_CODE=claude-opus-5 claude-code
+assert_model "claude-sonnet-5-20260101" "claude-code accepts a sonnet variant" \
+  E2E_MODEL=claude-sonnet-5-20260101 claude-code
+# The constraint is claude-code's alone — the rest share one gateway.
+for h in opencode codex copilot pi; do
+  assert_model "claude-opus-5" "$h is unconstrained" E2E_MODEL=claude-opus-5 "$h"
+done
+
+# --- failure modes ---------------------------------------------------------
+assert_rejected "unknown harness has no pin to fall back to" nope
+assert_rejected "missing versions.go is a loud failure" \
+  VERSIONS_GO="$TMP/absent.go" opencode
+
+# A VERSIONS_GO elsewhere is honoured — the escape hatch for a caller reading
+# pins from a checkout the resolver does not sit inside.
+cat > "$TMP/versions.go" <<'EOF'
+var modelIDs = map[string]string{
+	"opencode": "elsewhere/model-9",
+}
+EOF
+assert_model "elsewhere/model-9" "VERSIONS_GO points at another checkout" \
+  VERSIONS_GO="$TMP/versions.go" opencode
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+echo "all resolve-model.sh checks passed"


### PR DESCRIPTION
**Issue:** Closes #182

## What

- Every LLM-driven workflow gains a `model` workflow_dispatch input (plus
  `claude_code_model` and `context_limit` where a harness runs): `E2E: full`,
  `E2E: drift`, `E2E: onboarding`, `Doc drift`, `Security Scan`, `Release`.
- One resolution path replaces five hardcoded copies of the model id.
- The resolved model is now reported everywhere a result is reported.
- The declared context window is overridable, defaulting to `100000`.

## Why

The model id came from a single hardcoded source — `modelIDs` in
`internal/e2e/versions.go`, or an awk-extraction of it duplicated across three
workflows and two scripts. Running CI against a different model meant editing
that file and pushing a commit, unlike the `*_version` harness pins which have
had dispatch inputs since `e2e.yml:21`.

The output was also silent about which model ran, so a compat-matrix row, a
drift report, or a scan's finding counts could not be attributed to a model
after the fact — the thing that matters most on a run that overrode it.

## How

- `internal/e2e/versions.go` — `modelID(harness)` mirroring the existing
  `pinnedPackage()`: `E2E_MODEL_<HARNESS>` → `E2E_MODEL` → the pinned map. All
  nine direct `modelIDs[...]` reads in `harnesses.go` now go through it.
- `scripts/resolve-model.sh` — the same precedence for shell steps, replacing
  the awk extraction in `release.yml`, `e2e-smoke.yml`, `security-scan.yml` and
  the `DEFAULT_MODEL` constants in `doc-drift.sh` /
  `e2e-readme-onboarding.sh`. `scripts/resolve-model_test.sh` asserts parity
  with the Go side and runs on every PR via `CI` → `E2E: model-free`.
- Two constraints are enforced at resolution, not left to fail opaquely
  mid-run:
  - **claude-code launches sonnet/haiku only** — `validateModel()`
    (`versions.go`) fails in `claudeCodeConfig`'s `ProviderSetup`, and the
    resolver fails the workflow's *Resolve model* step in seconds rather than
    after ~15 min of installs. Hence the separate `claude_code_model` input.
  - **The declared context window must not exceed the model's real one** —
    `contextLimit()` defaults to `100000`, under every pinned model. Declaring
    more overflows mid-turn; declaring less only compacts earlier.
- Reporting: `model=` on every `OMAC_COMPAT` line
  (`internal/e2e/contract.go:189`), a `Model` column on the compatibility
  matrix (**appended**, so the report job's positional `$7..$10` stage marks and
  already-archived 9-column rows still parse — the archive header is widened
  in place), `model:` in `meta.txt`, the model in each workflow's step summary
  and an Actions notice, the model(s) and summariser model in the Slack
  message, and a provenance header on the drift/onboarding report artifacts.
  The provider config's display name follows the id instead of a literal
  `"GLM 5.2"`.

## Verification

```
$ go vet ./... && go vet -tags=e2e ./internal/e2e/ && go vet -tags=e2e_fast ./internal/e2e/
vet clean
$ gofmt -l internal/ cmd/ scripts/
(clean)
$ go test ./...
all ok
$ go test -tags=e2e_fast -race -count=1 ./internal/e2e/
ok  github.com/tngtech/oh-my-agentic-coder/internal/e2e  2.288s
$ scripts/resolve-model_test.sh
all resolve-model.sh checks passed
$ scripts/classify-compat-failure_test.sh
PASS: classify-compat-failure
$ actionlint .github/workflows/*.yml
actionlint clean
```

New tests: `TestModelIDOverride`, `TestValidateModel`,
`TestPinnedModelsAreLaunchable`, `TestContextLimitOverride`,
`TestModelEnvVarCompleteness`, extended `TestCompatLine`, plus 18 cases in
`scripts/resolve-model_test.sh`.

Behaviour verified against real generated artifacts, not just unit tests:

- The opencode provider config written by `ProviderSetup` under
  `E2E_MODEL=vendor/big-model E2E_CONTEXT_LIMIT=202752` (throwaway probe):
  `{"vendor/big-model":{"limit":{"context":202752,"output":32000},"name":"vendor/big-model"}}`
  — overridden model as key *and* display name, window raised.
- The same block as generated by `doc-drift.sh`'s heredoc: default
  `{"zai-org/GLM-5.2":{...,"context":100000}}`; with `E2E_MODEL` +
  `E2E_CONTEXT_LIMIT` it tracks both; `DRIFT_MODEL` still wins.
- `claudeCodeConfig`'s `ProviderSetup` fails at `harnesses.go:339` when
  `E2E_MODEL=zai-org/GLM-5.2` reaches it, rather than launching.
- The new `Model` cell lands at awk field 11 against sample rows, leaving the
  stage marks at `$7..$10` and the timestamp restamp at `$2` intact; a legacy
  9-column row yields an empty model rather than a shifted parse.

Not run (needs CI secrets / a live gateway): the model-calling tiers
themselves — `E2E: full`, `E2E: drift`'s `llm` stage, `Doc drift`,
`Security Scan`. Their model plumbing is covered by the parity test and the
artifact probes above, but the first real dispatch with a `model` override is
worth watching.

## Follow-up

- `.github/scripts/security_scan_triage.py:24` still carries a hardcoded
  `openai/zai-org/GLM-5.2` fallback for standalone use. Harmless today — the
  workflow always passes `STRIX_LLM` — but it is the last copy of the pin.