### PR TITLE
fix(e2e,ci): probe the gateway for a usable model before running LLM jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,12 @@ jobs:
           version: latest
           install-go: false
 
+      # Workflow `run:` bodies are shell that nothing else parses, so a quoting
+      # mistake ships and only surfaces the next time that job runs — days
+      # later for the weekly LLM workflows.
+      - name: Workflow shell syntax
+        run: python3 scripts/check-workflow-shell.py
+
   e2e-fast:
     # Model-free slice of the e2e suite (build tag `e2e_fast`): the security
     # regression tests that need no live LLM harness, API token, or OS
@@ -176,6 +182,12 @@ jobs:
       # it didn't use.
       - name: Check model resolver parity
         run: scripts/resolve-model_test.sh
+
+      # The gateway-probe paths (variant flip, tier priority, fallback,
+      # exhausted candidates) against a local stub gateway — the states that
+      # can't be produced on demand upstream. No credentials, no real network.
+      - name: Check model probe against a stub gateway
+        run: scripts/probe-model_test.sh
 
   cache-integration:
     name: Cache integration (${{ matrix.os }})

--- a/.github/workflows/doc-drift.yml
+++ b/.github/workflows/doc-drift.yml
@@ -43,8 +43,41 @@ permissions:
   contents: read
 
 jobs:
+  # Front-loads model selection: the gateway serves one name variant at a time
+  # and flips without notice (#184). Probing once here means a renamed model
+  # fails in seconds rather than after a 40-minute audit.
+  model:
+    name: Resolve model
+    runs-on: ubuntu-latest
+    outputs:
+      gateway: ${{ steps.probe.outputs.model }}
+      fallback: ${{ steps.probe.outputs.fallback }}
+      candidates: ${{ steps.probe.outputs.candidates }}
+    env:
+      SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+      SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+      E2E_MODEL: ${{ github.event.inputs.model }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Probe the gateway
+        id: probe
+        run: scripts/probe-model.sh opencode --github-output
+      - name: Report the selection
+        run: |
+          {
+            echo "## Model selection"
+            echo ""
+            echo "Model: \`${{ steps.probe.outputs.model }}\` · probed: \`${{ steps.probe.outputs.candidates }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ steps.probe.outputs.fallback }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Fallback model in use** — the intended model is not served by the gateway." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   drift:
     name: ${{ matrix.mode }} drift
+    needs: model
     strategy:
       fail-fast: false
       matrix:
@@ -59,21 +92,14 @@ jobs:
       SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
       E2E_VERSION_OPENCODE: ${{ github.event.inputs.opencode_version }}
       DRIFT_TIMEOUT_SECS: ${{ github.event.inputs.timeout_secs }}
-      # Read by scripts/resolve-model.sh (which doc-drift.sh consults) and by
-      # the provider config it writes. Both empty on schedule runs, so that run
-      # always uses the committed pin and the 100000 default.
-      E2E_MODEL: ${{ github.event.inputs.model }}
+      # From the preflight job: the input, the gateway probe and the -TEE flip
+      # already applied. Only opencode is involved here, so the cross-harness
+      # var is the right one to set.
+      E2E_MODEL: ${{ needs.model.outputs.gateway }}
       E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Resolve model
-        id: model
-        run: |
-          model=$(scripts/resolve-model.sh opencode)
-          echo "model=$model" >> "$GITHUB_OUTPUT"
-          echo "::notice title=Model::${{ matrix.mode }} drift audit runs against $model"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -90,7 +116,7 @@ jobs:
           {
             echo "## Doc drift — ${{ matrix.mode }}"
             echo ""
-            echo "Model: \`${{ steps.model.outputs.model }}\`"
+            echo "Model: \`${{ needs.model.outputs.gateway }}\`"
             echo ""
             echo '```markdown'
             cat "${{ runner.temp }}/doc-drift-logs/DRIFT_REPORT-${{ matrix.mode }}.md" 2>/dev/null \

--- a/.github/workflows/e2e-readme-onboarding.yml
+++ b/.github/workflows/e2e-readme-onboarding.yml
@@ -36,8 +36,41 @@ permissions:
   contents: read
 
 jobs:
+  # Front-loads model selection: the gateway serves one name variant at a time
+  # and flips without notice (#184). Probing once here means a renamed model
+  # fails in seconds rather than after a 20-minute agent session.
+  model:
+    name: Resolve model
+    runs-on: ubuntu-latest
+    outputs:
+      gateway: ${{ steps.probe.outputs.model }}
+      fallback: ${{ steps.probe.outputs.fallback }}
+      candidates: ${{ steps.probe.outputs.candidates }}
+    env:
+      SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+      SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+      E2E_MODEL: ${{ github.event.inputs.model }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Probe the gateway
+        id: probe
+        run: scripts/probe-model.sh opencode --github-output
+      - name: Report the selection
+        run: |
+          {
+            echo "## Model selection"
+            echo ""
+            echo "Model: \`${{ steps.probe.outputs.model }}\` · probed: \`${{ steps.probe.outputs.candidates }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ steps.probe.outputs.fallback }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Fallback model in use** — the intended model is not served by the gateway." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   readme-onboarding:
     name: README onboarding (${{ matrix.os }})
+    needs: model
     strategy:
       fail-fast: false
       matrix:
@@ -51,21 +84,14 @@ jobs:
       SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
       E2E_VERSION_OPENCODE: ${{ github.event.inputs.opencode_version }}
       E2E_ONBOARDING_TIMEOUT_SECS: ${{ github.event.inputs.timeout_secs }}
-      # Read by scripts/resolve-model.sh (which the onboarding script consults)
-      # and by the provider config it writes. This workflow is dispatch-only, so
-      # an empty input means the committed pin and the 100000 default.
-      E2E_MODEL: ${{ github.event.inputs.model }}
+      # From the preflight job: the input, the gateway probe and the -TEE flip
+      # already applied. Only opencode is involved here, so the cross-harness
+      # var is the right one to set.
+      E2E_MODEL: ${{ needs.model.outputs.gateway }}
       E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Resolve model
-        id: model
-        run: |
-          model=$(scripts/resolve-model.sh opencode)
-          echo "model=$model" >> "$GITHUB_OUTPUT"
-          echo "::notice title=Model::onboarding agent runs against $model"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -81,7 +107,7 @@ jobs:
         run: |
           echo "## README onboarding (${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Model: \`${{ steps.model.outputs.model }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Model: \`${{ needs.model.outputs.gateway }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.run_onboarding.outcome }}" = "success" ]; then
             echo "**Result:** README was sufficient — doctor healthy, report written." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -59,8 +59,55 @@ permissions:
   issues: write # report job maintains the tracking issue
 
 jobs:
+  # Front-loads model selection: the gateway serves one name variant at a time
+  # and flips without notice (#184), which reddened every non-opencode llm stage
+  # on 2026-07-29. Probing once here means a renamed model costs seconds instead
+  # of 18 legs, and the -TEE flip self-heals.
+  model:
+    name: Resolve model
+    runs-on: ubuntu-latest
+    outputs:
+      gateway: ${{ steps.probe.outputs.model }}
+      fallback: ${{ steps.probe.outputs.fallback }}
+      candidates: ${{ steps.probe.outputs.candidates }}
+      claude_code: ${{ steps.probe.outputs.claude_code }}
+    env:
+      SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+      SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+      E2E_MODEL: ${{ github.event.inputs.model }}
+      E2E_MODEL_CLAUDE_CODE: ${{ github.event.inputs.claude_code_model }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Probe the gateway
+        id: probe
+        run: |
+          scripts/probe-model.sh opencode --github-output
+          cc=$(E2E_MODEL= scripts/probe-model.sh claude-code)
+          echo "claude_code=$cc" >> "$GITHUB_OUTPUT"
+
+      - name: Report the selection
+        run: |
+          gateway='${{ steps.probe.outputs.model }}'
+          {
+            echo "## Model selection"
+            echo ""
+            echo "| Harness | Model |"
+            echo "|---|---|"
+            echo "| opencode, codex, copilot, pi | \`$gateway\` |"
+            echo "| claude-code | \`${{ steps.probe.outputs.claude_code }}\` |"
+            echo ""
+            echo "Probed: \`${{ steps.probe.outputs.candidates }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ steps.probe.outputs.fallback }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Fallback model in use** — \`$gateway\` is not the intended model." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   smoke:
     name: "${{ matrix.harness }} / ${{ matrix.os }} / omac@${{ matrix.omac }}"
+    needs: model
     strategy:
       fail-fast: false
       matrix:
@@ -88,19 +135,22 @@ jobs:
       E2E_HARNESS: ${{ matrix.harness }}
       # Schedule runs always test latest (drift); dispatch honors the input.
       E2E_USE_LATEST: ${{ (github.event_name == 'schedule' || github.event.inputs.use_latest != 'false') && '1' || '' }}
-      # Model overrides for a manual run. All empty on schedule runs, so that
-      # run always resolves to the pins in internal/e2e/versions.go.
-      E2E_MODEL: ${{ github.event.inputs.model }}
-      E2E_MODEL_CLAUDE_CODE: ${{ github.event.inputs.claude_code_model }}
+      # From the preflight job (input + gateway probe + -TEE flip applied). Set
+      # PER HARNESS, not via cross-harness E2E_MODEL: the probed value is a
+      # gateway model and claude-code is on another provider.
+      E2E_MODEL_OPENCODE: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_CODEX: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_COPILOT: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_PI: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_CLAUDE_CODE: ${{ needs.model.outputs.claude_code }}
       E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Fails the leg immediately on a model the harness can't launch
-      # (claude-code accepts sonnet/haiku only), rather than after the install.
-      # The row's Model cell comes from the test's own OMAC_COMPAT line, not
-      # from here — see "Build compatibility row".
+      # Selection already happened in the preflight job; this reports what this
+      # leg's harness resolved to. The row's Model cell comes from the test's own
+      # OMAC_COMPAT line, not from here — see "Build compatibility row".
       - name: Resolve model
         run: |
           echo "::notice title=Model::${{ matrix.harness }} runs against $(scripts/resolve-model.sh '${{ matrix.harness }}')"
@@ -312,7 +362,7 @@ jobs:
 
   report:
     name: Record & report
-    needs: smoke
+    needs: [model, smoke]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -377,9 +427,10 @@ jobs:
         env:
           SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
           SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
-          # The summariser is an LLM call too, so it follows the same override —
-          # this job has no matrix, so only the cross-harness input applies.
-          E2E_MODEL: ${{ github.event.inputs.model }}
+          # The summariser is an LLM call too, so it uses the model the preflight
+          # proved is served — re-resolving the pin here would 422 in exactly
+          # the situation the summary is most needed.
+          E2E_MODEL: ${{ needs.model.outputs.gateway }}
         run: |
           # Each failing leg already wrote a self-contained .ctx file (header
           # with harness/OS/omac + failing stage, plus its own log excerpts), so
@@ -434,6 +485,8 @@ jobs:
           TOTAL: ${{ steps.rows.outputs.total }}
           INFRA_ONLY: ${{ steps.reason.outputs.infra_only }}
           SUMMARY_MODEL: ${{ steps.summary.outputs.model }}
+          MODEL_FALLBACK: ${{ needs.model.outputs.fallback }}
+          GATEWAY_MODEL: ${{ needs.model.outputs.gateway }}
         run: |
           title="Harness compatibility matrix"
           # One stable issue, any state: reopen if it was closed so it is always
@@ -467,6 +520,10 @@ jobs:
             echo "$status — [run log]($RUN_URL). Updated in place by [\`e2e-smoke.yml\`]($WF_URL); rolling 30-day window (newest first, grouped by omac / OS / harness). Full permanent history is mirrored to a private archive repo."
             echo ""
             echo "\`✅\` pass · \`❌\` fail · \`➖\` not run"
+            if [ "$MODEL_FALLBACK" = "true" ]; then
+              echo ""
+              echo "> ⚠️ **This run used a fallback model** (\`$GATEWAY_MODEL\`): the intended model is not currently served by the gateway. Green rows below certify the fallback, not the intended model."
+            fi
             if [ "$HAS_FAILURES" = "true" ]; then
               echo ""
               echo "## Currently failing"
@@ -580,6 +637,7 @@ jobs:
           TOTAL: ${{ steps.rows.outputs.total }}
           INFRA_ONLY: ${{ steps.reason.outputs.infra_only }}
           SUMMARY_MODEL: ${{ steps.summary.outputs.model }}
+          MODEL_FALLBACK: ${{ needs.model.outputs.fallback }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "SLACK_WEBHOOK_URL not set — skipping Slack notification"
@@ -591,6 +649,9 @@ jobs:
           models=$(awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/,"",$11); if ($11!="") print $11}' run.rows \
             | sort -u | paste -sd',' - )
           [ -z "$models" ] && models="unknown"
+          if [ "${MODEL_FALLBACK:-}" = "true" ]; then
+            models="$models (FALLBACK — intended model not served)"
+          fi
           # Posted on every run — green and red alike.
           if [ "$HAS_FAILURES" = "true" ]; then
             hdr=$(printf '🔴 omac harness compatibility: %s of %s combination(s) FAILED.' "$FAIL_COUNT" "$TOTAL")

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,8 +57,62 @@ permissions:
   contents: read
 
 jobs:
+  # Front-loads model selection so a renamed or withdrawn model costs seconds
+  # instead of a whole matrix. The gateway serves one name variant at a time and
+  # flips without notice (#184); scripts/probe-model.sh asks GET /models what is
+  # advertised, then settles it with a 1-token chat probe, flipping the -TEE
+  # suffix and finally falling back to another family if it must.
+  model:
+    name: Resolve model
+    runs-on: ubuntu-latest
+    outputs:
+      gateway: ${{ steps.probe.outputs.model }}
+      fallback: ${{ steps.probe.outputs.fallback }}
+      candidates: ${{ steps.probe.outputs.candidates }}
+      claude_code: ${{ steps.probe.outputs.claude_code }}
+    env:
+      SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+      SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
+      E2E_MODEL: ${{ github.event.inputs.model }}
+      E2E_MODEL_CLAUDE_CODE: ${{ github.event.inputs.claude_code_model }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Probe the gateway
+        id: probe
+        run: |
+          # The gateway harnesses (opencode/codex/copilot/pi) share one model,
+          # so one probe covers all four.
+          scripts/probe-model.sh opencode --github-output
+          # claude-code is resolved but never probed: it talks to
+          # ANTHROPIC_BASE_URL, not this gateway. Its own input wins; failing
+          # here (rather than in the matrix) keeps an unlaunchable model from
+          # burning an install first.
+          cc=$(E2E_MODEL= scripts/probe-model.sh claude-code)
+          echo "claude_code=$cc" >> "$GITHUB_OUTPUT"
+
+      - name: Report the selection
+        run: |
+          gateway='${{ steps.probe.outputs.model }}'
+          {
+            echo "## Model selection"
+            echo ""
+            echo "| Harness | Model |"
+            echo "|---|---|"
+            echo "| opencode, codex, copilot, pi | \`$gateway\` |"
+            echo "| claude-code | \`${{ steps.probe.outputs.claude_code }}\` |"
+            echo ""
+            echo "Probed: \`${{ steps.probe.outputs.candidates }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ steps.probe.outputs.fallback }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Fallback model in use.** The intended model is not served by the gateway, so these results are for \`$gateway\` and do NOT certify the intended one." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   e2e:
     name: "${{ matrix.harness }} / ${{ matrix.os }}"
+    needs: model
     strategy:
       fail-fast: false
       matrix:
@@ -94,26 +148,28 @@ jobs:
       E2E_VERSION_CODEX: ${{ github.event.inputs.codex_version }}
       E2E_VERSION_COPILOT: ${{ github.event.inputs.copilot_version }}
       E2E_VERSION_PI: ${{ github.event.inputs.pi_version }}
-      # Model overrides for a manual run, so a different model can be tested
-      # without editing internal/e2e/versions.go. Both empty on schedule runs
-      # and whenever the inputs are left blank; modelID() then falls back to
-      # the pinned modelIDs map. E2E_MODEL_CLAUDE_CODE wins over E2E_MODEL for
-      # claude-code, which bills a different provider than the rest.
-      E2E_MODEL: ${{ github.event.inputs.model }}
-      E2E_MODEL_CLAUDE_CODE: ${{ github.event.inputs.claude_code_model }}
+      # Models come from the preflight job, which already applied the `model`
+      # input, the gateway probe, and the -TEE variant flip. Set PER HARNESS
+      # rather than via cross-harness E2E_MODEL: the probed value is a gateway
+      # model, and handing it to claude-code — which is on another provider and
+      # launches sonnet/haiku only — would fail its legs on every run,
+      # scheduled ones included.
+      E2E_MODEL_OPENCODE: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_CODEX: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_COPILOT: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_PI: ${{ needs.model.outputs.gateway }}
+      E2E_MODEL_CLAUDE_CODE: ${{ needs.model.outputs.claude_code }}
       # Empty (and on schedule runs) → contextLimit()'s 100000 default.
       E2E_CONTEXT_LIMIT: ${{ github.event.inputs.context_limit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Resolved with the same precedence the Go tests apply (modelID() in
-      # internal/e2e/versions.go), so what the summary reports is what ran.
+      # Selection happened in the preflight job; this only resolves what this
+      # leg's harness ended up with (per-harness env, set above) and reports it.
       - name: Resolve model
         id: model
         run: |
-          # Fails fast on a model the harness can't launch (claude-code accepts
-          # sonnet/haiku only), before the ~15 min of installs below.
           model=$(scripts/resolve-model.sh '${{ matrix.harness }}')
           # Reported as the label rather than the number so the default has one
           # definition (contextLimit() in internal/e2e/versions.go).
@@ -225,6 +281,10 @@ jobs:
           echo "## E2E failure classification (${{ matrix.harness }} / ${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Model: \`${{ steps.model.outputs.model }}\` · context: \`${{ steps.model.outputs.context }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ needs.model.outputs.fallback }}' = 'true' ] && [ '${{ matrix.harness }}' != 'claude-code' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ Fallback model — the intended model is not served by the gateway, so this result does NOT certify it." >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Assertion | Mode | Reason |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----------|------|--------|" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
         type: boolean
         default: true
       model:
-        description: "Model id for the release-notes summarizer, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go (zai-org/GLM-5.2)"
+        description: "Model id for the release-notes summarizer, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go. Whatever is resolved still goes through the gateway probe, so the -TEE variant flip and the fallback chain apply"
         type: string
         default: ''
 
@@ -128,8 +128,8 @@ jobs:
           # into user-facing highlights. Absent -> deterministic commit bullets.
           SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
           SKAINET_INTERNAL: ${{ secrets.SKAINET_EXTERNAL }}
-          # Read by scripts/resolve-model.sh below. Empty on a tag push (the
-          # normal path), so a real release always summarizes with the pin.
+          # Read by scripts/probe-model.sh below. Empty on a tag push (the
+          # normal path), so a real release starts from the committed pin.
           E2E_MODEL: ${{ github.event.inputs.model }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
@@ -179,12 +179,15 @@ jobs:
             max=48000
             [ "${#commits}" -gt "$max" ] && commits=${commits: -max}
             if [ -n "$commits" ]; then
-              # Single source of truth for the model id, override included:
-              # the `model` input, else internal/e2e/versions.go's pin.
+              # probe-model.sh, not resolve-model.sh: the gateway serves one
+              # name variant at a time and flips without notice (#184), so the
+              # committed pin alone would 422 and silently drop the release
+              # notes back to raw commit bullets. The probe flips the -TEE
+              # suffix and falls back a family if it must.
               # `|| true` because a release must never fail on its optional
               # summarizer: an empty model leaves llm_json empty below and the
               # deterministic commit bullets take over.
-              model=$(scripts/resolve-model.sh opencode || true)
+              model=$(scripts/probe-model.sh opencode || true)
               sys="You are the release-notes editor for oh-my-agentic-coder (omac), a CLI that runs coding agents in a sandbox. Below are the raw git commit messages for one release. Rewrite them into concise, user-facing highlights grouped into features (new capabilities) and fixes (bugs resolved). Write for end users: state what they can now do and why it matters. IGNORE anything only project developers care about: PR/issue numbers like (#123), commit SHAs, author or co-author trailers, internal refactors, and test/ci/build/chore changes. Drop internal module and scope names. Merge related commits into one bullet. Output ONLY minified JSON of the form {\"features\":[\"...\"],\"fixes\":[\"...\"]} with at most 6 items per group, each under 140 characters and starting with a capital letter. Use an empty array for a group with nothing user-facing. No preamble, no explanation, no chain-of-thought, no <think> tags."
               req=$(jq -n --arg m "$model" --arg s "$sys" --arg u "$commits" \
                 '{model:$m,temperature:0.2,max_tokens:1500,messages:[{role:"system",content:$s},{role:"user",content:$u}]}')

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -29,7 +29,7 @@ on:
         options: [quick, standard, deep]
         default: deep
       model:
-        description: 'Model id for the strix agent, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go (zai-org/GLM-5.2). The -TEE fallback probe below applies to whatever is resolved here'
+        description: 'Model id for the strix agent, for THIS RUN ONLY. Leave empty for the opencode pin in internal/e2e/versions.go. Whatever is resolved here still goes through the gateway probe, so the -TEE variant flip and the fallback chain apply'
         type: string
         default: ''
 
@@ -54,8 +54,8 @@ jobs:
       LLM_API_BASE: ${{ secrets.SKAINET_EXTERNAL }}
       LLM_API_KEY: ${{ secrets.SKAINET_TOKEN }}
       GH_TOKEN: ${{ github.token }}
-      # Read by scripts/resolve-model.sh below; empty on the scheduled run, so
-      # that run always resolves to the committed pin.
+      # Read by scripts/probe-model.sh below; empty on the scheduled run, so
+      # that run starts from the committed pin.
       E2E_MODEL: ${{ inputs.model }}
     steps:
       - name: Checkout target repo
@@ -130,38 +130,16 @@ jobs:
         id: model
         run: |
           set -euo pipefail
-          # Base model name: resolved by the checked-out repo's own resolver, so
-          # the same precedence the e2e Go tests apply -- the `model` input, else
-          # internal/e2e/versions.go's modelIDs map (opencode's entry, the plain
-          # GLM-5.2 name that opencode's own resolution uses). The resolver reads
-          # versions.go relative to itself, so the target/ checkout path is fine.
-          base=$(target/scripts/resolve-model.sh opencode)
-          # Harden against the gateway's raw /v1/chat/completions path only
-          # serving one model-name variant at a time: unlike opencode, strix
-          # calls that path directly, and it recently flipped from accepting the
-          # plain name to requiring the -TEE variant (422 model_unavailable).
-          # Probe the base name first, fall back to <base>-TEE, and use
-          # whichever the gateway currently accepts -- so a future flip in
-          # either direction self-heals. Model names aren't secret; the bearer
-          # in the header is and is never printed.
-          endpoint="${LLM_API_BASE%/}/chat/completions"
-          chosen=""
-          for candidate in "$base" "${base}-TEE"; do
-            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 \
-              -X POST "$endpoint" \
-              -H "authorization: Bearer ${LLM_API_KEY}" \
-              -H 'content-type: application/json' \
-              -d "{\"model\":\"${candidate}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":1}") || true
-            if [ "$code" = "200" ]; then chosen="$candidate"; break; fi
-            echo "model '${candidate}' not accepted (HTTP ${code}); trying next variant"
-          done
-          if [ -z "$chosen" ]; then
-            echo "::error::neither '${base}' nor '${base}-TEE' was accepted by the gateway -- check the model provider and SKAINET_TOKEN validity"
-            exit 1
-          fi
+          # This workflow's own base/-TEE probe used to live here inline. It is
+          # now target/scripts/probe-model.sh, shared with every other LLM
+          # workflow (#184): same bidirectional variant flip, plus a GET /models
+          # listing to order candidates and a configured fallback family. The
+          # resolver reads versions.go relative to itself, so the target/
+          # checkout path needs no extra wiring. Model names aren't secret; the
+          # bearer in the header is and is never printed.
+          chosen=$(target/scripts/probe-model.sh opencode --github-output)
           echo "selected model: ${chosen}"
           echo "strix_llm=openai/${chosen}" >> "$GITHUB_OUTPUT"
-          echo "model=${chosen}" >> "$GITHUB_OUTPUT"
           # Model names aren't findings -- safe on this public summary, and the
           # counts below are only interpretable against the model that produced
           # them (especially on a manual run against an override).
@@ -242,6 +220,10 @@ jobs:
           cat step-summary.md >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Model: \`${{ steps.model.outputs.model }}\` · scan mode: \`${{ inputs.scan_mode || 'deep' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ '${{ steps.model.outputs.fallback }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Fallback model** — the intended model is not served by the gateway, so this scan's coverage is not comparable to previous ones." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Stop context-compaction proxy
         if: always()

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -102,6 +102,68 @@ Actions notice, `meta.txt` in the uploaded e2e artifacts, the `model=` field on
 every `OMAC_COMPAT` line, the `Model` column of the compatibility matrix, and
 the header of the drift/onboarding report artifacts.
 
+### The gateway renames models; the probe absorbs it
+
+The SKAINET gateway serves **one name variant at a time** — the plain name or a
+`-TEE` suffixed one — and flips between them without notice. On 2026-07-29 it
+stopped accepting plain `zai-org/GLM-5.2` and every non-opencode `llm` stage
+went red about ten minutes into each leg (issue #184).
+
+So every LLM workflow now starts with a **preflight `Resolve model` job** that
+runs [`scripts/probe-model.sh`](../scripts/probe-model.sh) once and hands the
+result to the jobs that follow. A renamed model costs seconds instead of a whole
+matrix. The probe:
+
+1. asks `GET $base/models` what the gateway advertises, and
+2. settles it with a 1-token `POST $base/chat/completions` — the endpoint that
+   actually 422s, so the endpoint that gets asked. The listing only *orders*
+   candidates; it never excludes one, because a stale listing must not veto a
+   name that works.
+
+Candidates are tried in **priority tiers** — the resolved model and its variant
+flip first, then each fallback and its flip. The listing may reorder within a
+tier but never across tiers, so a backup is only ever reached after the primary
+has genuinely been refused. The flip is bidirectional, so pinning either variant
+survives the next flip in either direction.
+
+A non-200 from the probe means one of two very different things, and the probe
+keeps them apart:
+
+| Gateway says | Meaning | Probe does |
+|---|---|---|
+| `422` / `404` | it refuses this **name** | move to the next candidate — this is what the flip and the fallback are for |
+| `5xx` / `429` / no answer | it is **unwell**; says nothing about the name | retry the same name, then fail as a gateway-health problem — **never** fall back |
+
+That second row matters: on 2026-07-29 the gateway also answered `500 An internal
+error occurred while invoking the model. The model inference should recover
+automatically within a few minutes.` Treating that as "model missing" would
+silently swap model families over a 30-second cluster blip, changing what the run
+tested for no good reason.
+
+| Substitution | Reported how |
+|---|---|
+| variant flip (`X` → `X-TEE`) | quietly — same model, gateway naming quirk |
+| fallback family (`fallbackModels`) | `::warning::`, step summary, dashboard and Slack all say the results are **not** for the intended model |
+
+The fallback chain lives in `fallbackModels` (`internal/e2e/versions.go`) rather
+than a workflow input, because `e2e.yml` is at GitHub's 10-input cap;
+`E2E_MODEL_FALLBACK` overrides it for a one-off (comma- or space-separated).
+
+claude-code is never probed — it talks to `ANTHROPIC_BASE_URL`, not this
+gateway. For the same reason the preflight hands the probed model to the
+**per-harness** vars (`E2E_MODEL_OPENCODE` and friends) rather than to
+cross-harness `E2E_MODEL`: the probed value is a gateway model, and giving it to
+claude-code would fail its legs on every run.
+
+```bash
+scripts/probe-model.sh opencode      # what a gateway job would use, probed
+scripts/probe-model.sh claude-code   # resolved, never probed
+scripts/probe-model_test.sh          # stub-gateway coverage of every path
+```
+
+Without credentials on the env the probe is a pure passthrough, so local runs
+and model-free jobs need no network to name a model.
+
 ### Multi-directory serve mode (`omac serve`)
 
 End-to-end smoke test of the control plane, facade routing, per-workdir

--- a/internal/e2e/contract_test.go
+++ b/internal/e2e/contract_test.go
@@ -131,13 +131,18 @@ func TestCompatLine(t *testing.T) {
 	t.Setenv("E2E_MODEL", "")
 	t.Setenv("E2E_MODEL_CLAUDE_CODE", "")
 
+	// Built from modelIDs rather than the literal pin: this asserts that the
+	// line carries the resolved model, not what that model happens to be
+	// today — the pin moves whenever the gateway renames a variant (#184).
 	got := compatLine("claude-code", "2.1.197", "linux", "contract", "PASS")
-	want := "OMAC_COMPAT harness=claude-code version=2.1.197 os=linux model=claude-sonnet-5 stage=contract result=PASS"
+	want := "OMAC_COMPAT harness=claude-code version=2.1.197 os=linux model=" +
+		modelIDs["claude-code"] + " stage=contract result=PASS"
 	if got != want {
 		t.Fatalf("compatLine = %q, want %q", got, want)
 	}
 	if got, want := compatLine("pi", "", "linux", "llm", "FAIL"),
-		"OMAC_COMPAT harness=pi version=unknown os=linux model=zai-org/GLM-5.2 stage=llm result=FAIL"; got != want {
+		"OMAC_COMPAT harness=pi version=unknown os=linux model="+
+			modelIDs["pi"]+" stage=llm result=FAIL"; got != want {
 		t.Fatalf("empty-version compatLine = %q, want %q", got, want)
 	}
 

--- a/internal/e2e/versions.go
+++ b/internal/e2e/versions.go
@@ -39,12 +39,107 @@ var versionEnvVar = map[string]string{
 
 // Model identifiers per harness. Read through modelID(), never directly, so
 // a run's workflow_dispatch override is honoured.
+//
+// The gateway serves one name variant at a time and flips between the plain
+// name and a "-TEE" suffixed one without notice — on 2026-07-29 it stopped
+// accepting plain "zai-org/GLM-5.2" and every non-opencode llm stage went red
+// (see issue #184). Pin whichever variant is currently served;
+// scripts/probe-model.sh flips to the other one automatically, so a future flip
+// in either direction self-heals rather than reddening the matrix.
 var modelIDs = map[string]string{
-	"opencode":    "zai-org/GLM-5.2",
+	"opencode":    "zai-org/GLM-5.2-TEE",
 	"claude-code": "claude-sonnet-5",
-	"codex":       "zai-org/GLM-5.2",
-	"copilot":     "zai-org/GLM-5.2",
-	"pi":          "zai-org/GLM-5.2",
+	"codex":       "zai-org/GLM-5.2-TEE",
+	"copilot":     "zai-org/GLM-5.2-TEE",
+	"pi":          "zai-org/GLM-5.2-TEE",
+}
+
+// fallbackModels are tried, in order, when neither name variant of the
+// resolved model is served by the gateway. A different family, deliberately:
+// the point is to keep a run interpretable when the primary model disappears
+// entirely, so it has to be something the gateway is likely to still serve.
+//
+// Not a workflow input — e2e.yml is already at GitHub's 10-input cap for
+// workflow_dispatch — but overridable for a one-off via E2E_MODEL_FALLBACK
+// (space- or comma-separated for several).
+//
+// Substituting one of these is NOT silent: unlike a variant flip (same model,
+// gateway naming quirk), running a different family makes a green matrix mean
+// something weaker, so probe-model.sh annotates it and the reported model shows
+// what actually ran.
+var fallbackModels = []string{"moonshotai/Kimi-K3"}
+
+// fallbackModelEnvVar overrides fallbackModels for a single run. Kept in sync
+// with scripts/probe-model.sh.
+const fallbackModelEnvVar = "E2E_MODEL_FALLBACK"
+
+// teeSuffix is the gateway's confidential-computing name variant. Appending or
+// stripping it is the whole of the "variant flip" — see modelCandidates.
+const teeSuffix = "-TEE"
+
+// modelCandidates returns the model names to try for a harness, in order: the
+// resolved model, its variant flip, then each fallback and its flip. The flip
+// is bidirectional so pinning either variant survives the gateway changing its
+// mind. Duplicates are dropped, so a fallback that equals the primary does not
+// double the probe cost.
+//
+// claude-code gets exactly one candidate: it talks to ANTHROPIC_BASE_URL, not
+// the gateway, so neither the variant flip nor a gateway fallback applies.
+func modelCandidates(harness string) []string {
+	primary := modelID(harness)
+	if harness == "claude-code" {
+		return []string{primary}
+	}
+	var out []string
+	seen := map[string]bool{}
+	add := func(m string) {
+		if m == "" || seen[m] {
+			return
+		}
+		seen[m] = true
+		out = append(out, m)
+	}
+	for _, m := range append([]string{primary}, configuredFallbacks()...) {
+		add(m)
+		add(flipTEE(m))
+	}
+	return out
+}
+
+// flipTEE returns the other name variant of a model: the plain name gains
+// "-TEE", a "-TEE" name loses it.
+func flipTEE(model string) string {
+	if model == "" {
+		return ""
+	}
+	if strings.HasSuffix(model, teeSuffix) {
+		return strings.TrimSuffix(model, teeSuffix)
+	}
+	return model + teeSuffix
+}
+
+// configuredFallbacks returns the fallback chain, honouring
+// E2E_MODEL_FALLBACK (comma- or space-separated).
+func configuredFallbacks() []string {
+	raw := os.Getenv(fallbackModelEnvVar)
+	if strings.TrimSpace(raw) == "" {
+		return fallbackModels
+	}
+	var out []string
+	for _, f := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		out = append(out, f)
+	}
+	return out
+}
+
+// isFallbackModel reports whether model is a cross-family substitution rather
+// than the primary or its variant flip — the case that must be reported
+// loudly. Used by the workflows via scripts/probe-model.sh.
+func isFallbackModel(harness, model string) bool {
+	primary := modelID(harness)
+	return model != primary && model != flipTEE(primary)
 }
 
 // modelEnvVar maps a harness name to the env var that overrides its model id

--- a/internal/e2e/versions_test.go
+++ b/internal/e2e/versions_test.go
@@ -58,6 +58,95 @@ func TestModelIDOverride(t *testing.T) {
 	}
 }
 
+// TestFlipTEE covers the gateway's one naming quirk: it serves the plain name
+// or the -TEE name, never both, and flips without notice (#184). The flip must
+// work in both directions so pinning either variant survives the next flip.
+func TestFlipTEE(t *testing.T) {
+	cases := map[string]string{
+		"zai-org/GLM-5.2":     "zai-org/GLM-5.2-TEE",
+		"zai-org/GLM-5.2-TEE": "zai-org/GLM-5.2",
+		"":                    "",
+	}
+	for in, want := range cases {
+		if got := flipTEE(in); got != want {
+			t.Errorf("flipTEE(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// Flipping twice is the identity — otherwise a candidate list could miss
+	// the variant the gateway actually serves.
+	for _, m := range []string{"a/b", "a/b-TEE"} {
+		if got := flipTEE(flipTEE(m)); got != m {
+			t.Errorf("flipTEE(flipTEE(%q)) = %q, want %q", m, got, m)
+		}
+	}
+}
+
+// TestModelCandidates locks the probe order: primary, its variant flip, then
+// each fallback and its flip — deduped, so a fallback equal to the primary
+// doesn't double the probe cost.
+func TestModelCandidates(t *testing.T) {
+	t.Setenv("E2E_MODEL", "")
+	t.Setenv("E2E_MODEL_CLAUDE_CODE", "")
+	t.Setenv("E2E_MODEL_FALLBACK", "")
+
+	got := modelCandidates("pi")
+	want := []string{
+		modelIDs["pi"], flipTEE(modelIDs["pi"]),
+		fallbackModels[0], flipTEE(fallbackModels[0]),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("modelCandidates(pi) = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("modelCandidates(pi) = %v, want %v", got, want)
+		}
+	}
+
+	// claude-code is on a different provider: no gateway flip, no gateway
+	// fallback — exactly one candidate, or a run could silently retarget the
+	// billed Anthropic account at a model it can't launch.
+	if got := modelCandidates("claude-code"); len(got) != 1 || got[0] != modelIDs["claude-code"] {
+		t.Errorf("modelCandidates(claude-code) = %v, want exactly [%s]", got, modelIDs["claude-code"])
+	}
+
+	// A fallback that equals the primary must not produce duplicates.
+	t.Setenv("E2E_MODEL", "solo/model")
+	t.Setenv("E2E_MODEL_FALLBACK", "solo/model")
+	if got, want := modelCandidates("pi"), []string{"solo/model", "solo/model-TEE"}; len(got) != len(want) {
+		t.Errorf("deduped candidates = %v, want %v", got, want)
+	}
+
+	// Multiple fallbacks, comma- and space-separated.
+	t.Setenv("E2E_MODEL", "primary/m")
+	t.Setenv("E2E_MODEL_FALLBACK", "a/one, b/two")
+	got = modelCandidates("pi")
+	want = []string{"primary/m", "primary/m-TEE", "a/one", "a/one-TEE", "b/two", "b/two-TEE"}
+	for i := range want {
+		if i >= len(got) || got[i] != want[i] {
+			t.Fatalf("multi-fallback candidates = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestIsFallbackModel guards the reporting distinction: a variant flip is the
+// same model and may substitute silently, a cross-family fallback may not.
+func TestIsFallbackModel(t *testing.T) {
+	t.Setenv("E2E_MODEL", "")
+	t.Setenv("E2E_MODEL_PI", "")
+	pin := modelIDs["pi"]
+
+	if isFallbackModel("pi", pin) {
+		t.Errorf("the primary itself must not be reported as a fallback")
+	}
+	if isFallbackModel("pi", flipTEE(pin)) {
+		t.Errorf("a variant flip of the primary must not be reported as a fallback")
+	}
+	if !isFallbackModel("pi", "moonshotai/Kimi-K3") {
+		t.Errorf("a different family must be reported as a fallback")
+	}
+}
+
 // TestValidateModel locks the one harness-model constraint that exists: the
 // claude-code CLI launches only sonnet/haiku, so a cross-harness override
 // landing on it must be named as such rather than surfacing as an opaque

--- a/scripts/check-workflow-shell.py
+++ b/scripts/check-workflow-shell.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Bash-syntax-check every `run:` block in .github/workflows/.
+
+A workflow's `run:` body is shell, but nothing in the normal edit loop parses it
+— a quoting mistake ships and only surfaces when that job next runs, which for
+the weekly LLM workflows can be days later. The specific trap this was written
+for: an escaped backtick inside a double-quoted string. `\\\\`` leaves a literal
+backslash and an UNESCAPED backtick, silently turning step-summary markdown into
+command substitution:
+
+    echo "Model: \\\\`$m\\\\`"   ->   bash: $m\\: command not found
+
+`${{ ... }}` expressions are replaced with a placeholder token before parsing:
+they are substituted by the Actions runner before the shell ever sees them, so
+leaving them in would produce false positives on every step.
+
+This checks syntax only — it is not a linter. actionlint (with shellcheck)
+covers style and semantics; this covers "does bash accept it at all", which is
+the part that turns into a broken job.
+
+Exit 0 when clean, 1 with a per-step report otherwise.
+"""
+import glob
+import re
+import subprocess
+import sys
+
+import yaml
+
+EXPR = re.compile(r"\$\{\{[^}]*\}\}")
+
+
+def check_file(path):
+    """Yield a diagnostic string for each run block bash rejects."""
+    try:
+        doc = yaml.safe_load(open(path)) or {}
+    except yaml.YAMLError as exc:
+        yield f"{path}: not parseable as YAML: {exc}"
+        return
+    for job_name, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        for index, step in enumerate(job.get("steps") or []):
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if not run:
+                continue
+            shell = step.get("shell", "bash")
+            if shell not in ("bash", "sh"):
+                continue  # pwsh/python steps are not ours to parse
+            script = EXPR.sub("EXPR", run)
+            proc = subprocess.run(
+                ["bash", "-n"], input=script, text=True, capture_output=True
+            )
+            if proc.returncode != 0:
+                name = step.get("name", "<unnamed>")
+                detail = (proc.stderr or "").strip().splitlines()
+                first = detail[0] if detail else "bash -n failed"
+                yield f"{path}: job '{job_name}' step {index} ('{name}'): {first}"
+
+
+def main():
+    paths = sys.argv[1:] or sorted(glob.glob(".github/workflows/*.yml"))
+    if not paths:
+        print("no workflow files found", file=sys.stderr)
+        return 1
+    problems = [p for path in paths for p in check_file(path)]
+    for problem in problems:
+        print(problem, file=sys.stderr)
+    if problems:
+        print(
+            f"\n{len(problems)} run block(s) are not valid bash", file=sys.stderr
+        )
+        return 1
+    print(f"{len(paths)} workflow file(s): all run blocks are valid bash")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probe-model.sh
+++ b/scripts/probe-model.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# Pick a model the gateway will actually serve, and print it on stdout.
+#
+# The SKAINET gateway serves ONE name variant at a time — the plain name or a
+# "-TEE" suffixed one — and flips between them without notice. On 2026-07-29 it
+# stopped accepting plain "zai-org/GLM-5.2" and every non-opencode `llm` stage
+# went red about ten minutes into each leg (issue #184). This script front-loads
+# that discovery so a renamed model costs seconds, not a whole matrix, and
+# self-heals instead of failing.
+#
+# Candidate order (see modelCandidates() in internal/e2e/versions.go, which this
+# mirrors): the resolved model, its variant flip, then each configured fallback
+# and its flip. Duplicates dropped. The flip is bidirectional, so pinning either
+# variant survives the next flip in either direction.
+#
+# Two-stage selection:
+#   1. GET $base/models (OpenAI-compatible) lists what the gateway advertises.
+#      Candidates on that list are probed FIRST. The listing only orders the
+#      candidates — it never excludes one, because a stale or partial listing
+#      must not veto a name that actually works.
+#   2. A 1-token POST $base/chat/completions is the authority. First HTTP 200
+#      wins. This is what the gateway 422s on, so it is what gets asked.
+#
+# Usage:
+#   scripts/probe-model.sh [harness]              # default harness: opencode
+#   scripts/probe-model.sh [harness] --github-output
+#
+# --github-output additionally writes model= / fallback= / candidates= to
+# $GITHUB_OUTPUT so a workflow can consume the result without re-parsing stdout.
+#
+# Environment:
+#   SKAINET_INTERNAL | LLM_API_BASE | MODEL_PROBE_BASE   gateway base URL
+#   SKAINET_TOKEN    | LLM_API_KEY  | MODEL_PROBE_TOKEN  bearer token
+#   E2E_MODEL_FALLBACK   override the fallback chain (comma/space separated)
+#   E2E_MODEL[_<HARNESS>]  the model override itself — see resolve-model.sh
+#
+# Without credentials this is a pure passthrough: it prints what
+# resolve-model.sh resolved and exits 0. Model-free jobs and local runs must not
+# need network access to name a model.
+#
+# claude-code is never probed: it talks to ANTHROPIC_BASE_URL, not this gateway,
+# so its model is not on the listing and a gateway fallback would silently
+# retarget the billed Anthropic account.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+harness="opencode"
+github_output=0
+for arg in "$@"; do
+  case "$arg" in
+    --github-output) github_output=1 ;;
+    -*) echo "probe-model: unknown flag '$arg'" >&2; exit 2 ;;
+    *) harness="$arg" ;;
+  esac
+done
+
+base="${MODEL_PROBE_BASE:-${SKAINET_INTERNAL:-${LLM_API_BASE:-}}}"
+token="${MODEL_PROBE_TOKEN:-${SKAINET_TOKEN:-${LLM_API_KEY:-}}}"
+
+# The resolved model, before any gateway consideration. Not guarded with
+# `|| true`: an unresolvable model is a real misconfiguration and the caller
+# needs to see it, exactly as resolve-model.sh's own callers do.
+primary="$("$HERE/resolve-model.sh" "$harness")"
+
+emit() {
+  local model="$1" fallback="$2" tried="$3"
+  if [ "$github_output" = "1" ] && [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "model=$model"
+      echo "fallback=$fallback"
+      echo "candidates=$tried"
+    } >> "$GITHUB_OUTPUT"
+  fi
+  printf '%s\n' "$model"
+}
+
+# --- passthrough paths (no network) -----------------------------------------
+
+if [ "$harness" = "claude-code" ]; then
+  echo "probe-model: claude-code is on its own provider — not probing the gateway" >&2
+  emit "$primary" false "$primary"
+  exit 0
+fi
+
+if [ -z "$base" ] || [ -z "$token" ]; then
+  echo "probe-model: no gateway base URL / token on the env — using '$primary' unprobed" >&2
+  emit "$primary" false "$primary"
+  exit 0
+fi
+
+# --- candidate list ---------------------------------------------------------
+
+flip_tee() {
+  case "$1" in
+    "") printf '' ;;
+    *-TEE) printf '%s' "${1%-TEE}" ;;
+    *) printf '%s-TEE' "$1" ;;
+  esac
+}
+
+# Fallback chain: E2E_MODEL_FALLBACK, else fallbackModels in versions.go — the
+# single source of truth shared with the Go tests.
+fallbacks() {
+  if [ -n "${E2E_MODEL_FALLBACK:-}" ]; then
+    printf '%s' "$E2E_MODEL_FALLBACK" | tr ',\t\n' '   '
+    return
+  fi
+  local versions_go="${VERSIONS_GO:-$HERE/../internal/e2e/versions.go}"
+  [ -f "$versions_go" ] || return 0
+  awk '/^var fallbackModels = \[\]string\{/{ \
+         line=$0; sub(/.*\{/,"",line); sub(/\}.*/,"",line); print line; exit }' \
+    "$versions_go" | tr -d '"' | tr ',' ' '
+}
+
+# Candidates are grouped into PRIORITY TIERS, one per configured model: tier 0
+# is the primary and its variant flip, tier 1 the first fallback and its flip,
+# and so on. The listing may reorder within a tier but never across tiers —
+# a backup must only ever be reached after the primary has actually been
+# refused by chat/completions. Letting the listing promote a tier would silently
+# downgrade a run whenever the gateway under-advertises a working model, which
+# is the same failure mode as the advertised-but-broken case below.
+tiers=""   # newline-separated; each line is one tier's space-separated models
+seen_all=" "
+for m in "$primary" $(fallbacks); do
+  tier=""
+  for v in "$m" "$(flip_tee "$m")"; do
+    [ -z "$v" ] && continue
+    case "$seen_all" in *" $v "*) continue ;; esac
+    seen_all="$seen_all$v "
+    tier="${tier:+$tier }$v"
+  done
+  [ -n "$tier" ] && tiers="${tiers}${tier}
+"
+done
+
+# --- stage 1: what does the gateway advertise? ------------------------------
+
+served=""
+listing_ok=0
+if listing=$(curl -sS --max-time 30 "${base%/}/models" \
+      -H "authorization: Bearer $token" 2>/dev/null); then
+  # jq if available (it is on GH runners), else a grep fallback so the script
+  # still works on a bare machine.
+  if command -v jq >/dev/null 2>&1; then
+    served=$(printf '%s' "$listing" | jq -r '(.data // [])[]? | .id // empty' 2>/dev/null | tr '\n' ' ' || true)
+  else
+    served=$(printf '%s' "$listing" | grep -oE '"id"[[:space:]]*:[[:space:]]*"[^"]+"' \
+      | sed -E 's/.*"([^"]+)"$/\1/' | tr '\n' ' ' || true)
+  fi
+  [ -n "$(printf '%s' "$served" | tr -d '[:space:]')" ] && listing_ok=1
+fi
+if [ "$listing_ok" = "1" ]; then
+  echo "probe-model: gateway advertises: $served" >&2
+else
+  echo "probe-model: model listing unavailable — probing all candidates directly" >&2
+fi
+
+# Within each tier, advertised names go first; the listing orders, it never
+# excludes, and it never reorders across tiers.
+ordered=""
+while IFS= read -r tier; do
+  [ -z "$tier" ] && continue
+  if [ "$listing_ok" = "1" ]; then
+    for m in $tier; do
+      case " $served " in *" $m "*) ordered="${ordered:+$ordered }$m" ;; esac
+    done
+  fi
+  for m in $tier; do
+    case " $ordered " in *" $m "*) ;; *) ordered="${ordered:+$ordered }$m" ;; esac
+  done
+done <<EOF
+$tiers
+EOF
+
+# --- stage 2: chat/completions is the authority -----------------------------
+
+endpoint="${base%/}/chat/completions"
+tried=""
+inconclusive=""
+
+# A non-200 means one of two very different things, and conflating them is how a
+# 30-second GPU-cluster hiccup silently changes which model a run tested:
+#
+#   unavailable — the gateway refuses this NAME (422 model_unavailable, 404).
+#                 Move on; this is what the variant flip and fallback are for.
+#   transient   — the gateway is unwell (5xx, 429, connection failure). Says
+#                 nothing about the name. Retry it; never fall back on it.
+#
+# Observed in the wild: "500 An internal error occurred while invoking the
+# model. The model inference should recover automatically within a few minutes."
+classify_code() {
+  case "$1" in
+    200) printf 'ok' ;;
+    408|409|425|429|500|502|503|504|000) printf 'transient' ;;
+    *) printf 'unavailable' ;;
+  esac
+}
+
+probe_candidate() {
+  # Echoes "<verdict> <last-http-code>" for one candidate, retrying while
+  # transient. Both on stdout because this runs in a command substitution — a
+  # variable set here would not survive back to the caller.
+  local candidate="$1" attempt=1 max=3 code verdict
+  while :; do
+    code=$(curl -s -o /tmp/probe-model-resp.$$ -w '%{http_code}' --max-time 30 \
+      -X POST "$endpoint" \
+      -H "authorization: Bearer $token" \
+      -H 'content-type: application/json' \
+      -d "{\"model\":\"${candidate}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":1}" \
+      2>/dev/null) || code="000"
+    verdict=$(classify_code "$code")
+    [ "$verdict" != "transient" ] && break
+    if [ "$attempt" -ge "$max" ]; then break; fi
+    echo "probe-model: '$candidate' hit a transient gateway error (HTTP $code) — retrying ($((attempt + 1))/$max)" >&2
+    attempt=$((attempt + 1))
+    sleep $((attempt * 2))
+  done
+  printf '%s %s' "$verdict" "$code"
+}
+
+# Tier 0 — the intended model and its name variant. A TRANSIENT result here must
+# never let the loop reach a fallback: the gateway being briefly unwell says
+# nothing about the model, and silently swapping families over a 30-second blip
+# would change what the run tested for no good reason. Definitive
+# unavailability is the only thing a backup is for.
+primary_tier=" $primary $(flip_tee "$primary") "
+primary_transient=0
+
+for candidate in $ordered; do
+  case "$primary_tier" in
+    *" $candidate "*) ;;
+    *)
+      if [ "$primary_transient" = "1" ]; then
+        echo "::error title=Gateway unhealthy::'$primary' could not be verified — the gateway kept returning transient errors (last HTTP $code). NOT falling back to another model: a transient fault is no reason to change which model is under test. Re-run once the gateway recovers." >&2
+        exit 1
+      fi
+      ;;
+  esac
+  tried="${tried:+$tried,}$candidate"
+  read -r verdict code <<EOF
+$(probe_candidate "$candidate")
+EOF
+  if [ "$verdict" = "ok" ]; then
+    rm -f /tmp/probe-model-resp.$$
+    if [ "$candidate" = "$primary" ] || [ "$candidate" = "$(flip_tee "$primary")" ]; then
+      # Same model, gateway naming quirk — safe to substitute quietly.
+      [ "$candidate" != "$primary" ] && \
+        echo "probe-model: '$primary' not served; using name variant '$candidate'" >&2
+      emit "$candidate" false "$tried"
+    else
+      # A different family. A green run on this means something weaker than a
+      # green run on the intended model, so say so where CI will surface it.
+      echo "::warning title=Model fallback::'$primary' is not served by the gateway; fell back to '$candidate'. Results are for $candidate, NOT $primary." >&2
+      emit "$candidate" true "$tried"
+    fi
+    exit 0
+  fi
+  msg=$(sed -n 's/.*"message"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' /tmp/probe-model-resp.$$ 2>/dev/null | head -1)
+  rm -f /tmp/probe-model-resp.$$
+  if [ "$verdict" = "transient" ]; then
+    inconclusive="${inconclusive:+$inconclusive,}$candidate"
+    case "$primary_tier" in *" $candidate "*) primary_transient=1 ;; esac
+    echo "probe-model: '$candidate' inconclusive — gateway unwell (HTTP $code)${msg:+: $msg}" >&2
+  else
+    echo "probe-model: '$candidate' rejected (HTTP $code)${msg:+: $msg}" >&2
+  fi
+done
+
+if [ -n "$inconclusive" ]; then
+  # Distinguished from "the models are gone" so whoever reads the log knows to
+  # re-run rather than go hunting for a renamed model.
+  echo "::error title=Gateway unhealthy::could not verify any model — these were inconclusive (transient gateway errors, not name rejections): $inconclusive. Tried: $tried. Re-run once the gateway recovers." >&2
+  exit 1
+fi
+
+echo "::error title=No usable model::none of these models was accepted by the gateway: $tried" >&2
+[ "$listing_ok" = "1" ] && echo "probe-model: gateway advertises: $served" >&2
+echo "probe-model: check the model provider, SKAINET_TOKEN validity, and the pins in internal/e2e/versions.go" >&2
+exit 1

--- a/scripts/probe-model_test.sh
+++ b/scripts/probe-model_test.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# Tests for scripts/probe-model.sh against a stub gateway.
+#
+# A stub, not the real gateway: the whole point of the script is behaviour when
+# the gateway renames or drops a model, and those states can't be produced on
+# demand upstream. The stub reproduces exactly the two shapes that matter —
+# an OpenAI-style GET /models listing, and a POST /chat/completions that 422s
+# with "Requested model name ... is currently not available" for anything it
+# does not serve, which is what broke CI in #184.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+PROBE="$ROOT/scripts/probe-model.sh"
+TMP="$(mktemp -d)"
+STUB_PID=""
+cleanup() {
+  [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+failures=0
+fail() { printf 'FAIL: %s\n' "$*" >&2; failures=$((failures + 1)); }
+
+cat > "$TMP/stub.py" <<'PY'
+"""Stub gateway. STUB_LISTED / STUB_ACCEPTED are space-separated model ids.
+
+STUB_LIST_STATUS != 200 makes the listing endpoint fail, so the test can prove
+the listing never vetoes a model the chat endpoint accepts.
+"""
+import json, os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+LISTED = os.environ.get("STUB_LISTED", "").split()
+ACCEPTED = os.environ.get("STUB_ACCEPTED", "").split()
+LIST_STATUS = int(os.environ.get("STUB_LIST_STATUS", "200"))
+# Models that answer with a transient 500 rather than a name rejection — the
+# real "internal error occurred while invoking the model" case.
+TRANSIENT = os.environ.get("STUB_TRANSIENT", "").split()
+HITS = os.environ.get("STUB_HITS", "/tmp/stub-hits")
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _record(self, what):
+        with open(HITS, "a") as f:
+            f.write(what + "\n")
+
+    def _send(self, code, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        self._record("GET " + self.path)
+        if not self.path.endswith("/models"):
+            return self._send(404, {"error": "no such path"})
+        if LIST_STATUS != 200:
+            return self._send(LIST_STATUS, {"error": {"message": "listing down"}})
+        self._send(200, {"data": [{"id": m} for m in LISTED]})
+
+    def do_POST(self):
+        n = int(self.headers.get("content-length", 0))
+        req = json.loads(self.rfile.read(n) or b"{}")
+        model = req.get("model", "")
+        self._record("POST " + model)
+        if model in TRANSIENT:
+            return self._send(500, {"error": {"message":
+                "An internal error occurred while invoking the model. The model "
+                "inference should recover automatically within a few minutes."}})
+        if model in ACCEPTED:
+            return self._send(200, {"choices": [{"message": {"content": "ok"}}]})
+        self._send(422, {"error": {"message":
+            "Requested model name '%s' is currently not available. "
+            "Supported model names are: {%s}" % (model, ", ".join(repr(m) for m in LISTED))}})
+
+
+HTTPServer(("127.0.0.1", int(os.environ["STUB_PORT"])), H).serve_forever()
+PY
+
+PORT=8931
+HITS="$TMP/hits"
+
+start_stub() {
+  [ -n "$STUB_PID" ] && { kill "$STUB_PID" 2>/dev/null || true; wait "$STUB_PID" 2>/dev/null || true; }
+  : > "$HITS"
+  STUB_LISTED="$1" STUB_ACCEPTED="$2" STUB_LIST_STATUS="${3:-200}" \
+    STUB_TRANSIENT="${4:-}" \
+    STUB_PORT="$PORT" STUB_HITS="$HITS" python3 "$TMP/stub.py" &
+  STUB_PID=$!
+  local up=0 _
+  for _ in $(seq 1 40); do
+    if curl -s -o /dev/null "http://127.0.0.1:$PORT/models" 2>/dev/null; then up=1; break; fi
+    sleep 0.1
+  done
+  [ "$up" = "1" ] || { echo "stub did not come up" >&2; exit 1; }
+  # Discard the readiness request: the "did this run touch the network at all"
+  # assertions below must see only what the probe itself sent.
+  : > "$HITS"
+}
+
+# Runs the probe against the stub with a clean model env. VAR=value args become
+# env assignments; a bare arg is the harness.
+probe() {
+  local assignments=() args=() a
+  for a in "$@"; do
+    case "$a" in *=*) assignments+=("$a") ;; *) args+=("$a") ;; esac
+  done
+  env -u E2E_MODEL -u E2E_MODEL_OPENCODE -u E2E_MODEL_CLAUDE_CODE \
+      -u E2E_MODEL_CODEX -u E2E_MODEL_COPILOT -u E2E_MODEL_PI \
+      -u E2E_MODEL_FALLBACK -u LLM_API_BASE -u LLM_API_KEY -u GITHUB_OUTPUT \
+      -u SKAINET_TOKEN -u SKAINET_INTERNAL \
+      MODEL_PROBE_BASE="http://127.0.0.1:$PORT" MODEL_PROBE_TOKEN=stub-token \
+      ${assignments[@]+"${assignments[@]}"} \
+      "$PROBE" ${args[@]+"${args[@]}"}
+}
+
+PIN=$(awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' \
+  "$ROOT/internal/e2e/versions.go" | grep '"opencode"' | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/')
+case "$PIN" in
+  *-TEE) PIN_FLIP="${PIN%-TEE}" ;;
+  *)     PIN_FLIP="$PIN-TEE" ;;
+esac
+echo "committed pin: $PIN (variant: $PIN_FLIP)"
+
+# --- 1. the pin itself is served -------------------------------------------
+start_stub "$PIN" "$PIN"
+got=$(probe opencode 2>/dev/null || true)
+[ "$got" = "$PIN" ] || fail "pin served: got '$got', want '$PIN'"
+
+# --- 2. only the OTHER variant is served (the #184 breakage, both ways) -----
+start_stub "$PIN_FLIP" "$PIN_FLIP"
+got=$(probe opencode 2>/dev/null || true)
+[ "$got" = "$PIN_FLIP" ] || fail "variant flip: got '$got', want '$PIN_FLIP'"
+# A same-model variant flip must NOT be announced as a fallback.
+err=$(probe opencode 2>&1 >/dev/null || true)
+case "$err" in
+  *"title=Model fallback"*) fail "variant flip was mislabelled as a cross-model fallback" ;;
+esac
+
+# --- 3. neither variant served, fallback wins, loudly ----------------------
+start_stub "fb/model" "fb/model"
+out=$(probe E2E_MODEL_FALLBACK=fb/model opencode 2>"$TMP/err" || true)
+[ "$out" = "fb/model" ] || fail "fallback: got '$out', want 'fb/model'"
+grep -q "title=Model fallback" "$TMP/err" || fail "cross-model fallback was not announced with a warning"
+grep -q "NOT $PIN" "$TMP/err" || fail "fallback warning does not name the model that was intended"
+
+# --- 4. nothing usable -> loud failure, non-zero ---------------------------
+start_stub "other/thing" ""
+if out=$(probe E2E_MODEL_FALLBACK=fb/model opencode 2>"$TMP/err"); then
+  fail "no usable model: expected a non-zero exit, got '$out'"
+fi
+grep -q "title=No usable model" "$TMP/err" || fail "exhausted candidates did not emit an error annotation"
+grep -q "other/thing" "$TMP/err" || fail "failure diagnostic omits what the gateway does serve"
+
+# --- 5. listing endpoint down must not veto a working model ---------------
+start_stub "$PIN" "$PIN" 500
+got=$(probe opencode 2>/dev/null || true)
+[ "$got" = "$PIN" ] || fail "listing down: got '$got', want '$PIN' (chat probe must still decide)"
+
+# --- 6. advertised but rejected by chat -> chat is the authority -----------
+# The listing claims the pin, chat only accepts the variant. Picking from the
+# listing alone would strand the run on a model that 422s on every real call.
+start_stub "$PIN" "$PIN_FLIP"
+got=$(probe opencode 2>/dev/null || true)
+[ "$got" = "$PIN_FLIP" ] || fail "advertised-but-broken: got '$got', want '$PIN_FLIP'"
+
+# --- 6b. the listing must never promote a fallback over the primary ---------
+# The gateway under-advertises the primary but still serves it, while the
+# fallback is both advertised and served. Ordering by the listing alone would
+# jump straight to the backup and silently downgrade the run — the primary has
+# to be refused by chat before a backup is reachable.
+start_stub "fb/model" "$PIN fb/model"
+got=$(probe E2E_MODEL_FALLBACK=fb/model opencode 2>/dev/null || true)
+[ "$got" = "$PIN" ] || fail "listing promoted a fallback over a working primary: got '$got', want '$PIN'"
+grep -q "POST $PIN" "$HITS" || fail "the primary was never probed before falling back"
+
+# --- 7. claude-code is never probed ----------------------------------------
+start_stub "$PIN" "$PIN"
+got=$(probe claude-code 2>/dev/null || true)
+CC_PIN=$(awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' \
+  "$ROOT/internal/e2e/versions.go" | grep '"claude-code"' | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/')
+[ "$got" = "$CC_PIN" ] || fail "claude-code: got '$got', want '$CC_PIN'"
+if [ -s "$HITS" ]; then
+  fail "claude-code probed the gateway ($(tr '\n' ';' < "$HITS")) — it is on another provider"
+fi
+
+# --- 8. --github-output contract ------------------------------------------
+start_stub "fb/model" "fb/model"
+: > "$TMP/gh-out"
+probe GITHUB_OUTPUT="$TMP/gh-out" E2E_MODEL_FALLBACK=fb/model opencode --github-output >/dev/null 2>&1 || true
+grep -q '^model=fb/model$' "$TMP/gh-out" || fail "--github-output did not write model="
+grep -q '^fallback=true$' "$TMP/gh-out" || fail "--github-output did not flag the fallback"
+# candidates= is probe ORDER, not the logical candidate order: an advertised
+# model is tried first, so the chosen one can legitimately lead. Assert both the
+# intended model and the winner appear, not their positions.
+cands=$(sed -n 's/^candidates=//p' "$TMP/gh-out")
+case "$cands" in
+  *"$PIN"*) ;;
+  *) fail "--github-output candidates='$cands' omits the intended model '$PIN'" ;;
+esac
+case "$cands" in
+  *fb/model*) ;;
+  *) fail "--github-output candidates='$cands' omits the model actually used" ;;
+esac
+
+start_stub "$PIN" "$PIN"
+: > "$TMP/gh-out"
+probe GITHUB_OUTPUT="$TMP/gh-out" opencode --github-output >/dev/null 2>&1 || true
+grep -q '^fallback=false$' "$TMP/gh-out" || fail "a primary hit must report fallback=false"
+
+# --- 9. no creds -> passthrough, no network -------------------------------
+start_stub "$PIN" "$PIN"
+got=$(env -u SKAINET_TOKEN -u SKAINET_INTERNAL -u LLM_API_BASE -u LLM_API_KEY \
+       -u MODEL_PROBE_BASE -u MODEL_PROBE_TOKEN -u E2E_MODEL \
+       "$PROBE" opencode 2>/dev/null || true)
+[ "$got" = "$PIN" ] || fail "no creds: got '$got', want the unprobed pin '$PIN'"
+if [ -s "$HITS" ]; then
+  fail "credential-less run still hit the network ($(tr '\n' ';' < "$HITS"))"
+fi
+
+# --- 10. a transient primary must NOT trigger a fallback -------------------
+# Observed on 2026-07-29: the gateway answered 500 "internal error occurred
+# while invoking the model ... should recover automatically". That says nothing
+# about the model name, so swapping families over it would change what the run
+# tested for no reason. Must fail as infra, and must never emit the fallback.
+start_stub "$PIN fb/model" "fb/model" 200 "$PIN $PIN_FLIP"
+if out=$(probe E2E_MODEL_FALLBACK=fb/model opencode 2>"$TMP/err"); then
+  fail "transient primary: expected a non-zero exit, got '$out'"
+fi
+grep -q "title=Gateway unhealthy" "$TMP/err" || fail "a transient primary was not reported as a gateway-health problem"
+grep -q "title=Model fallback" "$TMP/err" && fail "a transient primary must not fall back to another family"
+# It must have retried rather than given up on the first 500.
+[ "$(grep -c "POST $PIN\$" "$HITS")" -ge 2 ] || fail "a transient result was not retried"
+
+# --- 11. a DEFINITIVELY unavailable primary still falls back ---------------
+# The distinction that makes case 10 safe: a name rejection is exactly what the
+# backup exists for, so this one must still substitute.
+start_stub "fb/model" "fb/model"
+out=$(probe E2E_MODEL_FALLBACK=fb/model opencode 2>"$TMP/err" || true)
+[ "$out" = "fb/model" ] || fail "unavailable primary should still fall back: got '$out'"
+grep -q "title=Model fallback" "$TMP/err" || fail "definitive unavailability did not announce the fallback"
+
+# --- 12. a transient blip that clears is not a failure ---------------------
+# Only the flip is transient; the primary is served. The primary is probed
+# first, so this must succeed without ever reaching the transient name.
+start_stub "$PIN" "$PIN" 200 "$PIN_FLIP"
+got=$(probe opencode 2>/dev/null || true)
+[ "$got" = "$PIN" ] || fail "served primary alongside a transient variant: got '$got', want '$PIN'"
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+echo "all probe-model.sh checks passed"

--- a/scripts/resolve-model_test.sh
+++ b/scripts/resolve-model_test.sh
@@ -59,10 +59,23 @@ assert_rejected() {
 }
 
 # --- the committed pin (no override) ---------------------------------------
-assert_model "zai-org/GLM-5.2" "default harness is opencode"
-assert_model "zai-org/GLM-5.2" "explicit opencode" opencode
-assert_model "claude-sonnet-5" "claude-code pin" claude-code
-assert_model "zai-org/GLM-5.2" "pi pin" pi
+# Read from versions.go, never hardcoded: the pin moves whenever the gateway
+# renames a variant (#184), and this asserts the resolution mechanism, not which
+# model happens to be pinned today.
+pin_for() {
+  awk '/^var modelIDs = map\[string\]string\{/{f=1;next} /^\}/{f=0} f' \
+    "$ROOT/internal/e2e/versions.go" \
+    | grep "\"$1\"" | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/' | head -1
+}
+PIN_OPENCODE=$(pin_for opencode)
+PIN_CLAUDE=$(pin_for claude-code)
+PIN_PI=$(pin_for pi)
+[ -n "$PIN_OPENCODE" ] || fail "could not read the opencode pin out of versions.go"
+
+assert_model "$PIN_OPENCODE" "default harness is opencode"
+assert_model "$PIN_OPENCODE" "explicit opencode" opencode
+assert_model "$PIN_CLAUDE" "claude-code pin" claude-code
+assert_model "$PIN_PI" "pi pin" pi
 
 # --- precedence ------------------------------------------------------------
 assert_model "vendor/candidate-1" "cross-harness override" \
@@ -71,7 +84,7 @@ assert_model "claude-haiku-4-5" "per-harness override wins over cross-harness" \
   E2E_MODEL=vendor/candidate-1 E2E_MODEL_CLAUDE_CODE=claude-haiku-4-5 claude-code
 assert_model "vendor/candidate-1" "per-harness override must not leak to others" \
   E2E_MODEL=vendor/candidate-1 E2E_MODEL_CLAUDE_CODE=claude-haiku-4-5 opencode
-assert_model "zai-org/GLM-5.2" "an empty override falls through to the pin" \
+assert_model "$PIN_OPENCODE" "an empty override falls through to the pin" \
   E2E_MODEL= E2E_MODEL_OPENCODE= opencode
 
 # --- claude-code's launchable-model constraint -----------------------------


### PR DESCRIPTION
**Issue:** Closes #184 · Refs #182

> Stacked on `feat/ci-model-override` (#183) — it reuses `scripts/resolve-model.sh`.
> Review/merge that one first; base retargets to `main` automatically.

## What

- `scripts/probe-model.sh` — picks a model the gateway will actually serve, and
  is now the single probe shared by every LLM workflow.
- Each LLM workflow gains a preflight `Resolve model` job that runs it once and
  feeds the result to the jobs after it.
- **Bumps the pin to `zai-org/GLM-5.2-TEE`**, which is what the gateway serves
  today — this alone un-reds `main`.
- `scripts/check-workflow-shell.py` — bash-syntax-checks every `run:` block.

## Why

`main` is red right now, and not because of anything in #183:

| Run | Model | `llm` stage |
|---|---|---|
| 30151651537 (2026-07-25, scheduled) | `zai-org/GLM-5.2` | ✅ |
| 30447587341 (2026-07-29 11:26, `main` @ `b9419da`) | `zai-org/GLM-5.2` | ❌ |

```
422 Requested model name 'zai-org/GLM-5.2' is currently not available.
Supported model names are: {'zai-org/GLM-5.2-TEE', 'moonshotai/Kimi-K3'}
```

The gateway serves one name variant at a time and flipped to requiring `-TEE`
within those four days, taking every non-opencode `llm` stage with it.
`security-scan.yml:136` already documented this exact hazard and had an inline
base/`-TEE` probe, so it was unaffected — nothing else had the protection. This
generalises that probe instead of leaving it in one workflow.

## How

- **Two-stage selection.** `GET $base/models` (OpenAI-compatible, `.data[].id`)
  says what is advertised; a 1-token `POST $base/chat/completions` decides,
  because that is the endpoint that 422s. The listing only *orders* candidates —
  it never excludes one, since a stale listing must not veto a working name.
- **Priority tiers.** Tier 0 is the resolved model and its variant flip, tier N
  the Nth fallback and its flip. The listing may reorder *within* a tier, never
  across. Without this, an under-advertised primary would be skipped and the run
  silently downgraded to a backup — the mirror image of the
  advertised-but-broken case, and caught by a test (below).
- **`5xx` ≠ "model gone".** The same run also produced `500 An internal error
  occurred while invoking the model. The model inference should recover
  automatically within a few minutes.` A non-200 is classified: `422`/`404` means
  the name is refused (advance), `5xx`/`429`/no-answer means the gateway is
  unwell (retry the same name, then fail as a health problem, **never** fall
  back). Otherwise a 30-second cluster blip would swap model families and
  quietly change what was tested.
- **Loud vs quiet substitution.** A variant flip is the same model, so it is
  quiet. A cross-family fallback emits `::warning::` and is called out in the
  step summary, the tracking issue and Slack.
- **Fallback chain in `internal/e2e/versions.go`** (`fallbackModels`),
  not a workflow input: `e2e.yml` is at GitHub's 10-input cap.
  `E2E_MODEL_FALLBACK` overrides it for a one-off.
- **claude-code is never probed** — it is on `ANTHROPIC_BASE_URL`. Same reason
  the probed model reaches the matrix via the **per-harness** vars
  (`E2E_MODEL_OPENCODE` …) rather than cross-harness `E2E_MODEL`: handing a
  gateway model to claude-code would fail its legs on every run, scheduled
  included.
- **`check-workflow-shell.py`** exists because this change nearly shipped a
  silent bug: `\\\`` in a generated `run:` block leaves a literal backslash and
  an *unescaped* backtick, turning step-summary markdown into command
  substitution. `actionlint` passed it. Now `bash -n` sees every `run:` body.

## Verification

```
$ go vet ./... && go vet -tags=e2e ./internal/e2e/ && go vet -tags=e2e_fast ./internal/e2e/
vet clean
$ gofmt -l internal/ scripts/          # clean
$ go test ./...                        # all ok
$ go test -tags=e2e_fast -race -count=1 ./internal/e2e/
ok  github.com/tngtech/oh-my-agentic-coder/internal/e2e  2.251s
$ scripts/resolve-model_test.sh && scripts/probe-model_test.sh
all resolve-model.sh checks passed
all probe-model.sh checks passed
$ actionlint .github/workflows/*.yml && python3 scripts/check-workflow-shell.py
8 workflow file(s): all run blocks are valid bash
```

New Go tests: `TestFlipTEE`, `TestModelCandidates`, `TestIsFallbackModel`.
`scripts/probe-model_test.sh` covers 12 paths against a local stub gateway (no
credentials, no real network): pin served · variant-only served, both directions
· fallback wins loudly · nothing usable · listing down · advertised-but-broken ·
listing must not promote a fallback · claude-code never touches the network ·
`--github-output` contract · transient primary must not fall back · definitively
unavailable primary still falls back · a transient blip that clears.

**Mutation-tested**, since a probe test that passes vacuously is worse than
none. Reverting the tier logic → 3 failures; removing the transient
classification → 4 failures, including `transient primary: expected a non-zero
exit, got 'fb/model'` (the exact silent downgrade). Breaking one escaped
backtick → `check-workflow-shell.py` reports
`unexpected EOF while looking for matching '`'`.

**Against the live gateway**, self-healing confirmed in the direction opposite to
CI's: the internal gateway serves the *plain* name, so the new `-TEE` pin
auto-flipped back and succeeded —
`probe-model: 'zai-org/GLM-5.2-TEE' not served; using name variant 'zai-org/GLM-5.2'`.

**Against real CI**, dispatched on the #183 branch before this fix existed:
- run 30452832536, `model=zai-org/GLM-4.7-Flash` → all GLM legs `llm ❌` with the
  422. Exactly the failure this PR front-loads.
- run 30453399690, `model=zai-org/GLM-5.2-TEE` → `pi` legs green, confirming
  `-TEE` is the served variant and that the pin bump is correct.

## Follow-up

- Run 30453399690 (`-TEE`) produced **no 422 at all** — the pin bump holds. Its
  remaining failures are separate and pre-existing:
  - `copilot`, **all 4 legs**: gateway `500 internal error occurred while
    invoking the model`, 5 internal retries, then the 12m timeout. Since it hit
    every copilot leg and no other harness, this is copilot-specific rather than
    a passing blip — worth its own issue, not just a retry. The probe now
    refuses to mask it as a missing model.
  - `codex`, 2 legs: 12m timeout / hang on `codex@0.146.0`. A genuine
    latest-release regression (the pin is `0.142.5`) — exactly what
    `E2E: drift` exists to catch, and unrelated to this PR.
  - `pi` on macOS, 1 leg: `did not exit within 5m0s`; the same combination
    passed on `omac@release`. Flake.
- `.github/scripts/security_scan_triage.py:24` still carries a hardcoded
  `openai/zai-org/GLM-5.2` default for standalone use — now doubly stale. The
  workflow always passes `STRIX_LLM`, so it is inert; worth deleting.

