### PR TITLE
fix(e2e,ci): refresh the model fallback chain and survive a findings-free scan

### DIFF
--- a/.github/scripts/security_scan_triage.py
+++ b/.github/scripts/security_scan_triage.py
@@ -74,6 +74,27 @@ def ask_llm_duplicate(finding, issues):
         return {"duplicate_of": None, "confidence": "low", "reasoning": f"LLM triage call failed: {e}"}
 
 
+def load_findings(path):
+    """Read strix's vulnerabilities.json, treating an absent file as zero findings.
+
+    A scan can leave the file unwritten while still having run correctly, which
+    used to abort the job with a FileNotFoundError and report a clean scan as a
+    failure. By the time this runs the scan step has already established that
+    the run itself was sound -- a run directory exists and the log is free of
+    context_length_exceeded -- so an absent findings file is an empty result,
+    not a broken scan.
+
+    A file that exists but does not parse is a different matter and still
+    raises: that means strix wrote something unexpected, and silently reporting
+    zero findings would turn a broken scan into a green one.
+    """
+    if not os.path.exists(path):
+        print(f"{path} not written -- treating as zero findings", file=sys.stderr)
+        return []
+    with open(path) as f:
+        return json.load(f)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--vulns", required=True)
@@ -82,10 +103,9 @@ def main():
     ap.add_argument("--summary-out", required=True, help="redacted, safe for public step summary")
     args = ap.parse_args()
 
-    with open(args.vulns) as f:
-        findings = json.load(f)
+    findings = load_findings(args.vulns)
 
-    issues = fetch_open_issues(args.repo)
+    issues = fetch_open_issues(args.repo) if findings else []
 
     triage_lines = ["# Security scan triage report\n"]
     counts = {}
@@ -112,8 +132,17 @@ def main():
         triage_lines.append(f"**Impact:** {finding.get('impact', '')}\n")
         triage_lines.append("---\n")
 
+    if not findings:
+        triage_lines.append("The scan completed and reported no vulnerabilities.\n")
+
     with open(args.triage_out, "w") as f:
         f.write("\n".join(triage_lines))
+
+    if not findings:
+        with open(args.summary_out, "w") as f:
+            f.write("No vulnerabilities reported by this scan.")
+        print(f"wrote {args.triage_out} (0 findings) and {args.summary_out}", file=sys.stderr)
+        return
 
     summary_lines = ["**Severity counts:**"]
     for sev in ("critical", "high", "medium", "low"):

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -39,7 +39,7 @@ on:
         type: boolean
         default: true
       model:
-        description: 'Model id for EVERY harness, for THIS RUN ONLY. Leave empty to use each harness''s pin in internal/e2e/versions.go (opencode/codex/copilot/pi/codewhale: zai-org/GLM-5.2-TEE, claude-code: claude-sonnet-5)'
+        description: 'Model id for EVERY harness, for THIS RUN ONLY. Leave empty to use each harness''s pin in internal/e2e/versions.go (opencode/codex/copilot/pi/codewhale: zai-org/GLM-5.2, claude-code: claude-sonnet-5)'
         type: string
         default: ''
       claude_code_model:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@
 #
 # Runs on manual trigger and every Saturday at 10:00 CET (08:00 UTC in
 # summer / 09:00 UTC in winter). Tests that each harness can start under
-# the omac sandbox and that an agent running on GLM-5.2-TEE (or
+# the omac sandbox and that an agent running on GLM-5.2 (or
 # claude-sonnet-5 for claude-code) can call the bundled echo-rest skill
 # through the omac facade.
 name: "E2E: full"
@@ -43,7 +43,7 @@ on:
         type: string
         default: 'codewhale@0.9.1'
       model:
-        description: 'Model id for EVERY harness, for THIS RUN ONLY (e.g. zai-org/GLM-5.2). Leave empty to use each harness''s pin in internal/e2e/versions.go (opencode/codex/copilot/pi/codewhale: zai-org/GLM-5.2-TEE, claude-code: claude-sonnet-5)'
+        description: 'Model id for EVERY harness, for THIS RUN ONLY (e.g. zai-org/GLM-5.2). Leave empty to use each harness''s pin in internal/e2e/versions.go (opencode/codex/copilot/pi/codewhale: zai-org/GLM-5.2, claude-code: claude-sonnet-5)'
         type: string
         default: ''
       claude_code_model:

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -109,7 +109,10 @@ the header of the drift/onboarding report artifacts.
 The SKAINET gateway serves **one name variant at a time** — the plain name or a
 `-TEE` suffixed one — and flips between them without notice. On 2026-07-29 it
 stopped accepting plain `zai-org/GLM-5.2` and every non-opencode `llm` stage
-went red about ten minutes into each leg (issue #184).
+went red about ten minutes into each leg (issue #184); by 2026-08-04 it had
+flipped back to the plain name. Keeping the `modelIDs` pin on whichever variant
+is currently served is therefore an optimisation — one fewer probe round-trip —
+not a correctness requirement.
 
 So every LLM workflow now starts with a **preflight `Resolve model` job** that
 runs [`scripts/probe-model.sh`](../scripts/probe-model.sh) once and hands the
@@ -150,6 +153,14 @@ tested for no good reason.
 The fallback chain lives in `fallbackModels` (`internal/e2e/versions.go`) rather
 than a workflow input, because `e2e.yml` is at GitHub's 10-input cap;
 `E2E_MODEL_FALLBACK` overrides it for a one-off (comma- or space-separated).
+
+Because the chain is only reached once the primary is gone, a retired fallback
+rots without reddening anything — the original entry (`moonshotai/Kimi-K3`)
+stopped being served days before anyone noticed. So a run that resolves its
+primary normally still checks the chain against the gateway's listing and warns
+when **none** of it is advertised. One missing name says nothing (the listing
+under-advertises, which is why it only orders candidates), but a whole chain
+missing means there is no backup left to reach for.
 
 claude-code is never probed — it talks to `ANTHROPIC_BASE_URL`, not this
 gateway. For the same reason the preflight hands the probed model to the

--- a/internal/e2e/versions.go
+++ b/internal/e2e/versions.go
@@ -45,16 +45,18 @@ var versionEnvVar = map[string]string{
 // The gateway serves one name variant at a time and flips between the plain
 // name and a "-TEE" suffixed one without notice — on 2026-07-29 it stopped
 // accepting plain "zai-org/GLM-5.2" and every non-opencode llm stage went red
-// (see issue #184). Pin whichever variant is currently served;
-// scripts/probe-model.sh flips to the other one automatically, so a future flip
-// in either direction self-heals rather than reddening the matrix.
+// (see issue #184), then by 2026-08-04 it had flipped back to the plain name.
+// Pin whichever variant is currently served; scripts/probe-model.sh flips to
+// the other one automatically, so a future flip in either direction self-heals
+// rather than reddening the matrix. Keeping the pin current is therefore not a
+// correctness requirement, only a way to spend one fewer probe round-trip.
 var modelIDs = map[string]string{
-	"opencode":    "zai-org/GLM-5.2-TEE",
+	"opencode":    "zai-org/GLM-5.2",
 	"claude-code": "claude-sonnet-5",
-	"codex":       "zai-org/GLM-5.2-TEE",
-	"copilot":     "zai-org/GLM-5.2-TEE",
-	"pi":          "zai-org/GLM-5.2-TEE",
-	"codewhale":   "zai-org/GLM-5.2-TEE",
+	"codex":       "zai-org/GLM-5.2",
+	"copilot":     "zai-org/GLM-5.2",
+	"pi":          "zai-org/GLM-5.2",
+	"codewhale":   "zai-org/GLM-5.2",
 }
 
 // fallbackModels are tried, in order, when neither name variant of the
@@ -70,7 +72,13 @@ var modelIDs = map[string]string{
 // gateway naming quirk), running a different family makes a green matrix mean
 // something weaker, so probe-model.sh annotates it and the reported model shows
 // what actually ran.
-var fallbackModels = []string{"moonshotai/Kimi-K3"}
+//
+// This list is only ever exercised once the primary is gone, so it rots
+// invisibly: the previous entry ("moonshotai/Kimi-K3") stopped being served
+// some time before 2026-08-04 and nothing went red, because the primary kept
+// resolving. probe-model.sh now warns when no entry here is advertised, so the
+// rot surfaces on the next run instead of at the moment it is needed.
+var fallbackModels = []string{"deepseek-ai/DeepSeek-V4-Flash", "tngtech/DeepSeek-TNG-R1T2-Chimera"}
 
 // fallbackModelEnvVar overrides fallbackModels for a single run. Kept in sync
 // with scripts/probe-model.sh.

--- a/internal/e2e/versions_test.go
+++ b/internal/e2e/versions_test.go
@@ -90,9 +90,9 @@ func TestModelCandidates(t *testing.T) {
 	t.Setenv("E2E_MODEL_FALLBACK", "")
 
 	got := modelCandidates("pi")
-	want := []string{
-		modelIDs["pi"], flipTEE(modelIDs["pi"]),
-		fallbackModels[0], flipTEE(fallbackModels[0]),
+	want := []string{modelIDs["pi"], flipTEE(modelIDs["pi"])}
+	for _, fb := range fallbackModels {
+		want = append(want, fb, flipTEE(fb))
 	}
 	if len(got) != len(want) {
 		t.Fatalf("modelCandidates(pi) = %v, want %v", got, want)
@@ -142,7 +142,11 @@ func TestIsFallbackModel(t *testing.T) {
 	if isFallbackModel("pi", flipTEE(pin)) {
 		t.Errorf("a variant flip of the primary must not be reported as a fallback")
 	}
-	if !isFallbackModel("pi", "moonshotai/Kimi-K3") {
+	// A name unrelated to the pin, rather than an entry from fallbackModels:
+	// the distinction under test is primary-vs-other, and coupling it to the
+	// configured chain would make refreshing that chain look like a behaviour
+	// change.
+	if !isFallbackModel("pi", "other-vendor/some-other-model") {
 		t.Errorf("a different family must be reported as a fallback")
 	}
 }

--- a/scripts/probe-model.sh
+++ b/scripts/probe-model.sh
@@ -21,6 +21,10 @@
 #   2. A 1-token POST $base/chat/completions is the authority. First HTTP 200
 #      wins. This is what the gateway 422s on, so it is what gets asked.
 #
+# On a run that never needs a fallback, the chain is still checked against the
+# listing and a warning is emitted if none of it is advertised — otherwise a
+# retired fallback stays invisible until the run that depends on it.
+#
 # Usage:
 #   scripts/probe-model.sh [harness]              # default harness: opencode
 #   scripts/probe-model.sh [harness] --github-output
@@ -111,6 +115,27 @@ fallbacks() {
   awk '/^var fallbackModels = \[\]string\{/{ \
          line=$0; sub(/.*\{/,"",line); sub(/\}.*/,"",line); print line; exit }' \
     "$versions_go" | tr -d '"' | tr ',' ' '
+}
+
+# The fallback chain is only reached once the primary is gone, so a retired
+# fallback rots invisibly: "moonshotai/Kimi-K3" sat in the chain unserved for
+# days while every run stayed green on the primary, and the rot would only have
+# surfaced at the moment the backup was actually needed. Report it on the way
+# past instead.
+#
+# Requires ALL of the chain to be unadvertised before saying anything. A single
+# missing name proves nothing — the listing under-advertises, which is why it
+# only orders candidates and never excludes them (see stage 1) — but an entire
+# chain missing means there is no backup left.
+warn_if_chain_rotted() {
+  [ "$listing_ok" = "1" ] || return 0
+  local chain f
+  chain="$(fallbacks)"
+  [ -n "$(printf '%s' "$chain" | tr -d '[:space:]')" ] || return 0
+  for f in $chain; do
+    case " $served " in *" $f "*) return 0 ;; esac
+  done
+  echo "::warning title=Fallback chain unserved::the gateway advertises none of the configured fallback models ($chain). This run is unaffected — '$primary' resolved — but there would be no working backup if it disappeared. Refresh fallbackModels in internal/e2e/versions.go." >&2
 }
 
 # Candidates are grouped into PRIORITY TIERS, one per configured model: tier 0
@@ -247,6 +272,7 @@ EOF
       # Same model, gateway naming quirk — safe to substitute quietly.
       [ "$candidate" != "$primary" ] && \
         echo "probe-model: '$primary' not served; using name variant '$candidate'" >&2
+      warn_if_chain_rotted
       emit "$candidate" false "$tried"
     else
       # A different family. A green run on this means something weaker than a

--- a/scripts/probe-model_test.sh
+++ b/scripts/probe-model_test.sh
@@ -253,6 +253,37 @@ start_stub "$PIN" "$PIN" 200 "$PIN_FLIP"
 got=$(probe opencode 2>/dev/null || true)
 [ "$got" = "$PIN" ] || fail "served primary alongside a transient variant: got '$got', want '$PIN'"
 
+# --- 13. a rotted fallback chain is reported on an otherwise-fine run -------
+# The chain is only reached once the primary is gone, so an unserved fallback
+# stays invisible for as long as the primary keeps working — which is how
+# "moonshotai/Kimi-K3" survived in the chain long after the gateway dropped it.
+# A run that resolves normally must still say the backup is missing.
+start_stub "$PIN" "$PIN"
+got=$(probe E2E_MODEL_FALLBACK=gone/model opencode 2>"$TMP/err" || true)
+[ "$got" = "$PIN" ] || fail "rotted chain must not change the resolved model: got '$got', want '$PIN'"
+grep -q "title=Fallback chain unserved" "$TMP/err" || fail "an entirely unadvertised fallback chain was not reported"
+grep -q "gone/model" "$TMP/err" || fail "the rotted-chain warning does not name the chain"
+# It is a warning, not a failure: the run itself is fine.
+probe E2E_MODEL_FALLBACK=gone/model opencode >/dev/null 2>&1 \
+  || fail "a rotted chain must not fail a run whose primary resolved"
+
+# An advertised chain is healthy — no warning.
+start_stub "$PIN alive/model" "$PIN"
+probe E2E_MODEL_FALLBACK=alive/model opencode 2>"$TMP/err" >/dev/null || true
+grep -q "title=Fallback chain unserved" "$TMP/err" && fail "a served fallback chain must not be reported as rotted"
+
+# One live entry is enough; the listing under-advertises, so only a chain with
+# nothing left in it is worth reporting.
+start_stub "$PIN alive/model" "$PIN"
+probe E2E_MODEL_FALLBACK="gone/model alive/model" opencode 2>"$TMP/err" >/dev/null || true
+grep -q "title=Fallback chain unserved" "$TMP/err" && fail "a chain with one advertised entry must not be reported as rotted"
+
+# With the listing down there is no evidence either way, so say nothing rather
+# than cry wolf on every run the listing endpoint is flaky.
+start_stub "$PIN" "$PIN" 500
+probe E2E_MODEL_FALLBACK=gone/model opencode 2>"$TMP/err" >/dev/null || true
+grep -q "title=Fallback chain unserved" "$TMP/err" && fail "the chain must not be judged rotted when the listing is unavailable"
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
**Issue:** Closes #193

## What

- `fallbackModels` now names models the gateway actually serves, and its rot is
  detectable rather than silent.
- The `modelIDs` pin follows the gateway back to plain `zai-org/GLM-5.2`.
- A findings-free security scan reports zero findings instead of crashing the
  job.

## Why

The gateway flipped model names back: as of 2026-08-04 it serves plain
`zai-org/GLM-5.2` again and serves neither `-TEE` nor `moonshotai/Kimi-K3`.

`moonshotai/Kimi-K3` was the whole fallback chain, so there was no working
backup left — and nothing had gone red when it stopped being served, because the
chain is only reached once the primary is gone. That is the part worth fixing
properly: a backup that is never exercised until it is needed will always rot
unnoticed.

Separately, `Security Scan` failed on a step that has nothing to do with the
model — the triage script assumed `vulnerabilities.json` always exists, so a
scan that found nothing was reported as a failed scan.

## How

- `internal/e2e/versions.go` — chain is now
  `deepseek-ai/DeepSeek-V4-Flash`, `tngtech/DeepSeek-TNG-R1T2-Chimera`; both
  verified served. Pin flipped to `zai-org/GLM-5.2` for the five gateway
  harnesses, which costs one fewer 422 round-trip per run. The bidirectional
  flip already made the pin a matter of cost, not correctness, so this is an
  optimisation and the comment now says so.
- `scripts/probe-model.sh` — `warn_if_chain_rotted()` runs on the success path
  and warns when the listing advertises **none** of the chain. It requires the
  entire chain to be missing: the listing under-advertises, which is why stage 1
  only orders candidates and never excludes them, so a single absent name proves
  nothing. Silent when the listing is unavailable — no evidence either way.
- `.github/scripts/security_scan_triage.py` — `load_findings()` treats an absent
  file as zero findings and says so on stderr. A file that exists but does not
  parse still raises, so a broken scan cannot be laundered into a green one. The
  zero-findings path also skips the `gh` and LLM calls it has no use for.
- `internal/e2e/versions_test.go` — `TestModelCandidates` derives its
  expectation from all of `fallbackModels` rather than `[0]`;
  `TestIsFallbackModel` uses an unrelated name, so refreshing the chain no
  longer looks like a behaviour change.
- Workflow input descriptions and `docs/DEVELOP.md` updated to match.

## Verification

Local, on this branch:

```
gofmt -l .                                    clean
go build ./...                                ok
go vet ./... && go vet -tags=e2e ./internal/e2e/   ok
go test ./... -count=1                        ok
go test -tags=e2e_fast ./internal/e2e/        ok
scripts/resolve-model_test.sh                 all resolve-model.sh checks passed
scripts/probe-model_test.sh                   all probe-model.sh checks passed
scripts/check-workflow-shell.py               8 workflow file(s): all run blocks are valid bash
python3 -m py_compile .github/scripts/security_scan_triage.py   ok
```

`scripts/probe-model_test.sh` gains case 13 (4 new assertions) for the
chain-rot warning. Each was mutation-tested against the implementation to
confirm it actually fails without the fix:

| mutation | caught by |
|---|---|
| call to `warn_if_chain_rotted` removed | `an entirely unadvertised fallback chain was not reported` |
| warns on any single unadvertised entry | `a served fallback chain must not be reported as rotted` |
| `listing_ok` guard removed | `the chain must not be judged rotted when the listing is unavailable` |

Against the **live** gateway (`SKAINET_INTERNAL=https://chat.model.tngtech.com/v1`):

```
$ scripts/probe-model.sh opencode --github-output
model=zai-org/GLM-5.2
fallback=false
candidates=zai-org/GLM-5.2        # one round-trip, was two (-TEE 422 -> plain 200)
```

No chain warning — the gateway advertises both new fallbacks. Candidate names
confirmed individually against `POST /chat/completions`:
`zai-org/GLM-5.2` 200, `deepseek-ai/DeepSeek-V4-Flash` 200,
`tngtech/DeepSeek-TNG-R1T2-Chimera` 200, `zai-org/GLM-5.2-TEE` 422,
`moonshotai/Kimi-K3` 422.

Triage script, all three cases:

| input | result |
|---|---|
| `vulnerabilities.json` absent | exit 0, `No vulnerabilities reported by this scan.` |
| file present, malformed | exit 1, `JSONDecodeError` (still fails, as intended) |
| file present, `[]` | exit 0, same clean report |

## Follow-up

Two things found in the same audit that are deliberately **not** in this PR:

- **`SECURITY_SCAN_PAT` needs rotating.** `Push full report to private artifact
  repo` fails with `remote: Write access to repository not granted` / HTTP 403,
  exit 128 — a credential problem, not a code one. `Security Scan` stays red
  until that is done, independently of this PR.
- `TestE2EProvenance` hardcodes the opencode harness
  (`internal/e2e/provenance_test.go:22`), so it reaches the gateway on every
  matrix leg and made the `claude-code` legs of `E2E: full` look broken when
  claude-code's own stages had all passed. Misleading in the run list, but not
  wrong; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
