### PR TITLE
docs: add status badges and fix two doc defects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # oh-my-agentic-coder (omac)
 
+[![CI](https://github.com/TNG/oh-my-agentic-coder/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/TNG/oh-my-agentic-coder/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/TNG/oh-my-agentic-coder?sort=semver&label=release)](https://github.com/TNG/oh-my-agentic-coder/releases/latest)
+[![License](https://img.shields.io/github/license/TNG/oh-my-agentic-coder)](./LICENSE)
+[![Go](https://img.shields.io/github/go-mod/go-version/TNG/oh-my-agentic-coder)](./go.mod)
+
+[![Platforms](https://img.shields.io/badge/platforms-Linux%20%7C%20macOS%20%7C%20WSL2-blue)](#prerequisites)
+[![Harnesses](https://img.shields.io/badge/harnesses-opencode%20%7C%20claude--code%20%7C%20codex%20%7C%20copilot%20%7C%20pi%20%7C%20codewhale-blue)](#works-with-your-agent)
+
 **Run agentic coders against real code without handing them the keys.**
 
 AI coding agents are useful, but running one on your machine means letting an

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -64,8 +64,9 @@ omac resume claude     # ...with Claude Code
 `omac continue` re-enters the most recent session for this folder. Pass
 `-s`/`--session <id>` to target a specific session non-interactively
 (opencode `--session <id>`, claude `--resume <id>`, codex `resume <id>`,
-copilot `--session-id <id>`, pi `--session <id>`, codewhale `--resume <id>`). After the inner command
-exits, omac prints a one-line hint with the most recent session id:
+copilot `--session-id <id>`, pi `--session <id>`, codewhale `resume <id>`).
+After the inner command exits, omac prints a one-line hint with the most
+recent session id:
 
 ```
 To resume this session: omac continue -s ses_abc123

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -186,13 +186,14 @@ sandbox:
 > treats an empty `allow_vars` as inherit-all; the fail-closed seeding happens
 > in the `start`/`serve` launch path.
 
-For successfully inspectable built-in `{{self}} sandbox run` profiles,
-`omac doctor` warns when a profile re-introduces a broad read/write
-grant on the cache roots (`~/.cache`, `~/Library/Caches`) or the tool
-homes (`~/go`, `~/.cargo`, `~/.rustup`), and when a host Cargo sentinel
-(`~/.cargo/config`, `~/.cargo/config.toml`, `~/.cargo/credentials`, or
-`~/.cargo/credentials.toml`) exists but will be invisible to an
-isolated `CARGO_HOME`. It detects sentinels with `Lstat` only: doctor
+For built-in profiles omac can inspect — those whose `inner_cmd` is omac's
+own `{{self}} sandbox run` — `omac doctor` warns when a profile
+re-introduces a broad read/write grant on the cache roots (`~/.cache`,
+`~/Library/Caches`) or the tool homes (`~/go`, `~/.cargo`, `~/.rustup`), and
+when a host Cargo sentinel (`~/.cargo/config`, `~/.cargo/config.toml`,
+`~/.cargo/credentials`, or `~/.cargo/credentials.toml`) exists but will be
+invisible to an isolated `CARGO_HOME`. It detects sentinels with `Lstat`
+only: doctor
 never reads or copies their contents. External nono profiles are opaque
 to these diagnostics and skipped. The warnings are advisory — doctor
 never rewrites the profile. See


### PR DESCRIPTION
**Issue:** Closes #195  ·  Refs #130, #197

## What

- Status badges on the README, which had none: CI, release, license, Go version, platforms, harnesses
- `docs/HARNESSES.md`: codewhale session resume is `resume <id>`, not `--resume <id>`
- `docs/SECURITY_MODEL.md`: the `{{self}}` token no longer reads as a broken template

> **Re-scoped mid-flight.** This PR originally carried a copy-edit of the
> 1188-line `README.md`. #130 landed first and split that file into a
> 352-line entry point plus `docs/*.md`, which also fixed part of what this
> PR did (the "five harnesses" claim, the missing codewhale table rows, a
> dead nono anchor). Rebuilt on top of #130 and narrowed to what remains;
> the copy-edit moved to #197.

## Why

The README is the repo's front page and the sole input to
`e2e-readme-onboarding.yml`, which hands an agent that one file and asks it
to self-serve a dev setup — so a wrong flag documented there is a real cost.
`codewhale --resume <id>` does not work; the CLI rejects it with "unexpected
argument".

## How

**Badges** sit in two rows so the wide harness badge doesn't wrap the status
row. CI points at `ci.yml` on `main`; release/license/Go read from the repo
and `go.mod`; platforms and harnesses are static and link to `#prerequisites`
and `#works-with-your-agent`.

WSL2 is listed as a platform because it is first-class rather than
incidental: detected in `internal/osinfo` via `/proc/version`, given its own
keychain hint (`internal/cli/keychain_hint.go:15`), and covered by `ci.yml`'s
`wsl2-session` job.

**Fixes**, each checked against the source rather than inferred:

| Fix | Was | Now | Authority |
|---|---|---|---|
| codewhale resume | `--resume <id>` | `resume <id>` | `internal/config/harness.go` — `ResumeByIDArgs` returns `[resume ID]`; comment records `--resume` is rejected |
| `{{self}}` phrasing | "For successfully inspectable built-in `{{self}} sandbox run` profiles" | "For built-in profiles omac can inspect — those whose `inner_cmd` is omac's own `{{self}} sandbox run` —" | `internal/config/launcher.go:172` |

## Verification

Docs-only; no Go source touched. No test asserts doc prose (checked
`grep -rn README --include=*_test.go`).

- Repo's own doc gate passes:
  ```
  $ python3 scripts/check-docs.py
  [ok] README.md 360/400 lines; all doc links resolve
  ```
  This is the gate #130 added to the CI lint job — it enforces the 400-line
  README cap and resolves every relative link and `#anchor`, so both new
  badge anchors are verified by CI.
- Codewhale flag verified against the registry with a throwaway test, then deleted:
  ```
  $ go test ./internal/config/ -run TestCodewhaleReadmeClaims -v
  ContinueArgs=[--continue]  ResumeByIDArgs=[resume ID]
  --- PASS
  ```
- All 6 badge URLs return HTTP 200 with the expected rendered values:
  `CI: passing`, `release: v0.6.0`, `license: Apache-2.0`, `Go: v1.25.0`,
  `platforms: Linux | macOS | WSL2`,
  `harnesses: opencode | claude-code | codex | copilot | pi | codewhale`
- `go vet ./...` clean, `gofmt -l .` empty.
- No other doc repeats the wrong codewhale flag
  (`grep -rn -- "--resume <id>" docs/ README.md | grep -i codewhale` → empty).

## Follow-up

- **#197** — copy-edit the prose #130 moved into `docs/*.md` verbatim
  (~119 emphasis-bold spans across 8 files; `docs/CLI.md` is already clean and
  serves as the style reference).
- **Coverage badge** — not included: no coverage infra in CI. Locally ~65-70%
  weighted (`internal/keychain` 40.6%, `internal/supervisor` 38.7% are the low
  ones). Needs Codecov or a shields endpoint JSON; happy to file it.
- **E2E / security-scan badges** — deliberately omitted; those workflows are
  weekly drift detection designed to go red on upstream changes, so a badge
  would misreport health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
