### PR TITLE
fix(ci,skills): stop python sidecars reverse-resolving their bind address

### DIFF
--- a/.opencode/skills/echo-rest/scripts/sidecar.py
+++ b/.opencode/skills/echo-rest/scripts/sidecar.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import socketserver
 import sys
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -179,11 +180,25 @@ class Handler(BaseHTTPRequestHandler):
         )
 
 
+class Server(ThreadingHTTPServer):
+    """ThreadingHTTPServer without the reverse-DNS lookup in server_bind().
+
+    The base class resolves the bind address with socket.getfqdn() between
+    bind() and listen(). On macOS that lookup of 127.0.0.1 has no answer and
+    times out after ~35s, delaying every sidecar start by that much before the
+    facade can reach it. server_name only fills in CGI variables, unused here.
+    """
+
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+
 def main() -> int:
     if PORT == 0:
         print("echo-rest: $SIDECAR_PORT not set", file=sys.stderr)
         return 2
-    srv = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    srv = Server(("127.0.0.1", PORT), Handler)
     print(
         f"[echo-rest] listening on 127.0.0.1:{PORT} skill={SKILL} "
         f"secret={fingerprint(SECRET)}",

--- a/.opencode/skills/self-audit/scripts/sidecar.py
+++ b/.opencode/skills/self-audit/scripts/sidecar.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import socketserver
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse
@@ -62,11 +63,25 @@ class Handler(BaseHTTPRequestHandler):
         self._json(404, {"error": "not found", "path": self.path})
 
 
+class Server(ThreadingHTTPServer):
+    """ThreadingHTTPServer without the reverse-DNS lookup in server_bind().
+
+    The base class resolves the bind address with socket.getfqdn() between
+    bind() and listen(). On macOS that lookup of 127.0.0.1 has no answer and
+    times out after ~35s, delaying every sidecar start by that much before the
+    facade can reach it. server_name only fills in CGI variables, unused here.
+    """
+
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+
 def main() -> int:
     if PORT == 0:
         print("self-audit: $SIDECAR_PORT not set", file=sys.stderr)
         return 2
-    srv = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    srv = Server(("127.0.0.1", PORT), Handler)
     print(
         f"[self-audit] listening on 127.0.0.1:{PORT} skill={SKILL} "
         f"secret={fingerprint(SECRET)}",

--- a/CREATING_A_SKILL.md
+++ b/CREATING_A_SKILL.md
@@ -427,7 +427,7 @@ Your sidecar is a normal HTTP server. Requirements:
 
 ```python
 #!/usr/bin/env python3
-import json, os, sys
+import json, os, socketserver, sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 SKILL  = os.environ.get("SIDECAR_SKILL", "my-skill")
@@ -451,7 +451,19 @@ class H(BaseHTTPRequestHandler):
 
 if PORT == 0:
     print("SIDECAR_PORT not set", file=sys.stderr); sys.exit(2)
-ThreadingHTTPServer(("127.0.0.1", PORT), H).serve_forever()
+class Server(ThreadingHTTPServer):
+    """Skip the reverse-DNS lookup the base class does in server_bind().
+
+    It resolves the bind address between bind() and listen(); on macOS that
+    lookup of 127.0.0.1 goes unanswered and times out after ~35s, delaying
+    every sidecar start. server_name only fills in CGI variables.
+    """
+
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+Server(("127.0.0.1", PORT), H).serve_forever()
 ```
 
 ### Streaming (Server-Sent Events, long polls, WebSockets)

--- a/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
+++ b/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
@@ -427,7 +427,7 @@ Your sidecar is a normal HTTP server. Requirements:
 
 ```python
 #!/usr/bin/env python3
-import json, os, sys
+import json, os, socketserver, sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 SKILL  = os.environ.get("SIDECAR_SKILL", "my-skill")
@@ -451,7 +451,19 @@ class H(BaseHTTPRequestHandler):
 
 if PORT == 0:
     print("SIDECAR_PORT not set", file=sys.stderr); sys.exit(2)
-ThreadingHTTPServer(("127.0.0.1", PORT), H).serve_forever()
+class Server(ThreadingHTTPServer):
+    """Skip the reverse-DNS lookup the base class does in server_bind().
+
+    It resolves the bind address between bind() and listen(); on macOS that
+    lookup of 127.0.0.1 goes unanswered and times out after ~35s, delaying
+    every sidecar start. server_name only fills in CGI variables.
+    """
+
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+Server(("127.0.0.1", PORT), H).serve_forever()
 ```
 
 ### Streaming (Server-Sent Events, long polls, WebSockets)

--- a/internal/facade/integration_test.go
+++ b/internal/facade/integration_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const sidecarPython = `
-import os, json, hashlib, sys, time
+import os, json, hashlib, socketserver, sys, time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 # Bind an ephemeral loopback port chosen by the kernel, then print it
@@ -82,7 +82,16 @@ class H(BaseHTTPRequestHandler):
         body = json.loads(raw.decode() or "{}")
         self._j(200, {"echoed": body, "secret_fingerprint": fp(SECRET)})
 
-srv = ThreadingHTTPServer(("127.0.0.1", PORT), H)
+class Server(ThreadingHTTPServer):
+    # ThreadingHTTPServer.server_bind() reverse-resolves the bind address
+    # between bind() and listen(). On macOS that lookup of 127.0.0.1 has no
+    # answer and times out after ~35s, so every spawn of this sidecar paid
+    # 35s before the parent could reach it. server_name is CGI-only.
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+srv = Server(("127.0.0.1", PORT), H)
 # Report the kernel-assigned port to the parent. Flush so the parent
 # can read it before we enter serve_forever().
 sys.stdout.write("PORT=%d\n" % srv.server_address[1])

--- a/scripts/probe-model_test.sh
+++ b/scripts/probe-model_test.sh
@@ -28,7 +28,7 @@ cat > "$TMP/stub.py" <<'PY'
 STUB_LIST_STATUS != 200 makes the listing endpoint fail, so the test can prove
 the listing never vetoes a model the chat endpoint accepts.
 """
-import json, os
+import json, os, socketserver
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 LISTED = os.environ.get("STUB_LISTED", "").split()
@@ -80,7 +80,22 @@ class H(BaseHTTPRequestHandler):
             "Supported model names are: {%s}" % (model, ", ".join(repr(m) for m in LISTED))}})
 
 
-HTTPServer(("127.0.0.1", int(os.environ["STUB_PORT"])), H).serve_forever()
+class Stub(HTTPServer):
+    """HTTPServer without the reverse-DNS lookup in server_bind().
+
+    The base class resolves the bind address with socket.getfqdn() between
+    bind() and listen(). On a macOS CI runner that lookup of 127.0.0.1 has no
+    answer and times out after ~35s, once per stub process — 17 restarts turned
+    this file into an 11-minute step. server_name is only used to fill in CGI
+    variables, which no stub here serves.
+    """
+
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+
+Stub(("127.0.0.1", int(os.environ["STUB_PORT"])), H).serve_forever()
 PY
 
 PORT=8931


### PR DESCRIPTION
**Issue:** Closes #199

## What

- `server_bind()` override that takes `server_name` from the bind address
  instead of reverse-resolving it, in the probe-model stub gateway and both
  sidecar skills
- same override in the facade integration test's inline python sidecar
- same in the `CREATING_A_SKILL.md` sidecar template and its mirrored
  builtin-skill asset, so new skills stop inheriting the stall

## Why

`HTTPServer.server_bind()` resolves the bind address with `socket.getfqdn()`
between `bind()` and `listen()`. On a macOS runner that reverse lookup of
`127.0.0.1` has no answer and times out after **~35s**, once per server
process. `scripts/probe-model_test.sh` restarts its stub 17 times, so
`E2E: model-free (macos-latest)` has taken ~700s against ~60s on
ubuntu-latest on every run since #183 — green, but the sole critical path of
every CI run.

Per-layer measurement (see #199 for the full table): `getfqdn` costs 35 028 ms
on the first call in a macOS process and 0 ms afterwards, `stub_cold_start`
35 277 ms vs 112 ms on Linux, while an actual request is 11.5 ms. Projection
from those rows was 621s; the traced test measured 658s.

`server_name` is only used to fill in CGI variables, which none of these
servers serve.

## How

The same four lines everywhere the pattern appears:

```python
def server_bind(self):
    socketserver.TCPServer.server_bind(self)
    self.server_name, self.server_port = self.server_address[:2]
```

- `scripts/probe-model_test.sh` — `Stub(HTTPServer)`
- `.opencode/skills/{echo-rest,self-audit}/scripts/sidecar.py` — `Server(ThreadingHTTPServer)`
- `internal/facade/integration_test.go` — inline `Server(ThreadingHTTPServer)`
- `CREATING_A_SKILL.md` + `internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md`

## Verification

Local (Linux):

- `bash scripts/probe-model_test.sh` → `all probe-model.sh checks passed`, 22.6s
  (unchanged; the 20s is case 10's deliberate retry sleeps)
- both sidecars started and answered `/status` → `{"ok": true, "skill": ...}`
- `go test ./internal/facade/ ./internal/builtinskills/` → ok (the latter is the
  doc/asset mirror-sync test)
- `go vet ./internal/facade/`, `gofmt -l internal/facade/` → clean
- `python3 scripts/check-docs.py` → `[ok] README.md 360/400 lines; all doc links resolve`

macOS is verified by this PR's own CI: `E2E: model-free (macos-latest)` is
expected to drop from ~700s to ~25s, and `Test (macos-latest)` to lose 35s from
the facade integration test. Numbers posted below once the run lands.

## Follow-up

The instrumentation that localized this — a per-case TRACE in
`probe-model_test.sh` and `scripts/diag-loopback-timing.py` — is on
`diag/probe-model-macos-timing` and deliberately not part of this PR. Say if
the timing script is worth keeping in-tree for the next platform-specific
stall; otherwise that branch gets deleted.
