### PR TITLE
fix(e2e,ci): neutralize per-harness model overrides in pinned-map tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -231,6 +231,31 @@ jobs:
           restore-keys: |
             e2e-install-${{ runner.os }}-${{ matrix.harness }}-
 
+      # The e2e_fast subset is network-free and agent-free, so every failure in
+      # it is deterministic and no amount of retrying can clear one. Gate on it
+      # here — under this job's resolved E2E_MODEL_*/E2E_VERSION_* env, which
+      # the PR-level e2e_fast run does not set — so an assertion that only
+      # breaks against the probed model fails in seconds and is named as a test
+      # defect, instead of burning three attempts and reporting as infra.
+      - name: Deterministic test gate
+        if: matrix.harness != 'claude-code' || github.event.inputs.skip_claude_code != 'true'
+        run: |
+          set -o pipefail
+          if ! go test -tags=e2e_fast -count=1 ./internal/e2e/ 2>&1 | tee /tmp/e2e-fast.txt; then
+            echo "::error::deterministic (e2e_fast) test failure — a test defect, not infra; retries cannot clear it"
+            {
+              echo "## E2E deterministic gate FAILED (${{ matrix.harness }} / ${{ matrix.os }})"
+              echo ""
+              echo "Network-free tests failed against the resolved model/version env."
+              echo "This is a test defect, not infra — the agent legs were not run."
+              echo ""
+              echo '```'
+              grep -E '^( *--- FAIL|.*_test\.go:)' /tmp/e2e-fast.txt | head -20
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
       - name: Run e2e test
         id: run_e2e
         # claude-code is the only harness billed against a real external

--- a/internal/e2e/contract_test.go
+++ b/internal/e2e/contract_test.go
@@ -129,8 +129,7 @@ func TestMissingTokens(t *testing.T) {
 }
 
 func TestCompatLine(t *testing.T) {
-	t.Setenv("E2E_MODEL", "")
-	t.Setenv("E2E_MODEL_CLAUDE_CODE", "")
+	clearModelEnv(t)
 
 	// Built from modelIDs rather than the literal pin: this asserts that the
 	// line carries the resolved model, not what that model happens to be

--- a/internal/e2e/versions_test.go
+++ b/internal/e2e/versions_test.go
@@ -4,6 +4,25 @@ package e2e
 
 import "testing"
 
+// clearModelEnv neutralizes every model override so a test can assert against
+// the pinned modelIDs map.
+//
+// The e2e workflow exports E2E_MODEL_<HARNESS> for every harness, carrying the
+// name the gateway actually serves — which flips between the plain and -TEE
+// variant without notice (#184). A per-harness override outranks the
+// cross-harness one, so clearing only E2E_MODEL leaves a pinned-map assertion
+// at the mercy of whichever variant the gateway served that day. Derived from
+// modelEnvVar rather than a literal list so a new harness is covered by
+// registering it, not by remembering this helper.
+func clearModelEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(crossHarnessModelEnvVar, "")
+	t.Setenv(fallbackModelEnvVar, "")
+	for _, ev := range modelEnvVar {
+		t.Setenv(ev, "")
+	}
+}
+
 // TestPinnedPackageOverride covers the precedence between the hardcoded
 // harnessVersions map, a per-harness E2E_VERSION_* override (wired from the
 // e2e workflow's workflow_dispatch *_version inputs), and E2E_USE_LATEST.
@@ -31,9 +50,7 @@ func TestPinnedPackageOverride(t *testing.T) {
 // the cross-harness E2E_MODEL override (the workflows' single `model` input),
 // and a per-harness E2E_MODEL_<HARNESS> override.
 func TestModelIDOverride(t *testing.T) {
-	t.Setenv("E2E_MODEL", "")
-	t.Setenv("E2E_MODEL_OPENCODE", "")
-	t.Setenv("E2E_MODEL_CLAUDE_CODE", "")
+	clearModelEnv(t)
 
 	if got, want := modelID("opencode"), modelIDs["opencode"]; got != want {
 		t.Errorf("with no override: modelID(opencode) = %q, want %q (pinned map)", got, want)
@@ -85,9 +102,7 @@ func TestFlipTEE(t *testing.T) {
 // each fallback and its flip — deduped, so a fallback equal to the primary
 // doesn't double the probe cost.
 func TestModelCandidates(t *testing.T) {
-	t.Setenv("E2E_MODEL", "")
-	t.Setenv("E2E_MODEL_CLAUDE_CODE", "")
-	t.Setenv("E2E_MODEL_FALLBACK", "")
+	clearModelEnv(t)
 
 	got := modelCandidates("pi")
 	want := []string{modelIDs["pi"], flipTEE(modelIDs["pi"])}
@@ -132,8 +147,7 @@ func TestModelCandidates(t *testing.T) {
 // TestIsFallbackModel guards the reporting distinction: a variant flip is the
 // same model and may substitute silently, a cross-family fallback may not.
 func TestIsFallbackModel(t *testing.T) {
-	t.Setenv("E2E_MODEL", "")
-	t.Setenv("E2E_MODEL_PI", "")
+	clearModelEnv(t)
 	pin := modelIDs["pi"]
 
 	if isFallbackModel("pi", pin) {


### PR DESCRIPTION
**Issue:** Closes #202

## What

- Clear *every* model override in tests that assert against the pinned
  `modelIDs` map, via a `clearModelEnv` helper derived from the `modelEnvVar`
  registry.
- Gate the network-free `e2e_fast` subset before the retry loop in
  `E2E: full`, so a deterministic failure is named as a test defect.

## Why

`E2E: full` was red on **all 11 legs** of
[run 30945366046](https://github.com/tngtech/oh-my-agentic-coder/actions/runs/30945366046),
and each leg burned all three retries reporting as *infra* (runs of 1h31m–2h50m).

The preflight probe resolved `zai-org/GLM-5.2-TEE` — the gateway currently
serves the `-TEE` variant (#184) — and the workflow exports it per harness as
`E2E_MODEL_<HARNESS>` (`e2e.yml:168-173`). `TestCompatLine` and
`TestModelCandidates` cleared the cross-harness `E2E_MODEL` but not the
per-harness one, which **outranks** it (`versions.go:182`), while building
`want` from the pinned map. Deterministic failure on every leg; green on PRs
only because the PR-level `e2e_fast` run does not set `E2E_MODEL_*`.

The retry loop (`e2e.yml:264`) refuses to retry only
`SANDBOX_FAIL|AGENT_REFUSED|AGENT_PARTIAL`, so a plain `--- FAIL` fell through
to "infra-only failure — retrying" — a 0.7s test defect presented as flaky
infrastructure for the whole matrix.

For **pi** and **opencode** these two tests were the *only* failures, so those
legs go green on this change alone.

## How

- `internal/e2e/versions_test.go` — `clearModelEnv(t)` clears
  `crossHarnessModelEnvVar`, `fallbackModelEnvVar`, and every value in
  `modelEnvVar`. Iterating the registry rather than a literal list means
  registering a new harness covers it automatically.
- Applied to the two broken tests plus `TestModelIDOverride` /
  `TestIsFallbackModel`, which neutralized only the vars for the harnesses they
  happened to touch. This also fixes latent breakage *later* in both broken
  tests, where they set `E2E_MODEL` and assert it wins — a leftover
  `E2E_MODEL_PI` would have shadowed it.
- `.github/workflows/e2e.yml` — new `Deterministic test gate` step runs
  `go test -tags=e2e_fast` (~0.7s) under the job's resolved model env before
  the retry loop, emitting a `::error::` and a step-summary excerpt. No change
  to retry behaviour for genuinely transient failures.

Not re-pinning `modelIDs` to `-TEE`: the probe is built to flip either way, so
pinning would chase a name that moves.

## Verification

```
$ go build ./...                                            # OK
$ go vet -tags=e2e_fast ./internal/e2e/ && go vet -tags=e2e ./internal/e2e/   # clean
$ gofmt -l internal/e2e/                                    # no output
```

Reproduced the CI failure locally, byte-identical to the run log, then
confirmed the fix — including the reverse flip, so it is variant-agnostic:

```
# before — reproduces CI exactly
$ E2E_MODEL_PI=zai-org/GLM-5.2-TEE go test -tags=e2e_fast -run 'TestModelCandidates|TestCompatLine' ./internal/e2e/
--- FAIL: TestCompatLine        (contract_test.go:147)
--- FAIL: TestModelCandidates   (versions_test.go:102)

# after — full CI model env injected
$ E2E_MODEL_PI=… E2E_MODEL_OPENCODE=… E2E_MODEL_CODEX=… E2E_MODEL_COPILOT=… \
  E2E_MODEL_CODEWHALE=… E2E_MODEL_CLAUDE_CODE=claude-sonnet-5 \
  go test -tags=e2e_fast -count=1 ./internal/e2e/
ok    github.com/tngtech/oh-my-agentic-coder/internal/e2e     1.099s

# after — no env (local/PR case), and reverse flip (gateway serves plain name)
$ go test -tags=e2e_fast -count=1 ./internal/e2e/                      # ok
$ E2E_MODEL_PI=zai-org/GLM-5.2 E2E_MODEL_FALLBACK="x/y" go test …      # ok
```

Gate failure path exercised by stashing the fix — fails in <1s with the exact
assertion detail and the "not infra" label.

Workflow YAML validated (`yaml.safe_load`); step lands after `Set up Go`,
before `Run e2e test`.

## Follow-up

Two independent causes found in the same run, deliberately **out of scope** —
worth their own issues:

| Leg | Residual failure |
|---|---|
| codewhale | `Invalid request (404): Not Found` → `exec turn failed` on every turn, though the probe validated the same model with a 200 `POST /chat/completions` at the same base URL |
| codex, copilot | `TestE2EEchoRest` + `TestE2ESecurityAudit` agent legs fail |
| opencode | one `panic: test timed out after 30m0s` (attempt 1; no test assertion failed) |

Also seen non-fatally on codex/copilot/codewhale: `sandbox profile "builtin"
could not be resolved … GET /sandbox/denied disabled`.
