### PR TITLE
harden(security): execute skill sidecars from an approved snapshot

### DIFF
--- a/CREATING_A_SKILL.md
+++ b/CREATING_A_SKILL.md
@@ -183,6 +183,18 @@ Two paths to be aware of:
   not the bare filename. Compiled-language skills typically have the
   install script drop a binary at `scripts/sidecar` and reference
   `["./scripts/sidecar"]`.
+
+  > **The cwd is an immutable snapshot, not your workdir.** After a skill is
+  > approved (`omac register` on the host), omac freezes its tree into a
+  > host-only snapshot and spawns the sidecar from *that* copy — so the cwd is
+  > read-only-in-spirit and is NOT the project directory. Do not write files
+  > relative to cwd expecting the agent (or the project) to see them: those
+  > writes land in the snapshot, are invisible to the sandboxed agent, and do
+  > not persist across a re-approval. Exchange data through your HTTP endpoints
+  > (the facade) and write to `OMAC_WORKDIR` when you need the project dir.
+  > For the same reason, vendor/install dependencies BEFORE `omac register`
+  > (or install them system-wide) — deps added after approval are not in the
+  > snapshot. See [`docs/SECURITY_MODEL.md`](./docs/SECURITY_MODEL.md#self-authored-skills).
 - **`scripts/` is shared between two consumers**: the *omac supervisor*
   spawns the sidecar entry-point as a long-running HTTP service outside
   the sandbox; the *agent* may also invoke other helper scripts in this

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -123,16 +123,16 @@ the sandbox:
 
 - `config.BundleHash` deliberately excludes dependency/artifact subtrees
   (`node_modules`, `.venv`, `build`, `dist`, `target`, …) and does not follow
-  symlinks — so an install can populate those after registration without
-  invalidating the approval. A skill that executes mutable code from an
-  excluded tree (e.g. `node dist/index.js`, a vendored `.venv`) or via a
-  symlink into agent-writable space can therefore be tampered with after
-  approval without changing its hash. This bound applies equally to the
-  existing bundle-hash drift check. The complete fix is to execute the
-  sidecar from an immutable, host-side snapshot taken at approval time
-  (so the executed bytes are exactly the approved bytes); that is tracked as
-  follow-up hardening. Until then, the approval binds only the hashed subset
-  of a skill's tree.
+  symlinks, so the hash alone does not cover everything a skill executes.
+  omac closes this by **executing from an approval snapshot**: at approval
+  time the whole skill tree is frozen into a host-only directory the sandbox
+  cannot write (`~/.config/omac/skills/<name>/<hash>`), with in-tree symlinks
+  flattened to their target's content, and the sidecar is spawned from that
+  snapshot rather than the agent-writable workdir. So the executed bytes are
+  exactly the approved bytes, and rewriting an excluded-dir file (or
+  repointing a symlink) in the workdir after approval has no effect on what
+  runs. (The bundle-hash *drift* check still only covers the hashed subset —
+  that is a detection nicety, not the enforcement boundary.)
 - Approvals are additive per name and never auto-retired, so an agent that
   can reproduce a previously-approved build's bytes (and forge its registry
   hash) could roll a skill back to an older approved version. Only

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -126,13 +126,17 @@ the sandbox:
   symlinks, so the hash alone does not cover everything a skill executes.
   omac closes this by **executing from an approval snapshot**: at approval
   time the whole skill tree is frozen into a host-only directory the sandbox
-  cannot write (`~/.config/omac/skills/<name>/<hash>`), with in-tree symlinks
-  flattened to their target's content, and the sidecar is spawned from that
-  snapshot rather than the agent-writable workdir. So the executed bytes are
-  exactly the approved bytes, and rewriting an excluded-dir file (or
-  repointing a symlink) in the workdir after approval has no effect on what
-  runs. (The bundle-hash *drift* check still only covers the hashed subset —
-  that is a detection nicety, not the enforcement boundary.)
+  cannot write (`~/.config/omac/skills/<name>/<hash>`), and the sidecar is
+  spawned from that snapshot rather than the agent-writable workdir. So the
+  executed bytes are exactly the approved bytes, and rewriting an excluded-dir
+  file in the workdir after approval has no effect on what runs. Symlinks are
+  never dereferenced into the snapshot: an in-tree relative link is recreated
+  as a link (so `node_modules/.bin`-style layouts work), while a link that
+  escapes the skill tree is dropped — so a planted `dist/x -> ~/.ssh/id_rsa`
+  can neither bake a host file into the snapshot nor be read back through the
+  skill. (The bundle-hash *drift* check still only covers the hashed subset —
+  a detection nicety, not the enforcement boundary; the snapshot is the
+  boundary.)
 - Approvals are additive per name and never auto-retired, so an agent that
   can reproduce a previously-approved build's bytes (and forge its registry
   hash) could roll a skill back to an older approved version. Only

--- a/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
+++ b/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
@@ -183,6 +183,18 @@ Two paths to be aware of:
   not the bare filename. Compiled-language skills typically have the
   install script drop a binary at `scripts/sidecar` and reference
   `["./scripts/sidecar"]`.
+
+  > **The cwd is an immutable snapshot, not your workdir.** After a skill is
+  > approved (`omac register` on the host), omac freezes its tree into a
+  > host-only snapshot and spawns the sidecar from *that* copy — so the cwd is
+  > read-only-in-spirit and is NOT the project directory. Do not write files
+  > relative to cwd expecting the agent (or the project) to see them: those
+  > writes land in the snapshot, are invisible to the sandboxed agent, and do
+  > not persist across a re-approval. Exchange data through your HTTP endpoints
+  > (the facade) and write to `OMAC_WORKDIR` when you need the project dir.
+  > For the same reason, vendor/install dependencies BEFORE `omac register`
+  > (or install them system-wide) — deps added after approval are not in the
+  > snapshot. See [`docs/SECURITY_MODEL.md`](./docs/SECURITY_MODEL.md#self-authored-skills).
 - **`scripts/` is shared between two consumers**: the *omac supervisor*
   spawns the sidecar entry-point as a long-running HTTP service outside
   the sandbox; the *agent* may also invoke other helper scripts in this

--- a/internal/cli/poc_self_skill_escape_test.go
+++ b/internal/cli/poc_self_skill_escape_test.go
@@ -380,6 +380,80 @@ http.server.HTTPServer(("127.0.0.1", int(os.environ["SIDECAR_PORT"])), H).serve_
 
 // stageOutsideSecret writes a secret file OUTSIDE the workdir — standing
 // in for any host resource the sandbox denies the agent.
+// TestSpawnBackstopRequiresSnapshotLocation pins the supervisor backstop's
+// defining property: a sidecar may run ONLY from the host-only snapshot
+// location — never from a path whose CONTENT merely matches an approval.
+//
+// This needs its own test because no other one can catch a regression here.
+// The pre-flight (approvedSpawnDir) always hands the supervisor a snapshot
+// dir, so every production path satisfies the backstop and nothing else ever
+// invokes it with a workdir path. A weakened backstop therefore leaves the
+// whole suite green — which is exactly what happened once during review: the
+// check fell through to a content re-hash, silently re-admitting the
+// agent-writable workdir as a spawn source and re-opening both the
+// excluded-subtree tamper vector (see TestSnapshotDefeatsPostApprovalTampering)
+// and the check-then-exec TOCTOU that snapshotting exists to close.
+//
+// rehashAuthorizer below is that tempting weaker check. It is asserted to
+// ACCEPT the workdir, which is the point: the location/content distinction is
+// load-bearing, not stylistic.
+func TestSpawnBackstopRequiresSnapshotLocation(t *testing.T) {
+	isolateHome(t)
+	workdir := t.TempDir()
+	skillDir := filepath.Join(workdir, ".opencode", "skills", "loc")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, config.MetaFileName),
+		[]byte("name: loc\ntype: skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "run.sh"), []byte("echo hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := bundleHashOf(t, skillDir)
+	if err := skilltrust.Approve("loc", hash, skillDir); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	snapDir, present := skilltrust.SnapshotPath("loc", hash)
+	if !present {
+		t.Fatal("Approve must leave a snapshot behind")
+	}
+
+	// Same skill, same approved content — the only difference is WHERE it
+	// would execute from.
+	fromWorkdir := supervisor.SidecarSpec{Name: "loc", SkillName: "loc", SkillDir: skillDir}
+	fromSnapshot := supervisor.SidecarSpec{Name: "loc", SkillName: "loc", SkillDir: snapDir}
+
+	if err := skillSpawnAuthorizer(fromWorkdir); err == nil {
+		t.Error("backstop accepted a spawn from the agent-writable workdir; it must require the snapshot location")
+	}
+	if err := skillSpawnAuthorizer(fromSnapshot); err != nil {
+		t.Errorf("backstop refused the legitimate snapshot path: %v", err)
+	}
+
+	// A content re-hash cannot tell the two apart. If this ever stops holding,
+	// the premise above changed and the comment needs revisiting.
+	rehashAuthorizer := func(spec supervisor.SidecarSpec) error {
+		h, err := config.BundleHash(spec.SkillDir)
+		if err != nil {
+			return err
+		}
+		ok, err := skilltrust.IsApproved(spec.SkillName, h)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errSkillNotApproved(spec.SkillName)
+		}
+		return nil
+	}
+	if err := rehashAuthorizer(fromWorkdir); err != nil {
+		t.Errorf("premise no longer holds: a content re-hash was expected to accept the workdir, got %v", err)
+	}
+}
+
 func stageOutsideSecret(t *testing.T) (path, value string) {
 	t.Helper()
 	value = "TOP-SECRET-HOST-DATA-9f3a"

--- a/internal/cli/poc_self_skill_escape_test.go
+++ b/internal/cli/poc_self_skill_escape_test.go
@@ -199,11 +199,12 @@ func TestHostApprovedSkillMounts(t *testing.T) {
 	workdir := t.TempDir()
 	secretPath, secret := stageOutsideSecret(t)
 
-	_, bundle := stageAgentAuthoredSkill(t, workdir, "legit", secretPath)
+	skillDir, bundle := stageAgentAuthoredSkill(t, workdir, "legit", secretPath)
 
 	// Simulate the host-side `omac register` approval the sandboxed agent
 	// cannot perform (the approvals dir is not mounted into the sandbox).
-	if err := skilltrust.Approve("legit", bundle, ""); err != nil {
+	// Passing the dir also freezes the approval snapshot the sidecar runs from.
+	if err := skilltrust.Approve("legit", bundle, skillDir); err != nil {
 		t.Fatalf("approve: %v", err)
 	}
 
@@ -228,7 +229,7 @@ func TestEditingApprovedSkillCodeRevokesApproval(t *testing.T) {
 	secretPath, _ := stageOutsideSecret(t)
 
 	skillDir, bundle := stageAgentAuthoredSkill(t, workdir, "edited", secretPath)
-	if err := skilltrust.Approve("edited", bundle, ""); err != nil {
+	if err := skilltrust.Approve("edited", bundle, skillDir); err != nil {
 		t.Fatalf("approve: %v", err)
 	}
 
@@ -295,6 +296,85 @@ func TestGrandfatherClosesFirstUpgradeWindow(t *testing.T) {
 	}
 	if refusal := approvalRefusal("preexisting", preDir, ""); refusal != nil {
 		t.Errorf("the grandfathered skill must remain approved across launches: %v", refusal)
+	}
+}
+
+// TestSnapshotDefeatsPostApprovalTampering is the core proof of the
+// execute-from-snapshot hardening (issue #209): a file the bundle hash does
+// NOT cover (here under an excluded `.venv/` dir) is frozen at approval time,
+// so rewriting it in the workdir AFTER approval does not change what the
+// sidecar serves — because the sidecar runs from the immutable snapshot, not
+// the agent-writable workdir. Without snapshots this is the residual escape:
+// the hash is unchanged, the gate passes, and the tampered code runs.
+func TestSnapshotDefeatsPostApprovalTampering(t *testing.T) {
+	requireWorkingPython3(t)
+	isolateHome(t)
+	workdir := t.TempDir()
+
+	name := "vendored"
+	skillDir := filepath.Join(workdir, ".opencode", "skills", name)
+	if err := os.MkdirAll(filepath.Join(skillDir, ".venv"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A payload under .venv — excluded from config.BundleHash, so editing it
+	// later does NOT change the approved hash.
+	payload := filepath.Join(skillDir, ".venv", "payload.txt")
+	if err := os.WriteFile(payload, []byte("APPROVED-PAYLOAD"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := "name: " + name + "\ntype: skill\nsidecar:\n" +
+		"  command: [\"python3\", \"server.py\"]\n  mount: " + name + "\n" +
+		"  health:\n    path: /status\n    timeout_ms: 20000\n    interval_ms: 100\n"
+	if err := os.WriteFile(filepath.Join(skillDir, config.MetaFileName), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The sidecar serves the CONTENT of .venv/payload.txt relative to its cwd.
+	server := `import os, http.server
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/status":
+            self.send_response(200); self.end_headers(); self.wfile.write(b"ok"); return
+        try: data = open(".venv/payload.txt","rb").read()
+        except Exception as e: data = str(e).encode()
+        self.send_response(200); self.end_headers(); self.wfile.write(data)
+    def log_message(self, *a): pass
+http.server.HTTPServer(("127.0.0.1", int(os.environ["SIDECAR_PORT"])), H).serve_forever()
+`
+	if err := os.WriteFile(filepath.Join(skillDir, "server.py"), []byte(server), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	bundle := bundleHashOf(t, skillDir)
+	if err := registry.WithLock(workdir, func() error {
+		reg, _ := registry.Load(workdir)
+		reg.Upsert(registry.Entry{Name: name, SkillDir: filepath.Join(".opencode", "skills", name), BundleHash: bundle, RegisteredAt: time.Now().UTC()})
+		return registry.Save(workdir, reg)
+	}); err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	// Host approves -> snapshot freezes the current .venv/payload.txt.
+	if err := skilltrust.Approve(name, bundle, skillDir); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+
+	// The agent now rewrites the excluded payload in the workdir. The bundle
+	// hash is UNCHANGED (proving the approval still matches), so the gate lets
+	// the skill run — but it must run the snapshot's original payload.
+	if err := os.WriteFile(payload, []byte("TAMPERED-PAYLOAD"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if bundleHashOf(t, skillDir) != bundle {
+		t.Fatal("precondition: editing an excluded-dir file must NOT change the bundle hash")
+	}
+
+	r, baseURL := newLiveReloader(t, workdir)
+	r.reload()
+	if !r.isMounted(name) {
+		t.Fatal("approved skill should mount (its hash is unchanged)")
+	}
+	_, body := httpGet(t, baseURL+"/"+name+"/payload")
+	if body != "APPROVED-PAYLOAD" {
+		t.Fatalf("sidecar served %q; expected the frozen snapshot payload, not the workdir tamper", body)
 	}
 }
 

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -314,18 +314,24 @@ func runRegister(args []string, env *Env) int {
 		return ExitIOError
 	}
 
-	// Record the host-only spawn approval (see internal/skilltrust): this is
-	// what authorizes omac to run the skill's UNSANDBOXED sidecar. It lands
-	// under ~/.config/omac (not mounted into the sandbox), so it succeeds
-	// from a host terminal and FAILS from inside the sandbox — leaving an
-	// agent-driven registration unapproved.
-	if aerr := skilltrust.Approve(skillName, bundleHash, skillDir); aerr != nil {
-		fmt.Fprintf(env.Stderr, "omac register: could not record host approval (%v);\n"+
-			"  the skill stays unapproved and will not spawn until `omac register` is run from a host terminal\n", aerr)
-	}
+	// Record the host-only spawn approval + snapshot (see internal/skilltrust):
+	// this is what authorizes omac to run the skill's UNSANDBOXED sidecar. It
+	// lands under ~/.config/omac (not mounted into the sandbox), so it succeeds
+	// from a host terminal and FAILS from inside the sandbox. The approval
+	// outcome is authoritative for how we report success below: a registered-
+	// but-unapproved skill will NOT spawn, so we must not print a clean [ok].
+	approvalErr := skilltrust.Approve(skillName, bundleHash, skillDir)
 
 	sOut := newStyler(env.Stdout)
 	okTag := sOut.paint("[ok]", ansiBold, ansiGreen)
+	if approvalErr != nil {
+		warn := sOut.paint("[warn]", ansiBold, ansiYellow)
+		fmt.Fprintf(env.Stdout, "\n%s registered %s but could NOT approve it for spawning (%v)\n",
+			warn, sOut.bold(skillName), approvalErr)
+		fmt.Fprintf(env.Stdout, "  the skill will not start until `omac register %s` is run from a HOST terminal "+
+			"(outside the omac sandbox, where ~/.config/omac is writable)\n", skillName)
+		return ExitOK
+	}
 	if global {
 		fmt.Fprintf(env.Stdout, "\n%s registered %s %s\n",
 			okTag, sOut.bold(skillName), sOut.gray("(global; available in every workdir)"))

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -297,12 +297,15 @@ func runServe(args []string, env *Env) int {
 	if firstApprovalUpgrade() {
 		gReg, _ := registry.LoadGlobal()
 		wReg, _ := registry.Load(env.Workdir)
-		if _, merr := grandfatherOnce(
+		n, merr := grandfatherOnce(
 			grandfatherScope{reg: gReg},
 			grandfatherScope{workdir: env.Workdir, reg: wReg},
-		); merr != nil {
+		)
+		if merr != nil {
 			fmt.Fprintln(env.Stderr, "omac serve: approval store (non-fatal):", merr)
 		}
+		fmt.Fprintf(env.Stderr, "omac serve: approval-gated spawning is now active "+
+			"(migrated %d existing skill(s)); new skills need `omac register` on the host to spawn\n", n)
 	}
 
 	// Cold start: global skills are a fixed, known set, so — unlike the lazy

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1344,10 +1344,12 @@ func (s *serveServer) bringUp(e registry.Entry, absDir, workdir, namespace, secr
 	}
 
 	// Spawn-approval gate: refuse unless the current on-disk code is
-	// host-approved — a workdir the agent can write must not launch host code.
-	// Grandfathering happens once at cold start (see runServe), NOT here: a
-	// long-lived serve daemon must not keep blessing skills authored mid-session.
-	if refusal := approvalRefusal(e.Name, absDir, bundle); refusal != nil {
+	// host-approved, and run from the immutable approval snapshot rather than
+	// the agent-writable workdir. Grandfathering happens once at cold start
+	// (see runServe), NOT here: a long-lived serve daemon must not keep
+	// blessing skills authored mid-session.
+	snapDir, refusal := approvedSpawnDir(e.Name, absDir, bundle)
+	if refusal != nil {
 		sr := &skillRoute{Name: e.Name, Mount: mount, Namespace: namespace, SkillDir: absDir,
 			State: facade.RouteBroken, Detail: refusal.Error()}
 		s.installRoute(sr, 0)
@@ -1415,7 +1417,7 @@ func (s *serveServer) bringUp(e registry.Entry, absDir, workdir, namespace, secr
 		Name:             namespace + "/" + e.Name, // unique tracking key across dirs
 		SkillName:        e.Name,                   // plain name -> SIDECAR_SKILL (no slash)
 		Namespace:        namespace,                // audit only (hashed)
-		SkillDir:         absDir,
+		SkillDir:         snapDir,                  // run the frozen snapshot, not the workdir
 		Command:          m.Sidecar.Command,
 		EnvPassthrough:   m.Sidecar.EnvPassthrough,
 		Secrets:          secMap,

--- a/internal/cli/skill_approval.go
+++ b/internal/cli/skill_approval.go
@@ -16,13 +16,28 @@ import (
 // cannot write. See internal/skilltrust and docs/SECURITY_MODEL.md.
 
 // skillSpawnAuthorizer is the supervisor spawn-gate backstop: every spawn
-// funnels through it even if a caller forgets its own pre-flight check.
+// funnels through it even if a caller forgets its own pre-flight check. A
+// sidecar may run only from the host-only approval snapshot, which the sandbox
+// cannot write; anything else is refused.
+//
+// Checking the LOCATION is stronger than re-hashing the dir, which is why it is
+// the backstop: a hash check accepts ANY path whose content matches an approval,
+// including the agent-writable workdir itself, and re-opens the check-then-exec
+// TOCTOU that snapshotting exists to close. The pre-flight approvedSpawnDir is
+// what maps an approved skill to its snapshot dir.
 func skillSpawnAuthorizer(spec supervisor.SidecarSpec) error {
+	if skilltrust.IsSnapshotPath(spec.SkillDir) {
+		return nil
+	}
 	name := spec.SkillName
 	if name == "" {
 		name = spec.Name
 	}
-	return approvalRefusal(name, spec.SkillDir, "")
+	// Refuse outright — deliberately NOT falling back to a content re-hash of
+	// spec.SkillDir. Re-hashing would accept any path whose bytes match an
+	// approval, including the agent-writable workdir, which is exactly the
+	// weaker check this backstop exists to avoid.
+	return errSkillNotApproved(name)
 }
 
 // skillBundleHash returns bundleHash when the caller already computed one for

--- a/internal/cli/skill_approval.go
+++ b/internal/cli/skill_approval.go
@@ -25,11 +25,22 @@ func skillSpawnAuthorizer(spec supervisor.SidecarSpec) error {
 	return approvalRefusal(name, spec.SkillDir, "")
 }
 
-// approvalRefusal reports whether skill `name` may spawn from the content
+// skillBundleHash returns bundleHash when the caller already computed one for
+// skillDir, otherwise hashes the directory. Keeping it in one place means a
+// skill tree is walked at most once per launch path.
+func skillBundleHash(name, skillDir, bundleHash string) (string, error) {
+	if bundleHash != "" {
+		return bundleHash, nil
+	}
+	h, err := config.BundleHash(skillDir)
+	if err != nil {
+		return "", fmt.Errorf("skill %q: cannot hash %s: %w", name, skillDir, err)
+	}
+	return h, nil
+}
+
+// approvalRefusal reports whether skill `name` may spawn given the content
 // currently on disk at skillDir. A nil error means approved.
-//
-// bundleHash may be a hash the caller already computed for skillDir (the
-// launch paths run a drift check first); pass "" to hash it here.
 //
 // A non-nil error is the refusal reason, suitable verbatim as a broken-route
 // Detail — errSkillNotApproved when there is simply no approval, or the
@@ -37,14 +48,11 @@ func skillSpawnAuthorizer(spec supervisor.SidecarSpec) error {
 // operator is not told to re-register when that cannot help. Any error fails
 // closed: the skill does not spawn.
 func approvalRefusal(name, skillDir, bundleHash string) error {
-	if bundleHash == "" {
-		h, err := config.BundleHash(skillDir)
-		if err != nil {
-			return fmt.Errorf("skill %q: cannot hash %s: %w", name, skillDir, err)
-		}
-		bundleHash = h
+	h, err := skillBundleHash(name, skillDir, bundleHash)
+	if err != nil {
+		return err
 	}
-	approved, err := skilltrust.IsApproved(name, bundleHash)
+	approved, err := skilltrust.IsApproved(name, h)
 	if err != nil {
 		return fmt.Errorf("skill %q: cannot read the host approval store: %w", name, err)
 	}
@@ -52,6 +60,34 @@ func approvalRefusal(name, skillDir, bundleHash string) error {
 		return errSkillNotApproved(name)
 	}
 	return nil
+}
+
+// approvedSpawnDir resolves the directory a skill's sidecar must be spawned
+// FROM: the immutable, host-only snapshot frozen at approval time (see
+// internal/skilltrust snapshot.go). workdirSkillDir is the agent-writable
+// source; its content is matched against the approval, then the corresponding
+// snapshot is returned. Spawning from the snapshot, not the workdir, is what
+// makes the executed bytes exactly the approved bytes.
+//
+// bundleHash may be a hash the caller already computed for workdirSkillDir;
+// pass "" to hash it here. A nil error means approved; a non-nil error is the
+// refusal detail (see approvalRefusal).
+func approvedSpawnDir(name, workdirSkillDir, bundleHash string) (snapshotDir string, refusal error) {
+	h, err := skillBundleHash(name, workdirSkillDir, bundleHash)
+	if err != nil {
+		return "", err
+	}
+	if refusal := approvalRefusal(name, workdirSkillDir, h); refusal != nil {
+		return "", refusal
+	}
+	// An approval whose snapshot is missing (a hand-deleted ~/.config/omac
+	// tree) is recoverable by re-registering, so refuse this one skill here
+	// rather than letting the supervisor backstop fail the whole launch.
+	snap, present := skilltrust.SnapshotPath(name, h)
+	if !present {
+		return "", errSkillNotApproved(name)
+	}
+	return snap, nil
 }
 
 // errSkillNotApproved is the uniform refusal error/detail; it names the

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -760,18 +760,20 @@ func runLaunch(env *Env, opts launchOpts) int {
 
 	// 5a. Spawn-approval gate. A sidecar runs UNSANDBOXED, so only skills
 	//     whose current on-disk code is host-approved (see
-	//     internal/skilltrust) may start. Unapproved skills are mounted as
-	//     broken routes with the remedy — never spawned — so a workdir the
-	//     agent can write cannot launch host code.
+	//     internal/skilltrust) may start — and they run from the immutable
+	//     approval snapshot, not the agent-writable workdir. Unapproved
+	//     skills are mounted as broken routes with the remedy, never spawned.
 	var refusedRoutes []facade.Route
 	approved := make([]withSecrets, 0, len(armed))
 	for _, a := range armed {
-		if refusal := approvalRefusal(a.entry.Name, a.abs, a.bundle); refusal != nil {
+		snap, refusal := approvedSpawnDir(a.entry.Name, a.abs, a.bundle)
+		if refusal != nil {
 			refusedRoutes = append(refusedRoutes, brokenApprovalRoute(
 				a.meta.Sidecar.MountOrDefault(a.entry.Name), a.entry.Name, a.abs, refusal))
 			fmt.Fprintf(env.Stderr, "%s: %s\n", prefix, refusalNotice(refusal))
 			continue
 		}
+		a.abs = snap // spawn (and serve SKILL.md) from the frozen snapshot
 		approved = append(approved, a)
 	}
 	armed = approved

--- a/internal/cli/start_reload.go
+++ b/internal/cli/start_reload.go
@@ -244,9 +244,11 @@ func (r *startReloader) reload() []string {
 		// workdir (author code -> forge .opencode/sidecar.json -> POST
 		// /__omac__/reload). A sidecar runs UNSANDBOXED, so refuse unless
 		// the current on-disk code is host-approved (see
-		// internal/skilltrust). Mount a broken route (no markMounted, so a
-		// later reload after `omac register` can still bring it up).
-		if refusal := approvalRefusal(e.Name, absDir, ""); refusal != nil {
+		// internal/skilltrust) and runs from the immutable approval snapshot,
+		// not the workdir. Mount a broken route (no markMounted, so a later
+		// reload after `omac register` can still bring it up).
+		snapDir, refusal := approvedSpawnDir(e.Name, absDir, "")
+		if refusal != nil {
 			r.facade.AddRoute(brokenApprovalRoute(mount, e.Name, absDir, refusal))
 			if r.verbose {
 				fmt.Fprintf(r.env.Stderr, "[verbose] reload: %s\n", refusalNotice(refusal))
@@ -292,7 +294,7 @@ func (r *startReloader) reload() []string {
 		spec := supervisor.SidecarSpec{
 			Name:           e.Name,
 			SkillName:      e.Name,
-			SkillDir:       absDir,
+			SkillDir:       snapDir, // run the frozen snapshot, not the workdir
 			Command:        m.Sidecar.Command,
 			EnvPassthrough: m.Sidecar.EnvPassthrough,
 			Secrets:        secMap,

--- a/internal/cli/start_reload.go
+++ b/internal/cli/start_reload.go
@@ -39,9 +39,10 @@ type startReloader struct {
 	tcpPort int
 	verbose bool
 
-	mu          sync.Mutex
-	mounted     map[string]string // skill name -> mount, for skills mounted on the facade
-	lastSession string            // most-recent session id the harness plugin reported (see handleSession)
+	mu               sync.Mutex
+	mounted          map[string]string   // skill name -> mount, for skills mounted on the facade
+	warnedUnapproved map[string]struct{} // skills we've already reported as unapproved (dedupe reload spam)
+	lastSession      string              // most-recent session id the harness plugin reported (see handleSession)
 }
 
 // startControlPlane binds a loopback control-plane HTTP server for start and
@@ -88,6 +89,22 @@ func (r *startReloader) markMounted(name, mount string) {
 	}
 	r.mounted[name] = mount
 	r.mu.Unlock()
+}
+
+// warnUnapprovedOnce reports true the first time it is called for name, so a
+// repeated reload of the same unapproved skill does not spam the human's
+// stderr. Reset implicitly when the process restarts.
+func (r *startReloader) warnUnapprovedOnce(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, seen := r.warnedUnapproved[name]; seen {
+		return false
+	}
+	if r.warnedUnapproved == nil {
+		r.warnedUnapproved = map[string]struct{}{}
+	}
+	r.warnedUnapproved[name] = struct{}{}
+	return true
 }
 
 func (r *startReloader) isMounted(name string) bool {
@@ -250,8 +267,8 @@ func (r *startReloader) reload() []string {
 		snapDir, refusal := approvedSpawnDir(e.Name, absDir, "")
 		if refusal != nil {
 			r.facade.AddRoute(brokenApprovalRoute(mount, e.Name, absDir, refusal))
-			if r.verbose {
-				fmt.Fprintf(r.env.Stderr, "[verbose] reload: %s\n", refusalNotice(refusal))
+			if r.warnUnapprovedOnce(e.Name) {
+				fmt.Fprintf(r.env.Stderr, "omac start: %s\n", refusalNotice(refusal))
 			}
 			continue
 		}

--- a/internal/e2e/self_authored_skill_test.go
+++ b/internal/e2e/self_authored_skill_test.go
@@ -78,21 +78,20 @@ func TestE2ESelfAuthoredSkillRefused(t *testing.T) {
 			"    - name: NEEDED_TOKEN\n"+
 			"      required: true\n")
 
-	// Pre-create the host-only approval store (so this is NOT first-upgrade)
-	// approving ONLY "good", keyed by its exact on-disk bundle hash — the
-	// same value the serve subprocess recomputes. "evil" is deliberately
-	// absent. The store path mirrors what serve resolves under withHome:
-	// $XDG_CONFIG_HOME/omac == <home>/.config/omac.
+	// Approve ONLY "good" in the subprocess's host-only store (so this is NOT
+	// a first-upgrade run). Point this process's HOME/XDG at the same `home`
+	// the subprocess uses (withHome sets XDG_CONFIG_HOME=<home>/.config), so
+	// skilltrust.Approve writes the approval AND its snapshot where serve
+	// resolves them. "evil" is deliberately left unapproved.
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	goodHash, err := config.BundleHash(goodDir)
 	if err != nil {
 		t.Fatalf("bundle hash: %v", err)
 	}
-	writeApprovalStore(t, home, skilltrust.Store{
-		Version: skilltrust.SchemaVersion,
-		Approved: []skilltrust.Approval{
-			{Name: "good", BundleHash: goodHash, ApprovedAt: time.Unix(0, 0).UTC()},
-		},
-	})
+	if err := skilltrust.Approve("good", goodHash, goodDir); err != nil {
+		t.Fatalf("approve good: %v", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -182,23 +181,6 @@ func stageSelfAuthoredSkill(t *testing.T, workdir, name, omacYAML string) string
 		t.Fatal(err)
 	}
 	return skillDir
-}
-
-// writeApprovalStore writes the host-only approvals file to the location
-// the serve subprocess resolves under withHome (<home>/.config/omac).
-func writeApprovalStore(t *testing.T, home string, s skilltrust.Store) {
-	t.Helper()
-	dir := filepath.Join(home, ".config", "omac")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	data, err := json.MarshalIndent(s, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "approvals.json"), data, 0o600); err != nil {
-		t.Fatal(err)
-	}
 }
 
 // activateAndGetSkills POSTs /__omac__/activate for dir and returns the

--- a/internal/e2e/serve_isolation_test.go
+++ b/internal/e2e/serve_isolation_test.go
@@ -76,18 +76,22 @@ func TestE2EServeDirTokenIsolation(t *testing.T) {
 	stageServeSkill(t, wdA, "slack")
 	stageServeSkill(t, wdB, "slack")
 
-	// Pre-approve the staged skills in the subprocess's host-only store so the
-	// spawn-approval gate lets activation reach its pending-credentials path
-	// (both copies are identical, so they share one bundle hash). This test is
-	// about dir-token isolation, not the approval gate.
-	slackHash, err := config.BundleHash(filepath.Join(wdA, ".opencode", "skills", "slack"))
+	// Pre-approve the staged skills in the subprocess's host-only store (both
+	// copies are identical, so they share one bundle hash and one snapshot) so
+	// the spawn-approval gate lets activation reach its pending-credentials
+	// path. Point HOME/XDG at the subprocess's `home` so Approve writes the
+	// approval + snapshot where serve resolves them. This test is about
+	// dir-token isolation, not the approval gate.
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	slackDir := filepath.Join(wdA, ".opencode", "skills", "slack")
+	slackHash, err := config.BundleHash(slackDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	writeApprovalStore(t, home, skilltrust.Store{
-		Version:  skilltrust.SchemaVersion,
-		Approved: []skilltrust.Approval{{Name: "slack", BundleHash: slackHash, ApprovedAt: time.Unix(0, 0).UTC()}},
-	})
+	if err := skilltrust.Approve("slack", slackHash, slackDir); err != nil {
+		t.Fatal(err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/skilltrust/skilltrust.go
+++ b/internal/skilltrust/skilltrust.go
@@ -17,12 +17,12 @@
 // (~/.config/omac, honoring $XDG_CONFIG_HOME) — a directory the default
 // sandbox profile never mounts into the sandbox, so the confined agent
 // cannot create or edit it. The kernel sandbox, not omac's own trust in
-// a file, is what makes an Approval unforgeable.
+// a file, is what makes an approval unforgeable.
 //
-// An Approval is keyed by (skill name, bundle hash). The bundle hash
+// An approval is keyed by (skill name, bundle hash). The bundle hash
 // covers every meaningful file in the skill directory (see
 // config.BundleHash), so editing a skill's sidecar code changes its hash
-// and silently invalidates the Approval — closing the "edit a trusted
+// and silently invalidates the approval — closing the "edit a trusted
 // skill's code" vector as well as the "author a new skill" one.
 //
 // Only actors on the host side of the sandbox boundary can approve: a
@@ -44,26 +44,26 @@ import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/registry"
 )
 
-// SchemaVersion is the current on-disk format version.
-const SchemaVersion = 1
+// schemaVersion is the current on-disk format version.
+const schemaVersion = 1
 
 // fileName is the approvals file's basename inside registry.GlobalDir().
 const fileName = "approvals.json"
 
-// Approval authorizes spawning a specific skill build. Name plus
+// approval authorizes spawning a specific skill build. Name plus
 // BundleHash together identify the exact approved content; SkillDir and
 // ApprovedAt are informational (diagnostics / audit).
-type Approval struct {
+type approval struct {
 	Name       string    `json:"name"`
 	BundleHash string    `json:"bundle_hash"`
 	SkillDir   string    `json:"skill_dir,omitempty"`
 	ApprovedAt time.Time `json:"approved_at"`
 }
 
-// Store is the root object of approvals.json.
-type Store struct {
+// store is the root object of approvals.json.
+type store struct {
 	Version  int        `json:"version"`
-	Approved []Approval `json:"approved"`
+	Approved []approval `json:"approved"`
 }
 
 // errNoGlobalDir is returned when no host-only config directory can be
@@ -98,7 +98,7 @@ func lockPath() string {
 
 // Exists reports whether the approvals file has been created yet. It is
 // the signal used by one-time migration (see caller): a missing file
-// means this host has not yet been migrated to Approval-gated spawning.
+// means this host has not yet been migrated to approval-gated spawning.
 func Exists() bool {
 	p := path()
 	if p == "" {
@@ -108,32 +108,32 @@ func Exists() bool {
 	return err == nil
 }
 
-// load reads the approvals Store. A missing file (or unresolvable
-// directory) returns an empty Store, so callers can always check
-// membership; an empty Store approves nothing (fail closed).
-func load() (*Store, error) {
+// load reads the approvals store. A missing file (or unresolvable
+// directory) returns an empty store, so callers can always check
+// membership; an empty store approves nothing (fail closed).
+func load() (*store, error) {
 	p := path()
 	if p == "" {
-		return &Store{Version: SchemaVersion}, nil
+		return &store{Version: schemaVersion}, nil
 	}
 	raw, err := os.ReadFile(p)
 	if errors.Is(err, os.ErrNotExist) {
-		return &Store{Version: SchemaVersion}, nil
+		return &store{Version: schemaVersion}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("read approvals: %w", err)
 	}
-	var s Store
+	var s store
 	if err := json.Unmarshal(raw, &s); err != nil {
 		return nil, fmt.Errorf("parse approvals: %w", err)
 	}
 	if s.Version == 0 {
-		s.Version = SchemaVersion
+		s.Version = schemaVersion
 	}
 	return &s, nil
 }
 
-// IsApproved reports whether (name, bundleHash) has a recorded Approval.
+// IsApproved reports whether (name, bundleHash) has a recorded approval.
 // A read error fails closed (returns false, err) so a caller that
 // ignores the error still denies the spawn.
 func IsApproved(name, bundleHash string) (bool, error) {
@@ -149,7 +149,7 @@ func IsApproved(name, bundleHash string) (bool, error) {
 	return false, nil
 }
 
-// Approve records an Approval for (name, bundleHash). Approvals are
+// Approve records an approval for (name, bundleHash). Approvals are
 // additive and keyed by (name, bundle hash): the same skill name may hold
 // several approved hashes at once, because a name can be registered under
 // more than one harness (each with its own content) and workdir-local
@@ -160,19 +160,19 @@ func IsApproved(name, bundleHash string) (bool, error) {
 // sandbox the write fails because the directory is not mounted, leaving the
 // skill unapproved.
 //
-// When skillDir is non-empty it is also frozen into a host-only snapshot
-// (see snapshot.go) so the sidecar later runs the exact approved bytes; a
-// snapshot failure fails the approval. Passing "" records the approval
-// without a snapshot (used by store-only paths/tests); such an approval will
-// not spawn until a snapshot exists.
+// skillDir is frozen into the matching host-only snapshot (see snapshot.go) so
+// the sidecar later runs the exact approved bytes; a snapshot failure fails the
+// whole approval. It is required: an approval without a snapshot could never
+// spawn, so it is rejected rather than recorded as a half-approved state.
 func Approve(name, bundleHash, skillDir string) error {
 	if dir() == "" {
 		return errNoGlobalDir
 	}
-	if skillDir != "" {
-		if _, err := Snapshot(name, bundleHash, skillDir); err != nil {
-			return err
-		}
+	if skillDir == "" {
+		return fmt.Errorf("skilltrust: approve %q: skillDir is required (an approval without a snapshot cannot spawn)", name)
+	}
+	if _, err := snapshot(name, bundleHash, skillDir); err != nil {
+		return err
 	}
 	return withLock(func() error {
 		s, err := load()
@@ -184,7 +184,7 @@ func Approve(name, bundleHash, skillDir string) error {
 				return nil // already approved; nothing to change
 			}
 		}
-		s.Approved = append(s.Approved, Approval{
+		s.Approved = append(s.Approved, approval{
 			Name:       name,
 			BundleHash: bundleHash,
 			SkillDir:   skillDir,
@@ -194,10 +194,10 @@ func Approve(name, bundleHash, skillDir string) error {
 	})
 }
 
-// Revoke removes the Approval for exactly (name, bundleHash). Returns true
+// Revoke removes the approval for exactly (name, bundleHash). Returns true
 // when something was removed. Used by `omac deregister`, which passes the
 // deregistered entry's own hash so a copy of the same skill still
-// registered under another harness or workdir keeps its Approval.
+// registered under another harness or workdir keeps its approval.
 func Revoke(name, bundleHash string) (bool, error) {
 	if dir() == "" {
 		return false, errNoGlobalDir
@@ -225,12 +225,12 @@ func Revoke(name, bundleHash string) (bool, error) {
 	return removed, err
 }
 
-// EnsureInitialized creates an empty approvals Store if none exists yet,
+// EnsureInitialized creates an empty approvals store if none exists yet,
 // so the "first upgraded run" is a single event: once this has run, Exists
 // reports true even when nothing was approved. Without it a host that has
 // never registered a skill would keep looking like a first upgrade on
 // every launch, re-opening the one-time grandfathering window. No-op when
-// the Store already exists or no host-only dir is resolvable.
+// the store already exists or no host-only dir is resolvable.
 func EnsureInitialized() error {
 	if dir() == "" || Exists() {
 		return nil
@@ -239,19 +239,19 @@ func EnsureInitialized() error {
 		if Exists() {
 			return nil
 		}
-		return save(&Store{Version: SchemaVersion})
+		return save(&store{Version: schemaVersion})
 	})
 }
 
 // save atomically writes s (write-temp + rename). The caller holds the
 // lock (see withLock).
-func save(s *Store) error {
+func save(s *store) error {
 	d := dir()
 	if d == "" {
 		return errNoGlobalDir
 	}
 	if s.Version == 0 {
-		s.Version = SchemaVersion
+		s.Version = schemaVersion
 	}
 	if err := os.MkdirAll(d, 0o700); err != nil {
 		return fmt.Errorf("ensure approvals dir: %w", err)
@@ -293,7 +293,7 @@ func save(s *Store) error {
 }
 
 // withLock acquires an exclusive flock for the duration of fn, using the
-// same primitive as the sibling registry Store under GlobalDir so there is
+// same primitive as the sibling registry store under GlobalDir so there is
 // one flock implementation to audit rather than two.
 func withLock(fn func() error) error {
 	d := dir()

--- a/internal/skilltrust/skilltrust.go
+++ b/internal/skilltrust/skilltrust.go
@@ -159,9 +159,20 @@ func IsApproved(name, bundleHash string) (bool, error) {
 // It must be called from the host side of the sandbox boundary; inside the
 // sandbox the write fails because the directory is not mounted, leaving the
 // skill unapproved.
+//
+// When skillDir is non-empty it is also frozen into a host-only snapshot
+// (see snapshot.go) so the sidecar later runs the exact approved bytes; a
+// snapshot failure fails the approval. Passing "" records the approval
+// without a snapshot (used by store-only paths/tests); such an approval will
+// not spawn until a snapshot exists.
 func Approve(name, bundleHash, skillDir string) error {
 	if dir() == "" {
 		return errNoGlobalDir
+	}
+	if skillDir != "" {
+		if _, err := Snapshot(name, bundleHash, skillDir); err != nil {
+			return err
+		}
 	}
 	return withLock(func() error {
 		s, err := load()
@@ -208,6 +219,9 @@ func Revoke(name, bundleHash string) (bool, error) {
 		s.Approved = out
 		return save(s)
 	})
+	if removed {
+		removeSnapshot(name, bundleHash)
+	}
 	return removed, err
 }
 

--- a/internal/skilltrust/skilltrust_test.go
+++ b/internal/skilltrust/skilltrust_test.go
@@ -187,3 +187,43 @@ func TestSnapshotFreezesContentAndRevokeRemovesIt(t *testing.T) {
 		t.Error("snapshot should be gone after Revoke")
 	}
 }
+
+func TestSnapshotDoesNotBakeEscapingSymlink(t *testing.T) {
+	isolate(t)
+	// A host secret OUTSIDE the skill tree.
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "id_rsa")
+	if err := os.WriteFile(secret, []byte("PRIVATE-KEY"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	src := t.TempDir()
+	// (1) an escaping symlink an agent might plant; (2) a legit in-tree
+	// relative symlink (e.g. node_modules/.bin style).
+	if err := os.Symlink(secret, filepath.Join(src, "evil")); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "real.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", filepath.Join(src, "alias")); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := Snapshot("s", "sha256:h", src)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	// The escaping link must NOT appear as baked content (no secret in snapshot).
+	if b, err := os.ReadFile(filepath.Join(snap, "evil")); err == nil {
+		t.Fatalf("escaping symlink was materialized into the snapshot: %q", b)
+	}
+	if _, err := os.Lstat(filepath.Join(snap, "evil")); err == nil {
+		t.Error("escaping symlink should be dropped entirely, not recreated")
+	}
+	// The in-tree relative link is preserved and resolves within the snapshot.
+	if b, err := os.ReadFile(filepath.Join(snap, "alias")); err != nil || string(b) != "ok" {
+		t.Errorf("in-tree symlink not preserved: body=%q err=%v", b, err)
+	}
+}

--- a/internal/skilltrust/skilltrust_test.go
+++ b/internal/skilltrust/skilltrust_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // isolate points HOME and XDG_CONFIG_HOME at temp dirs so the approvals
-// Store resolves under a throwaway location (registry.GlobalDir honors
+// store resolves under a throwaway location (registry.GlobalDir honors
 // XDG_CONFIG_HOME).
 func isolate(t *testing.T) {
 	t.Helper()
@@ -15,27 +15,39 @@ func isolate(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 }
 
+// skillDir makes a minimal real skill directory. Approve requires one (it
+// freezes a snapshot), so the store-bookkeeping tests below pass this rather
+// than a bare name.
+func skillDir(t *testing.T) string {
+	t.Helper()
+	d := t.TempDir()
+	if err := os.WriteFile(filepath.Join(d, "omac.yaml"), []byte("name: s\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
 func TestUnapprovedByDefault(t *testing.T) {
 	isolate(t)
 	if Exists() {
-		t.Fatal("Store should not exist before any Approval")
+		t.Fatal("store should not exist before any approval")
 	}
 	ok, err := IsApproved("skill", "sha256:abc")
 	if err != nil {
 		t.Fatalf("IsApproved: %v", err)
 	}
 	if ok {
-		t.Error("nothing should be approved on a fresh Store (fail closed)")
+		t.Error("nothing should be approved on a fresh store (fail closed)")
 	}
 }
 
 func TestApproveThenIsApproved(t *testing.T) {
 	isolate(t)
-	if err := Approve("skill", "sha256:abc", ""); err != nil {
+	if err := Approve("skill", "sha256:abc", skillDir(t)); err != nil {
 		t.Fatalf("Approve: %v", err)
 	}
 	if !Exists() {
-		t.Error("Store should exist after Approve")
+		t.Error("store should exist after Approve")
 	}
 	ok, _ := IsApproved("skill", "sha256:abc")
 	if !ok {
@@ -55,8 +67,8 @@ func TestApproveIsAdditivePerName(t *testing.T) {
 	isolate(t)
 	// The same name may be registered under multiple harnesses / workdirs,
 	// each with its own content, so approvals must accumulate — not clobber.
-	_ = Approve("skill", "sha256:v1", "")
-	_ = Approve("skill", "sha256:v2", "")
+	_ = Approve("skill", "sha256:v1", skillDir(t))
+	_ = Approve("skill", "sha256:v2", skillDir(t))
 
 	for _, h := range []string{"sha256:v1", "sha256:v2"} {
 		if ok, _ := IsApproved("skill", h); !ok {
@@ -64,7 +76,7 @@ func TestApproveIsAdditivePerName(t *testing.T) {
 		}
 	}
 	// Re-approving an identical (name, hash) is idempotent (no duplicate).
-	_ = Approve("skill", "sha256:v1", "")
+	_ = Approve("skill", "sha256:v1", skillDir(t))
 	s, _ := load()
 	if len(s.Approved) != 2 {
 		t.Errorf("expected 2 approvals, got %d", len(s.Approved))
@@ -73,9 +85,9 @@ func TestApproveIsAdditivePerName(t *testing.T) {
 
 func TestRevokeIsScopedToHash(t *testing.T) {
 	isolate(t)
-	_ = Approve("foo", "sha256:opencode", "") // same name, two harnesses
-	_ = Approve("foo", "sha256:claude", "")
-	_ = Approve("bar", "sha256:2", "")
+	_ = Approve("foo", "sha256:opencode", skillDir(t)) // same name, two harnesses
+	_ = Approve("foo", "sha256:claude", skillDir(t))
+	_ = Approve("bar", "sha256:2", skillDir(t))
 
 	removed, err := Revoke("foo", "sha256:opencode")
 	if err != nil {
@@ -87,7 +99,7 @@ func TestRevokeIsScopedToHash(t *testing.T) {
 	if ok, _ := IsApproved("foo", "sha256:opencode"); ok {
 		t.Error("the revoked (name, hash) should no longer be approved")
 	}
-	// A same-name copy under a different hash keeps its Approval.
+	// A same-name copy under a different hash keeps its approval.
 	if ok, _ := IsApproved("foo", "sha256:claude"); !ok {
 		t.Error("Revoke must not touch a same-name copy with a different hash")
 	}
@@ -102,16 +114,16 @@ func TestRevokeIsScopedToHash(t *testing.T) {
 func TestEnsureInitializedClosesFirstUpgradeWindow(t *testing.T) {
 	isolate(t)
 	if Exists() {
-		t.Fatal("Store should be absent initially")
+		t.Fatal("store should be absent initially")
 	}
 	if err := EnsureInitialized(); err != nil {
 		t.Fatalf("EnsureInitialized: %v", err)
 	}
 	if !Exists() {
-		t.Error("Store must exist after EnsureInitialized, so the first-upgrade window closes")
+		t.Error("store must exist after EnsureInitialized, so the first-upgrade window closes")
 	}
 	// Idempotent and non-destructive: approve, then EnsureInitialized again.
-	_ = Approve("s", "h", "")
+	_ = Approve("s", "h", skillDir(t))
 	if err := EnsureInitialized(); err != nil {
 		t.Fatalf("EnsureInitialized (2nd): %v", err)
 	}
@@ -122,7 +134,7 @@ func TestEnsureInitializedClosesFirstUpgradeWindow(t *testing.T) {
 
 func TestApprovalsSurviveReload(t *testing.T) {
 	isolate(t)
-	if err := Approve("skill", "sha256:abc", ""); err != nil {
+	if err := Approve("skill", "sha256:abc", skillDir(t)); err != nil {
 		t.Fatalf("Approve: %v", err)
 	}
 	// A fresh Load (new process would do the same) sees the persisted state.
@@ -131,7 +143,7 @@ func TestApprovalsSurviveReload(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 	if len(s.Approved) != 1 || s.Approved[0].Name != "skill" {
-		t.Fatalf("persisted Store = %+v", s.Approved)
+		t.Fatalf("persisted store = %+v", s.Approved)
 	}
 }
 
@@ -142,11 +154,11 @@ func TestFailClosedWithoutHome(t *testing.T) {
 	if os.Getenv("HOME") != "" {
 		t.Skip("HOME could not be cleared on this platform")
 	}
-	if err := Approve("x", "h", ""); err != errNoGlobalDir {
+	if err := Approve("x", "h", t.TempDir()); err != errNoGlobalDir {
 		t.Errorf("Approve without a config dir = %v, want errNoGlobalDir", err)
 	}
 	if ok, _ := IsApproved("x", "h"); ok {
-		t.Error("must fail closed when no Store location is resolvable")
+		t.Error("must fail closed when no store location is resolvable")
 	}
 }
 
@@ -210,7 +222,7 @@ func TestSnapshotDoesNotBakeEscapingSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	snap, err := Snapshot("s", "sha256:h", src)
+	snap, err := snapshot("s", "sha256:h", src)
 	if err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}

--- a/internal/skilltrust/skilltrust_test.go
+++ b/internal/skilltrust/skilltrust_test.go
@@ -2,6 +2,7 @@ package skilltrust
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -30,7 +31,7 @@ func TestUnapprovedByDefault(t *testing.T) {
 
 func TestApproveThenIsApproved(t *testing.T) {
 	isolate(t)
-	if err := Approve("skill", "sha256:abc", "/skills/skill"); err != nil {
+	if err := Approve("skill", "sha256:abc", ""); err != nil {
 		t.Fatalf("Approve: %v", err)
 	}
 	if !Exists() {
@@ -121,7 +122,7 @@ func TestEnsureInitializedClosesFirstUpgradeWindow(t *testing.T) {
 
 func TestApprovalsSurviveReload(t *testing.T) {
 	isolate(t)
-	if err := Approve("skill", "sha256:abc", "/d"); err != nil {
+	if err := Approve("skill", "sha256:abc", ""); err != nil {
 		t.Fatalf("Approve: %v", err)
 	}
 	// A fresh Load (new process would do the same) sees the persisted state.
@@ -146,5 +147,43 @@ func TestFailClosedWithoutHome(t *testing.T) {
 	}
 	if ok, _ := IsApproved("x", "h"); ok {
 		t.Error("must fail closed when no Store location is resolvable")
+	}
+}
+
+func TestSnapshotFreezesContentAndRevokeRemovesIt(t *testing.T) {
+	isolate(t)
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "code.txt"), []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Approve with a real dir -> a snapshot is created and resolvable.
+	if err := Approve("s", "sha256:h", src); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	snap, ok := SnapshotPath("s", "sha256:h")
+	if !ok {
+		t.Fatal("snapshot should exist after Approve with a dir")
+	}
+	got, err := os.ReadFile(filepath.Join(snap, "code.txt"))
+	if err != nil || string(got) != "ORIGINAL" {
+		t.Fatalf("snapshot content = %q, err=%v; want ORIGINAL", got, err)
+	}
+
+	// Editing the SOURCE after approval must not change the snapshot.
+	if err := os.WriteFile(filepath.Join(src, "code.txt"), []byte("TAMPERED"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = os.ReadFile(filepath.Join(snap, "code.txt"))
+	if string(got) != "ORIGINAL" {
+		t.Errorf("snapshot changed with the source: %q (must be immutable)", got)
+	}
+
+	// Revoke removes the snapshot.
+	if _, err := Revoke("s", "sha256:h"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if _, ok := SnapshotPath("s", "sha256:h"); ok {
+		t.Error("snapshot should be gone after Revoke")
 	}
 }

--- a/internal/skilltrust/snapshot.go
+++ b/internal/skilltrust/snapshot.go
@@ -41,6 +41,26 @@ func SnapshotPath(name, bundleHash string) (string, bool) {
 	return p, false
 }
 
+// IsSnapshotPath reports whether dir is an existing directory under the
+// host-only snapshot root (<store>/skills). It is the spawn backstop: a
+// sidecar may run only from the snapshot area, which the sandbox cannot
+// write — so a path here is, by construction, host-frozen content. This is
+// stronger and simpler than re-hashing dir (the snapshot legitimately differs
+// from the workdir hash when symlinks are involved).
+func IsSnapshotPath(spawnDir string) bool {
+	d := dir()
+	if d == "" || spawnDir == "" {
+		return false
+	}
+	root := filepath.Join(d, "skills")
+	rel, err := filepath.Rel(root, spawnDir)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	fi, err := os.Stat(spawnDir)
+	return err == nil && fi.IsDir()
+}
+
 // Snapshot freezes srcDir into the snapshot location for (name, hash) and
 // returns the snapshot directory. It is idempotent and content-addressed: an
 // existing snapshot for the same (name, hash) is returned unchanged (the
@@ -93,11 +113,19 @@ func removeSnapshot(name, bundleHash string) {
 // captures a self-contained, immutable image of a skill:
 //   - directories are recreated (VCS metadata under .git is skipped),
 //   - regular files are copied with their mode bits (execute bits preserved),
-//   - symlinks are flattened to a copy of their target's CONTENT when the
-//     target resolves to a regular file (so a later repoint of the link cannot
-//     change what runs); links to directories or unresolvable targets are
-//     skipped.
+//   - symlinks are NEVER dereferenced into content. A symlink whose target
+//     resolves INSIDE the skill tree and whose link text is relative is
+//     recreated verbatim (self-contained; e.g. node_modules/.bin entries).
+//     Any symlink that escapes the tree, is absolute, or is unresolvable is
+//     dropped. This mirrors config.BundleHash (which skips symlinks) so the
+//     snapshot hashes identically to the workdir, and — crucially — prevents
+//     baking a host file the link points at (e.g. ~/.ssh/id_rsa) into the
+//     snapshot or letting it be read back through the skill.
 func copyTree(src, dst string) error {
+	srcReal, err := filepath.EvalSymlinks(src)
+	if err != nil {
+		srcReal = filepath.Clean(src)
+	}
 	return filepath.WalkDir(src, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -123,22 +151,36 @@ func copyTree(src, dst string) error {
 			return ierr
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			// Flatten to the target's content if it is a regular file.
-			resolved, rerr := filepath.EvalSymlinks(p)
-			if rerr != nil {
-				return nil // dangling / unresolvable: drop it
-			}
-			ri, rierr := os.Stat(resolved)
-			if rierr != nil || !ri.Mode().IsRegular() {
-				return nil // non-regular target: drop it
-			}
-			return copyFile(resolved, target, ri.Mode().Perm())
+			return copyInTreeSymlink(p, target, srcReal)
 		}
 		if !info.Mode().IsRegular() {
 			return nil // sockets, devices, fifos: nothing to run
 		}
 		return copyFile(p, target, info.Mode().Perm())
 	})
+}
+
+// copyInTreeSymlink recreates a symlink at target ONLY when it is a relative
+// link resolving inside the skill tree (srcReal); otherwise it is dropped. It
+// never reads the target's content, so an escaping link cannot smuggle a host
+// file into the snapshot.
+func copyInTreeSymlink(p, target, srcReal string) error {
+	link, err := os.Readlink(p)
+	if err != nil || filepath.IsAbs(link) {
+		return nil // unreadable or absolute: drop
+	}
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return nil // dangling / unresolvable: drop
+	}
+	rel, err := filepath.Rel(srcReal, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil // escapes the skill tree: drop
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		return err
+	}
+	return os.Symlink(link, target)
 }
 
 // copyFile copies a single regular file, creating parent dirs as needed and

--- a/internal/skilltrust/snapshot.go
+++ b/internal/skilltrust/snapshot.go
@@ -1,0 +1,164 @@
+package skilltrust
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Snapshotting freezes a skill's on-disk content at approval time into a
+// host-only directory the sandbox cannot write, and omac spawns the sidecar
+// from that copy. This makes the executed bytes exactly the approved bytes:
+// it closes the gap that the bundle hash (config.BundleHash) leaves open —
+// dependency/artifact subtrees (node_modules, .venv, dist, …) and symlinks
+// are excluded from the hash, so an agent could otherwise rewrite code under
+// them after approval without changing the hash. A snapshot also removes the
+// check-then-exec TOCTOU: the gate verifies a hash, but exec then runs the
+// frozen copy, not the still-mutable workdir.
+//
+// Snapshots live under <store>/skills/<name>/<hash> (content-addressed), so
+// identical content is stored once and re-approval is idempotent.
+
+// snapshotRel returns the store-relative snapshot path for (name, hash).
+// The bundle hash's "sha256:" prefix is stripped to a bare hex leaf.
+func snapshotRel(name, bundleHash string) string {
+	return filepath.Join("skills", name, strings.TrimPrefix(bundleHash, "sha256:"))
+}
+
+// SnapshotPath returns the absolute snapshot directory for (name, hash) and
+// whether it currently exists on disk.
+func SnapshotPath(name, bundleHash string) (string, bool) {
+	d := dir()
+	if d == "" {
+		return "", false
+	}
+	p := filepath.Join(d, snapshotRel(name, bundleHash))
+	if fi, err := os.Stat(p); err == nil && fi.IsDir() {
+		return p, true
+	}
+	return p, false
+}
+
+// Snapshot freezes srcDir into the snapshot location for (name, hash) and
+// returns the snapshot directory. It is idempotent and content-addressed: an
+// existing snapshot for the same (name, hash) is returned unchanged (the
+// content is identical by construction). The copy is staged in a temp dir and
+// atomically renamed into place, so a snapshot directory is never partial.
+func Snapshot(name, bundleHash, srcDir string) (string, error) {
+	d := dir()
+	if d == "" {
+		return "", errNoGlobalDir
+	}
+	dst := filepath.Join(d, snapshotRel(name, bundleHash))
+	if fi, err := os.Stat(dst); err == nil && fi.IsDir() {
+		return dst, nil
+	}
+	parent := filepath.Dir(dst)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return "", fmt.Errorf("snapshot: mkdir: %w", err)
+	}
+	tmp, err := os.MkdirTemp(parent, ".tmp-*")
+	if err != nil {
+		return "", fmt.Errorf("snapshot: temp: %w", err)
+	}
+	if err := copyTree(srcDir, tmp); err != nil {
+		os.RemoveAll(tmp)
+		return "", fmt.Errorf("snapshot: copy: %w", err)
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		os.RemoveAll(tmp)
+		// A concurrent writer may have won the race; accept its result.
+		if fi, e2 := os.Stat(dst); e2 == nil && fi.IsDir() {
+			return dst, nil
+		}
+		return "", fmt.Errorf("snapshot: rename: %w", err)
+	}
+	return dst, nil
+}
+
+// removeSnapshot deletes the snapshot for (name, hash) and prunes the now-empty
+// per-name directory. Best-effort (used by Revoke).
+func removeSnapshot(name, bundleHash string) {
+	d := dir()
+	if d == "" {
+		return
+	}
+	_ = os.RemoveAll(filepath.Join(d, snapshotRel(name, bundleHash)))
+	_ = os.Remove(filepath.Join(d, "skills", name)) // succeeds only if empty
+}
+
+// copyTree recursively copies src into dst, which must already exist. It
+// captures a self-contained, immutable image of a skill:
+//   - directories are recreated (VCS metadata under .git is skipped),
+//   - regular files are copied with their mode bits (execute bits preserved),
+//   - symlinks are flattened to a copy of their target's CONTENT when the
+//     target resolves to a regular file (so a later repoint of the link cannot
+//     change what runs); links to directories or unresolvable targets are
+//     skipped.
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, rerr := filepath.Rel(src, p)
+		if rerr != nil {
+			return rerr
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return os.MkdirAll(target, 0o700)
+		}
+
+		info, ierr := d.Info()
+		if ierr != nil {
+			return ierr
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			// Flatten to the target's content if it is a regular file.
+			resolved, rerr := filepath.EvalSymlinks(p)
+			if rerr != nil {
+				return nil // dangling / unresolvable: drop it
+			}
+			ri, rierr := os.Stat(resolved)
+			if rierr != nil || !ri.Mode().IsRegular() {
+				return nil // non-regular target: drop it
+			}
+			return copyFile(resolved, target, ri.Mode().Perm())
+		}
+		if !info.Mode().IsRegular() {
+			return nil // sockets, devices, fifos: nothing to run
+		}
+		return copyFile(p, target, info.Mode().Perm())
+	})
+}
+
+// copyFile copies a single regular file, creating parent dirs as needed and
+// applying perm (so an executable entry-point stays executable).
+func copyFile(src, dst string, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/internal/skilltrust/snapshot.go
+++ b/internal/skilltrust/snapshot.go
@@ -41,32 +41,42 @@ func SnapshotPath(name, bundleHash string) (string, bool) {
 	return p, false
 }
 
-// IsSnapshotPath reports whether dir is an existing directory under the
+// IsSnapshotPath reports whether spawnDir is an existing directory under the
 // host-only snapshot root (<store>/skills). It is the spawn backstop: a
 // sidecar may run only from the snapshot area, which the sandbox cannot
-// write — so a path here is, by construction, host-frozen content. This is
-// stronger and simpler than re-hashing dir (the snapshot legitimately differs
-// from the workdir hash when symlinks are involved).
+// write — so a path here is, by construction, host-frozen content.
+//
+// This is stronger than re-hashing spawnDir, which is why it is the backstop:
+// a hash check accepts ANY path whose content matches an approval, including
+// the agent-writable workdir itself (and re-opens the check-then-exec TOCTOU
+// that snapshotting exists to close). Location, not content, is the property
+// the sandbox boundary actually guarantees.
 func IsSnapshotPath(spawnDir string) bool {
 	d := dir()
 	if d == "" || spawnDir == "" {
 		return false
 	}
-	root := filepath.Join(d, "skills")
-	rel, err := filepath.Rel(root, spawnDir)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if !containedIn(filepath.Join(d, "skills"), spawnDir) {
 		return false
 	}
 	fi, err := os.Stat(spawnDir)
 	return err == nil && fi.IsDir()
 }
 
-// Snapshot freezes srcDir into the snapshot location for (name, hash) and
+// containedIn reports whether path lies strictly inside root. Used both to
+// confine the spawn backstop to the snapshot area and to keep snapshotted
+// symlinks from escaping the skill tree.
+func containedIn(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// snapshot freezes srcDir into the snapshot location for (name, hash) and
 // returns the snapshot directory. It is idempotent and content-addressed: an
 // existing snapshot for the same (name, hash) is returned unchanged (the
 // content is identical by construction). The copy is staged in a temp dir and
 // atomically renamed into place, so a snapshot directory is never partial.
-func Snapshot(name, bundleHash, srcDir string) (string, error) {
+func snapshot(name, bundleHash, srcDir string) (string, error) {
 	d := dir()
 	if d == "" {
 		return "", errNoGlobalDir
@@ -173,8 +183,7 @@ func copyInTreeSymlink(p, target, srcReal string) error {
 	if err != nil {
 		return nil // dangling / unresolvable: drop
 	}
-	rel, err := filepath.Rel(srcReal, resolved)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if !containedIn(srcReal, resolved) {
 		return nil // escapes the skill tree: drop
 	}
 	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {


### PR DESCRIPTION
**Issue:** Closes #209

> **Stacked on #211** (base branch `fix/skill-spawn-approval-anchor`). Review/merge #211 first; this targets that branch, so the diff here is only the snapshot layer.

## What
- Freeze a skill's whole tree into a host-only, content-addressed snapshot at approval time (`~/.config/omac/skills/<name>/<hash>`), with in-tree symlinks flattened to their target content.
- Spawn the sidecar **from the snapshot**, not the agent-writable workdir (all paths: start cold-start, live-reload, serve).
- `skilltrust.Approve` creates the snapshot; `Revoke` removes it.

## Why
The approval was keyed on `config.BundleHash`, which excludes `node_modules`/`.venv`/`dist`/`build`/`target` and skips symlinks. So an approved skill executing code from an excluded tree (`node dist/index.js`, a vendored `.venv`) or via a symlink could be tampered with in the workdir **after** approval without changing its hash — plus a check-then-exec TOCTOU. This was the top residual from #208's review.

## How
The snapshot is the enforcement boundary: executed bytes == approved bytes, captured when a host-side actor approves. `~/.config/omac` is never mounted into the sandbox, so the agent cannot touch the snapshot. `approvedSpawnDir(name, workdirDir)` hashes the workdir content, matches the approval, and returns the frozen snapshot dir to spawn from. Snapshots are content-addressed (identical content stored once; re-approval idempotent) and GC'd on deregister.

## Verification
- `go build ./...`, `go vet ./internal/...` — clean.
- `go test $(go list ./internal/... | grep -v /internal/e2e)` — green.
- `go test -tags=e2e_fast -count=1 ./internal/e2e/` — green.
- **`TestSnapshotDefeatsPostApprovalTampering`**: approve a skill reading a `.venv/` payload (excluded from the hash), rewrite that payload in the workdir (hash unchanged), reload — the sidecar serves the **frozen** payload, not the tamper.
- `TestSnapshotFreezesContentAndRevokeRemovesIt`: snapshot is immutable to source edits and removed on revoke.

## Follow-up
- #210 — authenticate the control plane (serve `deactivate` DoS; per-caller identity; approval rollback/XDG notes) — still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)