### PR TITLE
fix(sandbox): make the denial marker inert when sourced

### DIFF
--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -134,6 +134,16 @@ sandbox:
 | Environment variables in `environment.allow_vars` (`OMAC_*`, `HOME`, `PATH`, `LANG`, `TERM`, … + the selected harness's auth vars) | passed through | default profile `environment.allow_vars` + `harness.SandboxEnvAllow` (injected at launch) |
 | Any other ambient env var (cloud/CI secrets, `DOCKER_HOST`, `SSH_AUTH_SOCK`, proxy config) | **stripped** | not on the allowlist |
 
+> **Denial markers are inert.** On Linux a denied *file* inside a granted
+> tree is masked with a marker explaining the denial, not just hidden. The
+> protected set includes shell configs (`~/.profile`, `~/.bashrc`, …), which
+> exist to be executed, so every line of that marker is comment-prefixed
+> (`# X-Omac-Sandbox: denied`): a masked shell config sources as a silent
+> no-op while still telling the agent why the path is restricted. This also
+> applies to a profile's own `denial.marker_file` — the sandbox never binds
+> executable content over a file the confined process runs. Use
+> `filesystem.override_deny` when the agent genuinely needs the real file.
+
 > **Environment allowlist (upgrade note).** The default profile ships an
 > explicit `environment.allow_vars` allowlist, so the sandbox no longer
 > inherits arbitrary ambient variables from the launching shell — only the

--- a/internal/sandboxdeny/deny.go
+++ b/internal/sandboxdeny/deny.go
@@ -7,6 +7,8 @@
 // All user-facing strings live here so they form a single tunable knob.
 package sandboxdeny
 
+import "strings"
+
 // Text holds the configurable denial messages. It is a programmatic value
 // type built by sandboxrun.resolvedDenial from sandboxprofile.Denial; it is
 // never (un)marshalled itself, so it carries no struct tags — the config
@@ -14,6 +16,8 @@ package sandboxdeny
 type Text struct {
 	// MarkerFile is written into the sandbox over a protected file (Linux
 	// bwrap fast path). The first line is a machine-parseable sentinel.
+	// Stored as plain prose; Inert comment-prefixes it on the way into
+	// the sandbox (see prepareMarkers).
 	MarkerFile string
 
 	// MarkerDirName is the name of the placeholder file placed inside a
@@ -62,6 +66,38 @@ The user will see your reason when reviewing access.
 			"not grant access and raises no dialog. So tell the user which path you need and why, and ask " +
 			"them to add it and relaunch — do not tell them to approve a popup.",
 	}
+}
+
+// Inert returns text safe to bind over a file the confined process may
+// execute — a shell config, .envrc, .env. Every content line is
+// comment-prefixed, so sourcing the marker is a silent no-op while the
+// text stays readable and greppable (the sentinel survives as
+// "# X-Omac-Sandbox: denied").
+//
+// The sandbox must never inject executable content into the process it
+// confines — not its own denial text, and not text a profile author
+// supplied via denial.marker_file. Before this, the default marker's
+// "  POST $OMAC_BASE/sandbox/intent ..." line hung every login shell on
+// hosts where /usr/bin/POST is libwww-perl's lwp-request, which blocks
+// reading its body from stdin (#213).
+//
+// "#" comments every format the protected set covers: sh, bash, zsh,
+// fish, .envrc, .env, .npmrc, ini. Lines already commented are left
+// alone (no "# #" doubling) and blank lines are preserved, so Inert is
+// idempotent.
+func Inert(text string) string {
+	if text == "" {
+		return ""
+	}
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimLeft(line, " \t")
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		lines[i] = "# " + line
+	}
+	return strings.Join(lines, "\n")
 }
 
 // Resolve returns override when it has non-empty MarkerFile content,

--- a/internal/sandboxdeny/deny_test.go
+++ b/internal/sandboxdeny/deny_test.go
@@ -47,6 +47,53 @@ func TestResolveEmptyFallsBack(t *testing.T) {
 	}
 }
 
+// TestInertCommentsEveryContentLine guards #213: the default marker is
+// bound over shell configs, so every line that carries content must be
+// a comment — one uncommented line is one command the login shell runs.
+func TestInertCommentsEveryContentLine(t *testing.T) {
+	got := Inert(Default().MarkerFile)
+	for i, line := range strings.Split(got, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if !strings.HasPrefix(strings.TrimLeft(line, " \t"), "#") {
+			t.Errorf("line %d is executable content: %q", i+1, line)
+		}
+	}
+	// Still readable and greppable after neutralization.
+	for _, want := range []string{"X-Omac-Sandbox: denied", "/sandbox/intent", "intentionally"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("inert marker lost %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestInertIsIdempotentAndPreservesShape(t *testing.T) {
+	const in = "X-Omac-Sandbox: denied\n\n# already a comment\n  indented line\n"
+	const want = "# X-Omac-Sandbox: denied\n\n# already a comment\n#   indented line\n"
+	got := Inert(in)
+	if got != want {
+		t.Errorf("Inert(%q) = %q; want %q", in, got, want)
+	}
+	if again := Inert(got); again != got {
+		t.Errorf("Inert not idempotent: %q -> %q", got, again)
+	}
+	if Inert("") != "" {
+		t.Errorf("Inert(\"\") = %q; want empty", Inert(""))
+	}
+}
+
+// TestInertNeutralizesHostileOverride pins the scope note in #213:
+// denial.marker_file is profile-configurable, so a profile author must
+// not be able to place a command into a file the sandboxed process
+// executes.
+func TestInertNeutralizesHostileOverride(t *testing.T) {
+	got := Inert(Resolve(Text{MarkerFile: "touch /tmp/pwned\nrm -rf ~\n"}).MarkerFile)
+	if got != "# touch /tmp/pwned\n# rm -rf ~\n" {
+		t.Errorf("hostile marker not neutralized: %q", got)
+	}
+}
+
 func TestDefaultMentionsIntent(t *testing.T) {
 	d := Default()
 	if !strings.Contains(d.MarkerFile, "/sandbox/intent") {

--- a/internal/sandboxrun/bwrap_marker_test.go
+++ b/internal/sandboxrun/bwrap_marker_test.go
@@ -11,6 +11,33 @@ import (
 
 const testDenialText = "X-Omac-Sandbox: denied\nprotected\n"
 
+// wantInertMarker asserts the bytes bwrap binds into the sandbox carry
+// the denial text but cannot execute: every content line is commented
+// (#213 — the marker is bound over shell configs, which get sourced).
+func wantInertMarker(t *testing.T, path, wantText string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("marker unreadable: %v", err)
+	}
+	for i, line := range strings.Split(string(got), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if !strings.HasPrefix(strings.TrimLeft(line, " \t"), "#") {
+			t.Errorf("%s line %d is executable content: %q", path, i+1, line)
+		}
+	}
+	for _, want := range strings.Split(strings.TrimSpace(wantText), "\n") {
+		if want == "" {
+			continue
+		}
+		if !strings.Contains(string(got), strings.TrimSpace(want)) {
+			t.Errorf("%s lost denial text %q, got:\n%s", path, want, got)
+		}
+	}
+}
+
 func TestBwrapMarkerFileUsedWhenDenialTextSet(t *testing.T) {
 	home := t.TempDir()
 	netrc := filepath.Join(home, ".netrc")
@@ -42,13 +69,40 @@ func TestBwrapMarkerFileUsedWhenDenialTextSet(t *testing.T) {
 		t.Errorf("no marker-file bind found: %s", joined)
 	}
 	// The bind source must exist (bwrap reads it at launch) and carry the
-	// denial text verbatim.
+	// denial text — in its inert form, since the same marker masks shell
+	// configs.
+	wantInertMarker(t, g.markerFile, testDenialText)
+}
+
+// TestBwrapMarkerNeutralizesHostileDenialText pins the scope note in
+// #213: denial.marker_file is profile-configurable, so a profile must
+// not be able to bind a command over a file the sandboxed process
+// sources.
+func TestBwrapMarkerNeutralizesHostileDenialText(t *testing.T) {
+	home := t.TempDir()
+	profile := filepath.Join(home, ".profile")
+	if err := os.WriteFile(profile, []byte("export SECRET=1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	g := &Grants{
+		Workdir:        home,
+		AllowPaths:     []string{home},
+		ProtectedPaths: []string{profile},
+		NetworkMode:    sandboxprofile.ModeBlocked,
+		DenialText:     "touch " + filepath.Join(home, "pwned") + "\n",
+	}
+	cleanup, err := g.prepareMarkers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
 	got, err := os.ReadFile(g.markerFile)
 	if err != nil {
-		t.Fatalf("marker file unreadable: %v", err)
+		t.Fatal(err)
 	}
-	if string(got) != testDenialText {
-		t.Errorf("marker file content = %q, want %q", got, testDenialText)
+	if want := "# touch " + filepath.Join(home, "pwned") + "\n"; string(got) != want {
+		t.Errorf("marker file = %q; want neutralized %q", got, want)
 	}
 }
 
@@ -84,13 +138,7 @@ func TestBwrapMarkerDirUsedWhenDenialTextSet(t *testing.T) {
 	}
 	// The .omac-denied file inside the marker dir must exist and carry the
 	// denial text (not, e.g., a temp-file path — regression guard).
-	got, err := os.ReadFile(filepath.Join(g.markerDir, markerDirFileName))
-	if err != nil {
-		t.Fatalf("marker-dir notice unreadable: %v", err)
-	}
-	if string(got) != testDenialText {
-		t.Errorf("marker-dir notice content = %q, want %q", got, testDenialText)
-	}
+	wantInertMarker(t, filepath.Join(g.markerDir, markerDirFileName), testDenialText)
 }
 
 func TestBwrapMarkerDirHonorsCustomName(t *testing.T) {

--- a/internal/sandboxrun/grants.go
+++ b/internal/sandboxrun/grants.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxdeny"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
 )
 
@@ -54,6 +55,9 @@ type Grants struct {
 	// DenialText holds the configurable marker-file content written over
 	// protected files (Linux bwrap fast path). When empty, bwrap falls
 	// back to /dev/null (opaque ENOENT/EACCES, the historical behavior).
+	// Held as plain prose: prepareMarkers runs it through
+	// sandboxdeny.Inert before it becomes a bind source, so a masked
+	// shell config cannot execute it.
 	DenialText string
 
 	// DenialDirName is the filename of the notice placed inside a masked
@@ -79,6 +83,14 @@ const markerDirFileName = ".omac-denied"
 // files, and a directory holding a single .omac-denied file bound over
 // protected directories. Both carry DenialText.
 //
+// The text is written in its inert (comment-prefixed) form: the baseline
+// protected set includes shell configs, which exist to be executed, so a
+// marker of plain prose bound over ~/.profile is sourced by every login
+// shell inside the sandbox (#213). Neutralizing here — at the boundary
+// where bytes enter the sandbox — covers profile-supplied
+// denial.marker_file text too, so no profile can inject commands into
+// the process omac is confining.
+//
 // It sets g.markerFile and g.markerDir and returns a cleanup that removes
 // the backing temp dir. The caller MUST defer cleanup until after the
 // sandbox process has exited: bwrap reads bind sources at launch, not at
@@ -97,8 +109,9 @@ func (g *Grants) prepareMarkers() (func(), error) {
 		return noop, err
 	}
 	cleanup := func() { _ = os.RemoveAll(dir) }
+	text := []byte(sandboxdeny.Inert(g.DenialText))
 	markerFile := filepath.Join(dir, "file")
-	if err := os.WriteFile(markerFile, []byte(g.DenialText), 0o444); err != nil {
+	if err := os.WriteFile(markerFile, text, 0o444); err != nil {
 		cleanup()
 		return noop, err
 	}
@@ -111,7 +124,7 @@ func (g *Grants) prepareMarkers() (func(), error) {
 	if dirFileName == "" {
 		dirFileName = markerDirFileName
 	}
-	if err := os.WriteFile(filepath.Join(markerDir, dirFileName), []byte(g.DenialText), 0o444); err != nil {
+	if err := os.WriteFile(filepath.Join(markerDir, dirFileName), text, 0o444); err != nil {
 		cleanup()
 		return noop, err
 	}

--- a/internal/sandboxrun/integration_linux_test.go
+++ b/internal/sandboxrun/integration_linux_test.go
@@ -3,6 +3,8 @@
 package sandboxrun
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -12,7 +14,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxdeny"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
 )
 
@@ -60,6 +64,42 @@ func runBwrapped(t *testing.T, g *Grants, innerArgv ...string) (string, int) {
 		}
 	}
 	return string(out), code
+}
+
+// runBwrappedShell runs a shell command inside the sandbox with stdin
+// held open (as a harness holds its Bash tool's) and a deadline, so a
+// hang inside the namespace fails the test instead of the package.
+// finished=false means the deadline killed it.
+func runBwrappedShell(t *testing.T, g *Grants, timeout time.Duration, script string) (out string, code int, finished bool) {
+	t.Helper()
+	argv, err := BuildBwrapArgv(g, []string{"/bin/sh", "-c", script})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Stdin = r
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	// A process blocking on stdin outlives the kill and holds the output
+	// pipe open; WaitDelay stops Wait from blocking on it.
+	cmd.WaitDelay = 2 * time.Second
+	err = cmd.Run()
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil && ctx.Err() == nil {
+		t.Fatalf("exec: %v (%s)", err, buf.String())
+	}
+	return buf.String(), code, ctx.Err() == nil
 }
 
 func linuxTestGrants(t *testing.T) *Grants {
@@ -208,6 +248,58 @@ func TestIntegrationProtectedMarkerLaunchAndContent(t *testing.T) {
 	}
 	if _, code := runBwrapped(t, g, "/bin/cat", filepath.Join(secretDir, "key")); code == 0 {
 		t.Error("masked directory still exposes its original contents")
+	}
+}
+
+// TestIntegrationMaskedShellConfigSourcesCleanly is the end-to-end form
+// of #213: with $HOME as the workdir, ~/.profile is mounted and masked,
+// so every login shell inside the sandbox sources the marker. A marker
+// of plain prose hung there forever (its "POST ..." line runs
+// libwww-perl's lwp-request, which blocks on stdin) and spewed
+// command-not-found. The masked file must still hide its real contents.
+func TestIntegrationMaskedShellConfigSourcesCleanly(t *testing.T) {
+	requireBwrap(t)
+	if _, err := exec.LookPath("bash"); err != nil {
+		skipOrFailCI(t, "bash not installed: %v", err)
+	}
+	home := t.TempDir() // stands in for $HOME as the workdir
+	profile := filepath.Join(home, ".profile")
+	if err := os.WriteFile(profile, []byte("export TOPSECRET=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := &sandboxprofile.Profile{
+		Workdir: sandboxprofile.Workdir{Access: sandboxprofile.AccessReadWrite},
+		Network: sandboxprofile.Network{Mode: sandboxprofile.ModeBlocked},
+	}
+	g, err := ResolveGrants(p, home, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g.DenialText = sandboxdeny.Default().MarkerFile
+	g.ProtectedPaths = append(g.ProtectedPaths, profile)
+	cleanup, err := g.prepareMarkers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	// The stub POST stands in for libwww-perl's lwp-request so the hang
+	// reproduces on hosts without it installed.
+	stub := postStubDir(t)
+	script := "export HOME=" + home + "; export OMAC_BASE=http://127.0.0.1:9; " +
+		"export PATH=" + stub + ":$PATH; bash -lc 'echo REACHED'"
+	out, code, finished := runBwrappedShell(t, g, 30*time.Second, script)
+	if !finished {
+		t.Fatalf("login shell hung on the masked ~/.profile: %s", out)
+	}
+	if code != 0 || !strings.Contains(out, "REACHED") {
+		t.Errorf("login shell exit %d, output %q; want 0 and REACHED", code, out)
+	}
+	if strings.Contains(out, "command not found") {
+		t.Errorf("marker executed as shell commands: %q", out)
+	}
+	if strings.Contains(out, "TOPSECRET") {
+		t.Errorf("masked ~/.profile leaked its real contents: %q", out)
 	}
 }
 

--- a/internal/sandboxrun/marker_inert_exec_test.go
+++ b/internal/sandboxrun/marker_inert_exec_test.go
@@ -1,0 +1,121 @@
+package sandboxrun
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxdeny"
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
+)
+
+// The marker written over a protected file also lands over the shell
+// configs in the baseline protected set, so a login shell inside the
+// sandbox sources it. Nothing used to source a masked file — the marker
+// tests only read .netrc/.ssh, which are data — and the default text's
+// "  POST $OMAC_BASE/sandbox/intent ..." line hung every bash invocation
+// on hosts where /usr/bin/POST is libwww-perl's lwp-request, which
+// blocks reading its request body from stdin (#213).
+//
+// These tests source the real production marker bytes with a stub POST
+// on PATH, so the hang reproduces deterministically without libwww-perl
+// installed. They need no sandbox: the issue reproduced outside one.
+
+// postStubDir returns a directory holding an executable `POST` that
+// blocks forever on stdin, standing in for lwp-request.
+func postStubDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "POST")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\ncat > /dev/null\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// sourceUnderStub sources path with bash, holding stdin open the way a
+// harness does, and returns stdout, stderr and whether bash finished
+// before the deadline.
+func sourceUnderStub(t *testing.T, path string, timeout time.Duration) (stdout, stderr string, finished bool) {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not installed: %v", err)
+	}
+	// An open pipe stands in for the harness's stdin: without it bash
+	// inherits /dev/null and the stub returns immediately on EOF, hiding
+	// the hang this test exists to catch.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "-c", "source "+path+"; echo REACHED")
+	cmd.Stdin = r
+	cmd.Env = append(os.Environ(),
+		"PATH="+postStubDir(t)+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"OMAC_BASE=http://127.0.0.1:9",
+	)
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	// The stub POST outlives the bash the deadline kills and keeps the
+	// inherited stdout pipe open, so Wait would block on the output-copy
+	// goroutines forever. WaitDelay closes them shortly after the kill.
+	cmd.WaitDelay = 2 * time.Second
+	err = cmd.Run()
+	return out.String(), errb.String(), ctx.Err() == nil && err == nil
+}
+
+func TestMarkerFileIsInertWhenSourced(t *testing.T) {
+	home := t.TempDir()
+	profile := filepath.Join(home, ".profile")
+	if err := os.WriteFile(profile, []byte("export SECRET=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	g := &Grants{
+		Workdir:        home,
+		AllowPaths:     []string{home},
+		ProtectedPaths: []string{profile},
+		NetworkMode:    sandboxprofile.ModeBlocked,
+		DenialText:     sandboxdeny.Default().MarkerFile,
+	}
+	cleanup, err := g.prepareMarkers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	stdout, stderr, finished := sourceUnderStub(t, g.markerFile, 20*time.Second)
+	if !finished {
+		t.Fatalf("sourcing the marker did not complete: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "REACHED") {
+		t.Errorf("shell did not reach the end: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if stderr != "" {
+		t.Errorf("shell init noise from the marker: %q", stderr)
+	}
+}
+
+// TestRawMarkerTextHangsWhenSourced proves the guard above can actually
+// fail: the same text without neutralization is executable, so it hangs
+// on the stub POST (or at minimum spews command-not-found).
+func TestRawMarkerTextHangsWhenSourced(t *testing.T) {
+	raw := filepath.Join(t.TempDir(), "raw")
+	if err := os.WriteFile(raw, []byte(sandboxdeny.Default().MarkerFile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, finished := sourceUnderStub(t, raw, 5*time.Second)
+	if finished && stderr == "" {
+		t.Errorf("raw marker text sourced cleanly — the inert test proves nothing: stdout=%q", stdout)
+	}
+}


### PR DESCRIPTION
**Issue:** Closes #213

## What

- Marker text written over a protected file is now comment-prefixed
  before it becomes a bwrap bind source, so sourcing it is a silent
  no-op.
- Applies to the compiled-in default *and* a profile's own
  `denial.marker_file`, for both the file marker and the `.omac-denied`
  dir notice.
- Adds the missing coverage: nothing previously sourced a masked file.

## Why

The baseline protected set includes shell configs, which exist to be
executed. With `$HOME` as the workdir, `~/.profile` is mounted, masked
with the marker, and sourced by every login shell inside the sandbox.
Line 7 of the default text starts with `POST` — on Debian/Ubuntu
`/usr/bin/POST` is libwww-perl's `lwp-request`, which blocks reading its
body from stdin — so **every `bash` invocation hung forever**. Harnesses
initialise their Bash tool from a login shell, which left the agent with
no shell and no tool calls. Without libwww-perl it merely emitted five
`command not found` errors into every shell init.

Denying shell configs is intentional and stays. The defect was
delivering the denial as executable content — which also meant a profile
author could put arbitrary commands into a file the confined process
runs.

## How

- `internal/sandboxdeny/deny.go` — new `Inert(text)`: comment-prefixes
  every content line, leaves blank and already-commented lines alone, so
  it is idempotent. `Default()` keeps its prose form; the transformation
  happens on the way into the sandbox, not in the string table, so the
  sentinel survives as `# X-Omac-Sandbox: denied`.
- `internal/sandboxrun/grants.go:112` — `prepareMarkers` writes
  `sandboxdeny.Inert(g.DenialText)`. Neutralizing at the boundary where
  bytes enter the sandbox covers profile-supplied text for free. The
  empty-text `/dev/null` fallback is unchanged.
- `internal/sandboxrun/marker_inert_exec_test.go` — sources the real
  production marker with a stub `POST` on `PATH` that blocks on stdin, so
  the hang reproduces deterministically without libwww-perl installed.
  A companion test asserts the *raw* text does not source cleanly, so
  the guard cannot silently become vacuous.
- `internal/sandboxrun/integration_linux_test.go` — bwrap end-to-end: a
  temp `$HOME` whose `.profile` is masked, running `bash -lc 'echo
  REACHED'` with stdin held open under a deadline. Adds
  `runBwrappedShell` so a regression fails fast instead of hanging the
  package.
- `internal/sandboxrun/bwrap_marker_test.go` — the two exact-equality
  assertions on written bytes become inertness checks; new case pins the
  hostile `marker_file` vector.
- `docs/SECURITY_MODEL.md` — notes that markers are inert and that
  `filesystem.override_deny` remains the way to reach the real file.

`internal/sandboxbrief/brief.md` is deliberately untouched: the sentinel
is still a substring, and the brief costs context in every session.

## Verification

Linux (Pop!_OS, bash 5.2.21, git 2.43, `/usr/bin/POST` -> `lwp-request`
present, so the bug reproduced here):

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — pass except two failures that also fail on
  unmodified `main` on this host (verified by stashing the change):
  `TestIntegrationWorkflowInterpretersRunnable/node` (node installed
  outside every granted path, so invisible in the sandbox) and
  `TestIntegrationWorktreeKnownLimitations` (git 2.43 reports the
  `packed-refs` EBUSY as `fatal:`, which the assertion doesn't
  tolerate). Neither touches this change.
- `go test -race -count=1 ./internal/sandboxdeny/... ./internal/sandboxrun/...` — pass
- `go test -tags=e2e_fast -race -count=1 -timeout=5m ./internal/e2e/` — pass

Issue repro, from `$HOME` with stdin held open:

```
$ timeout 40 omac sandbox run --profile tng-default -- bash -lc 'echo REACHED' < <(sleep 60)
REACHED
exit=0          # was 124 (hung)

$ omac sandbox run --profile tng-default -- bash -lc 'cat ~/.profile'
# X-Omac-Sandbox: denied
# This path is protected by the omac sandbox policy and is intentionally
# restricted. ...
```

Mutation check: reverting only the `Inert` call makes all four
new/changed guards fail, with the issue's exact symptom
(`line 1: X-Omac-Sandbox:: command not found`, then a 30s hang) — so
they are not vacuous.

Acceptance criteria: (1) repro above, (2) empty stderr on shell init,
(3) the `cat` output plus the integration test's secret-absent
assertion, (4) `TestIntegrationOverrideDenyGrantsAccess` untouched and
passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
