### PR TITLE
fix(cli,sandbox): resolve the sandbox plan once so /sandbox/denied answers

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -109,7 +109,9 @@ environment variables.
 The built-in sandbox reads JSON profiles from
 `~/.config/omac/sandbox-profiles/`. On first `omac start` with the
 `builtin` profile, omac scaffolds `default.json` from the compiled-in
-defaults so you can edit it:
+defaults so you can edit it (only the launch itself writes it — the
+inspection commands `omac doctor`, `omac diagnose` and `omac provenance`
+read the compiled-in defaults instead of creating files):
 
 ```
 ~/.config/omac/sandbox-profiles/

--- a/internal/cli/diagnose.go
+++ b/internal/cli/diagnose.go
@@ -45,7 +45,7 @@ func runDiagnose(args []string, env *Env) int {
 		return ExitMisuse
 	}
 
-	profile, profPath, err := sandboxprofile.ResolveReadOnly(*profileRef)
+	profile, profPath, err := sandboxprofile.Resolve(*profileRef)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac diagnose:", err)
 		return ExitConfigInvalid

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -160,8 +160,10 @@ func runDoctor(args []string, env *Env) int {
 
 	// Static security lint of the resolved profile (advisory). Reuses the
 	// same engine as `omac provenance --check` — findings are warnings
-	// here, never a doctor failure.
-	doctorProfileLint(env, "")
+	// here, never a doctor failure. The ref follows the default launcher
+	// profile's template, so a config pointing at a non-default policy gets
+	// that policy linted rather than an unused "default".
+	doctorProfileLint(env, defaultPolicyRef(lc))
 
 	fmt.Fprintln(env.Stdout, "\nWhen a run fails, `omac diagnose` shows what the sandbox blocked and why.")
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -176,7 +176,7 @@ func runDoctor(args []string, env *Env) int {
 // the gap where doctor never surfaced the security lint (previously only
 // reachable via `omac provenance --check`).
 func doctorProfileLint(env *Env, profileRef string) {
-	profile, _, err := sandboxprofile.ResolveReadOnly(profileRef)
+	profile, _, err := sandboxprofile.Resolve(profileRef)
 	if err != nil {
 		return // profile problems are already reported by the sandbox section
 	}
@@ -282,13 +282,13 @@ func doctorSandboxProfileWarnings(env *Env, lc config.LauncherConfig) {
 		if len(prof.Command) == 0 {
 			continue
 		}
-		ref, ok := inspectBuiltinProfileRef(prof.Command)
-		if !ok {
+		ref, native := prof.PolicyRef()
+		if !native {
 			// Opaque external launcher (nono, no-sandbox-debug, etc.):
 			// doctor can't see into its profile, so skip silently.
 			continue
 		}
-		p, _, err := sandboxprofile.ResolveReadOnly(ref)
+		p, _, err := sandboxprofile.Resolve(ref)
 		if err != nil {
 			fmt.Fprintf(env.Stdout, "  [warn] sandbox profile %q: %v\n", profName, err)
 			continue
@@ -322,36 +322,6 @@ func doctorSandboxProfileWarnings(env *Env, lc config.LauncherConfig) {
 			fmt.Fprintf(env.Stdout, "         remediation: %s\n", w.remediation)
 		}
 	}
-}
-
-// inspectBuiltinProfileRef looks at a sandbox profile Command argv
-// template and, if it is a {{self}} sandbox run invocation, extracts
-// the --profile reference. Recognized run forms:
-//   - "--profile", "default"   (separate args)
-//   - "--profile=default"      (inline)
-//   - omitted --profile        (resolves to "default")
-//
-// Only {{self}} sandbox run commands are inspectable; other sandbox
-// subcommands and external launchers are opaque and return ok=false.
-func inspectBuiltinProfileRef(command []string) (string, bool) {
-	if len(command) < 3 || command[0] != "{{self}}" || command[1] != "sandbox" || command[2] != "run" {
-		return "", false
-	}
-	// Find "--profile" (separate or inline) before "--".
-	for i := 3; i < len(command); i++ {
-		arg := command[i]
-		if arg == "--" {
-			break
-		}
-		if arg == "--profile" && i+1 < len(command) {
-			return command[i+1], true
-		}
-		if strings.HasPrefix(arg, "--profile=") {
-			return strings.TrimPrefix(arg, "--profile="), true
-		}
-	}
-	// Omitted --profile resolves to "default".
-	return "default", true
 }
 
 // profileGrantWarnings returns warnings for broad tool-home and

--- a/internal/cli/facade_wiring.go
+++ b/internal/cli/facade_wiring.go
@@ -21,9 +21,17 @@ import (
 // disabling the endpoint. The intent registry is always wired: in-memory,
 // session-scoped, written by the agent via POST /sandbox/intent and read
 // by the popup via GET.
-func wireFacadeSandbox(f *facade.Facade, noSandbox bool, plan sandboxPlan, warn func(format string, args ...any)) {
+//
+// learnMode (`omac serve --learn`) is a launch fact the policy file cannot
+// carry: it lifts every filesystem restriction in the child, so the static
+// protected set must not be reported for that session.
+func wireFacadeSandbox(f *facade.Facade, noSandbox, learnMode bool, plan sandboxPlan, warn func(format string, args ...any)) {
 	if !noSandbox {
 		switch {
+		case learnMode:
+			// Nothing is protected in a learn session; say so rather than
+			// claiming the profile's static set is in force.
+			f.ProtectedPathChecker = sandboxrun.UnrestrictedProtectedPathSet()
 		case plan.Policy != nil:
 			f.ProtectedPathChecker = sandboxrun.NewProtectedPathSet(plan.Policy)
 			if d := plan.Policy.Denial; d != nil && d.FacadeNote != "" {

--- a/internal/cli/facade_wiring.go
+++ b/internal/cli/facade_wiring.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/facade"
 	"github.com/tngtech/oh-my-agentic-coder/internal/intent"
-	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxrun"
 )
 
@@ -11,24 +10,34 @@ import (
 // (/sandbox/denied and /sandbox/intent) to f. Shared by `start` and
 // `serve` so the two entry points cannot drift.
 //
-// When the sandbox is active it re-resolves the profile — cheap (path
-// expansion only, no existence walks) since the full grant resolution
-// happens inside the `omac sandbox run` child — to build the
-// protected-path checker the agent queries via GET /sandbox/denied?path=X
-// to tell a sandbox denial from a genuinely missing file. A resolve
-// failure is reported via warn rather than silently disabling the
-// endpoint. The intent registry is always wired: in-memory,
+// When the sandbox is active it builds the protected-path checker from the
+// plan's already-resolved policy profile — the set the agent queries via
+// GET /sandbox/denied?path=X to tell a sandbox denial from a genuinely
+// missing file. Taking the plan rather than a profile name is the fix for
+// #173: the callers hold a LAUNCHER profile name ("builtin"), which is not
+// a POLICY reference ("default"), and resolving the former as the latter
+// always failed — leaving the endpoint 404 on every default launch. A plan
+// without a usable policy is reported via warn rather than silently
+// disabling the endpoint. The intent registry is always wired: in-memory,
 // session-scoped, written by the agent via POST /sandbox/intent and read
 // by the popup via GET.
-func wireFacadeSandbox(f *facade.Facade, noSandbox bool, profName string, warn func(format string, args ...any)) {
+func wireFacadeSandbox(f *facade.Facade, noSandbox bool, plan sandboxPlan, warn func(format string, args ...any)) {
 	if !noSandbox {
-		if prof, _, err := sandboxprofile.Resolve(profName); err == nil {
-			f.ProtectedPathChecker = sandboxrun.NewProtectedPathSet(prof)
-			if prof.Denial != nil && prof.Denial.FacadeNote != "" {
-				f.DenialNote = prof.Denial.FacadeNote
+		switch {
+		case plan.Policy != nil:
+			f.ProtectedPathChecker = sandboxrun.NewProtectedPathSet(plan.Policy)
+			if d := plan.Policy.Denial; d != nil && d.FacadeNote != "" {
+				f.DenialNote = d.FacadeNote
 			}
-		} else {
-			warn("omac: sandbox profile %q could not be resolved: %v; GET /sandbox/denied disabled", profName, err)
+		case plan.PolicyErr != nil:
+			warn("omac: sandbox profile %q could not be resolved: %v; GET /sandbox/denied disabled",
+				plan.PolicyRef, plan.PolicyErr)
+		default:
+			// An external launcher (nono), the no-sandbox debug shell, or
+			// an unknown profile name: omac cannot see the policy, so it
+			// cannot say which paths that sandbox protects.
+			warn("omac: sandbox profile %q does not run omac's native sandbox; GET /sandbox/denied disabled",
+				plan.Name)
 		}
 	}
 	f.IntentRegistry = intent.New(intent.DefaultTTL)

--- a/internal/cli/facade_wiring_test.go
+++ b/internal/cli/facade_wiring_test.go
@@ -14,13 +14,18 @@ import (
 // ("" = the config default) and returns the facade plus any warnings.
 func wireForTest(t *testing.T, launcherProfile string, noSandbox bool) (*facade.Facade, []string) {
 	t.Helper()
+	return wireModeForTest(t, launcherProfile, noSandbox, false)
+}
+
+func wireModeForTest(t *testing.T, launcherProfile string, noSandbox, learnMode bool) (*facade.Facade, []string) {
+	t.Helper()
 	plan, err := resolveSandboxPlan(config.DefaultLauncherConfig(), launcherProfile)
 	if err != nil {
 		t.Fatalf("resolveSandboxPlan(%q): %v", launcherProfile, err)
 	}
 	f := facade.New("", "", nil, 0, 0, "", "test")
 	var warnings []string
-	wireFacadeSandbox(f, noSandbox, plan, func(format string, args ...any) {
+	wireFacadeSandbox(f, noSandbox, learnMode, plan, func(format string, args ...any) {
 		warnings = append(warnings, fmt.Sprintf(format, args...))
 	})
 	return f, warnings
@@ -117,5 +122,29 @@ func TestWireFacadeSandboxNoSandboxIsSilent(t *testing.T) {
 	}
 	if f.IntentRegistry == nil {
 		t.Error("IntentRegistry must be wired even without a sandbox")
+	}
+}
+
+// TestWireFacadeSandboxLearnModeProtectsNothing: `omac serve --learn` lifts
+// every filesystem restriction in the child (Grants.withUnrestrictedFilesystem
+// drops ProtectedPaths and grants "/"), so the endpoint must not report the
+// profile's static set — that would tell the agent a genuinely missing file
+// was blocked by the sandbox, inverting the very confusion the endpoint
+// exists to remove.
+func TestWireFacadeSandboxLearnModeProtectsNothing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	f, warnings := wireModeForTest(t, "", false, true)
+
+	if len(warnings) != 0 {
+		t.Errorf("learn mode must not warn; got %v", warnings)
+	}
+	if f.ProtectedPathChecker == nil {
+		t.Fatal("learn mode should still answer the endpoint (with denied:false), not 404")
+	}
+	creds := filepath.Join(home, ".aws", "credentials")
+	if rule, ok := f.ProtectedPathChecker.IsProtected(creds); ok {
+		t.Errorf("IsProtected(%q) = (%q, true) under --learn; nothing is protected in a learn session", creds, rule)
 	}
 }

--- a/internal/cli/facade_wiring_test.go
+++ b/internal/cli/facade_wiring_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/tngtech/oh-my-agentic-coder/internal/facade"
+)
+
+// wireForTest runs the real launch wiring for the named launcher profile
+// ("" = the config default) and returns the facade plus any warnings.
+func wireForTest(t *testing.T, launcherProfile string, noSandbox bool) (*facade.Facade, []string) {
+	t.Helper()
+	plan, err := resolveSandboxPlan(config.DefaultLauncherConfig(), launcherProfile)
+	if err != nil {
+		t.Fatalf("resolveSandboxPlan(%q): %v", launcherProfile, err)
+	}
+	f := facade.New("", "", nil, 0, 0, "", "test")
+	var warnings []string
+	wireFacadeSandbox(f, noSandbox, plan, func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+	return f, warnings
+}
+
+// TestWireFacadeSandboxDefaultProfileWiresChecker is the regression guard
+// for #173: the default launch resolves the LAUNCHER profile "builtin",
+// whose POLICY ref is "default". Feeding the launcher name to the policy
+// resolver (what wireFacadeSandbox used to do) always failed, leaving
+// ProtectedPathChecker nil and GET /sandbox/denied answering 404 on every
+// default `omac start` / `omac serve` — the endpoint's whole purpose is to
+// distinguish a sandbox denial from a missing file.
+func TestWireFacadeSandboxDefaultProfileWiresChecker(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	f, warnings := wireForTest(t, "", false)
+
+	if len(warnings) != 0 {
+		t.Errorf("default profile must wire cleanly; got warnings: %v", warnings)
+	}
+	if f.ProtectedPathChecker == nil {
+		t.Fatal("ProtectedPathChecker is nil; GET /sandbox/denied would 404 on a default launch")
+	}
+	// A baseline-protected path must be recognized, so the agent gets a
+	// real answer rather than a 404.
+	creds := filepath.Join(home, ".aws", "credentials")
+	rule, ok := f.ProtectedPathChecker.IsProtected(creds)
+	if !ok {
+		t.Errorf("IsProtected(%q) = false; baseline credentials path must be protected", creds)
+	}
+	if rule != "baseline" {
+		t.Errorf("rule = %q, want baseline", rule)
+	}
+	if _, ok := f.ProtectedPathChecker.IsProtected(filepath.Join(home, "code", "main.go")); ok {
+		t.Error("an ordinary path must not be reported as protected")
+	}
+	if f.IntentRegistry == nil {
+		t.Error("IntentRegistry is nil; POST /sandbox/intent would 503")
+	}
+}
+
+// TestWireFacadeSandboxAppliesDenialFacadeNote: denial.facade_note from the
+// resolved POLICY profile must reach f.DenialNote — it never did while the
+// resolution failed.
+func TestWireFacadeSandboxAppliesDenialFacadeNote(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	const note = "custom note from the profile"
+	stageProfile(t, home, `{"meta": {"name": "default"}, "denial": {"facade_note": "`+note+`"}}`)
+
+	f, warnings := wireForTest(t, "", false)
+
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+	if f.DenialNote != note {
+		t.Errorf("DenialNote = %q, want %q", f.DenialNote, note)
+	}
+}
+
+// TestWireFacadeSandboxOpaqueLauncherDisablesEndpoint: an external launcher
+// (nono) has no omac policy to read, so the endpoint stays off — but the
+// warning now says why, instead of reporting a bogus resolve failure for a
+// policy file that was never meant to exist.
+func TestWireFacadeSandboxOpaqueLauncherDisablesEndpoint(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	f, warnings := wireForTest(t, "nono", false)
+
+	if f.ProtectedPathChecker != nil {
+		t.Error("an opaque launcher must not get a protected-path checker")
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "nono") {
+		t.Errorf("expected one warning naming the launcher profile; got %v", warnings)
+	}
+	if f.IntentRegistry == nil {
+		t.Error("IntentRegistry must be wired regardless of the sandbox backend")
+	}
+}
+
+// TestWireFacadeSandboxNoSandboxIsSilent: with --no-sandbox there is no
+// sandbox to describe, so the checker stays nil and nothing is warned.
+func TestWireFacadeSandboxNoSandboxIsSilent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	f, warnings := wireForTest(t, "", true)
+
+	if f.ProtectedPathChecker != nil {
+		t.Error("--no-sandbox must not wire a protected-path checker")
+	}
+	if len(warnings) != 0 {
+		t.Errorf("--no-sandbox must not warn; got %v", warnings)
+	}
+	if f.IntentRegistry == nil {
+		t.Error("IntentRegistry must be wired even without a sandbox")
+	}
+}

--- a/internal/cli/provenance_test.go
+++ b/internal/cli/provenance_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
 	"github.com/tngtech/oh-my-agentic-coder/internal/toolcache"
 )
 
@@ -624,5 +625,33 @@ func TestBuildCacheView_ErrorNotSwallowed(t *testing.T) {
 	}
 	if cv.Path != "" {
 		t.Errorf("expected empty cacheView on error; got Path=%q", cv.Path)
+	}
+}
+
+// Provenance is an inspection command: like `omac diagnose` it must not
+// scaffold default.json in a fresh home. (Regression guard for #173: it
+// used the mutating resolver, so merely viewing the effective policy —
+// or running --check — wrote a file into the user's config dir.)
+func TestProvenanceDoesNotScaffoldProfileInFreshHome(t *testing.T) {
+	for _, args := range [][]string{{}, {"--check"}} {
+		name := "view"
+		if len(args) > 0 {
+			name = args[0]
+		}
+		t.Run(name, func(t *testing.T) {
+			isolateHome(t)
+			env, _, _, drain := newPipeEnv(t, "")
+			env.Workdir = t.TempDir()
+			_ = runProvenance(args, env)
+			drain()
+
+			defaultPath, err := sandboxprofile.ProfilePath("default")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
+				t.Errorf("provenance %v scaffolded %s; must be read-only", args, defaultPath)
+			}
+		})
 	}
 }

--- a/internal/cli/sandboxplan.go
+++ b/internal/cli/sandboxplan.go
@@ -88,3 +88,21 @@ func resolveSandboxPlan(lc config.LauncherConfig, flagProfile string) (sandboxPl
 	plan.PolicyPath = path
 	return plan, nil
 }
+
+// defaultPolicyRef returns the policy ref the configured DEFAULT launcher
+// profile points at — the policy a plain `omac start` would enforce. Empty
+// means "the default policy": either the launcher profile is opaque (an
+// external launcher has no omac policy) or it is not configured at all.
+// Callers that inspect "the" policy must go through here rather than
+// hard-coding "default", which is a launcher-name/policy-ref conflation
+// waiting to happen (see sandboxPlan).
+func defaultPolicyRef(lc config.LauncherConfig) string {
+	prof, ok := lc.Sandbox.Profiles[lc.Sandbox.DefaultProfile]
+	if !ok {
+		return ""
+	}
+	if ref, native := prof.PolicyRef(); native {
+		return ref
+	}
+	return ""
+}

--- a/internal/cli/sandboxplan.go
+++ b/internal/cli/sandboxplan.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
+)
+
+// sandboxPlan is the launch's single resolved answer to "which sandbox is
+// this run using?" — it carries BOTH of omac's confusingly similar
+// "sandbox profile" namespaces side by side, resolved once:
+//
+//	launcher profile  a templated argv, keyed by the names in
+//	                  config.SandboxConfig.Profiles ("builtin", "nono",
+//	                  "no-sandbox-debug"), selected by --sandbox /
+//	                  sandbox.default_profile;
+//	policy profile    the grant JSON at ~/.config/omac/sandbox-profiles/
+//	                  <ref>.json ("default"), spelled INSIDE the launcher
+//	                  profile's command template.
+//
+// Both are plain strings, so before #173 nothing stopped a launcher name
+// from being handed to the policy resolver — which is exactly what the
+// facade wiring did, silently disabling GET /sandbox/denied on every
+// default launch. Consumers now take the plan, so the mix-up cannot be
+// expressed.
+type sandboxPlan struct {
+	// Name is the launcher profile key (e.g. "builtin").
+	Name string
+	// Launcher is the launcher profile itself; the zero value when Name
+	// is not configured (see Known).
+	Launcher config.SandboxProfile
+	// Known reports whether Name existed in the launcher config.
+	Known bool
+	// Native reports whether the launcher execs omac's own supervisor
+	// (`{{self}} sandbox run …`) — the only backend whose policy omac can
+	// inspect and whose launch-injected flags (--allow-env, …) it defines.
+	Native bool
+	// PolicyRef is the policy reference the launcher template passes to
+	// `omac sandbox run --profile`; "" when !Native.
+	PolicyRef string
+	// Policy is the resolved policy profile; nil when !Native or when
+	// PolicyErr is set.
+	Policy *sandboxprofile.Profile
+	// PolicyPath is the file Policy was loaded from; "" means the
+	// compiled-in defaults were used and no file was consulted.
+	PolicyPath string
+	// PolicyErr records a failed policy resolution. Never fatal: the
+	// launch proceeds (the `omac sandbox run` child resolves the policy
+	// itself), but facade features derived from the policy are disabled.
+	PolicyErr error
+}
+
+// resolveSandboxPlan resolves the launcher profile selected by flagProfile
+// (empty means sandbox.default_profile) and, when that launcher is omac's
+// native sandbox, its policy profile — read-only, so inspecting a profile
+// never scaffolds files. Resolution is cheap (one file read plus path
+// expansion; the full grant resolution happens inside the `omac sandbox
+// run` child), so it is done once per launch and shared.
+//
+// An unknown launcher name is returned as an error alongside a plan with
+// Name set and Known false: callers decide whether that is fatal (it is
+// not under --no-sandbox / --no-inner, where no sandbox is launched).
+func resolveSandboxPlan(lc config.LauncherConfig, flagProfile string) (sandboxPlan, error) {
+	name := flagProfile
+	if name == "" {
+		name = lc.Sandbox.DefaultProfile
+	}
+	plan := sandboxPlan{Name: name}
+	prof, ok := lc.Sandbox.Profiles[name]
+	if !ok {
+		return plan, fmt.Errorf("unknown sandbox profile %q", name)
+	}
+	plan.Launcher = prof
+	plan.Known = true
+	ref, native := prof.PolicyRef()
+	plan.Native = native
+	plan.PolicyRef = ref
+	if !native {
+		return plan, nil
+	}
+	policy, path, err := sandboxprofile.Resolve(ref)
+	if err != nil {
+		plan.PolicyErr = err
+		return plan, nil
+	}
+	plan.Policy = policy
+	plan.PolicyPath = path
+	return plan, nil
+}

--- a/internal/cli/sandboxplan_test.go
+++ b/internal/cli/sandboxplan_test.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+func TestResolveSandboxPlanDefaultProfileResolvesPolicy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	plan, err := resolveSandboxPlan(config.DefaultLauncherConfig(), "")
+	if err != nil {
+		t.Fatalf("resolveSandboxPlan: %v", err)
+	}
+	// The two namespaces: launcher name "builtin", policy ref "default".
+	if plan.Name != "builtin" {
+		t.Errorf("Name = %q, want builtin (the launcher profile)", plan.Name)
+	}
+	if plan.PolicyRef != "default" {
+		t.Errorf("PolicyRef = %q, want default (the policy profile)", plan.PolicyRef)
+	}
+	if !plan.Known || !plan.Native {
+		t.Errorf("Known = %v, Native = %v; want both true", plan.Known, plan.Native)
+	}
+	if plan.PolicyErr != nil {
+		t.Errorf("PolicyErr = %v; the default policy must resolve", plan.PolicyErr)
+	}
+	if plan.Policy == nil {
+		t.Fatal("Policy is nil; the default policy must resolve")
+	}
+	if plan.PolicyPath != "" {
+		t.Errorf("PolicyPath = %q; a fresh home has no file, want the compiled-in defaults", plan.PolicyPath)
+	}
+	// Read-only: resolving must not scaffold the user's profile file.
+	defaultPath := filepath.Join(home, ".config", "omac", "sandbox-profiles", "default.json")
+	if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
+		t.Errorf("resolving a plan scaffolded %s (err=%v); must be read-only", defaultPath, err)
+	}
+}
+
+func TestResolveSandboxPlanLoadsPolicyFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stageProfile(t, home, `{"meta": {"name": "default"}, "workdir": {"access": "read"}}`)
+
+	plan, err := resolveSandboxPlan(config.DefaultLauncherConfig(), "")
+	if err != nil {
+		t.Fatalf("resolveSandboxPlan: %v", err)
+	}
+	if plan.Policy == nil || plan.Policy.Workdir.Access != "read" {
+		t.Fatalf("staged policy file must win; got %+v", plan.Policy)
+	}
+	want := filepath.Join(home, ".config", "omac", "sandbox-profiles", "default.json")
+	if plan.PolicyPath != want {
+		t.Errorf("PolicyPath = %q, want %q", plan.PolicyPath, want)
+	}
+}
+
+// Opaque launchers (external nono, the no-sandbox debug shell) have no
+// inspectable omac policy: Native is false and no policy is resolved.
+func TestResolveSandboxPlanOpaqueLaunchersHaveNoPolicy(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	for _, name := range []string{"nono", "no-sandbox-debug"} {
+		t.Run(name, func(t *testing.T) {
+			plan, err := resolveSandboxPlan(config.DefaultLauncherConfig(), name)
+			if err != nil {
+				t.Fatalf("resolveSandboxPlan(%q): %v", name, err)
+			}
+			if !plan.Known {
+				t.Errorf("%q is a configured launcher profile; Known should be true", name)
+			}
+			if plan.Native {
+				t.Errorf("%q must not be classified as omac's native sandbox", name)
+			}
+			if plan.Policy != nil || plan.PolicyRef != "" || plan.PolicyErr != nil {
+				t.Errorf("%q must resolve no policy; got ref=%q policy=%v err=%v",
+					name, plan.PolicyRef, plan.Policy, plan.PolicyErr)
+			}
+		})
+	}
+}
+
+func TestResolveSandboxPlanUnknownProfileErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	plan, err := resolveSandboxPlan(config.DefaultLauncherConfig(), "nosuch")
+	if err == nil {
+		t.Fatal("expected an error for an unknown launcher profile")
+	}
+	if !strings.Contains(err.Error(), "nosuch") {
+		t.Errorf("error should name the profile: %v", err)
+	}
+	// The name is still reported so callers can mention it, but nothing
+	// downstream may treat the profile as usable.
+	if plan.Name != "nosuch" || plan.Known || plan.Native {
+		t.Errorf("plan = %+v; want Name=nosuch, Known=false, Native=false", plan)
+	}
+}
+
+// A launcher profile that spells its policy ref differently (inline form,
+// or a non-default name) must be followed, not assumed.
+func TestResolveSandboxPlanFollowsPolicyRefInTemplate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "omac", "sandbox-profiles")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "strict.json"),
+		[]byte(`{"meta": {"name": "strict"}, "workdir": {"access": "none"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lc := config.LauncherConfig{Sandbox: config.SandboxConfig{
+		DefaultProfile: "inline",
+		Profiles: map[string]config.SandboxProfile{"inline": {
+			Command: []string{"{{self}}", "sandbox", "run", "--profile=strict", "--", "{{inner_cmd}}"},
+		}},
+	}}
+
+	plan, err := resolveSandboxPlan(lc, "")
+	if err != nil {
+		t.Fatalf("resolveSandboxPlan: %v", err)
+	}
+	if plan.PolicyRef != "strict" {
+		t.Errorf("PolicyRef = %q, want strict", plan.PolicyRef)
+	}
+	if plan.Policy == nil || plan.Policy.Meta.Name != "strict" {
+		t.Fatalf("expected the strict policy to be loaded; got %+v", plan.Policy)
+	}
+}
+
+// A native launcher pointing at a policy that does not exist is NOT fatal:
+// the launch proceeds (the `omac sandbox run` child resolves the policy
+// itself and reports), but the error is recorded so policy-derived facade
+// features can be disabled with an accurate message.
+func TestResolveSandboxPlanMissingPolicyIsRecordedNotFatal(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	lc := config.LauncherConfig{Sandbox: config.SandboxConfig{
+		DefaultProfile: "builtin",
+		Profiles: map[string]config.SandboxProfile{"builtin": {
+			Command: []string{"{{self}}", "sandbox", "run", "--profile", "nosuch", "--", "{{inner_cmd}}"},
+		}},
+	}}
+
+	plan, err := resolveSandboxPlan(lc, "")
+	if err != nil {
+		t.Fatalf("a missing policy must not fail the plan: %v", err)
+	}
+	if plan.PolicyErr == nil {
+		t.Error("PolicyErr should record the failed policy resolution")
+	}
+	if plan.Policy != nil {
+		t.Error("Policy must be nil when resolution failed")
+	}
+	if !plan.Native {
+		t.Error("the launcher is still omac's native sandbox")
+	}
+}

--- a/internal/cli/sandboxplan_test.go
+++ b/internal/cli/sandboxplan_test.go
@@ -161,3 +161,30 @@ func TestResolveSandboxPlanMissingPolicyIsRecordedNotFatal(t *testing.T) {
 		t.Error("the launcher is still omac's native sandbox")
 	}
 }
+
+func TestDefaultPolicyRef(t *testing.T) {
+	if got := defaultPolicyRef(config.DefaultLauncherConfig()); got != "default" {
+		t.Errorf("defaultPolicyRef(default config) = %q, want default", got)
+	}
+
+	custom := config.LauncherConfig{Sandbox: config.SandboxConfig{
+		DefaultProfile: "builtin",
+		Profiles: map[string]config.SandboxProfile{
+			"builtin": {Command: []string{"{{self}}", "sandbox", "run", "--profile", "strict", "--", "{{inner_cmd}}"}},
+			"nono":    {Command: []string{"nono", "--", "{{inner_cmd}}"}},
+		},
+	}}
+	if got := defaultPolicyRef(custom); got != "strict" {
+		t.Errorf("defaultPolicyRef = %q; must follow the launcher template, want strict", got)
+	}
+
+	// Opaque or unconfigured default launcher: "" means the default policy.
+	custom.Sandbox.DefaultProfile = "nono"
+	if got := defaultPolicyRef(custom); got != "" {
+		t.Errorf("opaque launcher: defaultPolicyRef = %q, want empty", got)
+	}
+	custom.Sandbox.DefaultProfile = "nosuch"
+	if got := defaultPolicyRef(custom); got != "" {
+		t.Errorf("unknown launcher: defaultPolicyRef = %q, want empty", got)
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -114,15 +114,17 @@ func runServe(args []string, env *Env) int {
 		fmt.Fprintln(env.Stderr, "omac serve: launcher config:", err)
 		return ExitConfigInvalid
 	}
-	profName := *profile
-	if profName == "" {
-		profName = lc.Sandbox.DefaultProfile
-	}
-	prof, profOK := lc.Sandbox.Profiles[profName]
-	if !profOK && !*noSandbox && !*noInner {
-		fmt.Fprintf(env.Stderr, "omac serve: unknown sandbox profile %q\n", profName)
+	// One resolved sandbox plan for the whole run: the launcher profile
+	// (templated argv) plus, for omac's native backend, its policy profile
+	// (grant JSON). Everything downstream reads the plan instead of
+	// re-resolving a bare name — see internal/cli/sandboxplan.go.
+	plan, planErr := resolveSandboxPlan(lc, *profile)
+	if planErr != nil && !*noSandbox && !*noInner {
+		fmt.Fprintln(env.Stderr, "omac serve:", planErr)
 		return ExitConfigInvalid
 	}
+	profName := plan.Name
+	prof := plan.Launcher
 
 	// Pre-flight: inner harness binary must be on $PATH (unless --no-inner
 	// or --inner override).
@@ -255,7 +257,7 @@ func runServe(args []string, env *Env) int {
 		env.Version,
 	)
 	f.SetAuditor(auditor)
-	wireFacadeSandbox(f, *noSandbox, profName, func(format string, args ...any) {
+	wireFacadeSandbox(f, *noSandbox, plan, func(format string, args ...any) {
 		fmt.Fprintf(env.Stderr, format+"\n", args...)
 	})
 	if err := f.Start(ctx); err != nil {
@@ -380,7 +382,7 @@ func runServe(args []string, env *Env) int {
 	// applied — e.g. OpenCode gets `serve` inserted unless a subcommand is
 	// already present, while Claude Code (no server convention) runs as-is.
 	profileInner := prof.InnerCmd
-	if !profOK {
+	if !plan.Known {
 		profileInner = nil
 	}
 	// Resolve the inner command for the selected harness: --inner override
@@ -447,7 +449,7 @@ func runServe(args []string, env *Env) int {
 		// Forward the selected harness's auth env vars through the default
 		// profile's restrictive allow_vars filter. (Control-plane port and
 		// harness runtime dirs are granted inside sandboxServeArgv.)
-		argv = forwardHarnessEnv(env, argv, harness, prof, profName)
+		argv = forwardHarnessEnv(env, argv, harness, plan)
 		// Pass the resolved audit path to `omac sandbox run` so its
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the
@@ -669,14 +671,17 @@ var emptyAllowVarsWarnDelay = 2 * time.Second
 // profile is a misconfiguration, and omac does not silently push provider
 // credentials into the sandbox to paper over it. It warns that this differs
 // from the old inherit-everything behavior and pauses so the message is seen.
-func forwardHarnessEnv(env *Env, argv []string, harness config.Harness, prof config.SandboxProfile, profName string) []string {
-	if denied := sandboxProfileDeniedBaseVars(prof); len(denied) > 0 {
-		fmt.Fprintf(env.Stderr, "omac: sandbox profile %q denies operational base var(s): %s.\n", profName, strings.Join(denied, ", "))
+// The two warnings below name plan.PolicyRef, not the launcher profile
+// name: they describe the contents of the policy JSON (its allow_vars /
+// deny_vars), which is the file the user has to edit.
+func forwardHarnessEnv(env *Env, argv []string, harness config.Harness, plan sandboxPlan) []string {
+	if denied := planDeniedBaseVars(plan); len(denied) > 0 {
+		fmt.Fprintf(env.Stderr, "omac: sandbox profile %q denies operational base var(s): %s.\n", plan.PolicyRef, strings.Join(denied, ", "))
 		fmt.Fprintln(env.Stderr, "      deny_vars wins over everything, so these are stripped even though the harness")
 		fmt.Fprintln(env.Stderr, `      needs them to run. Remove them from deny_vars unless intended ("omac doctor").`)
 	}
-	if empty, ok := sandboxProfileAllowVarsEmpty(prof); ok && empty {
-		fmt.Fprintf(env.Stderr, "omac: sandbox profile %q has an empty environment.allow_vars.\n", profName)
+	if planAllowVarsEmpty(plan) {
+		fmt.Fprintf(env.Stderr, "omac: sandbox profile %q has an empty environment.allow_vars.\n", plan.PolicyRef)
 		fmt.Fprintln(env.Stderr, "      Forwarding only the operational minimum (HOME, PATH, TERM, locale, …).")
 		fmt.Fprintln(env.Stderr, "      No provider-auth or other ambient env vars are passed through (previously every")
 		fmt.Fprintln(env.Stderr, "      var was inherited). The harness starts but will not authenticate until you add")
@@ -684,41 +689,26 @@ func forwardHarnessEnv(env *Env, argv []string, harness config.Harness, prof con
 		fmt.Fprintln(env.Stderr, "      Continuing shortly…")
 		time.Sleep(emptyAllowVarsWarnDelay)
 		// Seed only the operational minimum; do NOT auto-forward auth vars.
-		return injectSandboxEnvAllow(argv, sandboxprofile.DefaultAllowVars(), prof)
+		return injectSandboxEnvAllow(argv, sandboxprofile.DefaultAllowVars(), plan)
 	}
-	return injectSandboxEnvAllow(argv, harness.SandboxEnvAllow, prof)
+	return injectSandboxEnvAllow(argv, harness.SandboxEnvAllow, plan)
 }
 
-// sandboxProfileAllowVarsEmpty reports whether the native sandbox profile
-// referenced by prof resolves to an empty environment.allow_vars. ok is false
-// when prof is not an inspectable native ({{self}} sandbox run) profile or the
-// referenced profile cannot be resolved read-only.
-func sandboxProfileAllowVarsEmpty(prof config.SandboxProfile) (empty bool, ok bool) {
-	ref, isNative := inspectBuiltinProfileRef(prof.Command)
-	if !isNative {
-		return false, false
-	}
-	sp, _, err := sandboxprofile.ResolveReadOnly(ref)
-	if err != nil {
-		return false, false
-	}
-	return len(sp.Environment.AllowVars) == 0, true
+// planAllowVarsEmpty reports whether the launch's resolved policy profile
+// has an empty environment.allow_vars. False for an opaque launcher or an
+// unresolvable policy — omac cannot know, so it changes nothing.
+func planAllowVarsEmpty(plan sandboxPlan) bool {
+	return plan.Policy != nil && len(plan.Policy.Environment.AllowVars) == 0
 }
 
-// sandboxProfileDeniedBaseVars returns the operational base vars that the
-// native sandbox profile's deny_vars would strip (see
-// sandboxprofile.DeniedBaseVars). It returns nil for non-native or
-// unresolvable profiles.
-func sandboxProfileDeniedBaseVars(prof config.SandboxProfile) []string {
-	ref, isNative := inspectBuiltinProfileRef(prof.Command)
-	if !isNative {
+// planDeniedBaseVars returns the operational base vars the resolved
+// policy's deny_vars would strip (see sandboxprofile.DeniedBaseVars). nil
+// for an opaque launcher or an unresolvable policy.
+func planDeniedBaseVars(plan sandboxPlan) []string {
+	if plan.Policy == nil {
 		return nil
 	}
-	sp, _, err := sandboxprofile.ResolveReadOnly(ref)
-	if err != nil {
-		return nil
-	}
-	return sandboxprofile.DeniedBaseVars(sp.Environment.DenyVars)
+	return sandboxprofile.DeniedBaseVars(plan.Policy.Environment.DenyVars)
 }
 
 // injectSandboxEnvAllow splices --allow-env flags for each harness-declared
@@ -729,9 +719,11 @@ func sandboxProfileDeniedBaseVars(prof config.SandboxProfile) []string {
 // (where FilterEnv applies the allowlist); other backends (nono) do their
 // own env filtering via their own profile, so injecting the flag there
 // would be meaningless and could fail on an unknown flag. Guarded by
-// profileRunsNativeSandbox. Empty/nil is a no-op.
-func injectSandboxEnvAllow(argv []string, names []string, prof config.SandboxProfile) []string {
-	if !profileRunsNativeSandbox(prof) {
+// plan.Native (config.SandboxProfile.PolicyRef anchors on the leading
+// template tokens, so a nono profile whose INNER command merely contains
+// "sandbox"/"run" is not misclassified). Empty/nil is a no-op.
+func injectSandboxEnvAllow(argv []string, names []string, plan sandboxPlan) []string {
+	if !plan.Native {
 		return argv
 	}
 	for _, n := range names {
@@ -741,18 +733,6 @@ func injectSandboxEnvAllow(argv []string, names []string, prof config.SandboxPro
 		argv = injectSandboxFlag(argv, "--allow-env", n)
 	}
 	return argv
-}
-
-// profileRunsNativeSandbox reports whether prof's command template invokes
-// omac's native sandbox supervisor ({{self}} sandbox run …) — the only
-// backend that parses the launch-injected sandbox flags omac defines (e.g.
-// --allow-env). Anchored on the leading template tokens rather than a bare
-// token scan of the expanded argv: {{self}} resolves to os.Executable() (an
-// absolute path, not "omac"), and a nono profile whose inner command merely
-// contains "sandbox"/"run" tokens must not be misclassified.
-func profileRunsNativeSandbox(prof config.SandboxProfile) bool {
-	c := prof.Command
-	return len(c) >= 3 && c[0] == "{{self}}" && c[1] == "sandbox" && c[2] == "run"
 }
 
 // injectSandboxFlag splices a sandbox flag (with optional value; pass

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -257,7 +257,7 @@ func runServe(args []string, env *Env) int {
 		env.Version,
 	)
 	f.SetAuditor(auditor)
-	wireFacadeSandbox(f, *noSandbox, plan, func(format string, args ...any) {
+	wireFacadeSandbox(f, *noSandbox, *learn, plan, func(format string, args ...any) {
 		fmt.Fprintf(env.Stderr, format+"\n", args...)
 	})
 	if err := f.Start(ctx); err != nil {

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -319,7 +319,17 @@ func TestInjectOpenPort(t *testing.T) {
 }
 
 func TestInjectSandboxEnvAllow(t *testing.T) {
-	profiles := config.DefaultLauncherConfig().Sandbox.Profiles
+	isolateHome(t)
+	lc := config.DefaultLauncherConfig()
+	profiles := lc.Sandbox.Profiles
+	planFor := func(t *testing.T, name string) sandboxPlan {
+		t.Helper()
+		plan, err := resolveSandboxPlan(lc, name)
+		if err != nil {
+			t.Fatalf("resolveSandboxPlan(%q): %v", name, err)
+		}
+		return plan
+	}
 	expand := func(t *testing.T, prof config.SandboxProfile) []string {
 		t.Helper()
 		argv, err := sandbox.Expand(prof, sandbox.Inputs{
@@ -339,8 +349,9 @@ func TestInjectSandboxEnvAllow(t *testing.T) {
 	// an absolute path — NOT the literal "omac"), so the detector cannot rely
 	// on argv[0] matching a hand-rolled name.
 	builtinProf := profiles["builtin"]
+	builtinPlan := planFor(t, "builtin")
 	builtin := expand(t, builtinProf)
-	got := injectSandboxEnvAllow(builtin, []string{"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"}, builtinProf)
+	got := injectSandboxEnvAllow(builtin, []string{"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"}, builtinPlan)
 	joined := strings.Join(got, " ")
 	if !strings.Contains(joined, "--allow-env ANTHROPIC_API_KEY") ||
 		!strings.Contains(joined, "--allow-env ANTHROPIC_BASE_URL") {
@@ -348,18 +359,19 @@ func TestInjectSandboxEnvAllow(t *testing.T) {
 	}
 
 	// Empty names is a no-op; empty entries are skipped.
-	if g := injectSandboxEnvAllow(builtin, nil, builtinProf); !equalStrings(g, builtin) {
+	if g := injectSandboxEnvAllow(builtin, nil, builtinPlan); !equalStrings(g, builtin) {
 		t.Errorf("nil names should be a no-op: %v", g)
 	}
-	if g := injectSandboxEnvAllow(builtin, []string{""}, builtinProf); !equalStrings(g, builtin) {
+	if g := injectSandboxEnvAllow(builtin, []string{""}, builtinPlan); !equalStrings(g, builtin) {
 		t.Errorf("empty entry should be skipped: %v", g)
 	}
 
 	// Non-native backend (nono) does not understand --allow-env: the argv
 	// must be left untouched (env filtering is nono's own concern).
 	nonoProf := profiles["nono"]
+	nonoPlan := planFor(t, "nono")
 	nono := expand(t, nonoProf)
-	if g := injectSandboxEnvAllow(nono, []string{"ANTHROPIC_API_KEY"}, nonoProf); !equalStrings(g, nono) {
+	if g := injectSandboxEnvAllow(nono, []string{"ANTHROPIC_API_KEY"}, nonoPlan); !equalStrings(g, nono) {
 		t.Errorf("nono argv must be untouched: %v", g)
 	}
 
@@ -378,7 +390,7 @@ func TestInjectSandboxEnvAllow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expand nono-inner: %v", err)
 	}
-	if g := injectSandboxEnvAllow(nonoArgv, []string{"ANTHROPIC_API_KEY"}, nonoInnerProf); !equalStrings(g, nonoArgv) {
+	if g := injectSandboxEnvAllow(nonoArgv, []string{"ANTHROPIC_API_KEY"}, nonoPlan); !equalStrings(g, nonoArgv) {
 		t.Errorf("nono argv with inner sandbox/run tokens must be untouched: %v", g)
 	}
 }
@@ -397,11 +409,11 @@ func TestForwardHarnessEnvEmptyProfileForwardsOperationalMinimum(t *testing.T) {
 	defer func() { emptyAllowVarsWarnDelay = old }()
 
 	env, _, errBuf, drain := newPipeEnv(t, "")
-	prof := config.SandboxProfile{Command: []string{"{{self}}", "sandbox", "run", "--profile", "default", "--", "x"}}
+	plan := nativePlanForTest(t)
 	harness := config.Harness{Name: "test", SandboxEnvAllow: []string{"ANTHROPIC_API_KEY"}}
 	argv := []string{"/usr/bin/omac", "sandbox", "run", "--profile", "default", "--", "x"}
 
-	got := forwardHarnessEnv(env, argv, harness, prof, "default")
+	got := forwardHarnessEnv(env, argv, harness, plan)
 	drain()
 
 	joined := strings.Join(got, " ")
@@ -428,11 +440,11 @@ func TestForwardHarnessEnvNonEmptyProfileInjects(t *testing.T) {
 	stageProfile(t, home, `{"meta": {"name": "default"}, "environment": {"allow_vars": ["HOME"]}}`)
 
 	env, _, errBuf, drain := newPipeEnv(t, "")
-	prof := config.SandboxProfile{Command: []string{"{{self}}", "sandbox", "run", "--profile", "default", "--", "x"}}
+	plan := nativePlanForTest(t)
 	harness := config.Harness{Name: "test", SandboxEnvAllow: []string{"ANTHROPIC_API_KEY"}}
 	argv := []string{"/usr/bin/omac", "sandbox", "run", "--profile", "default", "--", "x"}
 
-	got := forwardHarnessEnv(env, argv, harness, prof, "default")
+	got := forwardHarnessEnv(env, argv, harness, plan)
 	drain()
 
 	if !strings.Contains(strings.Join(got, " "), "--allow-env ANTHROPIC_API_KEY") {
@@ -441,6 +453,24 @@ func TestForwardHarnessEnvNonEmptyProfileInjects(t *testing.T) {
 	if strings.Contains(errBuf.String(), "allow_vars") {
 		t.Errorf("non-empty profile must not warn; got:\n%s", errBuf.String())
 	}
+}
+
+// nativePlanForTest resolves the launch plan for a minimal native launcher
+// profile, so a test's staged policy file (stageProfile) is what the plan's
+// policy-derived behaviour is read from.
+func nativePlanForTest(t *testing.T) sandboxPlan {
+	t.Helper()
+	lc := config.LauncherConfig{Sandbox: config.SandboxConfig{
+		DefaultProfile: "builtin",
+		Profiles: map[string]config.SandboxProfile{"builtin": {
+			Command: []string{"{{self}}", "sandbox", "run", "--profile", "default", "--", "x"},
+		}},
+	}}
+	plan, err := resolveSandboxPlan(lc, "")
+	if err != nil {
+		t.Fatalf("resolveSandboxPlan: %v", err)
+	}
+	return plan
 }
 
 func equalStrings(a, b []string) bool {

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -801,7 +801,9 @@ func runLaunch(env *Env, opts launchOpts) int {
 		env.Version,
 	)
 	f.SetAuditor(auditor)
-	wireFacadeSandbox(f, noSandbox, plan, func(format string, args ...any) {
+	// `omac start` has no --learn (serve-only), so the protected set is
+	// always the profile's.
+	wireFacadeSandbox(f, noSandbox, false, plan, func(format string, args ...any) {
 		fmt.Fprintf(env.Stderr, prefix+": "+format+"\n", args...)
 	})
 	if err := f.Start(ctx); err != nil {

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -225,15 +225,17 @@ func runLaunch(env *Env, opts launchOpts) int {
 	if verbose && cfgPath != "" {
 		fmt.Fprintf(env.Stderr, "[verbose] loaded launcher config: %s\n", cfgPath)
 	}
-	profName := profile
-	if profName == "" {
-		profName = lc.Sandbox.DefaultProfile
-	}
-	prof, ok := lc.Sandbox.Profiles[profName]
-	if !ok && !noSandbox {
-		fmt.Fprintf(env.Stderr, prefix+": unknown sandbox profile %q\n", profName)
+	// One resolved sandbox plan for the whole launch: the launcher profile
+	// (templated argv) plus, for omac's native backend, its policy profile
+	// (grant JSON). Everything downstream reads the plan instead of
+	// re-resolving a bare name — see internal/cli/sandboxplan.go.
+	plan, planErr := resolveSandboxPlan(lc, profile)
+	if planErr != nil && !noSandbox {
+		fmt.Fprintln(env.Stderr, prefix+":", planErr)
 		return ExitConfigInvalid
 	}
+	profName := plan.Name
+	prof := plan.Launcher
 
 	// 1b. Pre-flight: inner harness binary must be on $PATH.
 	if innerCmdOverride == "" {
@@ -799,7 +801,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 		env.Version,
 	)
 	f.SetAuditor(auditor)
-	wireFacadeSandbox(f, noSandbox, profName, func(format string, args ...any) {
+	wireFacadeSandbox(f, noSandbox, plan, func(format string, args ...any) {
 		fmt.Fprintf(env.Stderr, prefix+": "+format+"\n", args...)
 	})
 	if err := f.Start(ctx); err != nil {
@@ -880,7 +882,7 @@ func runLaunch(env *Env, opts launchOpts) int {
 		// Forward the selected harness's auth env vars through the
 		// default profile's restrictive allow_vars filter — only for the
 		// selected harness.
-		argv = forwardHarnessEnv(env, argv, harness, prof, profName)
+		argv = forwardHarnessEnv(env, argv, harness, plan)
 		// Pass the resolved audit path down to `omac sandbox run` so the
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the

--- a/internal/config/launcher.go
+++ b/internal/config/launcher.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -100,6 +101,44 @@ type SandboxProfile struct {
 	// per_skill_env_flags) must stand alone in their slot.
 	Command  []string `yaml:"command"   json:"command"`
 	InnerCmd []string `yaml:"inner_cmd" json:"inner_cmd"`
+}
+
+// PolicyRef reports the sandbox-*policy* reference this launcher profile's
+// argv template hands to `omac sandbox run --profile` — the second,
+// unrelated "sandbox profile" namespace (a grant JSON under
+// ~/.config/omac/sandbox-profiles), keyed differently from the launcher
+// profile names in SandboxConfig.Profiles. The default launcher profile
+// is named "builtin" and its policy ref is "default"; the two must never
+// be interchanged.
+//
+// Recognized run forms:
+//   - "--profile", "default"   (separate args)
+//   - "--profile=default"      (inline)
+//   - omitted --profile        (resolves to "default")
+//
+// native is false for launchers whose policy omac cannot see: external
+// launchers (nono), the no-sandbox debug shell, and any non-`sandbox run`
+// subcommand. Only `{{self}} sandbox run` templates are inspectable.
+func (p SandboxProfile) PolicyRef() (ref string, native bool) {
+	c := p.Command
+	if len(c) < 3 || c[0] != "{{self}}" || c[1] != "sandbox" || c[2] != "run" {
+		return "", false
+	}
+	// Find "--profile" (separate or inline) before "--".
+	for i := 3; i < len(c); i++ {
+		arg := c[i]
+		if arg == "--" {
+			break
+		}
+		if arg == "--profile" && i+1 < len(c) {
+			return c[i+1], true
+		}
+		if strings.HasPrefix(arg, "--profile=") {
+			return strings.TrimPrefix(arg, "--profile="), true
+		}
+	}
+	// Omitted --profile resolves to "default".
+	return "default", true
 }
 
 // FacadeConfig tunes the reverse proxy.

--- a/internal/config/launcher_test.go
+++ b/internal/config/launcher_test.go
@@ -32,3 +32,92 @@ func TestSandboxBriefingEmptyWhenAbsent(t *testing.T) {
 		t.Errorf("Sandbox.Briefing = %q; want empty", lc.Sandbox.Briefing)
 	}
 }
+
+// TestSandboxProfilePolicyRef covers the launcher→policy mapping: a
+// launcher profile's argv template is the ONLY place the policy reference
+// is spelled, and the two namespaces must never be conflated (#173 — the
+// default launcher profile is named "builtin" while its policy is
+// "default").
+func TestSandboxProfilePolicyRef(t *testing.T) {
+	cases := []struct {
+		name       string
+		command    []string
+		wantRef    string
+		wantNative bool
+	}{
+		{
+			name:       "separate args",
+			command:    []string{"{{self}}", "sandbox", "run", "--profile", "strict", "--", "{{inner_cmd}}"},
+			wantRef:    "strict",
+			wantNative: true,
+		},
+		{
+			name:       "inline form",
+			command:    []string{"{{self}}", "sandbox", "run", "--profile=strict", "--", "{{inner_cmd}}"},
+			wantRef:    "strict",
+			wantNative: true,
+		},
+		{
+			name:       "omitted profile defaults",
+			command:    []string{"{{self}}", "sandbox", "run", "--open-port", "{{tcp_port}}", "--", "{{inner_cmd}}"},
+			wantRef:    "default",
+			wantNative: true,
+		},
+		{
+			// A --profile appearing AFTER the separator belongs to the inner
+			// command, not to `omac sandbox run`.
+			name:       "profile after separator is the inner command's",
+			command:    []string{"{{self}}", "sandbox", "run", "--", "tool", "--profile", "notmine"},
+			wantRef:    "default",
+			wantNative: true,
+		},
+		{
+			name:       "external launcher is opaque",
+			command:    []string{"nono", "--profile", "tng-sandbox.json", "--", "{{inner_cmd}}"},
+			wantRef:    "",
+			wantNative: false,
+		},
+		{
+			// The no-sandbox debug profile runs the inner command directly.
+			name:       "bare inner command is opaque",
+			command:    []string{"{{inner_cmd}}", "{{inner_args}}"},
+			wantRef:    "",
+			wantNative: false,
+		},
+		{
+			name:       "other sandbox subcommand is opaque",
+			command:    []string{"{{self}}", "sandbox", "stage2", "--", "{{inner_cmd}}"},
+			wantRef:    "",
+			wantNative: false,
+		},
+		{
+			name:       "empty command is opaque",
+			command:    nil,
+			wantRef:    "",
+			wantNative: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, native := SandboxProfile{Command: tc.command}.PolicyRef()
+			if ref != tc.wantRef || native != tc.wantNative {
+				t.Errorf("PolicyRef() = (%q, %v), want (%q, %v)", ref, native, tc.wantRef, tc.wantNative)
+			}
+		})
+	}
+}
+
+// The shipped default launcher profile is the case the bug was about.
+func TestDefaultLauncherProfilePolicyRefIsDefault(t *testing.T) {
+	prof, ok := DefaultLauncherConfig().Sandbox.Profiles["builtin"]
+	if !ok {
+		t.Fatal(`the default config must ship a "builtin" launcher profile`)
+	}
+	ref, native := prof.PolicyRef()
+	if !native {
+		t.Error("builtin must be recognized as omac's native sandbox")
+	}
+	if ref != "default" {
+		t.Errorf("builtin policy ref = %q, want default (NOT the launcher name)", ref)
+	}
+}

--- a/internal/e2e/fixtures.go
+++ b/internal/e2e/fixtures.go
@@ -3,11 +3,13 @@
 package e2e
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -141,4 +143,27 @@ func withEnv(env []string, key, value string) []string {
 		out = append(out, prefix+value)
 	}
 	return out
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer. Tests that drive `omac serve`
+// as a long-lived subprocess read its captured output for diagnostics while
+// os/exec's copier goroutine is still writing to it (the daemon runs until
+// teardown), so a plain bytes.Buffer races — and CI runs the model-free slice
+// under -race, where that race fails the test instead of reporting the real
+// assertion. Lives in the e2e_fast build set so both slices can use it.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/internal/e2e/sandbox_denied_test.go
+++ b/internal/e2e/sandbox_denied_test.go
@@ -1,0 +1,139 @@
+//go:build e2e || e2e_fast
+
+package e2e
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestE2ESandboxDeniedAnswersOnDefaultLaunch is the live regression test for
+// #173: on a DEFAULT launch (no flags) the facade must be able to tell the
+// agent whether a path it could not read is protected by the sandbox or
+// simply absent.
+//
+// The bug was a namespace mix-up. omac has two unrelated things called
+// "sandbox profile": the LAUNCHER profile (a templated argv, named
+// "builtin" by default) and the POLICY profile (the grant JSON, named
+// "default"). The facade wiring fed the launcher name to the policy
+// resolver, which always failed, so ProtectedPathChecker stayed nil and
+// GET /sandbox/denied answered 404 for every path — indistinguishable from
+// "endpoint present, path not protected" only by the X-Omac-Reason header
+// the agent does not read.
+//
+// The in-process tests (internal/cli/facade_wiring_test.go,
+// internal/facade/sandbox_denied_test.go) inject a plan or a stub checker.
+// This one drives the real compiled binary through the real launch path and
+// talks to its facade over loopback. It runs with --no-inner (control plane
+// + facade only, no inner harness), so it needs no harness install, no
+// model credentials, and no OS sandbox — and is part of the model-free
+// e2e_fast slice.
+func TestE2ESandboxDeniedAnswersOnDefaultLaunch(t *testing.T) {
+	omacBin := buildOmac(t)
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// No --no-sandbox: this is the default wiring path, the one that was
+	// broken. --no-inner keeps it fast and harness-independent.
+	cmd := exec.CommandContext(ctx, omacBin, "serve", "opencode", "--no-inner", "--control-addr", "127.0.0.1:0")
+	cmd.Dir = cwd
+	cmd.Env = withHome(os.Environ(), home)
+	if shortTmp := shortTmpDirForNested(t); shortTmp != "" {
+		cmd.Env = withEnv(cmd.Env, "TMPDIR", shortTmp)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start omac serve: %v", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	facadePortCh := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdoutPipe)
+		for scanner.Scan() {
+			if m := facadePortRe.FindStringSubmatch(scanner.Text()); m != nil {
+				select {
+				case facadePortCh <- m[1]:
+				default:
+				}
+			}
+		}
+	}()
+	var facadePort string
+	select {
+	case facadePort = <-facadePortCh:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("omac serve did not print facade port within 15s; stderr:\n%s", stderrBuf.String())
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	query := func(path string) (int, map[string]any) {
+		t.Helper()
+		url := fmt.Sprintf("http://127.0.0.1:%s/sandbox/denied?path=%s", facadePort, path)
+		resp, err := client.Get(url)
+		if err != nil {
+			t.Fatalf("GET %s: %v", url, err)
+		}
+		defer resp.Body.Close()
+		var m map[string]any
+		// A disabled endpoint answers text/plain, so a decode failure is
+		// informative rather than fatal here.
+		_ = json.NewDecoder(resp.Body).Decode(&m)
+		return resp.StatusCode, m
+	}
+
+	// A baseline-protected credentials path: the endpoint must answer
+	// "denied by the sandbox", not 404.
+	protected := filepath.Join(home, ".aws", "credentials")
+	code, body := query(protected)
+	if code != http.StatusOK {
+		t.Fatalf("GET /sandbox/denied?path=%s → %d (want 200); the protected-path checker is not wired.\n"+
+			"body=%v\nserve stderr:\n%s", protected, code, body, stderrBuf.String())
+	}
+	if denied, _ := body["denied"].(bool); !denied {
+		t.Errorf("denied = %v, want true for %s (body=%v)", body["denied"], protected, body)
+	}
+	if rule, _ := body["rule"].(string); rule != "baseline" {
+		t.Errorf("rule = %v, want baseline (body=%v)", body["rule"], body)
+	}
+	if note, _ := body["note"].(string); note == "" {
+		t.Errorf("note must carry the denial guidance; body=%v", body)
+	}
+
+	// An ordinary path inside the workdir is not protected: 404 with an
+	// explicit denied:false — the other half of the answer, which proves the
+	// 200 above is a real verdict and not a blanket response.
+	ordinary := filepath.Join(cwd, "main.go")
+	code, body = query(ordinary)
+	if code != http.StatusNotFound {
+		t.Errorf("GET /sandbox/denied?path=%s → %d (want 404); body=%v", ordinary, code, body)
+	}
+	if denied, ok := body["denied"].(bool); !ok || denied {
+		t.Errorf("denied = %v, want false for an unprotected path (body=%v)", body["denied"], body)
+	}
+
+	// The bogus resolve warning fired on every default launch before the fix.
+	if bytes.Contains(stderrBuf.Bytes(), []byte("could not be resolved")) {
+		t.Errorf("default launch warned about an unresolvable sandbox profile:\n%s", stderrBuf.String())
+	}
+}

--- a/internal/e2e/sandbox_denied_test.go
+++ b/internal/e2e/sandbox_denied_test.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -12,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -56,8 +56,10 @@ func TestE2ESandboxDeniedAnswersOnDefaultLaunch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
+	// Goroutine-safe: the assertions below read this while os/exec is still
+	// copying the daemon's stderr into it (CI runs this slice under -race).
+	stderrBuf := &syncBuffer{}
+	cmd.Stderr = stderrBuf
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start omac serve: %v", err)
 	}
@@ -133,7 +135,7 @@ func TestE2ESandboxDeniedAnswersOnDefaultLaunch(t *testing.T) {
 	}
 
 	// The bogus resolve warning fired on every default launch before the fix.
-	if bytes.Contains(stderrBuf.Bytes(), []byte("could not be resolved")) {
+	if strings.Contains(stderrBuf.String(), "could not be resolved") {
 		t.Errorf("default launch warned about an unresolvable sandbox profile:\n%s", stderrBuf.String())
 	}
 }

--- a/internal/e2e/serve_isolation_test.go
+++ b/internal/e2e/serve_isolation_test.go
@@ -90,8 +90,8 @@ func TestE2EServeDirTokenIsolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
+	stderrBuf := &syncBuffer{}
+	cmd.Stderr = stderrBuf
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start omac serve: %v", err)
 	}

--- a/internal/e2e/smoke_test.go
+++ b/internal/e2e/smoke_test.go
@@ -49,7 +49,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 )
@@ -376,26 +375,6 @@ func runServeProbe(t *testing.T, h harnessConfig, omacBin, home, workdir, cwd st
 	default:
 	}
 	return nil
-}
-
-// syncBuffer is a goroutine-safe bytes.Buffer. The serve probe reads captured
-// stderr for diagnostics while the subprocess may still be writing to it (the
-// daemon runs until teardown), so plain bytes.Buffer would race.
-type syncBuffer struct {
-	mu  sync.Mutex
-	buf bytes.Buffer
-}
-
-func (b *syncBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.Write(p)
-}
-
-func (b *syncBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.String()
 }
 
 // waitForControlBase polls the captured stdout for the control-plane URL

--- a/internal/sandboxprofile/profile_test.go
+++ b/internal/sandboxprofile/profile_test.go
@@ -454,6 +454,16 @@ func TestResolveIsReadOnlyByDefault(t *testing.T) {
 	})
 }
 
+// An empty profile path (Resolve fell back to the compiled-in defaults,
+// consulting no file) has no sibling pages file. Returning the relative
+// ".pages.json" would make callers read — or write — a stray file in the
+// current working directory.
+func TestPagesPathEmptyProfilePath(t *testing.T) {
+	if got := PagesPath(""); got != "" {
+		t.Errorf("PagesPath(\"\") = %q, want empty", got)
+	}
+}
+
 func TestPagesPath(t *testing.T) {
 	if got := PagesPath("/x/sandbox-profiles/default.json"); got != "/x/sandbox-profiles/default.pages.json" {
 		t.Errorf("PagesPath = %q", got)

--- a/internal/sandboxprofile/profile_test.go
+++ b/internal/sandboxprofile/profile_test.go
@@ -224,7 +224,7 @@ func TestExpandExistingSkipsMissing(t *testing.T) {
 func TestResolveFirstStartScaffoldsDefault(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	p, path, err := Resolve("")
+	p, path, err := Resolve("", WithScaffold())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,13 +357,16 @@ func TestResolveUnknownProfileNamesExpectedPath(t *testing.T) {
 	}
 }
 
-// TestResolveReadOnly verifies the read-only resolver mirrors Resolve
-// for existing/explicit-path profiles but never scaffolds a default.json
-// when "default" is missing.
-func TestResolveReadOnly(t *testing.T) {
+// TestResolveIsReadOnlyByDefault verifies that Resolve without
+// WithScaffold loads existing/explicit-path profiles exactly like the
+// scaffolding variant but never writes default.json when "default" is
+// missing — inspection callers (doctor, diagnose, provenance, facade
+// wiring) must not mutate the user's filesystem as a side effect of
+// reading (#173).
+func TestResolveIsReadOnlyByDefault(t *testing.T) {
 	t.Run("missing named profile errors", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
-		_, _, err := ResolveReadOnly("nosuch")
+		_, _, err := Resolve("nosuch")
 		if err == nil {
 			t.Fatal("expected error for missing named profile")
 		}
@@ -383,7 +386,7 @@ func TestResolveReadOnly(t *testing.T) {
 			[]byte(`{"meta": {"name": "custom"}}`), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		p, path, err := ResolveReadOnly("custom")
+		p, path, err := Resolve("custom")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -399,7 +402,7 @@ func TestResolveReadOnly(t *testing.T) {
 	t.Run("missing default returns DefaultProfile without scaffolding", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
-		p, path, err := ResolveReadOnly("default")
+		p, path, err := Resolve("default")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -412,7 +415,7 @@ func TestResolveReadOnly(t *testing.T) {
 		// No file must have been created.
 		defaultPath := filepath.Join(home, ".config", "omac", "sandbox-profiles", "default.json")
 		if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
-			t.Errorf("ResolveReadOnly scaffolded default.json (err=%v); must not mutate filesystem", err)
+			t.Errorf("Resolve scaffolded default.json (err=%v); must not mutate filesystem", err)
 		}
 	})
 
@@ -422,7 +425,7 @@ func TestResolveReadOnly(t *testing.T) {
 		if err := os.WriteFile(path, []byte(`{"meta": {"name": "x"}}`), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		p, gotPath, err := ResolveReadOnly(path)
+		p, gotPath, err := Resolve(path)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -437,7 +440,7 @@ func TestResolveReadOnly(t *testing.T) {
 	t.Run("empty ref resolves default without scaffolding", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
-		p, _, err := ResolveReadOnly("")
+		p, _, err := Resolve("")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -446,7 +449,7 @@ func TestResolveReadOnly(t *testing.T) {
 		}
 		defaultPath := filepath.Join(home, ".config", "omac", "sandbox-profiles", "default.json")
 		if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
-			t.Errorf("ResolveReadOnly(\"\") scaffolded default.json; must not mutate filesystem")
+			t.Errorf("Resolve(\"\") scaffolded default.json; must not mutate filesystem")
 		}
 	})
 }

--- a/internal/sandboxprofile/resolve.go
+++ b/internal/sandboxprofile/resolve.go
@@ -91,59 +91,38 @@ func PagesPath(profilePath string) string {
 	return strings.TrimSuffix(profilePath, ".json") + ".pages.json"
 }
 
-// ResolveReadOnly is the inspection variant of Resolve: it loads the
-// referenced profile exactly like Resolve, but never scaffolds a
-// default.json when "default" is missing. Instead it returns the
-// compiled-in DefaultProfile() with an empty path, so callers (doctor,
-// provenance) can reason about the effective policy without mutating
-// the user's filesystem.
-//
-// Resolution rules mirror Resolve:
-//   - a ref containing a path separator or ending in .json is loaded
-//     from that exact path (returned path is the ref itself);
-//   - otherwise the profile is looked up under
-//     ~/.config/omac/sandbox-profiles/<ref>.json;
-//   - an empty ref means "default";
-//   - a missing named (non-default) profile is an error;
-//   - a missing "default" returns DefaultProfile() with path "".
-func ResolveReadOnly(ref string) (*Profile, string, error) {
-	if ref == "" {
-		ref = "default"
-	}
-	if strings.ContainsRune(ref, os.PathSeparator) || strings.HasSuffix(ref, ".json") {
-		p, err := loadFile(ref)
-		return p, ref, err
-	}
-	path, err := ProfilePath(ref)
-	if err != nil {
-		return nil, "", fmt.Errorf("resolve sandbox profile dir: %w", err)
-	}
-	if _, statErr := os.Stat(path); statErr != nil {
-		if !os.IsNotExist(statErr) {
-			return nil, "", fmt.Errorf("stat sandbox profile %s: %w", path, statErr)
-		}
-		if ref != "default" {
-			return nil, "", fmt.Errorf("sandbox profile %q not found (expected %s)", ref, path)
-		}
-		// Missing default: return compiled-in defaults without
-		// scaffolding the file. Path is "" so callers know no file
-		// was consulted.
-		return DefaultProfile(), "", nil
-	}
-	p, err := loadFile(path)
-	return p, path, err
+// resolveOpts holds the (currently single) Resolve knob.
+type resolveOpts struct {
+	scaffold bool
+}
+
+// ResolveOption tunes Resolve. The zero set is read-only.
+type ResolveOption func(*resolveOpts)
+
+// WithScaffold lets Resolve create ~/.config/omac/sandbox-profiles/default.json
+// from DefaultProfile when it is missing, then load it back. Reserved for
+// first-run setup on the launch path (`omac sandbox run`) — inspection
+// callers (doctor, diagnose, provenance, facade wiring) must not mutate
+// the user's filesystem as a side effect of reading.
+func WithScaffold() ResolveOption {
+	return func(o *resolveOpts) { o.scaffold = true }
 }
 
 // Resolve loads a profile reference:
-//   - a path (contains a separator or ends in .json): load that file;
+//   - a path (contains a separator or ends in .json): load that file
+//     (the returned path is the ref itself);
 //   - otherwise ~/.config/omac/sandbox-profiles/<ref>.json.
 //
-// An empty ref means "default". On first use the default profile file
-// is scaffolded from DefaultProfile (pretty-printed) and then loaded.
-// Returns the profile and the path it was loaded from (the path is ""
-// for explicit-path refs whose pages file should sit next to them —
-// in that case the returned path is the explicit path itself).
-func Resolve(ref string) (*Profile, string, error) {
+// An empty ref means "default". A missing named (non-default) profile is
+// an error. Resolve is READ-ONLY by default: a missing "default" yields
+// the compiled-in DefaultProfile() with path "" so callers know no file
+// was consulted. Pass WithScaffold() to write default.json instead —
+// only the launch path does.
+func Resolve(ref string, opts ...ResolveOption) (*Profile, string, error) {
+	var o resolveOpts
+	for _, apply := range opts {
+		apply(&o)
+	}
 	if ref == "" {
 		ref = "default"
 	}
@@ -161,6 +140,9 @@ func Resolve(ref string) (*Profile, string, error) {
 		}
 		if ref != "default" {
 			return nil, "", fmt.Errorf("sandbox profile %q not found (expected %s)", ref, path)
+		}
+		if !o.scaffold {
+			return DefaultProfile(), "", nil
 		}
 		// First start: scaffold default.json so the user has an
 		// editable copy, then load it back (round-trip keeps the file

--- a/internal/sandboxprofile/resolve.go
+++ b/internal/sandboxprofile/resolve.go
@@ -87,7 +87,16 @@ func ProfilePath(name string) (string, error) {
 
 // PagesPath returns the sibling pages file for a profile path or name:
 // <dir>/<name>.pages.json.
+//
+// An empty profilePath means no file was consulted (Resolve fell back to
+// the compiled-in defaults), so there is no sibling pages file either. It
+// must NOT become the relative ".pages.json", which would read — or write —
+// a stray file in the current working directory. Callers treat "" as the
+// empty learned store (netprompt.LoadLearnedPolicy("")).
 func PagesPath(profilePath string) string {
+	if profilePath == "" {
+		return ""
+	}
 	return strings.TrimSuffix(profilePath, ".json") + ".pages.json"
 }
 

--- a/internal/sandboxrun/protected_paths.go
+++ b/internal/sandboxrun/protected_paths.go
@@ -57,6 +57,14 @@ func NewProtectedPathSet(p *sandboxprofile.Profile) *ProtectedPathSet {
 	return set
 }
 
+// UnrestrictedProtectedPathSet returns a set that protects nothing — the
+// facade-side counterpart to Grants.withUnrestrictedFilesystem, which learn
+// mode (`omac serve --learn`) uses to drop every protected path and grant
+// "/". Reporting the profile's static set during a learn session would tell
+// the agent that a genuinely missing file was blocked by the sandbox, which
+// is the confusion GET /sandbox/denied exists to remove.
+func UnrestrictedProtectedPathSet() *ProtectedPathSet { return &ProtectedPathSet{} }
+
 // IsProtected reports whether absPath lies under (or equals) any
 // protected entry. Returns the rule tag of the first match.
 func (s *ProtectedPathSet) IsProtected(absPath string) (rule string, ok bool) {

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -76,7 +76,12 @@ func Run(opts Options) int {
 		return 1
 	}
 
-	profile, profilePath, err := sandboxprofile.Resolve(opts.Flags.ProfileRef)
+	// WithScaffold: this is the launch path — the child the default
+	// launcher template invokes — so first run creates the user's editable
+	// ~/.config/omac/sandbox-profiles/default.json. Every inspection
+	// caller (doctor, diagnose, provenance, facade wiring) resolves
+	// read-only instead.
+	profile, profilePath, err := sandboxprofile.Resolve(opts.Flags.ProfileRef, sandboxprofile.WithScaffold())
 	if err != nil {
 		return fail("%v", err)
 	}


### PR DESCRIPTION
**Issue:** Closes #173

## What

- The launcher/policy namespace split becomes one resolved value per launch (`sandboxPlan`), so a launcher profile name can no longer be handed to the policy resolver — it is a compile error.
- `GET /sandbox/denied` answers on a default `omac start` / `omac serve` instead of 404, and `denial.facade_note` reaches the facade.
- `sandboxprofile.Resolve` is read-only by default (`WithScaffold()` on the launch path only), so inspecting a profile no longer writes `default.json`.
- First regression coverage for the default-profile path: `facade_wiring_test.go`, `sandboxplan_test.go`, `PolicyRef` table tests, and a model-free `e2e_fast` test that drives the real binary.

## Why

`wireFacadeSandbox` took a bare profile name and fed it to the **policy** resolver, while both callers passed the **launcher** name. The default launcher profile is `builtin`; its policy ref is `default`, spelled inside the command template (`internal/config/launcher.go:174`). `Resolve("builtin")` therefore looked for a file that never exists, on **every default launch**:

- `ProtectedPathChecker` stayed nil → `GET /sandbox/denied` returned 404, so the agent could not tell a sandbox denial from a genuinely missing file — the endpoint's entire purpose;
- `denial.facade_note` was never applied;
- a warning was printed on stderr every time.

Both namespaces are plain `string`, so the compiler could not tell them apart. Nothing in `internal/cli` or `internal/e2e` asserted a non-nil checker after a launch.

## How

- `config.SandboxProfile.PolicyRef() (ref string, native bool)` owns the launcher→policy mapping — moved from the untested `cli.inspectBuiltinProfileRef`, and it subsumes `profileRunsNativeSandbox` (identical anchor check), which is deleted.
- `internal/cli/sandboxplan.go`: `resolveSandboxPlan(lc, flagProfile)` resolves the launcher profile and, when native, its policy — once per launch, read-only. An unknown launcher name is returned as an error; callers keep today's fatality rule (not fatal under `--no-sandbox` / `--no-inner`). A missing policy is recorded in `PolicyErr`, never fatal — the `omac sandbox run` child resolves it itself.
- `wireFacadeSandbox`, `forwardHarnessEnv` and `injectSandboxEnvAllow` take the plan; `serve.go`'s two duplicated resolver helpers collapse into `planAllowVarsEmpty` / `planDeniedBaseVars`. The two env warnings now name the policy ref (the file the user edits) rather than the launcher name.
- `Resolve(ref string, opts ...ResolveOption)` replaces the `Resolve` / `ResolveReadOnly` pair, which differed in exactly one branch. Only `internal/sandboxrun/run.go` passes `WithScaffold()`, so first launch still creates the user's editable `default.json` — from the child rather than from the parent's HTTP wiring.

Second commit addresses review findings — two latent inconsistencies that a live `ProtectedPathChecker` made reachable, plus the last instance of the conflation:

- `omac serve --learn` lifts every filesystem restriction in the child (`Grants.withUnrestrictedFilesystem` drops `ProtectedPaths` and grants `/`), but the facade would still report the profile's static set, telling the agent a genuinely missing file was blocked. The wiring now takes the learn flag and installs `sandboxrun.UnrestrictedProtectedPathSet()`.
- Read-only `Resolve` can return an empty profile path (compiled-in defaults, no file consulted); `PagesPath("")` turned that into the **relative** `.pages.json`, so `omac provenance` in a directory holding such a file would report it as the profile's learned network decisions. Fixed at the root, which also covers the pre-existing caller in `diagnose_probe.go:41`.
- `doctorProfileLint` hard-coded the `"default"` policy ref; it now follows the default launcher template via `defaultPolicyRef`.

## Verification

```
go build ./... && go vet ./... && go vet -tags=e2e_fast ./internal/e2e/     # clean
go test -race -count=1 ./internal/...                                      # pass *
go test -tags=e2e_fast -race -count=3 -timeout=8m ./internal/e2e/          # ok (4.4s)
```

The third commit fixes a defect in the second: the new e2e test read its
stderr `bytes.Buffer` while `os/exec`'s copier goroutine was writing to it, so
the model-free CI leg — which runs with `-race` — reported a data race instead
of the assertions. It passed locally only because I had not used `-race`. Now
reproduced and verified with CI's exact invocation, repeated three times.

\* `internal/sandboxrun` has two failures on my host that are identical on `main` (`TestIntegrationWorktreeKnownLimitations` — git `packed-refs`/`Device or resource busy`; `TestIntegrationWorkflowInterpretersRunnable` — missing interpreters). Verified by stashing the change and re-running.

Every new guard was checked **red** against the unfixed code — the pre-fix wiring, `learnMode` ignored, and the unguarded `PagesPath`:

```
--- FAIL: TestWireFacadeSandboxDefaultProfileWiresChecker
    ProtectedPathChecker is nil; GET /sandbox/denied would 404 on a default launch
--- FAIL: TestWireFacadeSandboxAppliesDenialFacadeNote
--- FAIL: TestE2ESandboxDeniedAnswersOnDefaultLaunch
--- FAIL: TestWireFacadeSandboxLearnModeProtectsNothing
--- FAIL: TestPagesPathEmptyProfilePath
```

Manual end-to-end against the compiled binary, fresh `HOME`, default launch (no flags):

```
$ curl -si ".../sandbox/denied?path=$HOME/.aws/credentials"
HTTP/1.1 200 OK
{"denied":true,"path":"…/.aws/credentials","rule":"baseline","note":"Intentionally restricted…"}   # was 404
$ curl -si ".../sandbox/denied?path=$HOME/main.go"    -> 404 {"denied":false,…}
$ grep -c "could not be resolved" serve.stderr        -> 0
$ HOME=$fresh omac provenance && ls $fresh/.config    -> no such directory   # inspection writes nothing
$ HOME=$fresh omac sandbox run -- /bin/true && ls …/sandbox-profiles/  -> default.json   # launch still scaffolds
```

Linux only; the macOS Seatbelt path is unaffected by this change (the new e2e test runs with `--no-inner`, so it is sandbox-free) and is covered by the `e2e.yml` matrix.

CI on this branch: all legs green (`E2E: model-free` ubuntu + macOS, `Test`
ubuntu + macOS, `Cache integration`, `External tooling`, `Lint`, `WSL2-style
session`, DCO).

## Follow-up

- Named types for the refs themselves (`config.LauncherProfileName`, `sandboxprofile.Ref`) would make the two namespaces unmixable everywhere, not just at this seam. Left out deliberately: it ripples into the launcher YAML map key, `sandboxprofile.Flags`/`ParseFlags` and the audit event fields.
- #174, #175, #176 are the remaining findings from the same architecture review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
