### PR TITLE
feat(sandbox): allow local app/dev-server ports via --open-port

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -107,6 +107,14 @@ omac [--workdir <dir>] <subcommand> [flags] [args]
                (silently) skills whose directory has vanished; secrets +
                config persist for safety. Flags:
                  --sandbox <profile>     pick a sandbox profile
+                 --open-port <port>      let the sandbox bind+connect on
+                                         <port> (repeatable). For a local
+                                         app/dev server the agent or tools
+                                         use (Playwright, Vite, Next, …).
+                                         On Linux Landlock cannot limit
+                                         that to loopback: outbound TCP to
+                                         any host on the same port is also
+                                         allowed
                  --inner <cmd>           override inner_cmd
                  --no-sandbox            debug: run inner cmd directly
                                          (disables the entire omac sandbox;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -197,6 +197,99 @@ the same daemon problem without opening general network access. The `0`
 sentinel is **macOS-only**: on Linux it is a silent no-op (there is no
 Landlock rule that can express it), so Linux needs `env-only`.
 
+**Numeric `open_port` on Linux is also address-blind.** Landlock's
+net-port rules have no host dimension: granting `"open_port": [3000]`
+(or `omac start --open-port 3000`) allows bind **and** connect on port
+3000 to *any* host, not only loopback. Prefer pinning a single known
+dev-server port and keep the list short. `omac doctor` / `omac provenance
+--check` flag every numeric `open_port` as a low-severity finding for
+this reason.
+
+## Browser tests (Playwright / Puppeteer)
+
+Headless Playwright or Puppeteer suites can run **inside** the omac
+sandbox when the sandbox profile grants the browser binary paths and the
+local webServer port is opened.
+
+**Profile grants** (add to `~/.config/omac/sandbox-profiles/<name>.json`):
+
+```json
+"filesystem": {
+  "read": [
+    "$PLAYWRIGHT_BROWSERS_PATH",
+    "~/.cache/ms-playwright",
+    "~/.cache/puppeteer",
+    "~/Library/Caches/ms-playwright"
+  ]
+},
+"environment": {
+  "allow_vars": ["PLAYWRIGHT_*", "PUPPETEER_*"]
+}
+```
+
+A broader `~/.cache` / `~/Library/Caches` allow (as in some org profiles)
+already covers the default Playwright/Puppeteer install locations; the
+entries above are the minimal set. Org installers that ship a custom
+profile should put these grants there — there is no separate CLI overlay.
+
+A Linux integration test exercises the full runner path:
+
+`go test ./internal/sandboxrun/ -run TestIntegrationPlaywrightSmoke -v`
+
+(fixture under `internal/sandboxrun/testdata/playwright-smoke/`; skips when
+node/Chromium are missing).
+
+**Port.** Pin the webServer port and grant it at launch or in the profile:
+
+```bash
+omac start --open-port 3000
+```
+
+```ts
+// playwright.config.ts
+export default defineConfig({
+  webServer: {
+    command: 'npm run start',
+    port: 3000,          // must match --open-port / profile open_port
+    reuseExistingServer: !process.env.CI,
+  },
+});
+```
+
+Or permanently in the profile: `"network": { "open_port": [3000] }`
+(see the Landlock address-blind caveat above).
+
+**Chromium launch flags.** Inside omac you do **not** need
+`--no-sandbox` or `--disable-dev-shm-usage`. Modern Chromium uses its
+user-namespace sandbox inside bwrap, and bwrap's `--dev /dev` already
+provides a writable `/dev/shm`. (Playwright already defaults
+`chromiumSandbox: false` for its own reasons — that is independent of
+omac.)
+
+**Supported target: local loopback only.** Chromium ignores credentials
+embedded in `HTTP_PROXY`/`HTTPS_PROXY` URLs, so it cannot authenticate to
+omac's filtering proxy. Requests to external hosts from the browser are
+denied (`net DENY … missing/invalid proxy token`). Tests that only hit
+`127.0.0.1` / `localhost` are unaffected (`NO_PROXY` covers loopback).
+If a suite must reach the public internet from the browser, configure
+Playwright's own proxy auth from the injected `HTTP_PROXY` URL:
+
+```ts
+// optional escape hatch — not required for local webServer tests
+const u = new URL(process.env.HTTP_PROXY!);
+use: {
+  proxy: {
+    server: `http://${u.hostname}:${u.port}`,
+    username: u.username,
+    password: u.password,
+  },
+}
+```
+
+`--open-port` also works on `omac continue`, `omac resume`, and
+`omac serve`. It applies only to the native (`builtin`) sandbox backend;
+nono profiles ignore it with a warning.
+
 ## Corporate proxy
 
 In corporate environments where outbound traffic must go through a proxy,

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -184,6 +184,10 @@ The agent starts restricted and gains access only where you grant it:
 Widening access means editing a readable JSON sandbox profile — a reviewable
 change rather than an accidental default. See
 [Configuration → Sandbox profiles](./CONFIGURATION.md#sandbox-profiles).
+For browser tests (Playwright/Puppeteer), put the binary-path and env grants
+in that profile and open the local webServer port with `--open-port` or
+`network.open_port` — see
+[Configuration → Browser tests](./CONFIGURATION.md#browser-tests-playwright--puppeteer).
 
 ## What the sandbox can see
 
@@ -210,6 +214,7 @@ sandbox:
 | Workdir and granted-tree `.env` / `.envrc` (incl. nested) | **denied** | baseline workdir-protected set (override with `filesystem.override_deny: [".env"]`) |
 | Files matching `filesystem.deny` (e.g. `*.key`) inside granted trees | **denied** | user deny list (`filesystem.deny` / `--deny`) |
 | Environment variables in `environment.allow_vars` (`OMAC_*`, `HOME`, `PATH`, `LANG`, `TERM`, … + the selected harness's auth vars) | passed through | default profile `environment.allow_vars` + `harness.SandboxEnvAllow` (injected at launch) |
+| Browser binary caches (`~/.cache/ms-playwright`, …) + `PLAYWRIGHT_*` / `PUPPETEER_*` | read / passed through | sandbox profile `filesystem.read` / `environment.allow_vars` (org profiles may grant a broader `~/.cache`) |
 | Any other ambient env var (cloud/CI secrets, `DOCKER_HOST`, `SSH_AUTH_SOCK`, proxy config) | **stripped** | not on the allowlist |
 
 > **Environment allowlist (upgrade note).** The default profile ships an

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -82,6 +82,28 @@ func TestParseLaunchArgsEphemeralCache(t *testing.T) {
 	}
 }
 
+func TestParseLaunchArgsOpenPort(t *testing.T) {
+	opts, ok := parseLaunchArgs("start", []string{
+		"--open-port", "3000",
+		"--open-port", "4173",
+	}, devnullEnv(t))
+	if !ok {
+		t.Fatal("parseLaunchArgs() returned false")
+	}
+	if len(opts.openPorts) != 2 || opts.openPorts[0] != 3000 || opts.openPorts[1] != 4173 {
+		t.Errorf("openPorts = %v", opts.openPorts)
+	}
+}
+
+func TestParseLaunchArgsRejectsBadOpenPort(t *testing.T) {
+	if _, ok := parseLaunchArgs("start", []string{"--open-port", "0"}, devnullEnv(t)); ok {
+		t.Error("port 0 should be rejected")
+	}
+	if _, ok := parseLaunchArgs("start", []string{"--open-port", "nope"}, devnullEnv(t)); ok {
+		t.Error("non-integer port should be rejected")
+	}
+}
+
 func TestParseLaunchArgsRejectsEphemeralWithoutSandbox(t *testing.T) {
 	if _, ok := parseLaunchArgs("start", []string{"--ephemeral-cache", "--no-sandbox"}, devnullEnv(t)); ok {
 		t.Error("parseLaunchArgs() succeeded with --ephemeral-cache and --no-sandbox")

--- a/internal/cli/sandbox_cmd.go
+++ b/internal/cli/sandbox_cmd.go
@@ -68,7 +68,11 @@ Flags (list flags are repeatable; they merge additively onto the profile):
                              directory (the cwd included)
   --allow-file <path>        grant read+write on a single file (e.g. a unix socket)
   --allow-unix-dir <dir>     allow AF_UNIX connect to any socket under <dir> (dynamic sockets)
-  --open-port <port>         localhost TCP, connect+bind (e.g. the omac bridge port)
+  --open-port <port>         allow bind+connect on this TCP port (local
+                             app/dev server the agent or tools use, e.g.
+                             Playwright/Vite on :3000; also used for the
+                             omac bridge). On Linux, outbound to any host
+                             on the same port is also allowed
   --listen-port <port>       allow binding/listening on a TCP port
   --allow-tcp-connect <port> direct outbound TCP to any host on this port (e.g. 22)
   --allow-domain <domain>    add to the proxy allowlist (exact or *.suffix)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -764,7 +764,7 @@ func injectUserOpenPorts(env *Env, argv []string, ports []int, prof config.Sandb
 	if len(ports) == 0 {
 		return argv
 	}
-	if !profileRunsNativeSandbox(prof) {
+	if _, native := prof.PolicyRef(); !native {
 		if env != nil {
 			fmt.Fprintln(env.Stderr, "omac: --open-port applies only to the native sandbox backend; ignoring on this profile.")
 		}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -66,7 +66,9 @@ func runServe(args []string, env *Env) int {
 		auditStrict      = fs.Bool("audit-strict", false, "Fail-closed: abort if the audit log cannot be written.")
 	)
 	var roots multiFlag
+	var openPorts intMultiFlag
 	fs.Var(&roots, "root", "Pre-declared root directory under which projects may be activated (§5.4 Option B). Repeatable. Empty = allow any directory.")
+	fs.Var(&openPorts, "open-port", "Allow the sandboxed process to bind and connect on this TCP port (repeatable). Useful for a local app/dev server the agent or its tools talk to — e.g. Playwright/Vite/Next on :3000. On Linux, Landlock cannot limit that to loopback: outbound TCP to any host on the same port is also allowed.")
 	fs.Usage = func() {
 		fmt.Fprintln(env.Stderr, "Usage: omac serve [harness] [flags] [-- inner args...]")
 		fmt.Fprintf(env.Stderr, "\nharness: one of %s (default: %s)\n\n",
@@ -469,6 +471,7 @@ func runServe(args []string, env *Env) int {
 		// profile's restrictive allow_vars filter. (Control-plane port and
 		// harness runtime dirs are granted inside sandboxServeArgv.)
 		argv = forwardHarnessEnv(env, argv, harness, plan)
+		argv = injectUserOpenPorts(env, argv, openPorts, prof)
 		// Pass the resolved audit path to `omac sandbox run` so its
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the
@@ -754,6 +757,28 @@ func injectSandboxEnvAllow(argv []string, names []string, plan sandboxPlan) []st
 	return argv
 }
 
+// injectUserOpenPorts splices user --open-port values into a native-sandbox
+// argv. On non-native backends it leaves argv untouched and warns once when
+// any port was requested (nono does not understand these flags).
+func injectUserOpenPorts(env *Env, argv []string, ports []int, prof config.SandboxProfile) []string {
+	if len(ports) == 0 {
+		return argv
+	}
+	if !profileRunsNativeSandbox(prof) {
+		if env != nil {
+			fmt.Fprintln(env.Stderr, "omac: --open-port applies only to the native sandbox backend; ignoring on this profile.")
+		}
+		return argv
+	}
+	for _, port := range ports {
+		if port < 1 || port > 65535 {
+			continue
+		}
+		argv = injectOpenPort(argv, strconv.Itoa(port))
+	}
+	return argv
+}
+
 // injectSandboxFlag splices a sandbox flag (with optional value; pass
 // "" for boolean flags) into a sandbox argv. It inserts right before
 // the `--` argument separator (the conventional boundary between
@@ -790,6 +815,22 @@ type multiFlag []string
 func (m *multiFlag) String() string { return fmt.Sprint([]string(*m)) }
 func (m *multiFlag) Set(v string) error {
 	*m = append(*m, v)
+	return nil
+}
+
+// intMultiFlag collects a repeatable integer flag (e.g. --open-port 3000).
+type intMultiFlag []int
+
+func (m *intMultiFlag) String() string { return fmt.Sprint([]int(*m)) }
+func (m *intMultiFlag) Set(v string) error {
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fmt.Errorf("invalid port %q: not an integer", v)
+	}
+	if n < 1 || n > 65535 {
+		return fmt.Errorf("invalid port %d: want 1..65535", n)
+	}
+	*m = append(*m, n)
 	return nil
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -406,6 +406,67 @@ func TestInjectSandboxEnvAllow(t *testing.T) {
 	}
 }
 
+func TestInjectUserOpenPorts(t *testing.T) {
+	profiles := config.DefaultLauncherConfig().Sandbox.Profiles
+	builtinProf := profiles["builtin"]
+	argv, err := sandbox.Expand(builtinProf, sandbox.Inputs{
+		Workdir:  "/w",
+		Socket:   "/w/bridge.sock",
+		TCPPort:  6000,
+		InnerCmd: []string{"claude"},
+		TmpDir:   "/w/tmp",
+	})
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+
+	got := injectUserOpenPorts(nil, argv, []int{3000, 4173}, builtinProf)
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "--open-port 3000") || !strings.Contains(joined, "--open-port 4173") {
+		t.Errorf("missing open-port flags: %s", joined)
+	}
+
+	if g := injectUserOpenPorts(nil, argv, nil, builtinProf); !equalStrings(g, argv) {
+		t.Errorf("empty inject should be no-op: %v", g)
+	}
+
+	nonoProf := profiles["nono"]
+	nono, err := sandbox.Expand(nonoProf, sandbox.Inputs{
+		Workdir:  "/w",
+		Socket:   "/w/bridge.sock",
+		TCPPort:  6000,
+		InnerCmd: []string{"claude"},
+		TmpDir:   "/w/tmp",
+	})
+	if err != nil {
+		t.Fatalf("Expand nono: %v", err)
+	}
+	env2, _, errBuf2, drain2 := newPipeEnv(t, "")
+	if g := injectUserOpenPorts(env2, nono, []int{3000}, nonoProf); !equalStrings(g, nono) {
+		t.Errorf("nono argv must be untouched: %v", g)
+	}
+	drain2()
+	if !strings.Contains(errBuf2.String(), "ignoring") {
+		t.Errorf("expected non-native warning, got %q", errBuf2.String())
+	}
+}
+
+func TestIntMultiFlag(t *testing.T) {
+	var m intMultiFlag
+	if err := m.Set("3000"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Set("0"); err == nil {
+		t.Error("port 0 should be rejected")
+	}
+	if err := m.Set("abc"); err == nil {
+		t.Error("non-integer should be rejected")
+	}
+	if len(m) != 1 || m[0] != 3000 {
+		t.Errorf("got %v", m)
+	}
+}
+
 // TestForwardHarnessEnvEmptyProfileForwardsOperationalMinimum: with an
 // empty-allow_vars profile, omac fails closed — it seeds ONLY the operational
 // minimum (so HOME/PATH keep the harness runnable), does NOT auto-forward the

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -69,6 +69,9 @@ type launchOpts struct {
 	// sessionID, when non-empty, selects a specific session to continue by id
 	// (`omac continue -s <id>`). Empty means "most recent" (the default).
 	sessionID string
+	// openPorts are extra loopback ports from --open-port (repeatable),
+	// typically a local webServer port for browser tests.
+	openPorts []int
 	// innerArgs are appended to the resolved inner command (user-supplied
 	// trailing `-- args` plus any command-specific flags like --continue).
 	innerArgs []string
@@ -98,6 +101,8 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 		auditStrict        = fs.Bool("audit-strict", false, "Fail-closed: abort if the audit log cannot be written.")
 		sessionID          = fs.String("session", "", "Continue a specific session by id instead of the most recent one. (shorthand: -s)")
 	)
+	var openPorts intMultiFlag
+	fs.Var(&openPorts, "open-port", "Allow the sandboxed process to bind and connect on this TCP port (repeatable). Useful for a local app/dev server the agent or its tools talk to — e.g. Playwright/Vite/Next on :3000. On Linux, Landlock cannot limit that to loopback: outbound TCP to any host on the same port is also allowed.")
 	// -s is the documented shorthand for --session (opencode mirrors this
 	// with `opencode -s <id>`; claude uses --resume, so its shorthand is
 	// different, but `omac -s` is harness-agnostic).
@@ -161,6 +166,7 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, bool)
 		noAudit:            *noAudit,
 		auditStrict:        *auditStrict,
 		sessionID:          *sessionID,
+		openPorts:          append([]int(nil), openPorts...),
 		innerArgs:          innerArgs,
 	}, true
 }
@@ -931,6 +937,9 @@ func runLaunch(env *Env, opts launchOpts) int {
 		// default profile's restrictive allow_vars filter — only for the
 		// selected harness.
 		argv = forwardHarnessEnv(env, argv, harness, plan)
+		// User --open-port grants (e.g. local Playwright webServer). Additive
+		// on top of the profile; no-op on non-native backends (with a warning).
+		argv = injectUserOpenPorts(env, argv, opts.openPorts, prof)
 		// Pass the resolved audit path down to `omac sandbox run` so the
 		// network-filter subprocess appends net.decision events to the
 		// same persistent log. Inherit the parent's run_id + mode so the

--- a/internal/profileaudit/check.go
+++ b/internal/profileaudit/check.go
@@ -328,7 +328,19 @@ func checkNetwork(profile *sandboxprofile.Profile) []Finding {
 				Value:    "0",
 				Message:  "any loopback port",
 			})
+			continue
 		}
+		// Landlock (Linux) net-port rules have no host dimension: an
+		// open_port grant permits bind+connect on that port to ANY host,
+		// not only loopback. Surface as LOW so doctor / provenance --check
+		// make the egress implication visible without failing closed.
+		findings = append(findings, Finding{
+			Severity: SeverityLow,
+			Category: CatNetwork,
+			Field:    "network.open_port",
+			Value:    strconv.Itoa(port),
+			Message:  "Linux Landlock is address-blind: also allows outbound TCP to any host on this port",
+		})
 	}
 	for _, port := range profile.Network.AllowTCPConnect {
 		switch port {

--- a/internal/profileaudit/check_test.go
+++ b/internal/profileaudit/check_test.go
@@ -355,6 +355,28 @@ func TestCheck_NetworkOpenPortZeroIsLow(t *testing.T) {
 	}
 }
 
+func TestCheck_NetworkOpenPortNumericIsLow(t *testing.T) {
+	p := cleanProfile()
+	p.Network.OpenPort = []int{3000}
+	findings := Check(p)
+	var got *Finding
+	for i := range findings {
+		if findings[i].Category == CatNetwork && findings[i].Field == "network.open_port" && findings[i].Value == "3000" {
+			got = &findings[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("no finding for open_port 3000; got %+v", findings)
+	}
+	if got.Severity != SeverityLow {
+		t.Errorf("severity = %q; want low", got.Severity)
+	}
+	if !strings.Contains(got.Message, "address-blind") {
+		t.Errorf("message should mention address-blind Landlock: %q", got.Message)
+	}
+}
+
 func TestCheck_NetworkAllowTCPConnect22IsMedium(t *testing.T) {
 	p := cleanProfile()
 	p.Network.AllowTCPConnect = []int{22}

--- a/internal/sandboxrun/browser_integration_linux_test.go
+++ b/internal/sandboxrun/browser_integration_linux_test.go
@@ -1,0 +1,128 @@
+//go:build linux
+
+package sandboxrun
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxprofile"
+)
+
+// findChromiumForTest locates a Chromium/Chrome binary for hermetic sandbox
+// browser tests. Prefers a Playwright cache install (a real ELF binary)
+// over PATH names, because distro "chromium" is often a snap wrapper that
+// cannot run inside bwrap. Returns "" when nothing usable is found.
+func findChromiumForTest() string {
+	home, err := os.UserHomeDir()
+	if err == nil {
+		matches, _ := filepath.Glob(filepath.Join(home, ".cache", "ms-playwright", "chromium-*", "chrome-linux", "chrome"))
+		if len(matches) > 0 {
+			best := matches[0]
+			for _, m := range matches[1:] {
+				if m > best {
+					best = m
+				}
+			}
+			return best
+		}
+	}
+	for _, name := range []string{"google-chrome-stable", "google-chrome", "chromium", "chromium-browser"} {
+		p, err := exec.LookPath(name)
+		if err != nil {
+			continue
+		}
+		// Snap wrappers fail inside bwrap ("timeout waiting for snap system
+		// profiles"); skip them so the test skips cleanly instead of failing.
+		if strings.Contains(p, "/snap/") {
+			continue
+		}
+		return p
+	}
+	return ""
+}
+
+// TestIntegrationBrowserHeadlessLocalPage runs a real Chromium inside
+// bwrap+Landlock against a host-side httptest server. It proves the
+// browser grant set (binary read + open_port) is sufficient for
+// a headless local-page fetch — no internet, no npm, no Playwright runner.
+//
+// Skips when no Chromium binary is available (CI default runners do not
+// install one). Does NOT use skipOrFailCI: a missing browser is expected
+// outside dedicated jobs.
+func TestIntegrationBrowserHeadlessLocalPage(t *testing.T) {
+	requireBwrap(t)
+	if !LandlockNetSupported() {
+		t.Skipf("Landlock ABI %d < 4", LandlockABI())
+	}
+	chrome := findChromiumForTest()
+	if chrome == "" {
+		t.Skip("chromium not installed (PATH or ~/.cache/ms-playwright)")
+	}
+	chromeDir := filepath.Dir(chrome)
+
+	const marker = "omac-browser-probe-ok"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, "<html><body>%s</body></html>", marker)
+	}))
+	defer srv.Close()
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	url := fmt.Sprintf("http://127.0.0.1:%d/", port)
+
+	// Build omac with the real host env before any HOME override.
+	omac := filepath.Join(t.TempDir(), "omac")
+	build := exec.Command("go", "build", "-o", omac, "github.com/tngtech/oh-my-agentic-coder/cmd/omac")
+	build.Env = os.Environ()
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build omac: %v\n%s", err, out)
+	}
+
+	wd := t.TempDir()
+	userData := filepath.Join(wd, "chrome-profile")
+	if err := os.MkdirAll(userData, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	p := sandboxprofile.DefaultProfile()
+	p.Network.OpenPort = []int{port}
+	p.Filesystem.Read = append(p.Filesystem.Read, chromeDir)
+	g, err := ResolveGrants(p, wd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g.ReadPaths = append(g.ReadPaths, filepath.Dir(omac))
+
+	inner := []string{
+		chrome,
+		"--headless=new",
+		"--disable-gpu",
+		"--no-first-run",
+		"--disable-component-update",
+		"--disable-background-networking",
+		"--user-data-dir=" + userData,
+		"--dump-dom",
+		url,
+	}
+	stage2 := append([]string{omac, "sandbox", "stage2"}, Stage2Args(g)...)
+	argvTail := append(append([]string{}, stage2...), append([]string{"--"}, inner...)...)
+	argv, err := BuildBwrapArgv(g, argvTail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(argv[0], argv[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("chromium inside sandbox failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), marker) {
+		t.Errorf("marker %q not found in chromium output:\n%s", marker, out)
+	}
+}

--- a/internal/sandboxrun/browser_integration_linux_test.go
+++ b/internal/sandboxrun/browser_integration_linux_test.go
@@ -20,6 +20,13 @@ import (
 // browser tests. Prefers a Playwright cache install (a real ELF binary)
 // over PATH names, because distro "chromium" is often a snap wrapper that
 // cannot run inside bwrap. Returns "" when nothing usable is found.
+//
+// The result is always symlink-resolved: callers grant filepath.Dir() of it,
+// and a distro package typically leaves only a /usr/bin symlink pointing at
+// the real tree elsewhere (Google's .deb: /usr/bin/google-chrome-stable ->
+// /opt/google/chrome/...). Granting the symlink's own dir would grant /usr,
+// which the baseline already covers, while the target tree stays unmounted
+// and the symlink dangles inside the sandbox.
 func findChromiumForTest() string {
 	home, err := os.UserHomeDir()
 	if err == nil {
@@ -31,6 +38,9 @@ func findChromiumForTest() string {
 					best = m
 				}
 			}
+			if real, rerr := filepath.EvalSymlinks(best); rerr == nil {
+				return real
+			}
 			return best
 		}
 	}
@@ -39,12 +49,18 @@ func findChromiumForTest() string {
 		if err != nil {
 			continue
 		}
-		// Snap wrappers fail inside bwrap ("timeout waiting for snap system
-		// profiles"); skip them so the test skips cleanly instead of failing.
-		if strings.Contains(p, "/snap/") {
+		real, err := filepath.EvalSymlinks(p)
+		if err != nil {
 			continue
 		}
-		return p
+		// Snap wrappers fail inside bwrap ("timeout waiting for snap system
+		// profiles"); skip them so the test skips cleanly instead of failing.
+		// Checked after resolution too: on Ubuntu /usr/bin/chromium is a
+		// symlink into /snap/bin.
+		if strings.Contains(p, "/snap/") || strings.Contains(real, "/snap/") {
+			continue
+		}
+		return real
 	}
 	return ""
 }

--- a/internal/sandboxrun/playwright_integration_linux_test.go
+++ b/internal/sandboxrun/playwright_integration_linux_test.go
@@ -64,29 +64,39 @@ func TestIntegrationPlaywrightSmoke(t *testing.T) {
 	// open_port is the grant under test: without it the in-sandbox webServer
 	// cannot bind/connect on `port`. Browser binaries are granted read-only.
 	chromeDir := filepath.Dir(chrome)
-	msPlaywright := filepath.Dir(filepath.Dir(chromeDir)) // …/chromium-N/chrome-linux → …/ms-playwright (usually)
-	// Prefer the real cache root when present.
+	// The Playwright cache root is only meaningful when chrome actually lives
+	// under it (…/ms-playwright/chromium-N/chrome-linux/chrome). A distro
+	// package resolves to something like /opt/google/chrome/chrome, where
+	// walking up two levels would grant an unrelated parent such as /opt;
+	// executablePath in the generated config makes the cache root optional.
+	msPlaywright := ""
 	if home, err := os.UserHomeDir(); err == nil {
-		if _, err := os.Stat(filepath.Join(home, ".cache", "ms-playwright")); err == nil {
-			msPlaywright = filepath.Join(home, ".cache", "ms-playwright")
+		cache := filepath.Join(home, ".cache", "ms-playwright")
+		if strings.HasPrefix(chrome, cache+string(filepath.Separator)) {
+			msPlaywright = cache
 		}
 	}
 
-	cmd := exec.Command(omac, "sandbox", "run",
+	args := []string{"sandbox", "run",
 		"--profile", "default",
 		"--open-port", strconv.Itoa(port),
 		"--read", chromeDir,
-		"--read", msPlaywright,
+	}
+	if msPlaywright != "" {
+		args = append(args, "--read", msPlaywright)
+	}
+	args = append(args,
 		"--allow-env", "PLAYWRIGHT_*",
 		"--allow-env", "PORT",
 		"--",
 		"npx", "playwright", "test", "--reporter=line",
 	)
+	cmd := exec.Command(omac, args...)
 	cmd.Dir = wd
-	cmd.Env = append(os.Environ(),
-		"PORT="+strconv.Itoa(port),
-		"PLAYWRIGHT_BROWSERS_PATH="+msPlaywright,
-	)
+	cmd.Env = append(os.Environ(), "PORT="+strconv.Itoa(port))
+	if msPlaywright != "" {
+		cmd.Env = append(cmd.Env, "PLAYWRIGHT_BROWSERS_PATH="+msPlaywright)
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("playwright inside omac sandbox failed: %v\n%s", err, out)

--- a/internal/sandboxrun/playwright_integration_linux_test.go
+++ b/internal/sandboxrun/playwright_integration_linux_test.go
@@ -1,0 +1,173 @@
+//go:build linux
+
+package sandboxrun
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestIntegrationPlaywrightSmoke runs a real `npx playwright test` suite
+// inside `omac sandbox run`, with Landlock open_port for the local
+// webServer. This is the end-to-end counterpart to
+// TestIntegrationBrowserHeadlessLocalPage (raw Chromium): here the
+// Playwright runner starts both the Node server and Chromium as children
+// of the sandboxed process tree.
+//
+// Hermetic enough for local/CI without LLM: the page is served from
+// loopback inside the sandbox; Chromium is taken from the host Playwright
+// cache (executablePath) so no browser download is required. `npm install`
+// needs registry access once — if it fails, the test skips.
+//
+// Skips (not skipOrFailCI) when node/npm/chromium/bwrap are missing.
+func TestIntegrationPlaywrightSmoke(t *testing.T) {
+	requireBwrap(t)
+	if !LandlockNetSupported() {
+		t.Skipf("Landlock ABI %d < 4", LandlockABI())
+	}
+	for _, bin := range []string{"node", "npm", "npx"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not installed", bin)
+		}
+	}
+	chrome := findChromiumForTest()
+	if chrome == "" {
+		t.Skip("chromium not installed (PATH or ~/.cache/ms-playwright)")
+	}
+
+	port := freeTCPPort(t)
+	wd := t.TempDir()
+	copyPlaywrightFixture(t, wd)
+	writePlaywrightConfig(t, wd, port, chrome)
+
+	npm := exec.Command("npm", "install", "--no-fund", "--no-audit")
+	npm.Dir = wd
+	npm.Env = os.Environ()
+	if out, err := npm.CombinedOutput(); err != nil {
+		t.Skipf("npm install failed (registry/network required once): %v\n%s", err, out)
+	}
+
+	omac := filepath.Join(t.TempDir(), "omac")
+	build := exec.Command("go", "build", "-o", omac, "github.com/tngtech/oh-my-agentic-coder/cmd/omac")
+	build.Env = os.Environ()
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build omac: %v\n%s", err, out)
+	}
+
+	// open_port is the grant under test: without it the in-sandbox webServer
+	// cannot bind/connect on `port`. Browser binaries are granted read-only.
+	chromeDir := filepath.Dir(chrome)
+	msPlaywright := filepath.Dir(filepath.Dir(chromeDir)) // …/chromium-N/chrome-linux → …/ms-playwright (usually)
+	// Prefer the real cache root when present.
+	if home, err := os.UserHomeDir(); err == nil {
+		if _, err := os.Stat(filepath.Join(home, ".cache", "ms-playwright")); err == nil {
+			msPlaywright = filepath.Join(home, ".cache", "ms-playwright")
+		}
+	}
+
+	cmd := exec.Command(omac, "sandbox", "run",
+		"--profile", "default",
+		"--open-port", strconv.Itoa(port),
+		"--read", chromeDir,
+		"--read", msPlaywright,
+		"--allow-env", "PLAYWRIGHT_*",
+		"--allow-env", "PORT",
+		"--",
+		"npx", "playwright", "test", "--reporter=line",
+	)
+	cmd.Dir = wd
+	cmd.Env = append(os.Environ(),
+		"PORT="+strconv.Itoa(port),
+		"PLAYWRIGHT_BROWSERS_PATH="+msPlaywright,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("playwright inside omac sandbox failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "passed") {
+		t.Fatalf("playwright output missing pass marker:\n%s", out)
+	}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	return port
+}
+
+func copyPlaywrightFixture(t *testing.T, dst string) {
+	t.Helper()
+	src := filepath.Join("testdata", "playwright-smoke")
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", src, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if name == "README.md" {
+			continue
+		}
+		in, err := os.Open(filepath.Join(src, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		outPath := filepath.Join(dst, name)
+		out, err := os.Create(outPath)
+		if err != nil {
+			in.Close()
+			t.Fatal(err)
+		}
+		_, err = io.Copy(out, in)
+		in.Close()
+		cerr := out.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cerr != nil {
+			t.Fatal(cerr)
+		}
+	}
+}
+
+func writePlaywrightConfig(t *testing.T, wd string, port int, chrome string) {
+	t.Helper()
+	// Escape backslashes for Windows paths; on Linux this is a no-op for
+	// typical paths, but keeps the generated TS valid if chrome has quotes.
+	chromeEsc := strings.ReplaceAll(chrome, `\`, `\\`)
+	chromeEsc = strings.ReplaceAll(chromeEsc, `'`, `\'`)
+	cfg := fmt.Sprintf(`import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  reporter: 'line',
+  webServer: {
+    command: 'node server.js',
+    url: 'http://127.0.0.1:%d/',
+    reuseExistingServer: false,
+    env: { PORT: '%d' },
+  },
+  use: {
+    headless: true,
+    launchOptions: { executablePath: '%s' },
+  },
+});
+`, port, port, chromeEsc)
+	if err := os.WriteFile(filepath.Join(wd, "playwright.config.ts"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/sandboxrun/testdata/playwright-smoke/README.md
+++ b/internal/sandboxrun/testdata/playwright-smoke/README.md
@@ -1,0 +1,13 @@
+# Playwright smoke fixture for omac sandbox integration tests.
+
+Used by `TestIntegrationPlaywrightSmoke` in
+`playwright_integration_linux_test.go`. The Go test copies this tree into a
+temp dir, writes `playwright.config.ts` with a free port + host Chromium
+path, runs `npm install`, then executes:
+
+```
+omac sandbox run --open-port <port> --read <chrome-dir> -- … npx playwright test
+```
+
+No `node_modules` is committed; browsers come from the host
+`~/.cache/ms-playwright` (or an explicit Chromium on PATH).

--- a/internal/sandboxrun/testdata/playwright-smoke/package.json
+++ b/internal/sandboxrun/testdata/playwright-smoke/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "omac-playwright-smoke",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "1.40.1"
+  }
+}

--- a/internal/sandboxrun/testdata/playwright-smoke/server.js
+++ b/internal/sandboxrun/testdata/playwright-smoke/server.js
@@ -1,0 +1,10 @@
+// Minimal local HTTP server for the Playwright smoke fixture.
+// Port comes from PORT (set by playwright.config webServer.env).
+const http = require('http');
+const port = Number(process.env.PORT || 3456);
+http.createServer((_, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/html' });
+  res.end('<html><body>omac-playwright-smoke-ok</body></html>');
+}).listen(port, '127.0.0.1', () => {
+  console.log('listening on 127.0.0.1:' + port);
+});

--- a/internal/sandboxrun/testdata/playwright-smoke/smoke.spec.ts
+++ b/internal/sandboxrun/testdata/playwright-smoke/smoke.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('local page loads inside omac sandbox', async ({ page }) => {
+  const port = process.env.PORT || '3456';
+  await page.goto(`http://127.0.0.1:${port}/`);
+  await expect(page.locator('body')).toContainText('omac-playwright-smoke-ok');
+});


### PR DESCRIPTION
<!--
Keep this PR **concise**. See ../COLLABORATION.md for the full spec.
Conventional-Commit title with scope, e.g. fix(sandbox): protect docker.sock by default.
Resolve review comments as you address them (reply required only if you deviated).
-->
**Issue:** Refs #152
## What
- Expose `--open-port` on `omac start` / `continue` / `resume` / `serve` (same grant `sandbox run` already had).
- Document headless Playwright/Puppeteer inside the sandbox via profile grants + `--open-port` / `network.open_port`.
- Add hermetic Chromium and `npx playwright test` integration tests under bwrap+Landlock (skip if node/Chromium missing).
## Why
- #152: browser-based suites fail under the default sandbox because the local webServer port is Landlock-blocked; agents need a supported way to open it without disabling the sandbox.
- Profile-distributed browser paths (e.g. org `~/.cache`) already cover binaries; the missing piece for headless flows is the port grant on the start-family CLI plus docs/tests.
## How
- Parse repeatable `--open-port` in `parseLaunchArgs` / `serve`; inject via `injectUserOpenPorts` after `sandbox.Expand` (native backend only).
- `profileaudit`: LOW finding for numeric `network.open_port` (Linux Landlock is address-blind).
- Tests: `TestIntegrationBrowserHeadlessLocalPage`, `TestIntegrationPlaywrightSmoke` + `testdata/playwright-smoke/`.
- Docs: `CONFIGURATION.md` (browser tests), `CLI.md`, `SECURITY_MODEL.md`; clarified `--open-port` help text.
## Verification
- `go test ./internal/cli/ ./internal/profileaudit/ -count=1` — pass
- `go test ./internal/sandboxrun/ -run 'TestIntegrationBrowserHeadlessLocalPage|TestIntegrationPlaywrightSmoke' -v` — pass (local; Chromium present)
- `omac --help` shows updated `--open-port` text — pass
## Follow-up
- Headed/visible browser (#154).
- Optional: pin common ports in org-distributed profiles (`network.open_port`) so users need no flag.
