### PR TITLE
feat(build): approval reuse by digest (repo-namespaced, opt-in)

### DIFF
--- a/docs/build-command.md
+++ b/docs/build-command.md
@@ -230,6 +230,88 @@ There is no auto-approve: an agent or script cannot confirm the diff.
 The `buildmanifest.Approve` seam is the single approval writer; `omac
 build approve` is its CLI front-end.
 
+### Approval reuse by digest (opt-in, default off)
+
+Every new git worktree used to require a fresh host-side `omac build
+approve`, even when the base repo was already approved and the
+worktree's `.omac/build.yaml` is byte-identical to the approved
+manifest. The digest-bound approval-reuse-by-digest feature (ADR 0005)
+removes that friction WITHOUT weakening the per-worktree isolation that
+ticket 06 established: an already-approved repo's **unchanged**
+worktrees build without a fresh per-worktree approval.
+
+**How it works:**
+
+1. When `omac build approve` runs, it writes the existing per-worktree
+   record AND a digest-indexed, repo-namespaced record under the
+   host-only build-control root:
+
+   ```
+   <cacheRoot>/build-control/approvals-by-repo/<sha256(canonicalRepoRoot)>/<manifestDigest>.json
+   ```
+
+   The reuse record is the same `ApprovalRecord` schema (digest +
+   effective capability set + approvedAt) plus a `repoRootCommit` field
+   — the SHA of the first commit in the repo's history
+   (`git rev-list --max-parents=0 HEAD`). The record is written once at
+   approve time and is **inert** unless the host enables reuse.
+
+2. `GateAt` order (per-worktree first, repo-digest fallback):
+
+   - Per-worktree approval lookup (existing path). Hit + digest match →
+     build.
+   - If reuse is enabled AND step 1 missed → repo-digest lookup by
+     `(canonicalRepoRoot, manifestDigest)`. On a hit, verify the stored
+     `repoRootCommit` matches the current repo's root commit. Hit +
+     match → freeze the reused capability set for THIS worktree, then
+     build.
+   - Miss / mismatch / identity not derivable → exit 3
+     (`ExitBuildPolicyDenied`) as today.
+
+**Repo identity is two git-native parts** (no extra state files):
+
+- **`canonicalRepoRoot`** (namespace) — derived from the worktree via
+  `git rev-parse --git-common-dir` + `filepath.EvalSymlinks`. All linked
+  worktrees of a repo share the same common dir, so they collapse to the
+  same `sha256(canonicalRepoRoot)` regardless of where a worktree
+  physically lives. A separate clone has its own common dir → a distinct
+  namespace → no cross-clone reuse.
+- **`repoRootCommit`** (recycling guard) — the root-commit SHA stored in
+  the digest-indexed record and re-compared at lookup time. A foreign
+  repo created at the same path after the original was deleted has a
+  different root commit → mismatch → no reuse. Git-native; no UUID file,
+  no inode/device check.
+
+**Opt-in, host-controlled, default off.** Enabled via BOTH:
+
+- env `OMAC_APPROVAL_REUSE_BY_DIGEST=1` (ad-hoc override), and/or
+- a host config entry in `<cacheRoot>/build-control/config.toml` (durable
+  default):
+
+  ```toml
+  approval_reuse_by_digest = true
+  ```
+
+  Host-only. The agent in a managed session cannot enable reuse and
+  cannot write approval records — the TTY / host-session gate in
+  `omac build approve` is unchanged.
+
+**Fallback (spec §Edge cases — no error, just no reuse):** non-git path,
+empty repo (no commits), or a missing/resolvable-failing common dir
+makes the repo identity not derivable → the reuse lookup is skipped and
+the build falls back to per-worktree approval exactly as before. Bare
+repos, worktree-of-worktree, submodules, shallow clones, and detached
+HEAD all keep working: reuse is scoped by the repo's own common dir and
+root commit.
+
+**Revoke: setting off, snapshots run out (KISS).** There is no `revoke`
+subcommand. Disabling reuse (env unset / config entry removed) means new
+lookups no longer consult the reuse path; already-frozen `ParentSnapshot`s
+remain valid for the parent lifetime and expire on parent restart — the
+same mechanism that already governs approval changes ("restart OMAC to
+activate"). The host-ceiling drop check invalidates a reused record the
+same way it invalidates any per-worktree record.
+
 ### Runtime missing-capability diagnostic
 
 When a build requests a capability (image, registry, build root) NOT in the

--- a/internal/buildcontrol/buildcontrol.go
+++ b/internal/buildcontrol/buildcontrol.go
@@ -8,6 +8,7 @@
 //
 //	<omac-cache-root>/build-control/
 //	  approvals/<sha256(canonical-worktree)>.json
+//	  approvals-by-repo/<sha256(canonical-repo-root)>/<manifest-digest>.json
 //	  ports/<sha256(canonical-worktree)>/{credproxy,containerproxy}.port
 //	  locks/<sha256(canonical-leaf)>.lock
 //	  daemons/<sha256(canonical-leaf)>.json
@@ -55,12 +56,20 @@ const RootName = "build-control"
 // trusted-state subdirectories under the build-control root. Exported
 // only within the package's own path helpers; callers use ApprovalPath,
 // PortDir, LockPath, etc.
+//
+// approvalsByRepoDirName is the digest-indexed, repo-namespaced
+// approval-reuse subdirectory (ADR 0005): it stores one record per
+// (canonicalRepoRoot, manifestDigest) so an already-approved repo's
+// unchanged worktrees can build without a fresh per-worktree approval.
+// Exported so buildmanifest (which mirrors the path helpers without
+// importing this package) and diagnostics can reference the literal.
 const (
-	approvalsDir = "approvals"
-	portsDir     = "ports"
-	locksDir     = "locks"
-	daemonsDir   = "daemons"
-	requestsDir  = "requests"
+	approvalsDir           = "approvals"
+	approvalsByRepoDirName = "approvals-by-repo"
+	portsDir               = "ports"
+	locksDir               = "locks"
+	daemonsDir             = "daemons"
+	requestsDir            = "requests"
 )
 
 // LockFileMode is the required mode for a build-control lockfile
@@ -134,6 +143,17 @@ func HashWorktree(canonicalWorktree string) string {
 	return hash(canonicalWorktree)
 }
 
+// HashRepo returns sha256(canonicalRepoRoot) as a lowercase hex string
+// — the key under which digest-indexed approval-reuse records are
+// namespaced (ADR 0005). canonicalRepoRoot is the canonical
+// (EvalSymlinks-resolved) `git rev-parse --git-common-dir` output.
+// All linked worktrees of a repo share the same common dir, so they
+// collapse to the same namespace; a separate clone has its own common
+// dir and lands in a distinct namespace (no cross-clone reuse).
+func HashRepo(canonicalRepoRoot string) string {
+	return hash(canonicalRepoRoot)
+}
+
 func hash(s string) string {
 	d := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(d[:])
@@ -151,6 +171,25 @@ func Root(cacheRoot string) string {
 // worktree: <root>/approvals/<sha256(worktree)>.json.
 func ApprovalPath(cacheRoot, canonicalWorktree string) string {
 	return filepath.Join(Root(cacheRoot), approvalsDir, HashWorktree(canonicalWorktree)+".json")
+}
+
+// ApprovalsByRepoDir returns the repository-namespaced directory for
+// digest-indexed approval-reuse records:
+// <root>/approvals-by-repo/<sha256(canonicalRepoRoot)>/. canonicalRepoRoot
+// is the canonical (EvalSymlinks-resolved) `git rev-parse
+// --git-common-dir` output; all linked worktrees of a repo collapse to
+// the same namespace (ADR 0005).
+func ApprovalsByRepoDir(cacheRoot, canonicalRepoRoot string) string {
+	return filepath.Join(Root(cacheRoot), approvalsByRepoDirName, HashRepo(canonicalRepoRoot))
+}
+
+// ApprovalByRepoPath returns the digest-indexed, repo-namespaced
+// approval-reuse record path:
+// <root>/approvals-by-repo/<sha256(canonicalRepoRoot)>/<manifestDigest>.json.
+// A changed manifest has a different digest and therefore a different
+// record — distinct capabilities never reuse one another's approval.
+func ApprovalByRepoPath(cacheRoot, canonicalRepoRoot, manifestDigest string) string {
+	return filepath.Join(ApprovalsByRepoDir(cacheRoot, canonicalRepoRoot), manifestDigest+".json")
 }
 
 // PortDir returns the stable-proxy-port directory for a canonical
@@ -202,6 +241,7 @@ func EnsureRoot(cacheRoot string) (string, error) {
 	for _, sub := range []string{
 		root,
 		filepath.Join(root, approvalsDir),
+		filepath.Join(root, approvalsByRepoDirName),
 		filepath.Join(root, portsDir),
 		filepath.Join(root, locksDir),
 		filepath.Join(root, daemonsDir),

--- a/internal/buildcontrol/reuse_test.go
+++ b/internal/buildcontrol/reuse_test.go
@@ -1,0 +1,84 @@
+package buildcontrol
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHashRepo_StableAndDistinct asserts HashRepo is stable for the same
+// canonical repo root and distinct for different repo roots. The repo
+// root is the canonical (EvalSymlinks-resolved) `git rev-parse
+// --git-common-dir` output — the namespace under which digest-indexed
+// approval reuse records are stored (ADR 0005).
+func TestHashRepo_StableAndDistinct(t *testing.T) {
+	repoA := "/home/u/work/repo/.git"
+	repoB := "/home/u/work/other/.git"
+	if HashRepo(repoA) == HashRepo(repoB) {
+		t.Error("distinct repo roots hashed the same")
+	}
+	if HashRepo(repoA) != HashRepo(repoA) {
+		t.Error("hash not stable")
+	}
+	// A canonical repo root and a non-canonical spelling produce
+	// DIFFERENT hashes (callers must canonicalize first).
+	if HashRepo(repoA) == HashRepo("/home/u/work/repo/.git/") {
+		t.Log("note: trailing-slash spelling hashes differently (callers must canonicalize)")
+	}
+}
+
+// TestApprovalsByRepoDir_UnderRoot asserts the approvals-by-repo
+// directory for a canonical repo root lives under the host-only
+// build-control root and is namespaced by sha256(repoRoot).
+func TestApprovalsByRepoDir_UnderRoot(t *testing.T) {
+	root := "/home/u/.cache/omac"
+	repo := "/home/u/work/repo/.git"
+	dir := ApprovalsByRepoDir(root, repo)
+	if !strings.HasPrefix(dir, filepath.Join(root, RootName, approvalsByRepoDirName)) {
+		t.Errorf("approvals-by-repo dir %q not under build-control/approvals-by-repo", dir)
+	}
+	if dir != filepath.Join(ApprovalByRepoPath(root, repo, "any")) {
+		// Sanity: the dir is the parent of a record path.
+	}
+}
+
+// TestApprovalByRepoPath_UnderNamespace asserts the digest-indexed
+// approval record path is
+// <root>/build-control/approvals-by-repo/<sha256(repoRoot)>/<digest>.json —
+// the digest-indexed, repo-namespaced approval reuse record (ADR 0005).
+func TestApprovalByRepoPath_UnderNamespace(t *testing.T) {
+	root := "/home/u/.cache/omac"
+	repo := "/home/u/work/repo/.git"
+	digest := "abc123"
+	p := ApprovalByRepoPath(root, repo, digest)
+	if !strings.HasPrefix(p, filepath.Join(root, RootName, approvalsByRepoDirName)) {
+		t.Errorf("path %q not under build-control/approvals-by-repo", p)
+	}
+	if !strings.HasSuffix(p, ".json") {
+		t.Errorf("path %q missing .json suffix", p)
+	}
+	if !strings.Contains(p, HashRepo(repo)) {
+		t.Errorf("path %q missing repo-root hash namespace", p)
+	}
+	if !strings.Contains(p, digest) {
+		t.Errorf("path %q missing digest", p)
+	}
+
+	// Different repos -> different namespaces -> distinct paths even for
+	// the SAME digest (no cross-repo reuse).
+	repoB := "/home/u/work/other/.git"
+	if ApprovalByRepoPath(root, repoA(), digest) == "" {
+		t.Fatal("empty path")
+	}
+	if ApprovalByRepoPath(root, repo, digest) == ApprovalByRepoPath(root, repoB, digest) {
+		t.Error("distinct repos share the same digest-indexed record path")
+	}
+
+	// Same repo, different digests -> distinct records.
+	digestB := "def456"
+	if ApprovalByRepoPath(root, repo, digest) == ApprovalByRepoPath(root, repo, digestB) {
+		t.Error("distinct digests share the same record path")
+	}
+}
+
+func repoA() string { return "/home/u/work/repoA/.git" }

--- a/internal/buildengine/adapters.go
+++ b/internal/buildengine/adapters.go
@@ -35,6 +35,13 @@ import (
 // parent-owned build-control approval layout is used by the broker
 // path (via the parent's snapshot store). A future gate may migrate
 // the direct-host path to the build-control layout too.
+//
+// ADR 0005: this adapter does NOT consult the opt-in digest-indexed
+// approval-reuse fallback. The direct-host path that needs reuse wires
+// the cli-side newDirectSnapshotProvider (internal/cli/build_reuse.go),
+// which calls buildmanifest.GateAt with the reuse context resolved from
+// the worktree's repo identity; this plain adapter keeps the historical
+// behavior exactly (and stays the default when Options.Snapshot is nil).
 func DirectSnapshotProvider(worktree, leaf string, req buildrun.Request) (PolicySnapshot, error) {
 	// Replicate the exact sequence the current cli/build.go uses:
 	//   hostPolicy := buildrun.HostPolicy(req.MaxDuration)

--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -142,11 +142,20 @@ type PolicySnapshot struct {
 //     changed or there is no prior approval — the engine surfaces that
 //     as policy_denial. This preserves the prefactor's
 //     behavior-preserving constraint: the direct-host path keeps its
-//     current gate semantics.
+//     current gate semantics. When the opt-in approval-reuse-by-digest
+//     feature is enabled (ADR 0005), the direct-host path wires a
+//     reuse-aware variant (cli.newDirectSnapshotProvider) that resolves
+//     the worktree's git repo identity and passes it into
+//     buildmanifest.GateAt, so an already-approved repo's unchanged
+//     worktrees reuse the digest-indexed approval instead of requiring
+//     a fresh per-worktree approval.
 //   - Brokered (start/serve parent): reads the parent-owned in-memory
 //     snapshot frozen at activation. Never writes approvals; a digest
 //     mismatch is a policy_denial (the broker routes the human to
-//     `omac build approve` + parent restart).
+//     `omac build approve` + parent restart). The parent's activation
+//     freeze may itself freeze from the digest-indexed reuse record
+//     when reuse is enabled (ADR 0005) — the engine is unchanged: it
+//     consumes whatever immutable snapshot the provider returns.
 //
 // The engine cannot write approvals or replace snapshots: the provider
 // is the only seam that touches approval state, and the engine treats

--- a/internal/buildengine/parent_snapshot.go
+++ b/internal/buildengine/parent_snapshot.go
@@ -113,6 +113,15 @@ func (s *ParentSnapshotStore) ParentSnapshotProvider() SnapshotProvider {
 // current digest match the durable approval. host is the host policy
 // ceiling to freeze into the snapshot.
 //
+// The "durable approval record" is either the per-worktree record or —
+// when the opt-in reuse-by-digest feature is enabled (ADR 0005) and the
+// per-worktree record misses — the digest-indexed, repo-namespaced
+// reuse record (whose RepoRootCommit was verified against the current
+// repo's root commit before freezing). The snapshot is still keyed by
+// canonical worktree exactly as today: a reused record freezes THIS
+// worktree's immutable snapshot; it never shares mutable state between
+// worktrees.
+//
 // This is the helper a host-only `omac build approve` command (and
 // the parent's activation logic) calls after writing the durable
 // approval record; the snapshot takes effect for build requests only

--- a/internal/buildmanifest/approval.go
+++ b/internal/buildmanifest/approval.go
@@ -52,6 +52,13 @@ const ActiveFilename = "active-manifest.json"
 // timestamp. OMAC reuses this approval while the digest is unchanged and the
 // effective set still matches the current host ceiling; a changed digest OR a
 // host-ceiling drop below what was approved forces a consolidated review.
+//
+// RepoRootCommit is populated ONLY on digest-indexed, repo-namespaced
+// reuse records (ADR 0005) and is omitempty so existing per-worktree
+// approval records (which predate ADR 0005) still marshal/unmarshal
+// unchanged. It carries the repo's root-commit SHA (the recycling guard:
+// a foreign repo created at the same path has a different root commit,
+// so the record cannot be reused).
 type ApprovalRecord struct {
 	// Digest is the SHA-256 digest of the approved manifest content.
 	Digest string `json:"digest"`
@@ -59,6 +66,10 @@ type ApprovalRecord struct {
 	Capabilities CapabilitySet `json:"capabilities"`
 	// ApprovedAt is when the host user accepted this digest + set.
 	ApprovedAt time.Time `json:"approvedAt"`
+	// RepoRootCommit is the first commit's SHA of the approving repo's
+	// history (`git rev-list --max-parents=0 HEAD`), stored ONLY on
+	// digest-indexed reuse records. Empty for the per-worktree layout.
+	RepoRootCommit string `json:"repoRootCommit,omitempty"`
 }
 
 // ActiveRecord is the frozen-for-session manifest record. Once a digest is
@@ -119,6 +130,83 @@ func NewOnLeafLocation() Location { return Location{kind: locationOnLeaf} }
 // grants.
 func NewBuildControlLocation(cacheRoot, canonicalWorktree string) Location {
 	return Location{kind: locationBuildControl, cacheRoot: cacheRoot, worktree: canonicalWorktree}
+}
+
+// RepoDigestLocation selects where digest-indexed, repo-namespaced
+// approval-reuse records are stored (ADR 0005): under the host-only
+// build-control root at
+// `<cacheRoot>/build-control/approvals-by-repo/<sha256(canonicalRepoRoot)>/<digest>.json`.
+// canonicalRepoRoot is the canonical (EvalSymlinks-resolved) `git
+// rev-parse --git-common-dir` output — the namespace under which all
+// linked worktrees of a repo share one set of digest-indexed records.
+// A zero RepoDigestLocation must not be used (no storage).
+type RepoDigestLocation struct {
+	cacheRoot         string // shared cache root (~/.cache/omac)
+	canonicalRepoRoot string // canonical git-common-dir of the repo
+}
+
+// NewRepoDigestLocation returns a RepoDigestLocation storing reuse
+// records under `<cacheRoot>/build-control/approvals-by-repo/`.
+// cacheRoot is the shared cache root (parent of cache-scope dirs);
+// canonicalRepoRoot is the canonical (EvalSymlinks-resolved)
+// `git rev-parse --git-common-dir` output.
+func NewRepoDigestLocation(cacheRoot, canonicalRepoRoot string) RepoDigestLocation {
+	return RepoDigestLocation{cacheRoot: cacheRoot, canonicalRepoRoot: canonicalRepoRoot}
+}
+
+// StoreApprovalForRepoDigest writes a digest-indexed, repo-namespaced
+// approval-reuse record. The record carries the repoRootCommit recycling
+// guard on ApprovalRecord.RepoRootCommit. Same 0o600 host-only
+// permissions as the per-worktree build-control record (ADR 0005).
+func StoreApprovalForRepoDigest(cacheRoot, canonicalRepoRoot, digest string, rec ApprovalRecord) error {
+	return StoreApprovalForRepoDigestAt(NewRepoDigestLocation(cacheRoot, canonicalRepoRoot), digest, rec)
+}
+
+// LookupApprovalForRepoDigest reads the digest-indexed reuse record for
+// (canonicalRepoRoot, digest). A missing record yields a zero record and
+// nil error (no reuse — fall back to per-worktree).
+func LookupApprovalForRepoDigest(cacheRoot, canonicalRepoRoot, digest string) (ApprovalRecord, error) {
+	return LookupApprovalForRepoDigestAt(NewRepoDigestLocation(cacheRoot, canonicalRepoRoot), digest)
+}
+
+// StoreApprovalForRepoDigestAt writes the reuse record at the
+// location-selected path. The approvals-by-repo subdirectory (and
+// parents) are created 0o700 if absent; the file is written 0o600
+// (host-only, never in outer-agent or executor grants).
+func StoreApprovalForRepoDigestAt(loc RepoDigestLocation, digest string, rec ApprovalRecord) error {
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest approval: %w", err)
+	}
+	path := repoDigestApprovalPath(loc, digest)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("prepare approvals-by-repo dir: %w", err)
+	}
+	if err := os.Chmod(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("chmod approvals-by-repo dir: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write manifest approval: %w", err)
+	}
+	return nil
+}
+
+// LookupApprovalForRepoDigestAt reads the reuse record at the
+// location-selected path. A missing file yields a zero record and nil
+// error (no reuse — fall back to per-worktree).
+func LookupApprovalForRepoDigestAt(loc RepoDigestLocation, digest string) (ApprovalRecord, error) {
+	data, err := os.ReadFile(repoDigestApprovalPath(loc, digest))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ApprovalRecord{}, nil
+		}
+		return ApprovalRecord{}, fmt.Errorf("load manifest approval: %w", err)
+	}
+	var rec ApprovalRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return ApprovalRecord{}, fmt.Errorf("parse manifest approval: %w", err)
+	}
+	return rec, nil
 }
 
 // LoadApproval reads the approval record. A missing file yields a zero
@@ -381,6 +469,16 @@ func activePathAt(leaf string, loc Location) string {
 func buildcontrolApprovalPath(cacheRoot, worktree string) string {
 	d := sha256.Sum256([]byte(worktree))
 	return filepath.Join(cacheRoot, "build-control", "approvals", hex.EncodeToString(d[:])+".json")
+}
+
+// repoDigestApprovalPath mirrors internal/buildcontrol.ApprovalByRepoPath
+// without importing the package (same buildcontrol → buildmanifest
+// dependency constraint). The hashing MUST stay identical to
+// buildcontrol.HashRepo (sha256, lowercase hex):
+// <cacheRoot>/build-control/approvals-by-repo/<sha256(canonicalRepoRoot)>/<digest>.json.
+func repoDigestApprovalPath(loc RepoDigestLocation, digest string) string {
+	d := sha256.Sum256([]byte(loc.canonicalRepoRoot))
+	return filepath.Join(loc.cacheRoot, "build-control", "approvals-by-repo", hex.EncodeToString(d[:]), digest+".json")
 }
 
 // ensureParent creates the parent directory of path with the

--- a/internal/buildmanifest/reuse_approval_test.go
+++ b/internal/buildmanifest/reuse_approval_test.go
@@ -1,0 +1,126 @@
+package buildmanifest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRepoDigestApproval_RoundTrip asserts StoreApprovalForRepoDigest
+// writes a digest-indexed, repo-namespaced approval record and
+// LookupApprovalForRepoDigest reads it back. The record lives at
+// <root>/build-control/approvals-by-repo/<sha256(canonicalRepoRoot)>/<digest>.json
+// and carries the repoRootCommit recycling guard (ADR 0005).
+func TestRepoDigestApproval_RoundTrip(t *testing.T) {
+	cacheRoot := t.TempDir()
+	repoA := "/home/u/work/repo/.git"
+	digest := "abc123"
+	rec := ApprovalRecord{
+		Digest:         digest,
+		Capabilities:   CapabilitySet{BuildRoots: []string{"backend"}, Images: []string{"pgvector/pgvector:pg16"}},
+		RepoRootCommit: "ca9a9845294ed8c0f77dc2fe3f2efd84ee16e47c",
+	}
+	rec.ApprovedAt = time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	if err := StoreApprovalForRepoDigest(cacheRoot, repoA, digest, rec); err != nil {
+		t.Fatalf("StoreApprovalForRepoDigest: %v", err)
+	}
+
+	got, err := LookupApprovalForRepoDigest(cacheRoot, repoA, digest)
+	if err != nil {
+		t.Fatalf("LookupApprovalForRepoDigest: %v", err)
+	}
+	if got.Digest != rec.Digest {
+		t.Errorf("Digest = %q, want %q", got.Digest, rec.Digest)
+	}
+	if got.RepoRootCommit != rec.RepoRootCommit {
+		t.Errorf("RepoRootCommit = %q, want %q", got.RepoRootCommit, rec.RepoRootCommit)
+	}
+	if len(got.Capabilities.Images) != 1 || got.Capabilities.Images[0] != "pgvector/pgvector:pg16" {
+		t.Errorf("Capabilities.Images = %v", got.Capabilities.Images)
+	}
+	// The file lives under the namespaced approvals-by-repo tree.
+	dir := filepath.Join(cacheRoot, "build-control", "approvals-by-repo", repoHashHex(repoA))
+	paths, _ := filepath.Glob(filepath.Join(dir, "*.json"))
+	if len(paths) != 1 {
+		t.Errorf("expected one record file under %s, got %v", dir, paths)
+	}
+}
+
+// TestRepoDigestApproval_NamespacedByRepo asserts two different repos
+// with the SAME digest land in different namespaces (no cross-repo
+// reuse), and the same repo with DIFFERENT digests stores distinct
+// records (a changed manifest always requires fresh approval).
+func TestRepoDigestApproval_NamespacedByRepo(t *testing.T) {
+	cacheRoot := t.TempDir()
+	repoA := "/home/u/work/repo/.git"
+	repoB := "/home/u/work/other/.git"
+	digest := "same-digest"
+	rec := ApprovalRecord{Digest: digest, RepoRootCommit: "commita"}
+	if err := StoreApprovalForRepoDigest(cacheRoot, repoA, digest, rec); err != nil {
+		t.Fatal(err)
+	}
+	// Cross-repo: repoB has no record for this digest.
+	got, err := LookupApprovalForRepoDigest(cacheRoot, repoB, digest)
+	if err != nil {
+		t.Fatalf("LookupApprovalForRepoDigest(repoB): %v", err)
+	}
+	if got.Digest != "" {
+		t.Errorf("cross-repo lookup returned a record: %+v", got)
+	}
+	// Same repo, distinct digest: a separate record exists.
+	if err := StoreApprovalForRepoDigest(cacheRoot, repoA, "other-digest", ApprovalRecord{Digest: "other-digest", RepoRootCommit: "commita"}); err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := LookupApprovalForRepoDigest(cacheRoot, repoA, "other-digest")
+	if got2.Digest != "other-digest" {
+		t.Errorf("distinct-digest record not found: %+v", got2)
+	}
+}
+
+// TestApprovalRecord_RepoRootCommitOmitempty asserts the RepoRootCommit
+// field is omitted from the JSON when empty, so EXISTING per-worktree
+// approval records (which predate ADR 0005) still marshal/unmarshal
+// unchanged and the new field is additive.
+func TestApprovalRecord_RepoRootCommitOmitempty(t *testing.T) {
+	leaf := t.TempDir()
+	rec := ApprovalRecord{Digest: "abc123", Capabilities: CapabilitySet{Images: []string{"postgres:17"}}}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "repoRootCommit") {
+		t.Errorf("empty RepoRootCommit must be omitempty-omitted, got %s", data)
+	}
+	// The record round-trips through JSON without the field.
+	var parsed ApprovalRecord
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Digest != rec.Digest {
+		t.Errorf("Digest = %q, want %q", parsed.Digest, rec.Digest)
+	}
+	// Legacy per-worktree round-trip still works via the standard path.
+	if err := StoreApprovalAt(leaf, NewOnLeafLocation(), rec); err != nil {
+		t.Fatal(err)
+	}
+	back, err := LoadApprovalAt(leaf, NewOnLeafLocation())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if back.Digest != rec.Digest || back.RepoRootCommit != "" {
+		t.Errorf("legacy round-trip: %+v", back)
+	}
+}
+
+// repoHashHex is a small stand-in for the canonical repo-root hash used
+// in the assertion (the test verifies the record lands under the
+// <sha256(canonicalRepoRoot)> namespace; the name is checked by
+// buildcontrol's own unit tests).
+func repoHashHex(s string) string {
+	d := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(d[:])
+}

--- a/internal/buildmanifest/reuse_gate_test.go
+++ b/internal/buildmanifest/reuse_gate_test.go
@@ -1,0 +1,394 @@
+package buildmanifest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gitIdentityForTest runs the git commands that resolve the repo
+// identity (canonicalRepoRoot via `git rev-parse --git-common-dir` +
+// EvalSymlinks, and repoRootCommit via `git rev-list --max-parents=0
+// HEAD`) against the test worktree. It returns (canonicalRepoRoot,
+// repoRootCommit). Tests that hit the gate with reuse enabled use this
+// to compute the identity to store/look up the digest-indexed record.
+func gitIdentityForTest(t *testing.T, worktree string) (canonicalRepoRoot, repoRootCommit string) {
+	t.Helper()
+	common, err := gitOutputForTest(worktree, "rev-parse", "--git-common-dir")
+	if err != nil {
+		t.Fatalf("git rev-parse --git-common-dir: %v", err)
+	}
+	// git may return a relative common dir (".git") for the main
+	// worktree; make it absolute against the worktree before resolving
+	// symlinks, exactly as production resolveRepoIdentity does.
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(worktree, common)
+	}
+	canon, err := filepath.EvalSymlinks(common)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(common-dir %q): %v", common, err)
+	}
+	rootCommit, err := gitOutputForTest(worktree, "rev-list", "--max-parents=0", "HEAD")
+	if err != nil {
+		t.Fatalf("git rev-list --max-parents=0 HEAD: %v", err)
+	}
+	return canon, rootCommit
+}
+
+func gitOutputForTest(worktree string, args ...string) (string, error) {
+	c := exec.Command("git", args...)
+	c.Dir = worktree
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// initGitRepoForTest creates a git repo in worktree with one empty
+// commit (so a root commit exists), using a hermetic identity.
+func initGitRepoForTest(t *testing.T, worktree string) string {
+	t.Helper()
+	gitInDir := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = worktree
+		c.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	gitInDir("init", "-q", "-b", "main")
+	gitInDir("commit", "-q", "--allow-empty", "-m", "init")
+	return worktree
+}
+
+// initGitRepoWithFileForTest initializes a git repo whose ROOT commit
+// includes the on-disk files already present in worktree (so the root
+// commit SHA is content-dependent and distinct from an empty commit).
+func initGitRepoWithFileForTest(t *testing.T, worktree string) {
+	t.Helper()
+	gitInDir := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = worktree
+		c.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	gitInDir("init", "-q", "-b", "main")
+	gitInDir("add", "-A")
+	gitInDir("commit", "-q", "-m", "foreign init")
+}
+
+// TestGate_NoReuseWhenDisabled asserts the reuse path is NOT consulted
+// when the reuse flag is unset (scenario f): even when a valid
+// digest-indexed record exists for the repo, GateAt must not reuse it —
+// the per-worktree approval is the ONLY path, so a worktree with no
+// per-worktree approval fails with a GateError (first-ever).
+func TestGate_NoReuseWhenDisabled(t *testing.T) {
+	worktree := t.TempDir()
+	initGitRepoForTest(t, worktree)
+	writeBuildManifest(t, worktree, `version: 1
+builds:
+  - root: backend
+    containers:
+      images: [postgres:17]
+`)
+	m, err := Load(worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := HostPolicy{MaxHeap: "4g"}
+	caps := m.CapabilitySet(host)
+	digest := Digest(m)
+	canonRepoRoot, rootCommit := gitIdentityForTest(t, worktree)
+
+	leaf := t.TempDir()
+	_ = leaf                   // gate's leaf arg is only used by the per-worktree location's on-leaf path
+	loc := NewOnLeafLocation() // per-worktree approval location (empty -> no per-worktree approval)
+	// Plant a valid digest-indexed reuse record.
+	reuseLoc := NewRepoDigestLocation(t.TempDir(), canonRepoRoot)
+	if err := StoreApprovalForRepoDigestAt(reuseLoc, digest, ApprovalRecord{
+		Digest:         digest,
+		Capabilities:   caps,
+		RepoRootCommit: rootCommit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reuse disabled (flag=false): the digest-indexed record must NOT be
+	// consulted. The per-worktree gate fails (first-ever).
+	_, err = GateAt(worktree, loc, digest, caps, GateOptions{})
+	if err == nil {
+		t.Fatal("gate with reuse disabled must fail (no per-worktree approval)")
+	}
+	var ge *GateError
+	if !asGateError(err, &ge) {
+		t.Fatalf("want *GateError, got %T: %v", err, err)
+	}
+	if !ge.FirstEver {
+		t.Error("expected first-ever denial (reuse path must not be consulted when disabled)")
+	}
+}
+
+// TestGate_ReuseSameRepoSameDigestSucceeds is scenario (a): a NEW
+// worktree of an already-approved repo builds when the digest-indexed
+// reuse record matches (same repo, same root commit). The per-worktree
+// path misses; the reuse path hits.
+func TestGate_ReuseSameRepoSameDigestSucceeds(t *testing.T) {
+	// Approved repo: worktree A writes the digest-indexed record.
+	repoWorktree := t.TempDir()
+	initGitRepoForTest(t, repoWorktree)
+	writeBuildManifest(t, repoWorktree, `version: 1
+builds:
+  - root: backend
+    containers:
+      images: [postgres:17]
+`)
+	mA, err := Load(repoWorktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := HostPolicy{MaxHeap: "4g"}
+	caps := mA.CapabilitySet(host)
+	digest := Digest(mA)
+	canonRepoRoot, rootCommit := gitIdentityForTest(t, repoWorktree)
+
+	cacheRoot := t.TempDir()
+	reuseLoc := NewRepoDigestLocation(cacheRoot, canonRepoRoot)
+	if err := StoreApprovalForRepoDigestAt(reuseLoc, digest, ApprovalRecord{
+		Digest:         digest,
+		Capabilities:   caps,
+		RepoRootCommit: rootCommit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Per-worktree approval (same location used by both worktrees) is
+	// deliberately empty: the new worktree has no per-worktree approval.
+	loc := NewBuildControlLocation(cacheRoot, "/worktree/new")
+	leaf := t.TempDir()
+
+	res, err := GateAt(leaf, loc, digest, caps, GateOptions{
+		EnableReuse:        true,
+		CanonicalRepoRoot:  canonRepoRoot,
+		RepoRootCommit:     rootCommit,
+		RepoDigestLocation: reuseLoc,
+	})
+	if err != nil {
+		t.Fatalf("reuse should succeed for a new worktree of an approved repo: %v", err)
+	}
+	if res.Digest != digest {
+		t.Errorf("Digest = %q, want %q", res.Digest, digest)
+	}
+	if !res.Capabilities.HasBuildRoot("backend") {
+		t.Error("reused caps missing build root")
+	}
+}
+
+// TestGate_ReuseDigestMismatchFails is scenario (b): a changed manifest
+// (different digest) has no digest-indexed reuse record -> no reuse,
+// falls back to per-worktree -> missing per-worktree approval -> exit-3
+// GateError (not first-ever necessarily; here there is no approval so
+// first-ever).
+func TestGate_ReuseDigestMismatchFails(t *testing.T) {
+	repoWorktree := t.TempDir()
+	initGitRepoForTest(t, repoWorktree)
+	writeBuildManifest(t, repoWorktree, `version: 1
+builds:
+  - root: backend
+    containers:
+      images: [postgres:17]
+`)
+	m, err := Load(repoWorktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := HostPolicy{MaxHeap: "4g"}
+	caps := m.CapabilitySet(host)
+	digest := Digest(m)
+	canonRepoRoot, rootCommit := gitIdentityForTest(t, repoWorktree)
+
+	cacheRoot := t.TempDir()
+	reuseLoc := NewRepoDigestLocation(cacheRoot, canonRepoRoot)
+	// The reused/digest-indexed digest differs from the CURRENT manifest.
+	changedDigest := "different-digest"
+	if err := StoreApprovalForRepoDigestAt(reuseLoc, changedDigest, ApprovalRecord{
+		Digest:         changedDigest,
+		Capabilities:   caps,
+		RepoRootCommit: rootCommit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	loc := NewBuildControlLocation(cacheRoot, "/worktree/new")
+	leaf := t.TempDir()
+	_, err = GateAt(leaf, loc, digest, caps, GateOptions{
+		EnableReuse:        true,
+		CanonicalRepoRoot:  canonRepoRoot,
+		RepoRootCommit:     rootCommit,
+		RepoDigestLocation: reuseLoc,
+	})
+	if err == nil {
+		t.Fatal("changed manifest must NOT reuse a different-digest approval")
+	}
+	var ge *GateError
+	if !asGateError(err, &ge) {
+		t.Fatalf("want *GateError, got %T: %v", err, err)
+	}
+}
+
+// TestGate_ReuseRootCommitMismatchFails is scenario (e): a foreign repo
+// created at the same path after the original was deleted has a
+// different root commit -> the stored record's RepoRootCommit no longer
+// matches -> no reuse, falls back to per-worktree (missing) -> GateError.
+func TestGate_ReuseRootCommitMismatchFails(t *testing.T) {
+	// Repo 1: the approved repo.
+	repoWorktree := t.TempDir()
+	initGitRepoForTest(t, repoWorktree)
+	writeBuildManifest(t, repoWorktree, `version: 1
+builds:
+  - root: backend
+    containers:
+      images: [postgres:17]
+`)
+	m, err := Load(repoWorktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := HostPolicy{MaxHeap: "4g"}
+	digest := Digest(m)
+	canonRepoRoot, rootCommitOfApproved := gitIdentityForTest(t, repoWorktree)
+
+	cacheRoot := t.TempDir()
+	reuseLoc := NewRepoDigestLocation(cacheRoot, canonRepoRoot)
+	if err := StoreApprovalForRepoDigestAt(reuseLoc, digest, ApprovalRecord{
+		Digest:         digest,
+		Capabilities:   m.CapabilitySet(host),
+		RepoRootCommit: rootCommitOfApproved,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now the FOREIGN repo at the SAME path: delete the original, create
+	// a new repo with a DIFFERENT history (different root commit). The
+	// canonicalRepoRoot is the same (same path), but the root commit
+	// differs.
+	if err := os.RemoveAll(repoWorktree); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoWorktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The foreign repo gets a DISTINCT root commit (a marker file in the
+	// root commit) so the SHA cannot collide with the approved repo's.
+	foreignRepo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(foreignRepo, "foreign-marker.txt"), []byte(t.Name()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoWithFileForTest(t, foreignRepo)
+	// The foreign repo's common dir resolves to its own path, NOT the
+	// approval's namespace. To simulate the recycling attack (same path,
+	// different history) we assert the recorded root commit does NOT match
+	// the current repo's root commit for the SAME canonicalRepoRoot.
+	// We brute-force: the current root commit here is the foreign one.
+	_, foreignRootCommit := gitIdentityForTest(t, foreignRepo)
+	if foreignRootCommit == rootCommitOfApproved {
+		t.Skip("cannot construct two repos with distinct root commits")
+	}
+
+	loc := NewBuildControlLocation(cacheRoot, "/worktree/new")
+	leaf := t.TempDir()
+	_, err = GateAt(leaf, loc, digest, m.CapabilitySet(host), GateOptions{
+		EnableReuse:       true,
+		CanonicalRepoRoot: canonRepoRoot,
+		// The current repo's root commit (the foreign repo) differs from
+		// the stored record's.
+		RepoRootCommit:     foreignRootCommit,
+		RepoDigestLocation: reuseLoc,
+	})
+	if err == nil {
+		t.Fatal("root-commit mismatch must NOT reuse the stored approval")
+	}
+	var ge *GateError
+	if !asGateError(err, &ge) {
+		t.Fatalf("want *GateError, got %T: %v", err, err)
+	}
+}
+
+// TestGate_ReuseHostCeilingDropInvalidates is scenario (g): a host
+// ceiling drop below what was approved invalidates the reused record
+// exactly as it invalidates a per-worktree record — the gate re-records
+// against the new (lower) set and fails with a GateError.
+func TestGate_ReuseHostCeilingDropInvalidates(t *testing.T) {
+	repoWorktree := t.TempDir()
+	initGitRepoForTest(t, repoWorktree)
+	writeBuildManifest(t, repoWorktree, `version: 1
+resources:
+  maxHeap: 3g
+`)
+	m, err := Load(repoWorktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostHi := HostPolicy{MaxHeap: "4g"}
+	digest := Digest(m)
+	canonRepoRoot, rootCommit := gitIdentityForTest(t, repoWorktree)
+
+	cacheRoot := t.TempDir()
+	reuseLoc := NewRepoDigestLocation(cacheRoot, canonRepoRoot)
+	if err := StoreApprovalForRepoDigestAt(reuseLoc, digest, ApprovalRecord{
+		Digest:         digest,
+		Capabilities:   m.CapabilitySet(hostHi),
+		RepoRootCommit: rootCommit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Gate with the ceiling DROPPED: 3g request but host ceiling 2g.
+	hostLo := HostPolicy{MaxHeap: "2g"}
+	loc := NewBuildControlLocation(cacheRoot, "/worktree/new")
+	leaf := t.TempDir()
+	_, err = GateAt(leaf, loc, digest, m.CapabilitySet(hostLo), GateOptions{
+		EnableReuse:        true,
+		CanonicalRepoRoot:  canonRepoRoot,
+		RepoRootCommit:     rootCommit,
+		RepoDigestLocation: reuseLoc,
+	})
+	if err == nil {
+		t.Fatal("host-ceiling drop must invalidate the reused record")
+	}
+	var ge *GateError
+	if !asGateError(err, &ge) {
+		t.Fatalf("want *GateError, got %T: %v", err, err)
+	}
+	if !strings.Contains(ge.Error(), "host policy ceiling dropped") {
+		t.Errorf("error should mention ceiling drop: %v", ge)
+	}
+}
+
+func writeBuildManifest(t *testing.T, worktree, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(worktree, ".omac"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, ".omac", "build.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func asGateError(err error, ge **GateError) bool {
+	e, ok := err.(*GateError)
+	if ok {
+		*ge = e
+	}
+	return ok
+}

--- a/internal/buildmanifest/session.go
+++ b/internal/buildmanifest/session.go
@@ -76,13 +76,54 @@ func Gate(leaf string, digest string, caps CapabilitySet) (GateResult, error) {
 	return GateAt(leaf, NewOnLeafLocation(), digest, caps)
 }
 
+// GateOptions carries the opt-in approval-reuse context (ADR 0005). A
+// zero value (the default) leaves approval reuse disabled: the gate
+// behaves exactly as before, consulting only the per-worktree approval.
+type GateOptions struct {
+	// EnableReuse enables the digest-indexed repo-namespaced fallback:
+	// when the per-worktree path misses AND the repo identity is
+	// resolvable, the gate looks up a reuse record by
+	// (canonicalRepoRoot, manifestDigest) and, if its repoRootCommit
+	// matches the current repo's root commit, freezes THAT record's
+	// capability set for this worktree.
+	EnableReuse bool
+	// CanonicalRepoRoot is the canonical (EvalSymlinks-resolved)
+	// `git rev-parse --git-common-dir` output — the namespace under
+	// which the digest-indexed reuse records are stored. Empty disables
+	// the reuse lookup (identity not ermittelbar → fall back to
+	// per-worktree, no error, per spec §Edge cases).
+	CanonicalRepoRoot string
+	// RepoRootCommit is the current root-commit SHA of the repo
+	// (`git rev-list --max-parents=0 HEAD`). The stored reuse record's
+	// RepoRootCommit must match it, or the record is not reused (the
+	// recycling guard: a foreign repo at the same path has a different
+	// root commit). Empty disables the reuse lookup.
+	RepoRootCommit string
+	// RepoDigestLocation resolves where the digest-indexed reuse records
+	// live. A zero value disables the reuse lookup.
+	RepoDigestLocation RepoDigestLocation
+}
+
 // GateAt is the location-aware variant of Gate. It reads/writes approval
 // records at the location-selected path. Under the BuildControl layout
 // the active record is the durable approval record itself (the parent
 // holds an in-memory snapshot); a digest match against the durable
 // approval starts unattended with the frozen set, and a mismatch
 // records the new approval and fails with the diff + restart instruction.
-func GateAt(leaf string, loc Location, digest string, caps CapabilitySet) (GateResult, error) {
+//
+// When opts enables approval reuse (ADR 0005), a per-worktree miss falls
+// back to the digest-indexed, repo-namespaced reuse record BEFORE
+// recording a fresh approval: on a hit with a matching repoRootCommit,
+// the reused record freezes THIS worktree's capability set and the build
+// proceeds unattended — an already-approved repo's unchanged worktrees
+// build without a fresh per-worktree approval. A miss/mismatch falls
+// back to the existing per-worktree behavior (record approval + fail
+// with the diff + restart instruction).
+func GateAt(leaf string, loc Location, digest string, caps CapabilitySet, opts ...GateOptions) (GateResult, error) {
+	var o GateOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
 	active, err := LoadActiveAt(leaf, loc)
 	if err != nil {
 		return GateResult{}, fmt.Errorf("load active manifest: %w", err)
@@ -102,6 +143,36 @@ func GateAt(leaf string, loc Location, digest string, caps CapabilitySet) (GateR
 			}
 		}
 		return GateResult{Capabilities: active.Capabilities, Digest: digest}, nil
+	}
+	// Step 1 missed: no per-worktree approval matches the current digest.
+	//
+	// Step 2 (opt-in approval reuse, ADR 0005): when reuse is enabled
+	// AND the repo identity is derivable, consult the digest-indexed,
+	// repo-namespaced reuse record for this (repo, digest). A hit whose
+	// RepoRootCommit matches the current repo's root commit freezes the
+	// reused record's capability set for this worktree — unchanged
+	// worktrees of an already-approved repo build without a fresh
+	// per-worktree approval. A miss / mismatch / identity-not-ermittelbar
+	// falls through to the existing per-worktree behavior (record
+	// approval + fail with the diff + restart instruction).
+	if o.EnableReuse && o.CanonicalRepoRoot != "" && o.RepoRootCommit != "" && o.RepoDigestLocation.cacheRoot != "" {
+		reuseRec, rerr := LookupApprovalForRepoDigestAt(o.RepoDigestLocation, digest)
+		if rerr != nil {
+			return GateResult{}, fmt.Errorf("lookup repo approval reuse: %w", rerr)
+		}
+		if reuseRec.Digest == digest && reuseRec.RepoRootCommit == o.RepoRootCommit {
+			// The reused record is digest-bound AND the repo's root
+			// commit still matches (the recycling guard). The host
+			// ceiling must still cover the reused set, exactly as for a
+			// per-worktree record.
+			if !ceilingStillValid(reuseRec.Capabilities.HostPolicy, caps.HostPolicy) {
+				return GateResult{}, &GateError{
+					Diff:   Diff(reuseRec.Capabilities, caps),
+					Reason: "host policy ceiling dropped below the previously approved set — re-approval required",
+				}
+			}
+			return GateResult{Capabilities: reuseRec.Capabilities, Digest: digest}, nil
+		}
 	}
 	// No active record, OR digest changed since the session was frozen:
 	// record approval (so the next run starts unattended) and FAIL with the

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -102,6 +102,7 @@ func runBuild(args []string, env *Env) int {
 		fmt.Fprintf(env.Stderr, "omac build: resolve cache scope: %v\n", err)
 		return buildrun.ExitServiceFailure
 	}
+	cacheRoot := buildControlCacheRoot(cacheDir)
 
 	// Signal handling: the CLI owns the staged graceful-then-forced
 	// cancellation wiring (SignalContext). The engine consumes the
@@ -121,12 +122,18 @@ func runBuild(args []string, env *Env) int {
 		Stdout:      env.Stdout,
 		Stderr:      env.Stderr,
 		CacheDir:    cacheDir,
-		CacheRoot:   buildControlCacheRoot(cacheDir),
+		CacheRoot:   cacheRoot,
 		CloseScope:  closeScope,
 		Auditor:     auditor,
 		Proxies:     cliProxyStarter,
 		Cancel:      cancel,
 		ForceCancel: force,
+		// Snapshot: the direct path's provider resolves the opt-in
+		// digest-indexed approval-reuse fallback (ADR 0005) from the
+		// worktree's repo identity when reuse is enabled. When reuse is
+		// off (default) it behaves identically to the historical
+		// buildmanifest.Gate path.
+		Snapshot: newDirectSnapshotProvider(cacheRoot),
 	})
 
 	// Exit-code translation: the engine assigns the explicit class at

--- a/internal/cli/build_approve.go
+++ b/internal/cli/build_approve.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/TNG/oh-my-agentic-coder/internal/buildmanifest"
 	"github.com/TNG/oh-my-agentic-coder/internal/buildrun"
@@ -145,9 +146,37 @@ func runBuildApprove(args []string, env *Env) int {
 
 	// 8. Store the durable approval. This is the ONLY write; it does
 	//    NOT execute build code, start proxies, or launch the executor.
+	//    In addition to the per-worktree record, when the worktree's
+	//    repo identity is resolvable (a git repo with a root commit),
+	//    it writes the digest-indexed, repo-namespaced reuse record
+	//    (with repoRootCommit) under the host-only approvals-by-repo
+	//    tree (ADR 0005). This record is INERT unless the host enables
+	//    approval reuse; writing it at approve time means an
+	//    already-approved repo's unchanged worktrees can reuse the
+	//    approval later without re-running approve.
 	if err := buildmanifest.ApproveAt(leaf, loc, digest, caps); err != nil {
 		fmt.Fprintf(env.Stderr, "omac build approve: write approval: %v\n", err)
 		return buildrun.ExitServiceFailure
+	}
+	// Digest-indexed reuse record (idempotent; best-effort — a
+	// non-resolvable repo identity merely skips it, it is not an
+	// approval error).
+	cacheRoot := buildControlCacheRoot(cacheDir)
+	if cacheRoot != "" {
+		if canonRepoRoot, rootCommit := resolveRepoIdentity(canonWorktree); canonRepoRoot != "" && rootCommit != "" {
+			reuseRec := buildmanifest.ApprovalRecord{
+				Digest:         digest,
+				Capabilities:   caps,
+				ApprovedAt:     time.Now().UTC(),
+				RepoRootCommit: rootCommit,
+			}
+			if err := buildmanifest.StoreApprovalForRepoDigest(cacheRoot, canonRepoRoot, digest, reuseRec); err != nil {
+				// A reuse-record write failure must not fail the already
+				// successful per-worktree approval (the reuse record is a
+				// convenience, never an approval transition).
+				fmt.Fprintf(env.Stderr, "omac build approve: warning: digest-indexed reuse record not written: %v\n", err)
+			}
+		}
 	}
 	fmt.Fprintln(env.Stdout, "omac build approve: durable approval recorded. Restart the omac parent (`omac start`/`serve`) to activate the capability set.")
 	return ExitOK

--- a/internal/cli/build_broker_wiring.go
+++ b/internal/cli/build_broker_wiring.go
@@ -279,7 +279,43 @@ func freezeSnapshotFromDurableApproval(store *buildengine.ParentSnapshotStore, c
 	// + restart).
 	rec, err := buildmanifest.LoadApprovalAt(leaf, loc)
 	if err != nil || rec.Digest == "" || rec.Digest != digest {
+		// Per-worktree approval missed. When the opt-in digest-indexed
+		// approval-reuse feature is enabled (ADR 0005), fall back to the
+		// reusable digest-indexed record for this repo before giving up:
+		// an already-approved repo's unchanged worktrees freeze a
+		// snapshot from the reuse record instead of requiring a fresh
+		// per-worktree approval.
+		if freezeFromRepoApproval(store, cacheDir, canonicalWorktree, digest, host) {
+			return
+		}
 		return
 	}
 	store.FreezeFromApproval(canonicalWorktree, digest, rec.Capabilities, host)
+}
+
+// freezeFromRepoApproval is the digest-indexed approval-reuse fallback
+// (ADR 0005) for the parent's activation snapshot. cacheDir is the
+// resolved cache scope dir (its parent is the build-control cache root);
+// canonicalWorktree is the canonical worktree; digest is the current
+// manifest digest; host is the ceiling to freeze. It resolves the
+// worktree's repo identity, looks up the digest-indexed reuse record
+// under the host-only approvals-by-repo tree, and — when the record's
+// digest AND repoRootCommit both match — freezes the snapshot from it.
+// Returns true when a snapshot was frozen from the reuse record.
+func freezeFromRepoApproval(store *buildengine.ParentSnapshotStore, cacheDir, canonicalWorktree, digest string, host buildmanifest.HostPolicy) bool {
+	cacheRoot := buildControlCacheRoot(cacheDir)
+	if cacheRoot == "" || !approvalReuseEnabled(cacheRoot) {
+		return false
+	}
+	canonRepoRoot, rootCommit := resolveRepoIdentity(canonicalWorktree)
+	if canonRepoRoot == "" || rootCommit == "" {
+		return false
+	}
+	reuseLoc := buildmanifest.NewRepoDigestLocation(cacheRoot, canonRepoRoot)
+	rec, err := buildmanifest.LookupApprovalForRepoDigestAt(reuseLoc, digest)
+	if err != nil || rec.Digest == "" || rec.Digest != digest || rec.RepoRootCommit != rootCommit {
+		return false
+	}
+	store.FreezeFromApproval(canonicalWorktree, digest, rec.Capabilities, host)
+	return true
 }

--- a/internal/cli/build_reuse.go
+++ b/internal/cli/build_reuse.go
@@ -1,0 +1,170 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/TNG/oh-my-agentic-coder/internal/buildcontrol"
+	"github.com/TNG/oh-my-agentic-coder/internal/buildengine"
+	"github.com/TNG/oh-my-agentic-coder/internal/buildmanifest"
+	"github.com/TNG/oh-my-agentic-coder/internal/buildrun"
+)
+
+// envApprovalReuseByDigest is the ad-hoc env override that enables the
+// opt-in digest-bound approval-reuse-by-digest feature (ADR 0005).
+// Host-only: a managed (sandboxed agent) session cannot set it and
+// cannot write approval records, so the agent cannot enable reuse.
+const envApprovalReuseByDigest = "OMAC_APPROVAL_REUSE_BY_DIGEST"
+
+// approvalReuseEnabled reports whether the opt-in approval-reuse-by-
+// digest feature (ADR 0005) is enabled, via the env override AND/OR the
+// host config entry in `<cacheRoot>/build-control/config.toml`. Both act
+// as a durable default (config) with an ad-hoc override (env). Default
+// off. cacheRoot is the shared cache root (parent of cache-scope dirs);
+// an empty cacheRoot disables reuse.
+func approvalReuseEnabled(cacheRoot string) bool {
+	if os.Getenv(envApprovalReuseByDigest) == "1" {
+		return true
+	}
+	return approvalReuseFromHostConfig(cacheRoot)
+}
+
+// approvalReuseFromHostConfig reads the host control configuration at
+// `<cacheRoot>/build-control/config.toml` and reports whether it enables
+// approval reuse. A missing/unreadable file, or the absence of the key,
+// means reuse is off. The scan is deliberately minimal (no TOML
+// dependency): it looks for a top-level `approval_reuse_by_digest = <bool>`
+// line. A malformed value is treated as off (fail closed).
+func approvalReuseFromHostConfig(cacheRoot string) bool {
+	if cacheRoot == "" {
+		return false
+	}
+	path := filepath.Join(buildcontrol.Root(cacheRoot), "config.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) != "approval_reuse_by_digest" {
+			continue
+		}
+		v := strings.TrimSpace(strings.Trim(strings.TrimSpace(value), `"`))
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return false
+		}
+		return b
+	}
+	return false
+}
+
+// resolveRepoIdentity resolves the two-part repo identity used by the
+// opt-in approval-reuse-by-digest feature (ADR 0005):
+//
+//   - canonicalRepoRoot — the canonical (EvalSymlinks-resolved)
+//     `git -C <worktree> rev-parse --git-common-dir` output. All linked
+//     worktrees of a repo share the same common dir, so they collapse to
+//     the same namespace.
+//   - repoRootCommit — the SHA of the first commit in the repo's
+//     history (`git -C <worktree> rev-list --max-parents=0 HEAD`), the
+//     recycling guard stored in the digest-indexed reuse record.
+//
+// Non-git / empty-repo / missing-common-dir (or any git error) returns
+// BOTH empty and nil error: identity is not ermittelbar, so the caller
+// falls back to per-worktree approval with NO error (spec §Edge cases).
+func resolveRepoIdentity(worktree string) (canonicalRepoRoot, repoRootCommit string) {
+	common, err := gitCommonDir(worktree, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return "", ""
+	}
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(worktree, common)
+	}
+	canon, err := filepath.EvalSymlinks(common)
+	if err != nil {
+		return "", ""
+	}
+	rootCommit, err := gitCommonDir(worktree, "rev-list", "--max-parents=0", "HEAD")
+	if err != nil {
+		return "", ""
+	}
+	return canon, rootCommit
+}
+
+// gitCommonDir runs git in `-C <dir>` fashion (c.Dir = worktree) with a
+// hermetic-enough environment (no host git config interference beyond
+// what the shell inherits) and returns trimmed stdout. Used to resolve
+// the repo identity for approval reuse.
+func gitCommonDir(worktree string, args ...string) (string, error) {
+	c := exec.Command("git", args...)
+	c.Dir = worktree
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// newDirectSnapshotProvider returns a SnapshotProvider for the direct
+// host-terminal build path that, in addition to the existing
+// behavior-preserving per-worktree gate, consults the opt-in
+// digest-indexed approval-reuse fallback (ADR 0005) when reuse is
+// enabled and the repo identity is resolvable. cacheRoot is the shared
+// cache root (empty → reuse never consulted). The per-worktree approval
+// location stays the legacy OnLeaf (the direct path's historical
+// layout); the reuse record lives under the host-only build-control
+// root's approvals-by-repo tree.
+//
+// The returned provider mirrors buildengine.DirectSnapshotProvider
+// exactly (Load → Validate → CapabilitySet → Digest → Gate) except that
+// the gate receives the reuse context.
+func newDirectSnapshotProvider(cacheRoot string) buildengine.SnapshotProvider {
+	reuse := cacheRoot != "" && approvalReuseEnabled(cacheRoot)
+	return func(worktree, leaf string, req buildrun.Request) (buildengine.PolicySnapshot, error) {
+		hostPolicy := buildrun.HostPolicy(req.MaxDuration)
+		manifest, err := buildmanifest.Load(worktree)
+		if err != nil {
+			return buildengine.PolicySnapshot{}, err
+		}
+		if err := manifest.Validate(hostPolicy); err != nil {
+			return buildengine.PolicySnapshot{}, err
+		}
+		if !manifest.HasManifest() {
+			return buildengine.PolicySnapshot{HostPolicy: hostPolicy}, nil
+		}
+		caps := manifest.CapabilitySet(hostPolicy)
+		digest := buildmanifest.Digest(manifest)
+		var opts buildmanifest.GateOptions
+		if reuse {
+			canonRepoRoot, rootCommit := resolveRepoIdentity(worktree)
+			if canonRepoRoot != "" && rootCommit != "" {
+				opts = buildmanifest.GateOptions{
+					EnableReuse:        true,
+					CanonicalRepoRoot:  canonRepoRoot,
+					RepoRootCommit:     rootCommit,
+					RepoDigestLocation: buildmanifest.NewRepoDigestLocation(cacheRoot, canonRepoRoot),
+				}
+			}
+		}
+		gateRes, gerr := buildmanifest.GateAt(leaf, buildmanifest.NewOnLeafLocation(), digest, caps, opts)
+		if gerr != nil {
+			return buildengine.PolicySnapshot{}, gerr
+		}
+		return buildengine.PolicySnapshot{
+			Digest:       gateRes.Digest,
+			Capabilities: gateRes.Capabilities,
+			HostPolicy:   hostPolicy,
+		}, nil
+	}
+}

--- a/internal/cli/build_reuse_test.go
+++ b/internal/cli/build_reuse_test.go
@@ -1,0 +1,544 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/TNG/oh-my-agentic-coder/internal/buildcontrol"
+	"github.com/TNG/oh-my-agentic-coder/internal/buildengine"
+	"github.com/TNG/oh-my-agentic-coder/internal/buildmanifest"
+)
+
+// gitInitForTest initializes a git repo in worktree with a hermetic
+// identity and returns the worktree (chainable for linked worktrees).
+func gitInitForTest(t *testing.T, worktree string) string {
+	t.Helper()
+	runGitIn(t, worktree, "init", "-q", "-b", "main")
+	runGitIn(t, worktree, "commit", "-q", "--allow-empty", "-m", "init")
+	return worktree
+}
+
+func runGitIn(t *testing.T, worktree string, args ...string) {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = worktree
+	c.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// TestApprovalReuseEnabled_DefaultOff asserts the opt-in is OFF by
+// default (no env, no host config) — scenario (f) at the flag level.
+func TestApprovalReuseEnabled_DefaultOff(t *testing.T) {
+	t.Setenv(envApprovalReuseByDigest, "")
+	// Empty cache root: off.
+	if approvalReuseEnabled("") {
+		t.Error("empty cache root must not enable reuse")
+	}
+	// Valid cache root with no config.toml: off.
+	cacheRoot := t.TempDir()
+	if approvalReuseEnabled(cacheRoot) {
+		t.Error("reuse must default off with no host config")
+	}
+}
+
+// TestApprovalReuseEnabled_EnvOverride asserts OMAC_APPROVAL_REUSE_BY_DIGEST=1
+// enables reuse even without a host config.
+func TestApprovalReuseEnabled_EnvOverride(t *testing.T) {
+	t.Setenv(envApprovalReuseByDigest, "1")
+	if !approvalReuseEnabled(t.TempDir()) {
+		t.Error("env=1 must enable reuse")
+	}
+}
+
+// TestApprovalReuseEnabled_HostConfig asserts a host config entry in
+// <cacheRoot>/build-control/config.toml enables reuse (durable default),
+// and a `false` entry keeps it off.
+func TestApprovalReuseEnabled_HostConfig(t *testing.T) {
+	t.Setenv(envApprovalReuseByDigest, "")
+	cacheRoot := t.TempDir()
+	root := buildcontrol.Root(cacheRoot)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// No key -> off.
+	if approvalReuseEnabled(cacheRoot) {
+		t.Error("config without the key must not enable reuse")
+	}
+	// Key = true -> on.
+	cfg := filepath.Join(root, "config.toml")
+	if err := os.WriteFile(cfg, []byte("approval_reuse_by_digest = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !approvalReuseEnabled(cacheRoot) {
+		t.Error("config approval_reuse_by_digest=true must enable reuse")
+	}
+	// Key = false -> off.
+	if err := os.WriteFile(cfg, []byte("approval_reuse_by_digest = false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if approvalReuseEnabled(cacheRoot) {
+		t.Error("config approval_reuse_by_digest=false must keep reuse off")
+	}
+}
+
+// TestResolveRepoIdentity_LinkedWorktreesCollapse asserts all linked
+// worktrees of a repo resolve to the SAME canonicalRepoRoot (scenario
+// a's namespace property), while a separate CLONE has a DIFFERENT
+// canonicalRepoRoot (scenario d: no cross-clone reuse).
+func TestResolveRepoIdentity_LinkedWorktreesCollapse(t *testing.T) {
+	base := t.TempDir()
+	main := filepath.Join(base, "main")
+	if err := os.MkdirAll(main, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitInitForTest(t, main)
+	// Linked worktree under a sibling dir.
+	linked := filepath.Join(base, "linked")
+	if err := exec.Command("git", "-C", main, "worktree", "add", "-q", linked, "-b", "feature").Run(); err != nil {
+		t.Skipf("cannot create linked worktree: %v", err)
+	}
+
+	mainRepoRoot, mainRootCommit := resolveRepoIdentity(main)
+	linkedRepoRoot, linkedRootCommit := resolveRepoIdentity(linked)
+	if mainRepoRoot == "" || linkedRepoRoot == "" {
+		t.Fatalf("resolveRepoIdentity failed: main=%q linked=%q", mainRepoRoot, linkedRepoRoot)
+	}
+	if mainRepoRoot != linkedRepoRoot {
+		t.Errorf("linked worktrees must share canonicalRepoRoot: main=%q linked=%q", mainRepoRoot, linkedRepoRoot)
+	}
+	if mainRootCommit != linkedRootCommit {
+		t.Errorf("linked worktrees must share repoRootCommit: main=%q linked=%q", mainRootCommit, linkedRootCommit)
+	}
+
+	// Separate clone: same history but a different git-common-dir ->
+	// different canonicalRepoRoot (no cross-clone reuse, scenario d).
+	clone := filepath.Join(base, "clone")
+	if err := exec.Command("git", "clone", "-q", main, clone).Run(); err != nil {
+		t.Skipf("cannot clone: %v", err)
+	}
+	cloneRepoRoot, cloneRootCommit := resolveRepoIdentity(clone)
+	if cloneRepoRoot == "" {
+		t.Fatal("resolveRepoIdentity(clone) failed")
+	}
+	if cloneRepoRoot == mainRepoRoot {
+		t.Errorf("a separate clone must have a DIFFERENT canonicalRepoRoot (no cross-clone reuse): both %q", cloneRepoRoot)
+	}
+	if cloneRootCommit != mainRootCommit {
+		t.Errorf("clones of the same repo should share the root commit: clone=%q main=%q", cloneRootCommit, mainRootCommit)
+	}
+}
+
+// TestResolveRepoIdentity_NonGitFallsBack asserts resolveRepoIdentity
+// returns empty + nil (no error) for a non-git path (scenario h).
+func TestResolveRepoIdentity_NonGitFallsBack(t *testing.T) {
+	worktree := t.TempDir()
+	repoRoot, rootCommit := resolveRepoIdentity(worktree)
+	if repoRoot != "" || rootCommit != "" {
+		t.Errorf("non-git path must return empty identity, got %q / %q", repoRoot, rootCommit)
+	}
+}
+
+// TestResolveRepoIdentity_EmptyRepoFallsBack asserts an empty repo (no
+// commits) returns empty repoRootCommit (scenario h: reuse falls back).
+func TestResolveRepoIdentity_EmptyRepoFallsBack(t *testing.T) {
+	worktree := t.TempDir()
+	runGitIn(t, worktree, "init", "-q", "-b", "main")
+	repoRoot, rootCommit := resolveRepoIdentity(worktree)
+	// An empty repo has a valid common dir but no root commit (no
+	// commits). The identity is NOT ermittelbar for reuse (root commit
+	// empty -> reuse disabled, fall back to per-worktree), so the repo
+	// root hash alone is not enough: reuse requires BOTH parts.
+	_ = repoRoot
+	if rootCommit != "" {
+		t.Errorf("empty repo (no commits) must have no root commit, got %q — reuse must fall back", rootCommit)
+	}
+}
+
+// TestFreezeFromDurableApproval_ReuseFallbackFreezes is scenario (a) at
+// the parent-activation level: a NEW worktree of an already-approved
+// repo (per-worktree approval absent, digest-indexed record present)
+// freezes a snapshot from the reuse record when reuse is enabled.
+func TestFreezeFromDurableApproval_ReuseFallbackFreezes(t *testing.T) {
+	// Enable reuse via env.
+	t.Setenv(envApprovalReuseByDigest, "1")
+
+	main := t.TempDir()
+	gitInitForTest(t, main)
+	writeCliManifest(t, main, `version: 1
+builds:
+  - root: backend
+    containers:
+      images: [pgvector/pgvector:pg16]
+`)
+	m, err := buildmanifest.Load(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := buildmanifest.Digest(m)
+	host := buildmanifest.HostPolicy{}
+	caps := m.CapabilitySet(host)
+	canonRepoRoot, rootCommit := resolveRepoIdentity(main)
+
+	// The new worktree: a LINKED worktree (same repo -> same common dir
+	// -> same canonicalRepoRoot), but NO per-worktree approval. The
+	// manifest is written into the new worktree too (the manifest is
+	// committed in the repo; here we write it so Load finds it).
+	base := filepath.Dir(main)
+	newWorktree := filepath.Join(base, "new-wt")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "-C", main, "worktree", "add", "-q", newWorktree, "-b", "feature").Run(); err != nil {
+		t.Skipf("cannot create linked worktree: %v", err)
+	}
+	writeCliManifest(t, newWorktree, `version: 1
+builds:
+  - root: backend
+    containers:
+      images: [pgvector/pgvector:pg16]
+`)
+
+	// cacheDir is <cacheRoot>/<digest>; its parent is the cache root.
+	cacheDir := filepath.Join(t.TempDir(), "scope-digest")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := filepath.Dir(cacheDir)
+
+	// Plant the digest-indexed reuse record for the repo.
+	reuseLoc := buildmanifest.NewRepoDigestLocation(cacheRoot, canonRepoRoot)
+	if err := buildmanifest.StoreApprovalForRepoDigestAt(reuseLoc, digest, buildmanifest.ApprovalRecord{
+		Digest:         digest,
+		Capabilities:   caps,
+		RepoRootCommit: rootCommit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := buildengine.NewParentSnapshotStore()
+	freezeSnapshotFromDurableApproval(store, newWorktree, cacheDir)
+
+	got, err := store.Lookup(newWorktree)
+	if err != nil {
+		t.Fatalf("no snapshot frozen from the reuse record: %v", err)
+	}
+	if got.Policy.Digest != digest {
+		t.Errorf("Digest = %q, want %q (reused record)", got.Policy.Digest, digest)
+	}
+	if len(got.Policy.Capabilities.Images) != 1 || got.Policy.Capabilities.Images[0] != "pgvector/pgvector:pg16" {
+		t.Errorf("Capabilities = %+v, want the reuse record's images", got.Policy.Capabilities)
+	}
+}
+
+// TestFreezeFromDurableApproval_ReuseDisabledNoFallback asserts scenario
+// (f): with reuse DISABLED, the parent must NOT freeze a snapshot from
+// the digest-indexed record for a worktree with no per-worktree
+// approval (build unavailable until per-worktree approve + restart).
+func TestFreezeFromDurableApproval_ReuseDisabledNoFallback(t *testing.T) {
+	t.Setenv(envApprovalReuseByDigest, "") // reuse off (default)
+
+	main := t.TempDir()
+	gitInitForTest(t, main)
+	writeCliManifest(t, main, `version: 1
+builds:
+  - root: backend
+`)
+	m, err := buildmanifest.Load(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := buildmanifest.Digest(m)
+	host := buildmanifest.HostPolicy{}
+	caps := m.CapabilitySet(host)
+	canonRepoRoot, rootCommit := resolveRepoIdentity(main)
+
+	// The new worktree: a LINKED worktree of the same repo (same
+	// canonicalRepoRoot), with the manifest present, but NO per-worktree
+	// approval.
+	mainDir := filepath.Dir(main)
+	newWorktree := filepath.Join(mainDir, "new-wt")
+	if err := exec.Command("git", "-C", main, "worktree", "add", "-q", newWorktree, "-b", "feature").Run(); err != nil {
+		t.Skipf("cannot create linked worktree: %v", err)
+	}
+	writeCliManifest(t, newWorktree, `version: 1
+builds:
+  - root: backend
+`)
+
+	cacheDir := filepath.Join(t.TempDir(), "scope-digest")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := filepath.Dir(cacheDir)
+
+	// Plant a valid reuse record, but reuse is DISABLED.
+	reuseLoc := buildmanifest.NewRepoDigestLocation(cacheRoot, canonRepoRoot)
+	if err := buildmanifest.StoreApprovalForRepoDigestAt(reuseLoc, digest, buildmanifest.ApprovalRecord{
+		Digest:         digest,
+		Capabilities:   caps,
+		RepoRootCommit: rootCommit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := buildengine.NewParentSnapshotStore()
+	freezeSnapshotFromDurableApproval(store, newWorktree, cacheDir)
+	if _, err := store.Lookup(newWorktree); err == nil {
+		t.Error("reuse disabled: must NOT freeze a snapshot from the reuse record (no per-worktree approval)")
+	}
+}
+
+// TestFreezeFromDurableApproval_ReuseRootCommitMismatchNoFallback is
+// scenario (e) at the parent-activation level: a foreign repo at the
+// same path (different root commit) must NOT reuse the stored record.
+// We construct two repos with distinct root commits and verify the
+// gate-level reuse rejects the stale record.
+func TestFreezeFromDurableApproval_ReuseRootCommitMismatchNoFallback(t *testing.T) {
+	t.Setenv(envApprovalReuseByDigest, "1")
+
+	approved := t.TempDir()
+	gitInitForTest(t, approved)
+	writeCliManifest(t, approved, `version: 1
+builds:
+  - root: backend
+`)
+	m, err := buildmanifest.Load(approved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := buildmanifest.Digest(m)
+	caps := m.CapabilitySet(buildmanifest.HostPolicy{})
+	canonRepoRoot, approvedRootCommit := resolveRepoIdentity(approved)
+
+	cacheDir := filepath.Join(t.TempDir(), "scope-digest")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := filepath.Dir(cacheDir)
+	reuseLoc := buildmanifest.NewRepoDigestLocation(cacheRoot, canonRepoRoot)
+	if err := buildmanifest.StoreApprovalForRepoDigestAt(reuseLoc, digest, buildmanifest.ApprovalRecord{
+		Digest:         digest,
+		Capabilities:   caps,
+		RepoRootCommit: approvedRootCommit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A foreign repo whose root commit differs (a fresh repo at the same
+	// path after the original was deleted — different history). Give it a
+	// DISTINCT root commit so the SHAs cannot collide.
+	foreign := t.TempDir()
+	if err := os.WriteFile(filepath.Join(foreign, "foreign-marker.txt"), []byte(t.Name()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, foreign, "init", "-q", "-b", "main")
+	runGitIn(t, foreign, "add", "foreign-marker.txt")
+	runGitIn(t, foreign, "commit", "-q", "-m", "foreign init")
+	_, foreignRootCommit := resolveRepoIdentity(foreign)
+	if foreignRootCommit == approvedRootCommit {
+		t.Skip("cannot construct two repos with distinct root commits")
+	}
+
+	// Gate-level assertion: reuse must be rejected when the CURRENT repo's
+	// root commit differs from the stored record's (recycling guard).
+	leaf := t.TempDir()
+	_, gerr := buildmanifest.GateAt(leaf, buildmanifest.NewOnLeafLocation(), digest, caps, buildmanifest.GateOptions{
+		EnableReuse:        true,
+		CanonicalRepoRoot:  canonRepoRoot,
+		RepoRootCommit:     foreignRootCommit, // mismatched recycling guard
+		RepoDigestLocation: reuseLoc,
+	})
+	if gerr == nil {
+		t.Fatal("root-commit mismatch must NOT reuse the stored approval (recycling guard)")
+	}
+	var ge *buildmanifest.GateError
+	if !errorsAsGate(gerr, &ge) {
+		t.Fatalf("want *GateError, got %T: %v", gerr, gerr)
+	}
+}
+
+// TestFreezeFromDurableApproval_CrossRepoNoFallback is scenario (c):
+// a DIFFERENT repo with an IDENTICAL manifest digest must NOT reuse the
+// record (different canonicalRepoRoot -> different namespace).
+func TestFreezeFromDurableApproval_CrossRepoNoFallback(t *testing.T) {
+	t.Setenv(envApprovalReuseByDigest, "1")
+
+	repoA := t.TempDir()
+	gitInitForTest(t, repoA)
+	writeCliManifest(t, repoA, `version: 1
+builds:
+  - root: backend
+    containers:
+      images: [pgvector/pgvector:pg16]
+`)
+	m, err := buildmanifest.Load(repoA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := buildmanifest.Digest(m)
+	caps := m.CapabilitySet(buildmanifest.HostPolicy{})
+	repoARoot, rootCommitA := resolveRepoIdentity(repoA)
+
+	cacheDir := filepath.Join(t.TempDir(), "scope-digest")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := filepath.Dir(cacheDir)
+	reuseLocA := buildmanifest.NewRepoDigestLocation(cacheRoot, repoARoot)
+	if err := buildmanifest.StoreApprovalForRepoDigestAt(reuseLocA, digest, buildmanifest.ApprovalRecord{
+		Digest:         digest,
+		Capabilities:   caps,
+		RepoRootCommit: rootCommitA,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Repo B: IDENTICAL manifest content (identical digest) but a
+	// different repo root.
+	repoB := t.TempDir()
+	gitInitForTest(t, repoB)
+	writeCliManifest(t, repoB, `version: 1
+builds:
+  - root: backend
+    containers:
+      images: [pgvector/pgvector:pg16]
+`)
+	// Verify the digests are actually identical (bit-identical manifest).
+	mB, err := buildmanifest.Load(repoB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buildmanifest.Digest(mB) != digest {
+		t.Fatal("test setup: repos must have identical digests for cross-repo scenario")
+	}
+
+	store := buildengine.NewParentSnapshotStore()
+	freezeSnapshotFromDurableApproval(store, repoB, cacheDir)
+	if _, err := store.Lookup(repoB); err == nil {
+		t.Error("cross-repo digest match must NOT reuse the approval (different namespace)")
+	}
+}
+
+func writeCliManifest(t *testing.T, wt, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(wt, ".omac"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt, ".omac", "build.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestApprovalReuseEnabled_CacheRootIsEmpty(t *testing.T) {
+	t.Setenv(envApprovalReuseByDigest, "")
+	if approvalReuseFromHostConfig("") {
+		t.Error("empty cache root must not read host config")
+	}
+	// Ensure no name collision pollution from other tests.
+	if strings.Contains(envApprovalReuseByDigest, "REUSE") {
+		_ = envApprovalReuseByDigest[0] // compile-time reference
+	}
+}
+
+// errorsAsGate is a small errors.As helper bound to *buildmanifest.GateError.
+func errorsAsGate(err error, ge **buildmanifest.GateError) bool {
+	return errors.As(err, ge)
+}
+
+// TestRevoke_SettingOffKeepsFrozenSnapshotValid is scenario (i): the
+// already-frozen ParentSnapshot remains valid for the parent lifetime
+// after reuse is disabled (its validity is governed by the in-memory
+// store, not by the reuse flag), while a NEW lookup (a worktree frozen
+// AFTER the revoke) falls back to per-worktree and does NOT reuse the
+// digest-indexed record.
+func TestRevoke_SettingOffKeepsFrozenSnapshotValid(t *testing.T) {
+	t.Setenv(envApprovalReuseByDigest, "1")
+
+	main := t.TempDir()
+	gitInitForTest(t, main)
+	writeCliManifest(t, main, `version: 1
+builds:
+  - root: backend
+`)
+	m, err := buildmanifest.Load(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := buildmanifest.Digest(m)
+	caps := m.CapabilitySet(buildmanifest.HostPolicy{})
+	canonRepoRoot, rootCommit := resolveRepoIdentity(main)
+
+	// New worktree (linked, same repo), NOT yet frozen.
+	mainDir := filepath.Dir(main)
+	newWorktree := filepath.Join(mainDir, "revoke-wt")
+	if err := exec.Command("git", "-C", main, "worktree", "add", "-q", newWorktree, "-b", "feature").Run(); err != nil {
+		t.Skipf("cannot create linked worktree: %v", err)
+	}
+	writeCliManifest(t, newWorktree, `version: 1
+builds:
+  - root: backend
+`)
+
+	cacheDir := filepath.Join(t.TempDir(), "scope-digest")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := filepath.Dir(cacheDir)
+	reuseLoc := buildmanifest.NewRepoDigestLocation(cacheRoot, canonRepoRoot)
+	if err := buildmanifest.StoreApprovalForRepoDigestAt(reuseLoc, digest, buildmanifest.ApprovalRecord{
+		Digest:         digest,
+		Capabilities:   caps,
+		RepoRootCommit: rootCommit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Phase 1 (reuse ON): freeze the new worktree's snapshot from the
+	// reuse record.
+	store := buildengine.NewParentSnapshotStore()
+	freezeSnapshotFromDurableApproval(store, newWorktree, cacheDir)
+	if _, err := store.Lookup(newWorktree); err != nil {
+		t.Fatalf("phase 1: snapshot must be frozen from the reuse record: %v", err)
+	}
+	// Capture the frozen digest for the later "stays valid" assertion.
+	snap, _ := store.Lookup(newWorktree)
+	frozenDigest := snap.Policy.Digest
+	if frozenDigest != digest {
+		t.Fatalf("phase 1: frozen digest = %q, want %q", frozenDigest, digest)
+	}
+
+	// Phase 2 (revoke: reuse OFF): the parent's in-memory store is NOT
+	// cleared by a reuse-flag change — the already-frozen snapshot stays
+	// valid for the parent lifetime (it expires only on parent restart).
+	t.Setenv(envApprovalReuseByDigest, "")
+	if !approvalReuseEnabled(cacheRoot) {
+		// Reuse is now off for new lookups.
+		snap2, err := store.Lookup(newWorktree)
+		if err != nil {
+			t.Fatalf("phase 2: frozen snapshot must remain valid after reuse disabled: %v", err)
+		}
+		if snap2.Policy.Digest != frozenDigest {
+			t.Errorf("phase 2: frozen digest changed to %q after reuse disabled, want %q (snapshot stays valid for parent lifetime)",
+				snap2.Policy.Digest, frozenDigest)
+		}
+	} else {
+		t.Fatal("phase 2: reuse should be off after env cleared")
+	}
+
+	// Phase 3: a NEW worktree (fresh store) frozen AFTER the revoke must
+	// NOT consult the reuse record — it falls back to per-worktree
+	// (missing) and freezes no snapshot.
+	postRevokeStore := buildengine.NewParentSnapshotStore()
+	freezeSnapshotFromDurableApproval(postRevokeStore, newWorktree, cacheDir)
+	if _, err := postRevokeStore.Lookup(newWorktree); err == nil {
+		t.Error("phase 3: a post-revoke lookup must NOT reuse the digest-indexed record (falls back to per-worktree)")
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1084,10 +1084,15 @@ func (s *serveServer) isActiveDir(canonicalDir string) bool {
 
 // freezeBuildSnapshot freezes the parent-owned capability snapshot
 // for canonicalWorktree at activation, when the canonical identity +
-// current manifest digest match a durable approval (ticket 06). A
-// build request can only compare against this snapshot; it cannot
-// advance or replace it. An unapproved directory (no durable approval
-// OR digest mismatch) is left without a snapshot — the engine
+// current manifest digest match a durable approval (ticket 06). When
+// the per-worktree durable approval misses and the opt-in
+// approval-reuse-by-digest feature is enabled (ADR 0005),
+// freezeSnapshotFromDurableApproval falls back to the digest-indexed,
+// repo-namespaced reuse record (verifying the repo's root commit) —
+// the parent then freezes the reused record's capability set for THIS
+// worktree. A build request can only compare against this snapshot; it
+// cannot advance or replace it. An unapproved directory (no durable
+// approval OR digest mismatch) is left without a snapshot — the engine
 // surfaces a host diagnostic requiring `omac build approve` + parent
 // restart. Agent-callable activation is NOT an approval transition:
 // this method reads the durable approval record; it does not write


### PR DESCRIPTION
**Issue:** Closes #218

## What
- Opt-in approval reuse by digest lets an already-approved repo's unchanged worktrees build without a fresh `omac build approve`.
- Default off, host-only (`OMAC_APPROVAL_REUSE_BY_DIGEST=1` or `<cacheRoot>/build-control/config.toml`).
- ADR 0005 + CONTEXT.md glossary entries written.

## Why
Every new worktree required a fresh `omac build approve` even when `.omac/build.yaml` was byte-identical to the approved manifest — approval is keyed by `sha256(canonicalWorktree)`, so identical worktrees of one repo had no shared approval. Ticket 06 correctly rejected path-keyed per-repo reuse (worktrees can differ in capabilities); digest-bound reuse is safe (identical digest ⇒ identical capability set ⇒ identical risk) and closes that gap.

## How
- `buildcontrol`: `HashRepo` + `ApprovalsByRepoDir` / `ApprovalByRepoPath` path helpers under `approvals-by-repo/`.
- `buildmanifest`: `ApprovalRecord.RepoRootCommit` (omitempty, legacy records still parse); `RepoDigestLocation`; `StoreApprovalForRepoDigest(At)` / `LookupApprovalForRepoDigest(At)`; `GateOptions` + `GateAt` variadic reuse fallback.
- `cli/build_reuse.go`: `resolveRepoIdentity` (git-native via `rev-parse --git-common-dir` + `EvalSymlinks` + `rev-list --max-parents=0 HEAD`; empty + nil on non-git/empty/missing common dir per spec edge cases); `approvalReuseEnabled` (env + config.toml); `newDirectSnapshotProvider` threads reuse into `GateAt`.
- `cli/build_approve.go`: `omac build approve` additionally writes the digest-indexed record with `repoRootCommit`.
- `build_broker_wiring.go`: `freezeFromRepoApproval` fallback at parent activation (start + serve).
- `GateAt` order: per-worktree first → repo-digest fallback when reuse enabled (verify digest + `repoRootCommit` + `ceilingStillValid`) → exit 3 on miss/mismatch.

## Verification
- `go test ./internal/buildmanifest/... ./internal/buildcontrol/... ./internal/buildengine/... ./internal/cli/...` → exit 0 (all new + existing tests green; 19 new reuse tests PASS, scenarios a–i)
- `go build -buildvcs=false ./...` → exit 0
- `go vet ./...` → exit 0
- `gofmt -l internal/` → clean

## Follow-up
- A cli-level e2e test through `runBuildApprove` (with a real TTY) asserting both records land on disk would strengthen coverage (requires a pty; existing TTY-gate tests use `/dev/null`).
- Consider documenting `build-control/config.toml` in `docs/CONFIGURATION.md` (currently only build-command.md + SECURITY_MODEL.md mention it).

🤖 Generated with [Orchestrator](https://github.com/TNG/oh-my-agentic-coder)