### PR TITLE
fix(e2e,ci): stop the serve probe deadlocking on its own teardown

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -279,6 +279,23 @@ jobs:
               exit 0
             fi
             echo "::endgroup::"
+            # A go-test deadline is a test/product defect (a deadlocked or
+            # runaway test), never infra: the model provider cannot make a test
+            # hang for 30 minutes, and retrying costs another full deadline per
+            # attempt. Bail immediately and name the test that was still
+            # running, so the signal is not buried under "infra-only". See #222.
+            if grep -q '^panic: test timed out after' /tmp/e2e-out.txt; then
+              echo "::error::go test hit its deadline — a hung test, not infra; retries cannot clear it"
+              echo "test(s) still running at the deadline:"
+              sed -n '/^panic: test timed out after/,/^$/p' /tmp/e2e-out.txt | head -20
+              {
+                echo "## E2E deadline exceeded (${{ matrix.harness }} / ${{ matrix.os }})"
+                echo '```'
+                sed -n '/^panic: test timed out after/,/^$/p' /tmp/e2e-out.txt | head -20
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
             # Only retry when no failure this attempt was classified as a real
             # regression: SANDBOX_FAIL (a security property went unenforced)
             # or AGENT_REFUSED/AGENT_PARTIAL (a model-behavior signal, not

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -285,13 +285,16 @@ jobs:
             # attempt. Bail immediately and name the test that was still
             # running, so the signal is not buried under "infra-only". See #222.
             if grep -q '^panic: test timed out after' /tmp/e2e-out.txt; then
+              # The panic header through the blank line = the "running tests:"
+              # list, i.e. exactly what hung, without the goroutine dump.
+              hung=$(sed -n '/^panic: test timed out after/,/^$/p' /tmp/e2e-out.txt | head -20)
               echo "::error::go test hit its deadline — a hung test, not infra; retries cannot clear it"
               echo "test(s) still running at the deadline:"
-              sed -n '/^panic: test timed out after/,/^$/p' /tmp/e2e-out.txt | head -20
+              echo "$hung"
               {
                 echo "## E2E deadline exceeded (${{ matrix.harness }} / ${{ matrix.os }})"
                 echo '```'
-                sed -n '/^panic: test timed out after/,/^$/p' /tmp/e2e-out.txt | head -20
+                echo "$hung"
                 echo '```'
               } >> "$GITHUB_STEP_SUMMARY"
               exit 1

--- a/internal/e2e/security_assertions.go
+++ b/internal/e2e/security_assertions.go
@@ -46,19 +46,38 @@ func symlinkEscapeLeaked(output string) (readLeaked, writeLeaked bool) {
 func fsAllowDenied(output string, labels []string) string {
 	section := extractProbe(output, "fs_allow")
 	for _, label := range labels {
-		idx := strings.Index(section, label)
-		if idx < 0 {
+		line, ok := probeResultLine(section, label)
+		if !ok {
 			return label + ": probe label not found in fs_allow output"
-		}
-		line := section[idx:]
-		if nl := strings.IndexByte(line, '\n'); nl >= 0 {
-			line = line[:nl]
 		}
 		if !strings.Contains(line, "WRITABLE") && !strings.Contains(line, "READABLE") {
 			return line
 		}
 	}
 	return ""
+}
+
+// probeResultLine returns audit.sh's RESULT line for label: the line beginning
+// "<label>:", which is exactly what probe_read/probe_write emit via
+// `echo "$label: ..."`.
+//
+// Anchoring on that shape matters. Matching the label anywhere instead picks
+// its FIRST mention in the section, which need not be the result. When the
+// agent runs the script under `sh -x`, xtrace echoes every command, and
+// audit.sh redirects stderr into the same output file, so the trace of the
+// probe CALL — "probe_read <label> ./omac-audit-allow-test", carrying no
+// marker — lands in the section ahead of the probe's own
+// "<label>: READABLE (sandbox did not block)". Matching the call reported a
+// working sandbox as an over-restriction, and fsAllowed classifies as
+// SANDBOX_FAIL, which is never retried (#224).
+func probeResultLine(section, label string) (string, bool) {
+	for _, line := range strings.Split(section, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, label+":") {
+			return line, true
+		}
+	}
+	return "", false
 }
 
 // secretLeaked reports whether the plaintext secret value appears anywhere

--- a/internal/e2e/security_assertions_test.go
+++ b/internal/e2e/security_assertions_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -116,6 +117,69 @@ func TestFsAllowDeniedCatchesSingleDenial(t *testing.T) {
 		"=== END: fs_allow ===\n"
 	if denied := fsAllowDenied(oneDenied, labels); denied == "" {
 		t.Error("expected a denial to be detected when one of several legitimate paths was blocked")
+	}
+}
+
+// TestFsAllowDeniedIgnoresShellTraceLines pins the fix for #224 against the
+// output that produced it. The fixture is the fs_allow section captured
+// verbatim from run 31528427272 (claude-code / ubuntu-latest), where the agent
+// invoked audit.sh under `sh -x`: xtrace echoed every command, audit.sh
+// redirected stderr into the same file, and the trace of the probe CALL — which
+// carries no READABLE marker — preceded the probe's actual result line. Every
+// path here was in fact accessible, so the only correct answer is "no denial".
+func TestFsAllowDeniedIgnoresShellTraceLines(t *testing.T) {
+	labels := []string{
+		"--- write workdir file ---",
+		"--- read workdir file ---",
+		"--- write $HOME/.cache file ---",
+		"--- write ${TMPDIR:-/tmp} file ---",
+	}
+
+	xtraced := "+ echo === PROBE: fs_allow ===\n" +
+		"=== PROBE: fs_allow ===\n" +
+		"+ echo test\n" +
+		"+ echo --- write workdir file ---: WRITABLE (sandbox did not block)\n" +
+		"--- write workdir file ---: WRITABLE (sandbox did not block)\n" +
+		"+ probe_read --- read workdir file --- ./omac-audit-allow-test\n" +
+		"+ label=--- read workdir file ---\n" +
+		"+ path=./omac-audit-allow-test\n" +
+		"+ [ -r ./omac-audit-allow-test ]\n" +
+		"+ echo --- read workdir file ---: READABLE (sandbox did not block)\n" +
+		"--- read workdir file ---: READABLE (sandbox did not block)\n" +
+		"+ rm -f ./omac-audit-allow-test\n" +
+		"+ probe_write --- write $HOME/.cache file --- /tmp/x/.cache/omac-audit-allow-test\n" +
+		"+ label=--- write $HOME/.cache file ---\n" +
+		"+ echo --- write $HOME/.cache file ---: WRITABLE (sandbox did not block)\n" +
+		"--- write $HOME/.cache file ---: WRITABLE (sandbox did not block)\n" +
+		"+ probe_write --- write ${TMPDIR:-/tmp} file --- /tmp/omac-sandbox-tmp-1/omac-audit-allow-test\n" +
+		"+ label=--- write ${TMPDIR:-/tmp} file ---\n" +
+		"+ echo --- write ${TMPDIR:-/tmp} file ---: WRITABLE (sandbox did not block)\n" +
+		"--- write ${TMPDIR:-/tmp} file ---: WRITABLE (sandbox did not block)\n" +
+		"+ echo === END: fs_allow ===\n" +
+		"=== END: fs_allow ===\n"
+	if denied := fsAllowDenied(xtraced, labels); denied != "" {
+		t.Errorf("xtrace of the probe call must not read as a denial, got %q", denied)
+	}
+
+	// The trace must not mask a real denial either: same shape, but the read
+	// probe genuinely failed. Anchoring on the result line has to keep finding
+	// it when it reports an error instead of a marker.
+	xtracedDenied := "=== PROBE: fs_allow ===\n" +
+		"+ echo --- write workdir file ---: WRITABLE (sandbox did not block)\n" +
+		"--- write workdir file ---: WRITABLE (sandbox did not block)\n" +
+		"+ probe_read --- read workdir file --- ./omac-audit-allow-test\n" +
+		"+ [ -r ./omac-audit-allow-test ]\n" +
+		"+ cat ./omac-audit-allow-test\n" +
+		"--- read workdir file ---: cat: ./omac-audit-allow-test: Permission denied\n" +
+		"--- write $HOME/.cache file ---: WRITABLE (sandbox did not block)\n" +
+		"--- write ${TMPDIR:-/tmp} file ---: WRITABLE (sandbox did not block)\n" +
+		"=== END: fs_allow ===\n"
+	denied := fsAllowDenied(xtracedDenied, labels)
+	if denied == "" {
+		t.Fatal("a genuine denial must still be detected under xtrace")
+	}
+	if !strings.Contains(denied, "Permission denied") {
+		t.Errorf("expected the reported line to be the probe RESULT, got %q", denied)
 	}
 }
 

--- a/internal/e2e/smoke_test.go
+++ b/internal/e2e/smoke_test.go
@@ -40,6 +40,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -49,7 +50,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -68,6 +69,12 @@ const serveProbeTimeout = 3 * time.Minute
 // serveReadyTimeout bounds how long the probe waits for the control plane to
 // announce itself on stdout after `omac serve` starts.
 const serveReadyTimeout = 90 * time.Second
+
+// serveTeardownGrace bounds each step of the serve probe's teardown: first
+// waiting for a graceful exit after the context is cancelled, then waiting for
+// the process to be reaped after SIGKILL. Teardown must never be unbounded —
+// an unbounded wait here cost the suite the full 30-minute test deadline (#222).
+const serveTeardownGrace = 10 * time.Second
 
 // serveControlBaseRe extracts the control-plane base URL from the line
 // `omac serve` prints on startup: "control plane on http://127.0.0.1:PORT; ...".
@@ -294,14 +301,19 @@ func runServeProbe(t *testing.T, h harnessConfig, omacBin, home, workdir, cwd st
 	cmd.Env = append(withHome(os.Environ(), home), "PWD="+cwd)
 	cmd.Stdin = strings.NewReader("")
 
-	// Capture stdout/stderr into goroutine-safe buffers rather than an
-	// os/exec pipe: the probe polls stdout for the control-plane line while a
-	// background goroutine calls cmd.Wait(), and reading a StdoutPipe
-	// concurrently with Wait is a documented footgun. Buffers we own sidestep
-	// it entirely.
-	var stdout, stderr syncBuffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	// Capture stdout/stderr into files, NOT an os/exec pipe or an io.Writer
+	// (which os/exec turns into a pipe). See captureFile: a pipe makes
+	// cmd.Wait() outlive the direct child, which deadlocked teardown.
+	stdout := newCaptureFile(t, "serve-stdout.log")
+	stderr := newCaptureFile(t, "serve-stderr.log")
+	cmd.Stdout = stdout.file
+	cmd.Stderr = stderr.file
+
+	// Own process group, so teardown can signal the whole tree rather than
+	// just the leader. Both the context's cancel and the explicit kill below
+	// go to -pgid; killing the leader alone leaves omac's descendants running.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return killProcessGroup(cmd) }
 
 	t.Logf("serve probe: omac %s", strings.Join(args, " "))
 	if err := cmd.Start(); err != nil {
@@ -312,19 +324,31 @@ func runServeProbe(t *testing.T, h harnessConfig, omacBin, home, workdir, cwd st
 	// running" (healthy daemon) from "exited early" (inner launch failed).
 	waitCh := make(chan error, 1)
 	go func() { waitCh <- cmd.Wait() }()
+	// Teardown is bounded at every step. An unbounded wait here is what turned
+	// a passing probe into a 30-minute go-test timeout (#222): if Wait is still
+	// blocked after a SIGKILL to the whole group, report it and move on rather
+	// than hanging the suite.
 	t.Cleanup(func() {
 		cancel()
 		select {
 		case <-waitCh:
-		case <-time.After(10 * time.Second):
-			_ = cmd.Process.Kill()
-			<-waitCh
+			return
+		case <-time.After(serveTeardownGrace):
+		}
+		if err := killProcessGroup(cmd); err != nil {
+			t.Logf("serve probe: killing process group: %v", err)
+		}
+		select {
+		case <-waitCh:
+		case <-time.After(serveTeardownGrace):
+			t.Errorf("omac serve (pid %d) did not exit within %v of SIGKILL to its process group",
+				cmd.Process.Pid, serveTeardownGrace)
 		}
 	})
 
 	// Poll stdout for the control-plane URL the server prints on startup,
 	// bailing early if the process exits before announcing it.
-	controlBase, err := waitForControlBase(&stdout, waitCh, serveReadyTimeout)
+	controlBase, err := waitForControlBase(stdout, waitCh, serveReadyTimeout)
 	if err != nil {
 		return fmt.Errorf("%w\nSTDERR:\n%s", err, tailLines(stderr.String(), 60))
 	}
@@ -333,7 +357,7 @@ func runServeProbe(t *testing.T, h harnessConfig, omacBin, home, workdir, cwd st
 	// is announced BEFORE the child launches, so wait for the onReady marker
 	// (`--verbose`) rather than checking once — otherwise a slow runner could
 	// finish the API round-trip before the child has even spawned.
-	if err := waitForStderr(&stderr, "inner command started", waitCh, serveReadyTimeout); err != nil {
+	if err := waitForStderr(stderr, "inner command started", waitCh, serveReadyTimeout); err != nil {
 		return fmt.Errorf("inner daemon never started under the sandbox: %w\nSTDERR:\n%s",
 			err, tailLines(stderr.String(), 60))
 	}
@@ -378,30 +402,73 @@ func runServeProbe(t *testing.T, h harnessConfig, omacBin, home, workdir, cwd st
 	return nil
 }
 
-// syncBuffer is a goroutine-safe bytes.Buffer. The serve probe reads captured
-// stderr for diagnostics while the subprocess may still be writing to it (the
-// daemon runs until teardown), so plain bytes.Buffer would race.
-type syncBuffer struct {
-	mu  sync.Mutex
-	buf bytes.Buffer
+// captureFile captures a subprocess's stdout or stderr in a real file.
+//
+// Assigning any plain io.Writer to cmd.Stdout makes os/exec allocate a pipe
+// and a copy goroutine, and cmd.Wait() then blocks until EVERY process holding
+// the inherited write end exits — not just the direct child. omac passes its
+// own stdout down to the sandboxed inner daemon
+// (internal/sandbox/launcher.go), and that daemon survives a SIGKILLed parent
+// wherever bwrap's --die-with-parent does not apply (notably macOS Seatbelt).
+// Wait then never returns. An *os.File is dup'd straight into the child, so
+// Wait depends on the direct child alone.
+type captureFile struct {
+	file *os.File
+	path string
 }
 
-func (b *syncBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.Write(p)
+func newCaptureFile(t *testing.T, name string) *captureFile {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", name, err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return &captureFile{file: f, path: path}
 }
 
-func (b *syncBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.String()
+// String returns everything written so far. It reads via the path rather than
+// the write handle so polling never disturbs the child's file offset, and
+// returns "" on a read error — callers poll it in a loop and treat an empty
+// capture as "not yet".
+func (c *captureFile) String() string {
+	b, err := os.ReadFile(c.path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// killProcessGroup SIGKILLs the process group cmd leads. Killing cmd.Process
+// alone is not enough: omac forwards only catchable signals to its sandboxed
+// child (internal/sandbox/launcher.go), and SIGKILL is not catchable, so the
+// leader dies without tearing anything else down.
+//
+// An already-gone group reports os.ErrProcessDone, which is what cmd.Cancel
+// must return so os/exec does not turn a normal exit into a Wait error.
+func killProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		// Setpgid can race with Start; fall back to the leader alone.
+		return cmd.Process.Kill()
+	}
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return nil
 }
 
 // waitForControlBase polls the captured stdout for the control-plane URL
 // `omac serve` prints on startup, returning it once seen. It fails fast if the
 // process exits first (waitCh fires) or the timeout elapses.
-func waitForControlBase(stdout *syncBuffer, waitCh <-chan error, timeout time.Duration) (string, error) {
+func waitForControlBase(stdout fmt.Stringer, waitCh <-chan error, timeout time.Duration) (string, error) {
 	deadline := time.After(timeout)
 	tick := time.NewTicker(100 * time.Millisecond)
 	defer tick.Stop()
@@ -427,7 +494,7 @@ func waitForControlBase(stdout *syncBuffer, waitCh <-chan error, timeout time.Du
 // waitForStderr polls the captured stderr until it contains substr, returning
 // nil once seen. It fails fast if the process exits first or the timeout
 // elapses (the final drain-check covers a marker flushed just before exit).
-func waitForStderr(stderr *syncBuffer, substr string, waitCh <-chan error, timeout time.Duration) error {
+func waitForStderr(stderr fmt.Stringer, substr string, waitCh <-chan error, timeout time.Duration) error {
 	deadline := time.After(timeout)
 	tick := time.NewTicker(100 * time.Millisecond)
 	defer tick.Stop()


### PR DESCRIPTION
**Issue:** Closes #222, Closes #224

## What

- Serve probe captures stdout/stderr in files instead of `syncBuffer`, so
  `cmd.Wait()` no longer depends on descendants of the direct child
- Teardown is bounded at every step and SIGKILLs the process **group**
- `e2e.yml` treats a go-test deadline as a real failure, not infra
- `fsAllowDenied` anchors on the probe **result** line, so `sh -x` traces no
  longer read as a sandbox denial

## Why

**#222** — `TestHarnessServeProbe` **passed its assertions** and then deadlocked
in `t.Cleanup`, consuming the full go-test deadline. Because `e2e.yml:290`
classified the timeout as `infra-only`, it retried twice more.

The cost was larger than it looked. In `E2E: full` it burned ~90 min per leg
and failed. In `E2E: drift` it hit the 20-minute deadline on **all four**
opencode legs and still reported **green**, because that step swallows failures
with `|| true`:

| Leg | Before | After |
|---|---|---|
| opencode / ubuntu / main (drift) | 21m13s | **1m32s** |
| opencode / ubuntu / release (drift) | 21m2s | **1m44s** |
| opencode / macos / main (drift) | 26m54s | **1m59s** |
| opencode / macos / release (drift) | 22m57s | **2m50s** |
| opencode / macos (full) | 3x 30m deadline | **4m8s** |
| opencode / ubuntu (full) | 32m39s | **5m30s** |

**#224** — `claude-code / ubuntu-latest` failed `fsAllowed: SANDBOX_FAIL` while
the sandbox was working correctly, discovered in this PR's own verification run.

## How

### #222 — the deadlock

Assigning any plain `io.Writer` to `cmd.Stdout` makes `os/exec` allocate a pipe
plus a copy goroutine, and `Wait()` then blocks until *every* holder of the
inherited write end exits — not just the direct child.
`internal/sandbox/launcher.go:306-307` passes omac's stdout down to the
sandboxed inner daemon, and omac forwards only *catchable* signals to it
(`launcher.go:343`); the probe sent SIGKILL, which omac cannot handle, so
nothing was forwarded. Linux is usually rescued by bwrap's `--die-with-parent`
(`internal/sandboxrun/bwrap.go:36`); macOS Seatbelt has no equivalent.

The CI dump confirms `Wait` was already past `Process.Wait()`:

```
goroutine 340 [chan receive, 23 minutes]:
os/exec.(*Cmd).awaitGoroutines(...)   exec.go:973
os/exec.(*Cmd).Wait(...)              exec.go:940
...e2e.runServeProbe.func1()          smoke_test.go:314
```

1. `captureFile` hands the child a real `*os.File`, dup'd straight in — no pipe,
   no copy goroutine. `String()` reads via the path so polling never disturbs
   the child's file offset. The pollers now take `fmt.Stringer`.
2. `killProcessGroup` SIGKILLs `-pgid` (the probe sets `Setpgid` and wires
   `cmd.Cancel`), and each teardown step is bounded by `serveTeardownGrace`.
3. `e2e.yml` bails on `panic: test timed out after` before the infra
   classifier, printing the tests still running.

Fix 1 is load-bearing: omac's inner daemon gets its *own* process group
(`launcher.go:315`), so 2 does not reach it. Noted as a non-goal in #222 — a
SIGKILLed `omac serve` really does orphan its inner daemon on macOS; this PR
stops the *test* from hanging on it.

### #224 — the false SANDBOX_FAIL

`fsAllowDenied` used `strings.Index` to find a label, taking its first mention
anywhere in the section. Under `sh -x` the trace of the probe *call* comes
first and carries no marker (`audit.sh:53` redirects stderr into the same
file). From the failing run's artifact — every path was in fact accessible:

```
+ probe_read --- read workdir file --- ./omac-audit-allow-test   <- matched
+ [ -r ./omac-audit-allow-test ]
--- read workdir file ---: READABLE (sandbox did not block)      <- real result
```

Now matches the line beginning `<label>:`, which is exactly what
`probe_read`/`probe_write` emit. Deliberately not applied to
`fsReadLeaked`/`fsWriteLeaked`/`symlinkEscapeLeaked`: they scan for a marker,
and under xtrace `+ echo "$label: READABLE …"` is only emitted when the path
really was readable, so they cannot false-positive this way.

## Verification

**Dispatched both suites on this branch** —
[E2E: full 31528427272](https://github.com/TNG/oh-my-agentic-coder/actions/runs/31528427272),
[E2E: drift 31528429567](https://github.com/TNG/oh-my-agentic-coder/actions/runs/31528429567).
Zero real go-test deadlines across all 10 full legs and all 20 drift legs
(a raw grep shows 30 hits — all of them this PR's own workflow source echoed
into the log). Serve probe now `1.96s`–`3.83s` on both platforms, including the
macOS leg that previously hung 3/3.

**Mechanism isolated** — same surviving grandchild, only the stdio type changed:

| stdio | `Wait()` after `Process.Kill()` |
|---|---|
| pipe (`io.Writer`) | still blocked at 30s |
| `*os.File` | returned in 103µs |

Reproduced the hang locally at `4a109b1` before the fix (`FAIL … 540.110s`,
stack byte-identical to CI). After, on Fedora + bwrap:

```
go test -tags=e2e -run TestHarnessServeProbe ./internal/e2e/   # 5x, all ok (1.7-2.1s)
go test -tags=e2e -run 'TestHarnessCLIContract|TestHarnessLaunchProbe|TestHarnessServeProbe' ./internal/e2e/
                                                               # ok, 60.0s (all harnesses)
go test -tags=e2e_fast ./internal/e2e/                         # ok
go vet -tags=e2e ./internal/e2e/ && go vet -tags=e2e_fast ./internal/e2e/   # clean
```

**#224 regression test is mutation-checked**: reverting only the predicate makes
`TestFsAllowDeniedIgnoresShellTraceLines` fail with the exact string CI
reported — `"--- read workdir file --- ./omac-audit-allow-test"`. Its second
case proves a genuine denial is still caught under xtrace.

**Workflow logic executed, not eyeballed**: the deadline block was run against
real `go test` timeout output (correct annotation, stdout, step summary,
`exit 1`) and against a non-timeout failure (skips, falls through to the
existing classifier).

Teardown also got faster (2.4-2.6s → 1.7-2.1s): `Wait` no longer drains a pipe.

## Follow-up

Untouched by this PR, all pre-existing and unchanged across both verification
runs:

- **codewhale llm stage 404s deterministically** on every leg, both omac@main
  and @release, 0.9.1 and 0.9.4. On this gateway family `404` is a routing error
  (`422` = unknown model, `500` = backend), pointing at the `base_url` +
  `path_suffix` composition in `harnesses.go:726-728`.
- **copilot / codex gateway errors** — upstream noise, see #186.
- **`SECURITY_SCAN_PAT` 403** on the drift `Record & report` mirror step and the
  Security Scan report push. Reportedly rotated since; the next drift run will
  confirm.
