### PR TITLE
fix(cli): suggest re-register commands that survive a follow-up flag

### DIFF
--- a/CREATING_A_SKILL.md
+++ b/CREATING_A_SKILL.md
@@ -637,7 +637,7 @@ checked:
    `node_modules/`, `.git/`, `.DS_Store`, `*.pyc`, editor swap files,
    so a `pip install` doesn't trip detection. Refuses unless
    `--accept-skill-changes` is passed (or you re-register with
-   `omac register --force my-skill`). The flag exists for the case
+   `omac register my-skill --force`). The flag exists for the case
    where you've intentionally edited the skill in place during
    development and don't want to re-prompt.
 
@@ -646,8 +646,10 @@ checked:
    resolvable `default_from_env:`). Refuses with the list of missing
    names and the exact register command:
    ```
-   omac start: my-skill: required config field(s) missing: API_BASE_URL, REGION
-   Run: omac register --reprompt-fields my-skill
+   omac start: refusing to start, found 1 problem(s):
+
+     required config field missing:
+       my-skill — fields: API_BASE_URL, REGION — set them with: omac register my-skill --reprompt-fields
    ```
 
 In all refusal cases the exit is non-zero so wrapper scripts can
@@ -771,7 +773,7 @@ Field names share the env-var namespace with `secrets:` and
 Two ways:
 
 ```bash
-omac register --reprompt-fields my-skill   # interactive, keeps secrets
+omac register my-skill --reprompt-fields   # interactive, keeps secrets
 ```
 
 …or edit `.opencode/skill-config.yaml` directly (mode 0600 — chmod it

--- a/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
+++ b/internal/builtinskills/assets/omac-write-a-skill/references/creating-a-skill.md
@@ -637,7 +637,7 @@ checked:
    `node_modules/`, `.git/`, `.DS_Store`, `*.pyc`, editor swap files,
    so a `pip install` doesn't trip detection. Refuses unless
    `--accept-skill-changes` is passed (or you re-register with
-   `omac register --force my-skill`). The flag exists for the case
+   `omac register my-skill --force`). The flag exists for the case
    where you've intentionally edited the skill in place during
    development and don't want to re-prompt.
 
@@ -646,8 +646,10 @@ checked:
    resolvable `default_from_env:`). Refuses with the list of missing
    names and the exact register command:
    ```
-   omac start: my-skill: required config field(s) missing: API_BASE_URL, REGION
-   Run: omac register --reprompt-fields my-skill
+   omac start: refusing to start, found 1 problem(s):
+
+     required config field missing:
+       my-skill — fields: API_BASE_URL, REGION — set them with: omac register my-skill --reprompt-fields
    ```
 
 In all refusal cases the exit is non-zero so wrapper scripts can
@@ -771,7 +773,7 @@ Field names share the env-var namespace with `secrets:` and
 Two ways:
 
 ```bash
-omac register --reprompt-fields my-skill   # interactive, keeps secrets
+omac register my-skill --reprompt-fields   # interactive, keeps secrets
 ```
 
 …or edit `.opencode/skill-config.yaml` directly (mode 0600 — chmod it

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -108,6 +109,72 @@ func TestParseLaunchArgsRejectsEphemeralWithoutSandbox(t *testing.T) {
 	if _, code := parseLaunchArgs("start", []string{"--ephemeral-cache", "--no-sandbox"}, devnullEnv(t)); code == ExitOK {
 		t.Error("parseLaunchArgs() succeeded with --ephemeral-cache and --no-sandbox")
 	}
+}
+
+// TestParseLaunchArgsInnerFlagsNeedDashDash pins the start/serve contract after
+// boolean-aware reorder: flags after a positional are omac flags, not silently
+// forwarded to the harness. `--` is the documented pass-through.
+func TestParseLaunchArgsInnerFlagsNeedDashDash(t *testing.T) {
+	t.Run("dash-dash form forwards harness flags", func(t *testing.T) {
+		opts, code := parseLaunchArgs("start", []string{"opencode", "--verbose", "--", "run", "fix it", "--model", "x"}, devnullEnv(t))
+		if code != ExitOK {
+			t.Fatalf("parseLaunchArgs() code = %d, want ExitOK", code)
+		}
+		if !opts.verbose {
+			t.Error("verbose = false, want true")
+		}
+		want := []string{"run", "fix it", "--model", "x"}
+		if !reflect.DeepEqual(opts.innerArgs, want) {
+			t.Errorf("innerArgs = %v, want %v", opts.innerArgs, want)
+		}
+	})
+
+	t.Run("mixed form fails and points at dash-dash", func(t *testing.T) {
+		stderr, writer, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("pipe stderr: %v", err)
+		}
+		t.Cleanup(func() { stderr.Close() })
+		env := devnullEnv(t)
+		env.Stderr = writer
+		if _, code := parseLaunchArgs("start", []string{"opencode", "--verbose", "run", "fix it", "--model", "x"}, env); code == ExitOK {
+			t.Fatal("parseLaunchArgs() succeeded; want unknown-flag failure")
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close stderr writer: %v", err)
+		}
+		output, err := io.ReadAll(stderr)
+		if err != nil {
+			t.Fatalf("read stderr: %v", err)
+		}
+		if !strings.Contains(string(output), "pass harness flags after --") {
+			t.Errorf("stderr = %q, want inner-args -- hint", output)
+		}
+		got := string(output)
+		errAt := strings.Index(got, "flag provided but not defined")
+		hintAt := strings.Index(got, "pass harness flags after --")
+		usageAt := strings.Index(got, "Usage:")
+		if errAt < 0 || hintAt < 0 || usageAt < 0 || !(errAt < hintAt && hintAt < usageAt) {
+			t.Errorf("want error, then -- hint, then Usage; got %q", got)
+		}
+		if !strings.Contains(got, "Args after -- go to the harness") {
+			t.Errorf("stderr = %q, want Usage to explain --", got)
+		}
+	})
+
+	t.Run("bool plus positionals still forward", func(t *testing.T) {
+		opts, code := parseLaunchArgs("start", []string{"opencode", "--verbose", "run", "fix it"}, devnullEnv(t))
+		if code != ExitOK {
+			t.Fatalf("parseLaunchArgs() code = %d, want ExitOK", code)
+		}
+		if !opts.verbose {
+			t.Error("verbose = false, want true")
+		}
+		want := []string{"run", "fix it"}
+		if !reflect.DeepEqual(opts.innerArgs, want) {
+			t.Errorf("innerArgs = %v, want %v", opts.innerArgs, want)
+		}
+	})
 }
 
 func TestBuildContinueOptsPreservesEphemeralCache(t *testing.T) {

--- a/internal/cli/flagutil.go
+++ b/internal/cli/flagutil.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"errors"
 	"flag"
+	"fmt"
+	"io"
 	"strings"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
@@ -144,4 +146,53 @@ func parseFlags(fs *flag.FlagSet, args []string, env *Env) (code int, proceed bo
 		return ExitMisuse, false
 	}
 	return ExitOK, true
+}
+
+// writeLaunchUsage prints the start-family / serve usage: omac flags, then
+// `--` plus whatever the inner harness should see.
+func writeLaunchUsage(cmd string, fs *flag.FlagSet) {
+	w := fs.Output()
+	fmt.Fprintf(w, "Usage: omac %s [harness] [flags] [-- <harness args>]\n", cmd)
+	fmt.Fprintf(w, "  Args after -- go to the harness, e.g. omac %s --verbose -- run --model x\n", cmd)
+	fmt.Fprintf(w, "\nharness: one of %s (default: %s)\n\n",
+		strings.Join(config.HarnessNames(), ", "), config.DefaultHarness().Name)
+	fs.PrintDefaults()
+}
+
+// parseWithHarnessArgsHint parses fs after reorderFlagsFirst. On failure it
+// prints the stdlib error, a `--` reminder, then usage — in that order, so
+// the reminder is not buried under PrintDefaults. An explicit -h/--help
+// prints usage on stdout and returns ExitOK, matching parseFlags. Parse's
+// own error/usage write is discarded because FlagSet always emits those
+// before returning.
+func parseWithHarnessArgsHint(fs *flag.FlagSet, cmd string, args []string, env *Env) (code int, proceed bool) {
+	reordered := reorderFlagsFirst(fs, args)
+	if wantsHelp(reordered) {
+		fs.SetOutput(env.Stdout)
+		fs.Usage()
+		return ExitOK, false
+	}
+	fs.SetOutput(io.Discard)
+	err := fs.Parse(reordered)
+	fs.SetOutput(env.Stderr)
+	if err != nil {
+		if !errors.Is(err, flag.ErrHelp) {
+			fmt.Fprintln(env.Stderr, err)
+			writeInnerArgsParseHint(cmd, err, env.Stderr)
+		}
+		fs.Usage()
+		return ExitMisuse, false
+	}
+	return ExitOK, true
+}
+
+// writeInnerArgsParseHint reminds the user that harness flags go after --.
+// Boolean-aware reorderFlagsFirst no longer hides later harness flags behind
+// a glued positional, so mixed forms like `omac start --verbose run --model x`
+// now fail as unknown omac flags. Help requests already print Usage.
+func writeInnerArgsParseHint(cmd string, err error, w io.Writer) {
+	if err == nil || errors.Is(err, flag.ErrHelp) || w == nil {
+		return
+	}
+	fmt.Fprintf(w, "omac %s: pass harness flags after -- (e.g. omac %s --verbose -- run --model x)\n", cmd, cmd)
 }

--- a/internal/cli/flagutil.go
+++ b/internal/cli/flagutil.go
@@ -54,10 +54,15 @@ func splitHarnessToken(args []string) (config.Harness, []string, error) {
 //
 // without the stdlib flag package rejecting the first form.
 //
-// It does NOT know which flags take values; any "--foo bar" pair where the
-// second token is not itself a flag is kept adjacent. Users with a positional
-// literally starting with "-" should pass "--" first.
-func reorderFlagsFirst(args []string) []string {
+// Value-taking flags are kept adjacent to their value: any "--foo bar" pair
+// where the second token is not itself a flag moves as a unit. Boolean flags
+// are looked up on fs and never absorb the following token — the stdlib parser
+// does not consume a value for them, so gluing the next token on would make it
+// stop parsing at that positional and silently drop every later flag (see
+// TestReorderFlagsFirst_BoolFlagDoesNotSwallowPositional).
+//
+// Users with a positional literally starting with "-" should pass "--" first.
+func reorderFlagsFirst(fs *flag.FlagSet, args []string) []string {
 	var flags, positionals []string
 	for i := 0; i < len(args); i++ {
 		a := args[i]
@@ -70,7 +75,7 @@ func reorderFlagsFirst(args []string) []string {
 			flags = append(flags, a)
 			// If this looks like "--foo" with no "=" and a following value token
 			// that is not itself a flag, take that value with it.
-			if !strings.Contains(a, "=") && i+1 < len(args) && !isFlag(args[i+1]) {
+			if !strings.Contains(a, "=") && !isBoolFlag(fs, a) && i+1 < len(args) && !isFlag(args[i+1]) {
 				flags = append(flags, args[i+1])
 				i++
 			}
@@ -79,6 +84,25 @@ func reorderFlagsFirst(args []string) []string {
 		positionals = append(positionals, a)
 	}
 	return append(flags, positionals...)
+}
+
+// isBoolFlag reports whether token names a boolean flag registered on fs.
+// Unknown flags answer false: fs.Parse rejects them anyway, so keeping the
+// value-taking behavior leaves typo diagnostics unchanged.
+func isBoolFlag(fs *flag.FlagSet, token string) bool {
+	if fs == nil {
+		return false
+	}
+	name := strings.TrimLeft(token, "-")
+	if eq := strings.IndexByte(name, '='); eq >= 0 {
+		name = name[:eq]
+	}
+	f := fs.Lookup(name)
+	if f == nil {
+		return false
+	}
+	b, ok := f.Value.(interface{ IsBoolFlag() bool })
+	return ok && b.IsBoolFlag()
 }
 
 func isFlag(a string) bool {
@@ -103,7 +127,7 @@ func wantsHelp(args []string) bool {
 // message on stderr and stops with ExitMisuse. When proceed is true, parsing
 // succeeded and the caller should continue.
 func parseFlags(fs *flag.FlagSet, args []string, env *Env) (code int, proceed bool) {
-	reordered := reorderFlagsFirst(args)
+	reordered := reorderFlagsFirst(fs, args)
 	if wantsHelp(reordered) {
 		fs.SetOutput(env.Stdout)
 		fs.Usage()

--- a/internal/cli/flagutil_test.go
+++ b/internal/cli/flagutil_test.go
@@ -1,9 +1,24 @@
 package cli
 
 import (
+	"flag"
+	"io"
 	"reflect"
 	"testing"
 )
+
+// testFlagSet mirrors the shape real subcommands declare: a couple of
+// value-taking flags and a couple of booleans. reorderFlagsFirst needs the
+// distinction to know which flags may absorb the following token.
+func testFlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.String("from", "", "")
+	fs.String("harness", "", "")
+	fs.Bool("force", false, "")
+	fs.Bool("global", false, "")
+	return fs
+}
 
 func TestReorderFlagsFirst(t *testing.T) {
 	cases := []struct {
@@ -41,13 +56,55 @@ func TestReorderFlagsFirst(t *testing.T) {
 			in:   []string{"echo-rest", "--force"},
 			want: []string{"--force", "echo-rest"},
 		},
+		{
+			name: "bool flag does not absorb the following positional",
+			in:   []string{"--force", "echo-rest"},
+			want: []string{"--force", "echo-rest"},
+		},
+		{
+			name: "unknown flag keeps the value-taking behavior",
+			in:   []string{"--bogus", "value", "echo-rest"},
+			want: []string{"--bogus", "value", "echo-rest"},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := reorderFlagsFirst(c.in)
+			got := reorderFlagsFirst(testFlagSet(), c.in)
 			if !reflect.DeepEqual(got, c.want) {
 				t.Errorf("reorderFlagsFirst(%v) = %v, want %v", c.in, got, c.want)
 			}
 		})
+	}
+}
+
+// TestReorderFlagsFirst_BoolFlagDoesNotSwallowPositional pins the fix for
+// issue #227. A boolean flag written before the positional used to absorb the
+// skill name ("--force echo-rest"), which made flag.Parse stop at that
+// positional and silently discard every flag after it — so
+// `omac register --force <skill> --harness opencode` died with a usage dump
+// while the same flags in a different order worked.
+func TestReorderFlagsFirst_BoolFlagDoesNotSwallowPositional(t *testing.T) {
+	orders := [][]string{
+		{"--force", "echo-rest", "--harness", "opencode"},
+		{"echo-rest", "--force", "--harness", "opencode"},
+		{"--force", "--harness", "opencode", "echo-rest"},
+	}
+	for _, args := range orders {
+		fs := testFlagSet()
+		if err := fs.Parse(reorderFlagsFirst(fs, args)); err != nil {
+			t.Fatalf("args %v: parse: %v", args, err)
+		}
+		if got := fs.NArg(); got != 1 {
+			t.Fatalf("args %v: NArg = %d (%v), want 1", args, got, fs.Args())
+		}
+		if got := fs.Arg(0); got != "echo-rest" {
+			t.Errorf("args %v: positional = %q, want echo-rest", args, got)
+		}
+		if got := fs.Lookup("force").Value.String(); got != "true" {
+			t.Errorf("args %v: --force = %s, want true", args, got)
+		}
+		if got := fs.Lookup("harness").Value.String(); got != "opencode" {
+			t.Errorf("args %v: --harness = %q, want opencode", args, got)
+		}
 	}
 }

--- a/internal/cli/hints.go
+++ b/internal/cli/hints.go
@@ -1,0 +1,34 @@
+// Remediation hints shared by the consolidated "refusing to start" reports
+// that `omac start` and `omac serve` print. Both commands list the same
+// classes of skill problem, so the rendering lives here to keep the suggested
+// commands identical and copy-pasteable.
+package cli
+
+import "strings"
+
+// registerCmd renders an `omac register` invocation in the order the command
+// documents itself (`Usage: omac register <skill> [flags]`), i.e. skill name
+// first and flags after it.
+//
+// The order is cosmetic to the parser — reorderFlagsFirst normalizes either
+// form — but it matters to the reader: it matches the usage line, matches the
+// disambiguation hints in register.go, and stays correct when the user appends
+// another flag (typically `--harness`) to the command we handed them.
+func registerCmd(skill string, flags ...string) string {
+	cmd := "omac register " + skill
+	if len(flags) > 0 {
+		cmd += " " + strings.Join(flags, " ")
+	}
+	return cmd
+}
+
+// skillProblemLine renders one entry of a problem report: the offending skill,
+// a label naming the remedy, then the command to run.
+//
+// The label is not optional. Without it the line reads as one run-on string
+// ("skill-marketplace — omac register ..."), which is ambiguous about where the
+// command starts; see issue #227. Coloring the command reinforces the split on
+// terminals that support it.
+func skillProblemLine(s styler, skill, label, cmd string) string {
+	return "    " + skill + " — " + label + ": " + s.cyan(cmd)
+}

--- a/internal/cli/hints_test.go
+++ b/internal/cli/hints_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/registry"
+)
+
+func TestRegisterCmd(t *testing.T) {
+	cases := []struct {
+		name  string
+		skill string
+		flags []string
+		want  string
+	}{
+		{name: "no flags", skill: "echo-rest", want: "omac register echo-rest"},
+		{name: "one flag follows the skill", skill: "echo-rest", flags: []string{"--force"},
+			want: "omac register echo-rest --force"},
+		{name: "several flags follow the skill", skill: "echo-rest",
+			flags: []string{"--force", "--harness", "opencode"},
+			want:  "omac register echo-rest --force --harness opencode"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := registerCmd(c.skill, c.flags...); got != c.want {
+				t.Errorf("registerCmd(%q, %v) = %q, want %q", c.skill, c.flags, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSkillProblemLine pins the shape issue #227 complained about: the skill
+// name and the command must be separated by a label, so the line cannot be
+// misread as a single "skill-marketplace - omac register ..." command.
+func TestSkillProblemLine(t *testing.T) {
+	got := skillProblemLine(styler{}, "skill-marketplace", "re-register",
+		registerCmd("skill-marketplace", "--force"))
+	want := "    skill-marketplace — re-register: omac register skill-marketplace --force"
+	if got != want {
+		t.Errorf("skillProblemLine = %q, want %q", got, want)
+	}
+}
+
+// TestHintsUseDocumentedFlagOrder guards every hint the CLI prints against
+// regressing to the flag-before-skill order reported in issue #227. The
+// suggested command must match `Usage: omac register <skill> [flags]`, which is
+// also the form that reads unambiguously and survives the user appending
+// `--harness` after a disambiguation prompt.
+func TestHintsUseDocumentedFlagOrder(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Any "omac register" immediately followed by a flag is the bad order.
+	const bad = "omac register -"
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for lineNo, line := range strings.Split(string(src), "\n") {
+			// Only user-facing strings matter; skip comments, which discuss
+			// the historical form on purpose.
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			if strings.Contains(line, bad) {
+				t.Errorf("%s:%d suggests flags before the skill name; "+
+					"use registerCmd(skill, flags...) instead:\n\t%s",
+					name, lineNo+1, strings.TrimSpace(line))
+			}
+		}
+	}
+}
+
+// TestRegister_BoolFlagBeforeSkillKeepsLaterFlags pins the parser half of
+// issue #227. omac's drift hint used to suggest `omac register --force <skill>`;
+// when the skill name was ambiguous across harnesses, omac then asked the user
+// to add `--harness`, producing `--force <skill> --harness <h>`. reorderFlagsFirst
+// glued the skill name onto the boolean --force, so flag.Parse stopped at the
+// positional and never saw --harness: the command died with a usage dump.
+func TestRegister_BoolFlagBeforeSkillKeepsLaterFlags(t *testing.T) {
+	isolateHome(t)
+	wd := t.TempDir()
+	stageHarnessSkillBody(t, wd, "opencode", "slack", "# opencode copy\n")
+	stageHarnessSkillBody(t, wd, "claude", "slack", "# claude copy, different bytes\n")
+	env := makeEnv(wd)
+
+	if code := runRegister([]string{"slack", "--harness", "opencode"}, env); code != ExitOK {
+		t.Fatalf("seed register: code = %d, want ExitOK", code)
+	}
+
+	// The exact shape omac used to hand the user.
+	if code := runRegister([]string{"--force", "slack", "--harness", "claude"}, env); code != ExitOK {
+		t.Fatalf("register --force <skill> --harness <h>: code = %d, want ExitOK", code)
+	}
+
+	// --harness must actually have been honored, not silently dropped.
+	reg, err := registry.Load(wd)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	if cc, _ := reg.FindForHarness("slack", "claude-code"); cc == nil {
+		t.Error("claude-code entry missing: --harness was dropped by flag reordering")
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1031,22 +1031,25 @@ func (s *serveServer) checkGlobalDrift() int {
 
 	total := len(unregistered) + len(drifted) + len(brokenMeta)
 	fmt.Fprintf(s.env.Stderr, "omac serve: refusing to start, %d global-skill problem(s):\n", total)
+	sErr := newStyler(s.env.Stderr)
 	if len(brokenMeta) > 0 {
 		fmt.Fprintln(s.env.Stderr, "\n  "+config.MetaFileName+" broken:")
 		for _, n := range brokenMeta {
-			fmt.Fprintf(s.env.Stderr, "    %s — re-register: omac register --force %s\n", n, n)
+			fmt.Fprintln(s.env.Stderr, skillProblemLine(sErr, n,
+				"re-register", registerCmd(n, "--force")))
 		}
 	}
 	if len(unregistered) > 0 {
 		fmt.Fprintln(s.env.Stderr, "\n  global skill present but not registered:")
 		for _, n := range unregistered {
-			fmt.Fprintf(s.env.Stderr, "    %s — run: omac register %s\n", n, n)
+			fmt.Fprintln(s.env.Stderr, skillProblemLine(sErr, n, "run", registerCmd(n)))
 		}
 	}
 	if len(drifted) > 0 {
 		fmt.Fprintln(s.env.Stderr, "\n  bundle changed since register (re-register, or pass --accept-skill-changes):")
 		for _, n := range drifted {
-			fmt.Fprintf(s.env.Stderr, "    %s — omac register --force %s\n", n, n)
+			fmt.Fprintln(s.env.Stderr, skillProblemLine(sErr, n,
+				"re-register", registerCmd(n, "--force")))
 		}
 	}
 	fmt.Fprintln(s.env.Stderr)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -35,17 +35,34 @@ import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/toolcache"
 )
 
-// runServe implements `omac serve` — the long-lived, multi-directory mode
-// behind OpenCode Desktop. It wraps `opencode serve` (the inner command),
-// keeps the facade + supervisor mutable for the process lifetime, and
-// activates a directory's skills lazily on request. See
-// docs/MULTI_DIR_DESKTOP.md.
-//
-// This implementation focuses on the omac-side control/data plane and is
-// directly drivable over the control-plane HTTP API (so it can be tested
-// without OpenCode). When --workdir is given, that one directory is
-// auto-activated at cold start (§5.5).
-func runServe(args []string, env *Env) int {
+// serveParse is the parsed `omac serve` command line. Extracted so tests can
+// pin inner-arg routing without launching the control plane.
+type serveParse struct {
+	harness           config.Harness
+	innerArgs         []string
+	workdir           string
+	controlAddr       string
+	acceptChanges     bool
+	skipSecretPattern bool
+	profile           string
+	innerCmdOverride  string
+	noSandbox         bool
+	noInner           bool
+	ephemeralCache    bool
+	cacheScopeFlag    string
+	verbose           bool
+	forDesktop        bool
+	learn             bool
+	auditLog          string
+	noAudit           bool
+	auditStrict       bool
+	roots             multiFlag
+	openPorts         []int
+}
+
+// parseServeArgs parses serve's harness token, flags, and trailing `--`
+// harness args. On a parse/usage error it prints to stderr and returns false.
+func parseServeArgs(args []string, env *Env) (serveParse, bool) {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	fs.SetOutput(env.Stderr)
 	var (
@@ -70,13 +87,7 @@ func runServe(args []string, env *Env) int {
 	var openPorts intMultiFlag
 	fs.Var(&roots, "root", "Pre-declared root directory under which projects may be activated (§5.4 Option B). Repeatable. Empty = allow any directory.")
 	fs.Var(&openPorts, "open-port", "Allow the sandboxed process to bind and connect on this TCP port (repeatable). Useful for a local app/dev server the agent or its tools talk to — e.g. Playwright/Vite/Next on :3000. On Linux, Landlock cannot limit that to loopback: outbound TCP to any host on the same port is also allowed.")
-	fs.Usage = func() {
-		out := fs.Output()
-		fmt.Fprintln(out, "Usage: omac serve [harness] [flags] [-- inner args...]")
-		fmt.Fprintf(out, "\nharness: one of %s (default: %s)\n\n",
-			strings.Join(config.HarnessNames(), ", "), config.DefaultHarness().Name)
-		fs.PrintDefaults()
-	}
+	fs.Usage = func() { writeLaunchUsage("serve", fs) }
 	// Preserve everything after "--" verbatim as inner args.
 	var ourArgs, innerArgs []string
 	split := false
@@ -91,27 +102,83 @@ func runServe(args []string, env *Env) int {
 			ourArgs = append(ourArgs, a)
 		}
 	}
-	// Consume the optional leading positional harness token (e.g.
-	// `omac serve claude`) before flag parsing.
 	harness, ourArgs, err := splitHarnessToken(ourArgs)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve:", err)
-		return ExitMisuse
+		return serveParse{}, false
 	}
-	if code, ok := parseFlags(fs, ourArgs, env); !ok {
-		return code
+	if _, ok := parseWithHarnessArgsHint(fs, "serve", ourArgs, env); !ok {
+		return serveParse{}, false
 	}
 	if *ephemeralCache && *noSandbox {
 		fmt.Fprintln(env.Stderr, "omac serve: --ephemeral-cache cannot be used with --no-sandbox")
-		return ExitMisuse
+		return serveParse{}, false
 	}
 	if *cacheScopeFlag != "" {
 		if _, err := config.ValidateCacheScope(*cacheScopeFlag); err != nil {
 			fmt.Fprintln(env.Stderr, "omac serve:", err)
-			return ExitMisuse
+			return serveParse{}, false
 		}
 	}
-	innerArgs = append(fs.Args(), innerArgs...)
+	return serveParse{
+		harness:           harness,
+		innerArgs:         append(fs.Args(), innerArgs...),
+		workdir:           *workdir,
+		controlAddr:       *controlAddr,
+		acceptChanges:     *acceptChanges,
+		skipSecretPattern: *skipSecretPattern,
+		profile:           *profile,
+		innerCmdOverride:  *innerCmdOverride,
+		noSandbox:         *noSandbox,
+		noInner:           *noInner,
+		ephemeralCache:    *ephemeralCache,
+		cacheScopeFlag:    *cacheScopeFlag,
+		verbose:           *verbose,
+		forDesktop:        *forDesktop,
+		learn:             *learn,
+		auditLog:          *auditLog,
+		noAudit:           *noAudit,
+		auditStrict:       *auditStrict,
+		roots:             roots,
+		openPorts:         append([]int(nil), openPorts...),
+	}, true
+}
+
+// runServe implements `omac serve` — the long-lived, multi-directory mode
+// behind OpenCode Desktop. It wraps `opencode serve` (the inner command),
+// keeps the facade + supervisor mutable for the process lifetime, and
+// activates a directory's skills lazily on request. See
+// docs/MULTI_DIR_DESKTOP.md.
+//
+// This implementation focuses on the omac-side control/data plane and is
+// directly drivable over the control-plane HTTP API (so it can be tested
+// without OpenCode). When --workdir is given, that one directory is
+// auto-activated at cold start (§5.5).
+func runServe(args []string, env *Env) int {
+	parsed, ok := parseServeArgs(args, env)
+	if !ok {
+		return ExitMisuse
+	}
+	harness := parsed.harness
+	innerArgs := parsed.innerArgs
+	workdir := parsed.workdir
+	controlAddr := parsed.controlAddr
+	acceptChanges := parsed.acceptChanges
+	skipSecretPattern := parsed.skipSecretPattern
+	profile := parsed.profile
+	innerCmdOverride := parsed.innerCmdOverride
+	noSandbox := parsed.noSandbox
+	noInner := parsed.noInner
+	ephemeralCache := parsed.ephemeralCache
+	cacheScopeFlag := parsed.cacheScopeFlag
+	verbose := parsed.verbose
+	forDesktop := parsed.forDesktop
+	learn := parsed.learn
+	auditLog := parsed.auditLog
+	noAudit := parsed.noAudit
+	auditStrict := parsed.auditStrict
+	roots := parsed.roots
+	openPorts := parsed.openPorts
 
 	lc, cfgPath, err := config.LoadLauncher(env.Workdir)
 	if err != nil {
@@ -122,8 +189,8 @@ func runServe(args []string, env *Env) int {
 	// (templated argv) plus, for omac's native backend, its policy profile
 	// (grant JSON). Everything downstream reads the plan instead of
 	// re-resolving a bare name — see internal/cli/sandboxplan.go.
-	plan, planErr := resolveSandboxPlan(lc, *profile)
-	if planErr != nil && !*noSandbox && !*noInner {
+	plan, planErr := resolveSandboxPlan(lc, profile)
+	if planErr != nil && !noSandbox && !noInner {
 		fmt.Fprintln(env.Stderr, "omac serve:", planErr)
 		return ExitConfigInvalid
 	}
@@ -134,7 +201,7 @@ func runServe(args []string, env *Env) int {
 	// or --inner override). Checked on the RESOLVED argv so a profile-pinned
 	// inner_cmd is verified rather than the harness default the launch will
 	// not use — see checkInnerBinary.
-	if !*noInner && *innerCmdOverride == "" {
+	if !noInner && innerCmdOverride == "" {
 		preflightInner := prof.InnerCmd
 		if !plan.Known {
 			preflightInner = nil
@@ -146,7 +213,7 @@ func runServe(args []string, env *Env) int {
 
 	// Pre-flight: codex on macOS is incompatible with the omac Seatbelt
 	// sandbox (see start.go for the rationale).
-	if runtime.GOOS == "darwin" && harness.Name == "codex" && !*noSandbox {
+	if runtime.GOOS == "darwin" && harness.Name == "codex" && !noSandbox {
 		fmt.Fprintf(env.Stderr,
 			"omac serve: codex is incompatible with the macOS Seatbelt sandbox "+
 				"(its HTTP client disconnects mid-stream even with network=open). "+
@@ -169,7 +236,7 @@ func runServe(args []string, env *Env) int {
 		absRoots = append(absRoots, ar)
 	}
 
-	if *noAudit && *auditStrict {
+	if noAudit && auditStrict {
 		fmt.Fprintln(env.Stderr, "omac serve: --no-audit cannot be combined with --audit-strict")
 		return ExitMisuse
 	}
@@ -187,12 +254,12 @@ func runServe(args []string, env *Env) int {
 	// drives our provisioning and is inherited by the sandboxed child;
 	// an explicit value is respected. The dir is granted read+write in
 	// the sandbox in the --for-opencode-desktop block below.
-	if dir, set := resolveDesktopStateDir(*forDesktop); set {
+	if dir, set := resolveDesktopStateDir(forDesktop); set {
 		if err := os.Setenv("XDG_STATE_HOME", dir); err != nil {
 			fmt.Fprintln(env.Stderr, "omac serve: --for-opencode-desktop: set XDG_STATE_HOME:", err)
 			return ExitIOError
 		}
-		if *verbose {
+		if verbose {
 			fmt.Fprintf(env.Stderr, "[verbose] --for-opencode-desktop: XDG_STATE_HOME=%s\n", dir)
 		}
 	}
@@ -211,7 +278,7 @@ func runServe(args []string, env *Env) int {
 	// always logged and never values, and namespaces are always hashed.
 	var auditFatal func(error) // assigned once sup/facade exist
 	auditCfg, auditMisuse := resolveAuditConfig(lc.Audit, auditFlags{
-		logPath: *auditLog, disable: *noAudit, strict: *auditStrict,
+		logPath: auditLog, disable: noAudit, strict: auditStrict,
 	}, audit.ModeServe, env.Version, nil, func(err error) {
 		if auditFatal != nil {
 			auditFatal(err)
@@ -237,12 +304,12 @@ func runServe(args []string, env *Env) int {
 		return ExitIOError
 	}
 	defer os.RemoveAll(sandboxTmp)
-	scope, err := resolveCacheScope(lc.Cache, *cacheScopeFlag)
+	scope, err := resolveCacheScope(lc.Cache, cacheScopeFlag)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve: cache:", err)
 		return ExitConfigInvalid
 	}
-	cacheScope, err := prepareServeCache(*noSandbox, *noInner, *ephemeralCache, scope, *workdir, env.Workdir, cfgPath, sandboxTmp)
+	cacheScope, err := prepareServeCache(noSandbox, noInner, ephemeralCache, scope, workdir, env.Workdir, cfgPath, sandboxTmp)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve: cache:", err)
 		return ExitIOError
@@ -267,7 +334,7 @@ func runServe(args []string, env *Env) int {
 		env.Version,
 	)
 	f.SetAuditor(auditor)
-	wireFacadeSandbox(f, *noSandbox, *learn, plan, func(format string, args ...any) {
+	wireFacadeSandbox(f, noSandbox, learn, plan, func(format string, args ...any) {
 		fmt.Fprintf(env.Stderr, format+"\n", args...)
 	})
 	if err := f.Start(ctx); err != nil {
@@ -287,9 +354,9 @@ func runServe(args []string, env *Env) int {
 		sandboxTmp:        sandboxTmp,
 		socketPath:        socketPath,
 		tcpPort:           f.TCPPort(),
-		acceptChanges:     *acceptChanges,
-		skipSecretPattern: *skipSecretPattern,
-		verbose:           *verbose,
+		acceptChanges:     acceptChanges,
+		skipSecretPattern: skipSecretPattern,
+		verbose:           verbose,
 		roots:             absRoots,
 		dirs:              map[string]*dirState{},
 		byToken:           map[string]*dirState{},
@@ -335,8 +402,8 @@ func runServe(args []string, env *Env) int {
 	}
 
 	// --workdir convenience: pre-activate exactly one directory (§5.5).
-	if *workdir != "" {
-		abs, err := filepath.Abs(*workdir)
+	if workdir != "" {
+		abs, err := filepath.Abs(workdir)
 		if err != nil {
 			fmt.Fprintln(env.Stderr, "omac serve: --workdir:", err)
 			return ExitMisuse
@@ -348,7 +415,7 @@ func runServe(args []string, env *Env) int {
 	}
 
 	// Control-plane HTTP server (host-side; distinct from the facade).
-	cln, err := net.Listen("tcp", *controlAddr)
+	cln, err := net.Listen("tcp", controlAddr)
 	if err != nil {
 		fmt.Fprintln(env.Stderr, "omac serve: control listen:", err)
 		return ExitIOError
@@ -358,7 +425,7 @@ func runServe(args []string, env *Env) int {
 	// Publish the control URL so other omac CLI invocations (register,
 	// deregister, secrets, config) can notify this running serve to reload a
 	// directory after they change on-disk state. Best-effort.
-	if err := writeControlInfo(controlURL); err != nil && *verbose {
+	if err := writeControlInfo(controlURL); err != nil && verbose {
 		fmt.Fprintln(env.Stderr, "[verbose] could not write control-info file:", err)
 	}
 	defer removeControlInfo()
@@ -370,7 +437,7 @@ func runServe(args []string, env *Env) int {
 	}()
 	defer httpSrv.Close()
 
-	if *verbose {
+	if verbose {
 		fmt.Fprintf(env.Stderr, "[verbose] facade tcp=127.0.0.1:%d socket=%s\n", srv.tcpPort, socketPath)
 		fmt.Fprintf(env.Stderr, "[verbose] control plane: %s\n", controlURL)
 		if len(absRoots) > 0 {
@@ -380,7 +447,7 @@ func runServe(args []string, env *Env) int {
 	fmt.Fprintf(env.Stdout, "omac serve: control plane on %s; facade on 127.0.0.1:%d\n", controlURL, srv.tcpPort)
 
 	// --no-inner: run the control plane only (testing / headless drivers).
-	if *noInner {
+	if noInner {
 		auditor.Emit(audit.SessionStart(env.Version, harness.Name, profName, ""))
 		fmt.Fprintf(env.Stdout, "OMAC_CONTROL_BASE=%s\n", controlURL)
 		<-ctx.Done()
@@ -417,13 +484,13 @@ func runServe(args []string, env *Env) int {
 	}
 	// Resolve the inner command for the selected harness: --inner override
 	// wins, else the profile's inner_cmd, else the harness default.
-	inner := harness.ResolveInnerCmd(profileInner, *innerCmdOverride)
+	inner := harness.ResolveInnerCmd(profileInner, innerCmdOverride)
 	// Apply the harness's server-launch convention (e.g. OpenCode injects
 	// `serve` when no subcommand is present). Harnesses without a server
 	// mode leave the inner command unchanged.
 	inner = harness.ApplyServerLaunch(inner, innerArgs)
 	// Inject the sandbox briefing on the same terms as `omac start` (see there).
-	briefingText, injectBriefing := briefingInjection(*noSandbox, inner, harness, lc.Sandbox.Briefing, cacheScope)
+	briefingText, injectBriefing := briefingInjection(noSandbox, inner, harness, lc.Sandbox.Briefing, cacheScope)
 	if injectBriefing && harness.SystemContextArgs != nil {
 		inner = append(inner, harness.SystemContextArgs(briefingText)...)
 	}
@@ -458,7 +525,7 @@ func runServe(args []string, env *Env) int {
 	}
 
 	var argv []string
-	if *noSandbox {
+	if noSandbox {
 		argv = inner
 	} else {
 		argv, err = sandboxServeArgv(prof, sandbox.Inputs{
@@ -494,7 +561,7 @@ func runServe(args []string, env *Env) int {
 		// knows about. The kernel sandbox cannot grow after launch, so
 		// folders opened for the first time during this session still
 		// need a restart (or --learn).
-		if *forDesktop {
+		if forDesktop {
 			worktrees, skipped, derr := opencodestate.Worktrees()
 			if derr != nil {
 				fmt.Fprintln(env.Stderr, "omac serve: --for-opencode-desktop:", derr)
@@ -524,11 +591,11 @@ func runServe(args []string, env *Env) int {
 		}
 		// --learn: pass through to the built-in sandbox, which lifts
 		// filesystem restrictions and records folder usage.
-		if *learn {
+		if learn {
 			argv = injectSandboxFlag(argv, "--learn", "")
 		}
 	}
-	if *verbose {
+	if verbose {
 		fmt.Fprintf(env.Stderr, "[verbose] inner argv: %v\n", argv)
 	}
 
@@ -551,7 +618,7 @@ func runServe(args []string, env *Env) int {
 		httpSrv.Close()
 		os.Exit(ExitIOError)
 	}
-	sandboxed := !*noSandbox && !*noInner
+	sandboxed := !noSandbox && !noInner
 	backend := ""
 	if sandboxed {
 		backend = profName
@@ -560,7 +627,7 @@ func runServe(args []string, env *Env) int {
 	auditor.Emit(audit.InnerExec(argv, profName, sandboxed))
 
 	code, err := sandbox.ExecWithReady(argv, extra, func() {
-		if *verbose {
+		if verbose {
 			fmt.Fprintln(env.Stderr, "[verbose] inner command started; control plane live")
 		}
 	})

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -794,6 +795,59 @@ func TestRunServeRejectsEphemeralCacheWithoutSandbox(t *testing.T) {
 	if !strings.Contains(string(output), "--ephemeral-cache cannot be used with --no-sandbox") {
 		t.Errorf("stderr = %q, want invalid combination error", output)
 	}
+}
+
+func TestRunServeInnerFlagsNeedDashDash(t *testing.T) {
+	t.Run("dash-dash form forwards harness flags", func(t *testing.T) {
+		opts, ok := parseServeArgs([]string{"opencode", "--verbose", "--", "--port", "4096", "--print-logs"}, devnullEnv(t))
+		if !ok {
+			t.Fatal("parseServeArgs() returned false")
+		}
+		if !opts.verbose {
+			t.Error("verbose = false, want true")
+		}
+		if opts.harness.Name != "opencode" {
+			t.Errorf("harness = %q, want opencode", opts.harness.Name)
+		}
+		want := []string{"--port", "4096", "--print-logs"}
+		if !reflect.DeepEqual(opts.innerArgs, want) {
+			t.Errorf("innerArgs = %v, want %v", opts.innerArgs, want)
+		}
+	})
+
+	t.Run("mixed form fails and points at dash-dash", func(t *testing.T) {
+		stderr, writer, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("pipe stderr: %v", err)
+		}
+		t.Cleanup(func() { stderr.Close() })
+		env := devnullEnv(t)
+		env.Workdir = t.TempDir()
+		env.Stderr = writer
+		if code := runServe([]string{"opencode", "--verbose", "run", "--model", "x"}, env); code != ExitMisuse {
+			t.Errorf("exit = %d, want ExitMisuse (%d)", code, ExitMisuse)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close stderr writer: %v", err)
+		}
+		output, err := io.ReadAll(stderr)
+		if err != nil {
+			t.Fatalf("read stderr: %v", err)
+		}
+		if !strings.Contains(string(output), "pass harness flags after --") {
+			t.Errorf("stderr = %q, want inner-args -- hint", output)
+		}
+		got := string(output)
+		errAt := strings.Index(got, "flag provided but not defined")
+		hintAt := strings.Index(got, "pass harness flags after --")
+		usageAt := strings.Index(got, "Usage:")
+		if errAt < 0 || hintAt < 0 || usageAt < 0 || !(errAt < hintAt && hintAt < usageAt) {
+			t.Errorf("want error, then -- hint, then Usage; got %q", got)
+		}
+		if !strings.Contains(got, "Args after -- go to the harness") {
+			t.Errorf("stderr = %q, want Usage to explain --", got)
+		}
+	})
 }
 
 func TestRunServeRetainsCacheLockAndAllowsOnlyScope(t *testing.T) {

--- a/internal/cli/skillrefusal.go
+++ b/internal/cli/skillrefusal.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/tngtech/oh-my-agentic-coder/internal/config"
@@ -30,6 +31,7 @@ func renderSkillRefusal(w io.Writer, prefix string, problems []skillstate.Proble
 		return ExitOK
 	}
 	fmt.Fprintf(w, prefix+": refusing to start, found %d problem(s):\n", len(problems))
+	s := stylerFor(w)
 
 	// Section order is most-fundamental-first. A dead keychain leads because
 	// the next section's remedy (`omac secrets set`) cannot work until it is
@@ -40,8 +42,11 @@ func renderSkillRefusal(w io.Writer, prefix string, problems []skillstate.Proble
 	perSkill(w, problems, skillstate.MetaBroken,
 		config.MetaFileName+" broken:")
 
-	perSkill(w, problems, skillstate.BundleDrift,
-		"bundle changed since register (pass --accept-skill-changes to proceed, or re-register):")
+	// Bundle drift uses skillProblemLine so the skill name is labeled
+	// separately from the copy-pasteable command (issue #227).
+	labeledSkills(w, s, problems, skillstate.BundleDrift,
+		"bundle changed since register (pass --accept-skill-changes to proceed, or re-register):",
+		"re-register")
 
 	perField(w, problems, skillstate.MissingSecret,
 		"required secret missing:")
@@ -49,10 +54,10 @@ func renderSkillRefusal(w io.Writer, prefix string, problems []skillstate.Proble
 	perField(w, problems, skillstate.InvalidSecret,
 		"secret from environment failed pattern validation (pass --skip-secret-pattern if the pattern is outdated):")
 
-	// Config fields are grouped per skill: one `omac register
+	// Config fields are grouped per skill: one `omac register <skill>
 	// --reprompt-fields` run re-prompts all of a skill's fields, so listing
 	// the command per field would be misleading.
-	fieldsBySkill(w, problems, skillstate.MissingField,
+	fieldsBySkill(w, s, problems, skillstate.MissingField,
 		"required config field missing:")
 
 	fmt.Fprintln(w)
@@ -102,6 +107,15 @@ func keychainSection(w io.Writer, problems []skillstate.Problem) {
 	}
 }
 
+// stylerFor colors commands when w is a real terminal; tests writing to a
+// buffer get the unstyled form so assertions stay stable.
+func stylerFor(w io.Writer) styler {
+	if f, ok := w.(*os.File); ok {
+		return newStyler(f)
+	}
+	return styler{}
+}
+
 // perSkill renders a skill-level class: "<skill> — <detail/fix>".
 func perSkill(w io.Writer, problems []skillstate.Problem, kind skillstate.ProblemKind, header string) {
 	first := true
@@ -114,6 +128,22 @@ func perSkill(w io.Writer, problems []skillstate.Problem, kind skillstate.Proble
 			first = false
 		}
 		fmt.Fprintf(w, "    %s — %s\n", p.Skill, remedy(p))
+	}
+}
+
+// labeledSkills renders a skill-level class through skillProblemLine so the
+// remedy command is visually split from the skill name (issue #227).
+func labeledSkills(w io.Writer, s styler, problems []skillstate.Problem, kind skillstate.ProblemKind, header, label string) {
+	first := true
+	for _, p := range problems {
+		if p.Kind != kind {
+			continue
+		}
+		if first {
+			fmt.Fprintln(w, "\n  "+header)
+			first = false
+		}
+		fmt.Fprintln(w, skillProblemLine(s, p.Skill, label, p.Fix))
 	}
 }
 
@@ -133,8 +163,8 @@ func perField(w io.Writer, problems []skillstate.Problem, kind skillstate.Proble
 }
 
 // fieldsBySkill collapses a field-level class into one line per skill:
-// "<skill> — fields: A, B — <fix>".
-func fieldsBySkill(w io.Writer, problems []skillstate.Problem, kind skillstate.ProblemKind, header string) {
+// "<skill> — fields: A, B — set them with: <fix>".
+func fieldsBySkill(w io.Writer, s styler, problems []skillstate.Problem, kind skillstate.ProblemKind, header string) {
 	var order []string
 	fields := map[string][]string{}
 	fix := map[string]string{}
@@ -153,8 +183,9 @@ func fieldsBySkill(w io.Writer, problems []skillstate.Problem, kind skillstate.P
 	}
 	fmt.Fprintln(w, "\n  "+header)
 	for _, skill := range order {
-		fmt.Fprintf(w, "    %s — fields: %s — %s\n",
-			skill, strings.Join(fields[skill], ", "), fix[skill])
+		fmt.Fprintln(w, skillProblemLine(s, skill,
+			"fields: "+strings.Join(fields[skill], ", ")+" — set them with",
+			fix[skill]))
 	}
 }
 
@@ -166,9 +197,10 @@ func remedy(p skillstate.Problem) string {
 	switch {
 	case p.Fix == "":
 		return p.Detail
-	case p.Kind == skillstate.MissingSecret || p.Kind == skillstate.BundleDrift:
-		// The header already states the cause ("required secret missing",
-		// "bundle changed since register"); repeating it adds no information.
+	case p.Kind == skillstate.MissingSecret:
+		// The header already states the cause ("required secret missing");
+		// repeating it adds no information. Bundle drift is rendered via
+		// labeledSkills instead of remedy.
 		return p.Fix
 	default:
 		return p.Detail + " — " + p.Fix

--- a/internal/cli/skillrefusal_test.go
+++ b/internal/cli/skillrefusal_test.go
@@ -44,14 +44,15 @@ func TestRenderSkillRefusalEveryKind(t *testing.T) {
 		{
 			name: "meta broken",
 			problem: skillstate.Problem{Kind: skillstate.MetaBroken, Skill: "alpha",
-				Detail: "yaml: line 3: bad", Fix: "omac register --force alpha"},
-			want: []string{"omac.yaml broken", "alpha", "yaml: line 3: bad", "omac register --force alpha"},
+				Detail: "yaml: line 3: bad", Fix: "omac register alpha --force"},
+			want: []string{"omac.yaml broken", "alpha", "yaml: line 3: bad", "omac register alpha --force"},
 		},
 		{
 			name: "bundle drift",
 			problem: skillstate.Problem{Kind: skillstate.BundleDrift, Skill: "bravo",
-				Detail: "bundle changed since register", Fix: "omac register --force bravo"},
-			want: []string{"bundle changed since register", "--accept-skill-changes", "bravo", "omac register --force bravo"},
+				Detail: "bundle changed since register", Fix: "omac register bravo --force"},
+			want: []string{"bundle changed since register", "--accept-skill-changes", "bravo",
+				"re-register", "omac register bravo --force"},
 		},
 		{
 			name: "missing secret",
@@ -69,8 +70,9 @@ func TestRenderSkillRefusalEveryKind(t *testing.T) {
 		{
 			name: "missing field",
 			problem: skillstate.Problem{Kind: skillstate.MissingField, Skill: "echo", Field: "API_BASE",
-				Detail: "required config field missing", Fix: "omac register --reprompt-fields echo"},
-			want: []string{"required config field missing", "echo", "fields: API_BASE", "omac register --reprompt-fields echo"},
+				Detail: "required config field missing", Fix: "omac register echo --reprompt-fields"},
+			want: []string{"required config field missing", "echo", "fields: API_BASE",
+				"set them with", "omac register echo --reprompt-fields"},
 		},
 		{
 			name: "keychain unavailable",
@@ -101,8 +103,8 @@ func TestRenderSkillRefusalExitCodePriority(t *testing.T) {
 	keychainDown := skillstate.Problem{Kind: skillstate.KeychainUnavailable, Skill: "a", Field: "T", Detail: "no bus"}
 	missingSecret := skillstate.Problem{Kind: skillstate.MissingSecret, Skill: "b", Field: "T", Fix: "omac secrets set b T"}
 	invalidSecret := skillstate.Problem{Kind: skillstate.InvalidSecret, Skill: "c", Field: "T", Detail: "bad", Fix: "fix"}
-	missingField := skillstate.Problem{Kind: skillstate.MissingField, Skill: "d", Field: "F", Fix: "omac register --reprompt-fields d"}
-	drift := skillstate.Problem{Kind: skillstate.BundleDrift, Skill: "e", Fix: "omac register --force e"}
+	missingField := skillstate.Problem{Kind: skillstate.MissingField, Skill: "d", Field: "F", Fix: "omac register d --reprompt-fields"}
+	drift := skillstate.Problem{Kind: skillstate.BundleDrift, Skill: "e", Fix: "omac register e --force"}
 	metaBroken := skillstate.Problem{Kind: skillstate.MetaBroken, Skill: "f", Detail: "bad yaml"}
 
 	cases := []struct {
@@ -134,9 +136,9 @@ func TestRenderSkillRefusalExitCodePriority(t *testing.T) {
 // appear in every relevant section, not just the first.
 func TestRenderSkillRefusalReportsEveryClassForOneSkill(t *testing.T) {
 	problems := []skillstate.Problem{
-		{Kind: skillstate.BundleDrift, Skill: "alpha", Fix: "omac register --force alpha"},
+		{Kind: skillstate.BundleDrift, Skill: "alpha", Fix: "omac register alpha --force"},
 		{Kind: skillstate.MissingSecret, Skill: "alpha", Field: "TOKEN", Fix: "omac secrets set alpha TOKEN"},
-		{Kind: skillstate.MissingField, Skill: "alpha", Field: "API_BASE", Fix: "omac register --reprompt-fields alpha"},
+		{Kind: skillstate.MissingField, Skill: "alpha", Field: "API_BASE", Fix: "omac register alpha --reprompt-fields"},
 	}
 	out, code := render(problems)
 
@@ -144,9 +146,9 @@ func TestRenderSkillRefusalReportsEveryClassForOneSkill(t *testing.T) {
 		t.Errorf("want all three counted:\n%s", out)
 	}
 	for _, want := range []string{
-		"omac register --force alpha",
+		"omac register alpha --force",
 		"omac secrets set alpha TOKEN",
-		"omac register --reprompt-fields alpha",
+		"omac register alpha --reprompt-fields",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q — the user would need another round trip:\n%s", want, out)
@@ -157,21 +159,21 @@ func TestRenderSkillRefusalReportsEveryClassForOneSkill(t *testing.T) {
 	}
 }
 
-// TestRenderSkillRefusalGroupsFieldsPerSkill: one `omac register
+// TestRenderSkillRefusalGroupsFieldsPerSkill: one `omac register <skill>
 // --reprompt-fields` run re-prompts ALL of a skill's fields, so printing the
 // command once per field would imply it must be run repeatedly.
 func TestRenderSkillRefusalGroupsFieldsPerSkill(t *testing.T) {
 	problems := []skillstate.Problem{
-		{Kind: skillstate.MissingField, Skill: "alpha", Field: "A", Fix: "omac register --reprompt-fields alpha"},
-		{Kind: skillstate.MissingField, Skill: "alpha", Field: "B", Fix: "omac register --reprompt-fields alpha"},
-		{Kind: skillstate.MissingField, Skill: "bravo", Field: "C", Fix: "omac register --reprompt-fields bravo"},
+		{Kind: skillstate.MissingField, Skill: "alpha", Field: "A", Fix: "omac register alpha --reprompt-fields"},
+		{Kind: skillstate.MissingField, Skill: "alpha", Field: "B", Fix: "omac register alpha --reprompt-fields"},
+		{Kind: skillstate.MissingField, Skill: "bravo", Field: "C", Fix: "omac register bravo --reprompt-fields"},
 	}
 	out, _ := render(problems)
 
 	if !strings.Contains(out, "fields: A, B") {
 		t.Errorf("want alpha's fields on one line:\n%s", out)
 	}
-	if n := strings.Count(out, "omac register --reprompt-fields alpha"); n != 1 {
+	if n := strings.Count(out, "omac register alpha --reprompt-fields"); n != 1 {
 		t.Errorf("alpha's fix printed %d times, want once:\n%s", n, out)
 	}
 	if !strings.Contains(out, "fields: C") {
@@ -223,7 +225,7 @@ func TestRenderSkillRefusalNoFixNoInvention(t *testing.T) {
 func TestRenderSkillRefusalUsesPrefix(t *testing.T) {
 	var buf bytes.Buffer
 	renderSkillRefusal(&buf, "omac continue", []skillstate.Problem{
-		{Kind: skillstate.BundleDrift, Skill: "alpha", Fix: "omac register --force alpha"},
+		{Kind: skillstate.BundleDrift, Skill: "alpha", Fix: "omac register alpha --force"},
 	})
 	if !strings.HasPrefix(buf.String(), "omac continue: refusing to start") {
 		t.Errorf("want the caller's prefix:\n%s", buf.String())

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -108,13 +108,7 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, int) 
 	// with `opencode -s <id>`; claude uses --resume, so its shorthand is
 	// different, but `omac -s` is harness-agnostic).
 	fs.StringVar(sessionID, "s", "", "Shorthand for --session.")
-	fs.Usage = func() {
-		out := fs.Output()
-		fmt.Fprintf(out, "Usage: omac %s [harness] [flags] [-- inner args...]\n", cmdName)
-		fmt.Fprintf(out, "\nharness: one of %s (default: %s)\n\n",
-			strings.Join(config.HarnessNames(), ", "), config.DefaultHarness().Name)
-		fs.PrintDefaults()
-	}
+	fs.Usage = func() { writeLaunchUsage(cmdName, fs) }
 	// Preserve everything after "--" verbatim as inner args.
 	var ourArgs, innerArgs []string
 	split := false
@@ -137,7 +131,7 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, int) 
 		fmt.Fprintf(env.Stderr, "omac %s: %v\n", cmdName, err)
 		return launchOpts{}, ExitMisuse
 	}
-	if code, ok := parseFlags(fs, ourArgs, env); !ok {
+	if code, ok := parseWithHarnessArgsHint(fs, cmdName, ourArgs, env); !ok {
 		return launchOpts{}, code
 	}
 	if *ephemeralCache && *noSandbox {

--- a/internal/skillstate/skillstate.go
+++ b/internal/skillstate/skillstate.go
@@ -266,7 +266,7 @@ func (r *Resolver) Inspect(e registry.Entry, absDir string) (Armed, []Problem) {
 			Kind:   MetaBroken,
 			Skill:  e.Name,
 			Detail: err.Error(),
-			Fix:    "omac register --force " + e.Name,
+			Fix:    "omac register " + e.Name + " --force",
 			Cause:  err,
 		}}
 	}
@@ -275,7 +275,7 @@ func (r *Resolver) Inspect(e registry.Entry, absDir string) (Armed, []Problem) {
 			Kind:   MetaBroken,
 			Skill:  e.Name,
 			Detail: config.MetaFileName + " no longer has a sidecar block",
-			Fix:    "omac register --force " + e.Name,
+			Fix:    "omac register " + e.Name + " --force",
 		}}
 	}
 	return r.inspectMeta(m, e, absDir)
@@ -304,7 +304,7 @@ func (r *Resolver) inspectMeta(m *config.Meta, e registry.Entry, absDir string) 
 				Kind:   BundleDrift,
 				Skill:  e.Name,
 				Detail: "bundle changed since register",
-				Fix:    "omac register --force " + e.Name,
+				Fix:    "omac register " + e.Name + " --force",
 			})
 		}
 	}
@@ -511,7 +511,7 @@ func (r *Resolver) resolveConfig(armed *Armed, cfg *skillconfig.Store) []Problem
 			Skill:  armed.Entry.Name,
 			Field:  spec.Name,
 			Detail: "required config field missing",
-			Fix:    "omac register --reprompt-fields " + armed.Entry.Name,
+			Fix:    "omac register " + armed.Entry.Name + " --reprompt-fields",
 		})
 	}
 	return problems

--- a/internal/skillstate/skillstate_test.go
+++ b/internal/skillstate/skillstate_test.go
@@ -492,7 +492,7 @@ func TestBundleDrift(t *testing.T) {
 	armed, problems := New(Options{}).Resolve(m, e, dir, nil)
 	defer armed.Zero()
 	wantKinds(t, problems, BundleDrift)
-	if want := "omac register --force probe"; problems[0].Fix != want {
+	if want := "omac register probe --force"; problems[0].Fix != want {
 		t.Errorf("Fix = %q, want %q", problems[0].Fix, want)
 	}
 	if armed.Bundle == "" {

--- a/oh-my-agentic-coder.md
+++ b/oh-my-agentic-coder.md
@@ -379,7 +379,7 @@ Write semantics:
   runtime artifacts like virtualenvs, caches, `node_modules/`, VCS
   metadata). On `omac start`, if the current bundle hash differs,
   `omac` refuses to start unless `--accept-skill-changes` is passed
-  (or the user re-registers with `omac register --force <skill>`).
+  (or the user re-registers with `omac register <skill> --force`).
 
 ### 8.2 Skill layout
 
@@ -885,12 +885,12 @@ omac:
         (workdir wins, .agents wins over .opencode).
     c. For each registered skill, recompute bundle_hash; if it
        differs from the stored value, refuse unless
-       --accept-skill-changes is set. (`omac register --force <skill>`
+       --accept-skill-changes is set. (`omac register <skill> --force`
        is the supported way to re-register on intentional changes.)
     d. For each registered skill, ensure every required `config:`
        field resolves: stored value > spec default > default_from_env
        in the host shell. Refuse with the list of missing names if
-       not, suggesting `omac register --reprompt-fields <skill>`.
+       not, suggesting `omac register <skill> --reprompt-fields`.
  3. For each registered skill, read its declared secrets from the OS keychain
     (service = "omac/<skill>", account = <secret.name>).
     - Missing required secrets → abort with exit 9 and a clear prompt:


### PR DESCRIPTION
**Issue:** Closes #227

## What

- Argument reordering is now boolean-aware, so a bool flag written before a positional no longer causes every later flag to be dropped.
- The four skill-problem hints in `start`/`serve` render through a shared helper, labelled and in the documented `omac register <skill> [flags]` order.
- Docs and the bundled `omac-write-a-skill` copy of the skill guide updated to match.

## Why

#227 reported that `omac register --force <skill>` looks wrong. It turned out to parse fine on its own — but it is the fragile order, and that exposed a real bug.

`reorderFlagsFirst` glued the following token onto any flag without `=`, without knowing which flags take a value (`internal/cli/flagutil.go:71` on `main`). `--force` is boolean, so the stdlib parser consumes no value for it: it stopped at the glued skill name and silently discarded every flag after it.

- `omac register --force demo-echo --harness opencode` → usage dump, exit 2
- `omac register demo-echo --force --harness opencode` → `[ok] registered`

The reporter hit this by following omac's own advice: `skill-marketplace` exists under both opencode and claude-code, so the drift hint suggests `--force <skill>`, the ambiguity prompt then asks for `--harness`, and the combination dies. The bug is not register-specific — all 14 subcommands use this helper (reproduced on `deregister` too).

The display complaint is valid independently: `start.go:637` and `serve.go:989` printed a bare em dash with no label, so the line read as one run-on string, inconsistent with `register.go`'s disambiguation hints which were already labelled and skill-first.

## How

- `reorderFlagsFirst` takes the `*flag.FlagSet` and skips gluing for booleans (`internal/cli/flagutil.go:77`, `isBoolFlag` at `:91`). Unknown flags keep the value-taking behavior so typo diagnostics are unchanged. Threaded through all 14 call sites (one line each).
- New `internal/cli/hints.go`: `registerCmd` builds the command in documented order, `skillProblemLine` renders `<skill> — <label>: <cmd>` with the command colored. Keeps the four sites from drifting apart again.
- `CREATING_A_SKILL.md` + `oh-my-agentic-coder.md` updated and re-copied into the bundle (byte-identity enforced by `internal/builtinskills/builtinskills_test.go:113`).

Output before → after:

```
- demo-echo — omac register --force demo-echo
+ demo-echo — re-register: omac register demo-echo --force
```

## Verification

`go build ./...` — OK.

`go test ./internal/cli/ ./internal/builtinskills/` — both `ok`.

New tests:

- `TestReorderFlagsFirst_BoolFlagDoesNotSwallowPositional` — fails on `main`, pins the parser fix across three arg orders.
- `TestRegister_BoolFlagBeforeSkillKeepsLaterFlags` — the exact `--force <skill> --harness <h>` shape, and asserts the claude-code registry entry exists (i.e. `--harness` was honored, not dropped).
- `TestHintsUseDocumentedFlagOrder` — scans `internal/cli/*.go` and fails if any hint puts a flag before the skill name. Confirmed non-vacuous by temporarily reintroducing the old string.
- `TestRegisterCmd` / `TestSkillProblemLine` — pin the rendering.

Manual, built binaries from `main` and this branch (no setup needed; `nix-da` intentionally does not exist, so this isolates argument parsing):

```
$ omac register --force nix-da --harness claude
main:   Usage: omac register <skill> [flags]                            # --harness dropped
branch: omac register: "nix-da" not found in any in-scope skill source
```

Also verified the drift hint end-to-end by registering a skill, mutating its bundle and running `omac start`.

`go test ./...` — the two `internal/bridge` failures (`TestCodexBridge…`, `TestCopilotBridge…`) reproduce on unmodified `main` in this environment; they need node/bun, which is not installed. Everything else passes.

## Follow-up

The parser fix touches all 14 subcommands that reorder args, which is broader than the issue title suggests. Happy to split it into its own issue/PR if a reviewer prefers it isolated.
