### PR TITLE
fix(sandbox,cli): grant every hop of the harness symlink chain

### DIFF
--- a/internal/cli/binary_check_test.go
+++ b/internal/cli/binary_check_test.go
@@ -55,6 +55,48 @@ func TestCheckInnerBinaryChecksProfileInnerCmdNotTheHarnessDefault(t *testing.T)
 	}
 }
 
+// A profile-pinned inner_cmd may wrap the harness in an `env NAME=VALUE ...`
+// prefix. Without unwrapping, the pre-flight validates `env` (always present)
+// and silently passes while the real harness binary is missing.
+func TestCheckInnerBinaryUnwrapsEnvPrefix(t *testing.T) {
+	h := testHarnessWithInnerCmd("echo")
+
+	env, _, errBuf, drain := newPipeEnv(t, "")
+	code := checkInnerBinary(h.ResolveInnerCmd([]string{"env", "NPM_CONFIG_CACHE=/x", "nonexistent-binary-xyz-12345"}, ""), "test", env)
+	drain()
+
+	if code != ExitPrerequisiteMissing {
+		t.Errorf("env-wrapped missing harness unchecked: got %d, want ExitPrerequisiteMissing(%d)", code, ExitPrerequisiteMissing)
+	}
+	if !bytes.Contains(errBuf.Bytes(), []byte("nonexistent-binary-xyz-12345")) {
+		t.Errorf("stderr names wrapper instead of real binary; got:\n%s", errBuf.String())
+	}
+	if bytes.Contains(errBuf.Bytes(), []byte("harness binary \"env\"")) {
+		t.Errorf("stderr names `env` as missing, should name the real binary; got:\n%s", errBuf.String())
+	}
+}
+
+// An env wrapper may carry flags (e.g. `env -i cmd`). UnwrapEnv leaves them
+// in place; the pre-flight skips them so "-i" is not reported as the missing
+// binary.
+func TestCheckInnerBinarySkipsEnvFlags(t *testing.T) {
+	h := testHarnessWithInnerCmd("echo")
+
+	env, _, errBuf, drain := newPipeEnv(t, "")
+	code := checkInnerBinary(h.ResolveInnerCmd([]string{"env", "-i", "nonexistent-binary-xyz-12345"}, ""), "test", env)
+	drain()
+
+	if code != ExitPrerequisiteMissing {
+		t.Errorf("env -i wrapped missing harness unchecked: got %d, want ExitPrerequisiteMissing(%d)", code, ExitPrerequisiteMissing)
+	}
+	if !bytes.Contains(errBuf.Bytes(), []byte("nonexistent-binary-xyz-12345")) {
+		t.Errorf("stderr does not name the real binary after flag skip; got:\n%s", errBuf.String())
+	}
+	if bytes.Contains(errBuf.Bytes(), []byte("harness binary \"-i\"")) {
+		t.Errorf("stderr names the env flag as missing; got:\n%s", errBuf.String())
+	}
+}
+
 func testHarnessWithInnerCmd(bin string) config.Harness {
 	cmd := []string{}
 	if bin != "" {

--- a/internal/cli/binary_check_test.go
+++ b/internal/cli/binary_check_test.go
@@ -10,7 +10,7 @@ import (
 func TestCheckInnerBinaryFound(t *testing.T) {
 	env, _, _, _ := newPipeEnv(t, "")
 	h := testHarnessWithInnerCmd("echo")
-	if code := checkInnerBinary(h, "test", env); code != ExitOK {
+	if code := checkInnerBinary(h.ResolveInnerCmd(nil, ""), "test", env); code != ExitOK {
 		t.Errorf("checkInnerBinary(echo) = %d, want ExitOK(%d)", code, ExitOK)
 	}
 }
@@ -18,7 +18,7 @@ func TestCheckInnerBinaryFound(t *testing.T) {
 func TestCheckInnerBinaryMissing(t *testing.T) {
 	env, _, errBuf, drain := newPipeEnv(t, "")
 	h := testHarnessWithInnerCmd("nonexistent-binary-xyz-12345")
-	code := checkInnerBinary(h, "test", env)
+	code := checkInnerBinary(h.ResolveInnerCmd(nil, ""), "test", env)
 	drain()
 	if code != ExitPrerequisiteMissing {
 		t.Errorf("checkInnerBinary(nonexistent) = %d, want ExitPrerequisiteMissing(%d)", code, ExitPrerequisiteMissing)
@@ -31,8 +31,27 @@ func TestCheckInnerBinaryMissing(t *testing.T) {
 func TestCheckInnerBinaryEmptyCmd(t *testing.T) {
 	env, _, _, _ := newPipeEnv(t, "")
 	h := testHarnessWithInnerCmd("")
-	if code := checkInnerBinary(h, "test", env); code != ExitOK {
+	if code := checkInnerBinary(h.ResolveInnerCmd(nil, ""), "test", env); code != ExitOK {
 		t.Errorf("checkInnerBinary(empty) = %d, want ExitOK (skip)", code)
+	}
+}
+
+// A profile-pinned inner_cmd takes precedence over the harness default
+// (Harness.ResolveInnerCmd), so checking the default validated a binary the
+// launch would never run — reporting OK for opencode while starting something
+// else, which then failed inside the sandbox naming the wrong cause.
+func TestCheckInnerBinaryChecksProfileInnerCmdNotTheHarnessDefault(t *testing.T) {
+	h := testHarnessWithInnerCmd("echo") // installed; the pinned one is not
+
+	env, _, errBuf, drain := newPipeEnv(t, "")
+	code := checkInnerBinary(h.ResolveInnerCmd([]string{"nonexistent-binary-xyz-12345"}, ""), "test", env)
+	drain()
+
+	if code != ExitPrerequisiteMissing {
+		t.Errorf("profile inner_cmd unchecked: got %d, want ExitPrerequisiteMissing(%d)", code, ExitPrerequisiteMissing)
+	}
+	if !bytes.Contains(errBuf.Bytes(), []byte("nonexistent-binary-xyz-12345")) {
+		t.Errorf("stderr does not name the pinned binary; got:\n%s", errBuf.String())
 	}
 }
 

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -83,12 +83,12 @@ func TestParseLaunchArgsEphemeralCache(t *testing.T) {
 }
 
 func TestParseLaunchArgsOpenPort(t *testing.T) {
-	opts, ok := parseLaunchArgs("start", []string{
+	opts, code := parseLaunchArgs("start", []string{
 		"--open-port", "3000",
 		"--open-port", "4173",
 	}, devnullEnv(t))
-	if !ok {
-		t.Fatal("parseLaunchArgs() returned false")
+	if code != ExitOK {
+		t.Fatalf("parseLaunchArgs() code = %d, want ExitOK", code)
 	}
 	if len(opts.openPorts) != 2 || opts.openPorts[0] != 3000 || opts.openPorts[1] != 4173 {
 		t.Errorf("openPorts = %v", opts.openPorts)
@@ -96,10 +96,10 @@ func TestParseLaunchArgsOpenPort(t *testing.T) {
 }
 
 func TestParseLaunchArgsRejectsBadOpenPort(t *testing.T) {
-	if _, ok := parseLaunchArgs("start", []string{"--open-port", "0"}, devnullEnv(t)); ok {
+	if _, code := parseLaunchArgs("start", []string{"--open-port", "0"}, devnullEnv(t)); code == ExitOK {
 		t.Error("port 0 should be rejected")
 	}
-	if _, ok := parseLaunchArgs("start", []string{"--open-port", "nope"}, devnullEnv(t)); ok {
+	if _, code := parseLaunchArgs("start", []string{"--open-port", "nope"}, devnullEnv(t)); code == ExitOK {
 		t.Error("non-integer port should be rejected")
 	}
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -130,9 +130,15 @@ func runServe(args []string, env *Env) int {
 	prof := plan.Launcher
 
 	// Pre-flight: inner harness binary must be on $PATH (unless --no-inner
-	// or --inner override).
+	// or --inner override). Checked on the RESOLVED argv so a profile-pinned
+	// inner_cmd is verified rather than the harness default the launch will
+	// not use — see checkInnerBinary.
 	if !*noInner && *innerCmdOverride == "" {
-		if code := checkInnerBinary(harness, "omac serve", env); code != ExitOK {
+		preflightInner := prof.InnerCmd
+		if !plan.Known {
+			preflightInner = nil
+		}
+		if code := checkInnerBinary(harness.ResolveInnerCmd(preflightInner, ""), "omac serve", env); code != ExitOK {
 			return code
 		}
 	}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -172,15 +172,25 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, int) 
 	}, ExitOK
 }
 
-// checkInnerBinary verifies the harness's inner command binary is on $PATH.
+// checkInnerBinary verifies the RESOLVED inner command binary is on $PATH.
 // Returns ExitOK when found, ExitPrerequisiteMissing when missing, ExitOK
-// when InnerCmd is empty (defensive skip). Called by runLaunch and runServe.
-func checkInnerBinary(harness config.Harness, prefix string, env *Env) int {
-	if len(harness.InnerCmd) == 0 {
+// when innerCmd is empty (defensive skip). Called by runLaunch and runServe.
+//
+// It takes the resolved argv — Harness.ResolveInnerCmd's output — rather than
+// a Harness, because that argv is what the sandbox backend will actually try
+// to resolve. Checking only the harness default left two routes unguarded: a
+// profile-pinned inner_cmd (reached when the harness has no default of its
+// own) and an explicit --inner override, whose call sites skipped the
+// pre-flight outright. Either then fails much further downstream, where the
+// backend's own PATH lookup silently yields no grant and macOS reports the
+// denied in-sandbox lookup as a bare "No such file or directory" that names
+// the wrong cause.
+func checkInnerBinary(innerCmd []string, prefix string, env *Env) int {
+	if len(innerCmd) == 0 || innerCmd[0] == "" {
 		return ExitOK
 	}
-	if _, err := exec.LookPath(harness.InnerCmd[0]); err != nil {
-		fmt.Fprintf(env.Stderr, "%s: harness binary %q not found on $PATH; install it or pass --inner-cmd <path>\n", prefix, harness.InnerCmd[0])
+	if _, err := exec.LookPath(innerCmd[0]); err != nil {
+		fmt.Fprintf(env.Stderr, "%s: harness binary %q not found on $PATH; install it or pass --inner-cmd <path>\n", prefix, innerCmd[0])
 		return ExitPrerequisiteMissing
 	}
 	return ExitOK
@@ -247,9 +257,17 @@ func runLaunch(env *Env, opts launchOpts) int {
 	profName := plan.Name
 	prof := plan.Launcher
 
-	// 1b. Pre-flight: inner harness binary must be on $PATH.
+	// 1b. Pre-flight: inner harness binary must be on $PATH. Checked on the
+	//     RESOLVED argv — profile inner_cmd, else the harness default — which
+	//     is the same argv step 8 hands to the sandbox. Passing the harness
+	//     default instead validated the wrong binary whenever a config pinned
+	//     inner_cmd: it confirmed opencode while the launch ran something
+	//     else, which then failed inside Seatbelt naming the wrong cause.
+	//     An explicit --inner still skips: pointing at an exact binary is a
+	//     deliberate escape hatch. sandboxrun warns non-fatally if it cannot
+	//     be resolved either.
 	if innerCmdOverride == "" {
-		if code := checkInnerBinary(harness, prefix, env); code != ExitOK {
+		if code := checkInnerBinary(harness.ResolveInnerCmd(prof.InnerCmd, ""), prefix, env); code != ExitOK {
 			return code
 		}
 	}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tngtech/oh-my-agentic-coder/internal/keychain"
 	"github.com/tngtech/oh-my-agentic-coder/internal/registry"
 	"github.com/tngtech/oh-my-agentic-coder/internal/sandbox"
+	"github.com/tngtech/oh-my-agentic-coder/internal/sandboxrun"
 	"github.com/tngtech/oh-my-agentic-coder/internal/secrets"
 	"github.com/tngtech/oh-my-agentic-coder/internal/session"
 	"github.com/tngtech/oh-my-agentic-coder/internal/skillconfig"
@@ -172,25 +173,32 @@ func parseLaunchArgs(cmdName string, args []string, env *Env) (launchOpts, int) 
 	}, ExitOK
 }
 
-// checkInnerBinary verifies the RESOLVED inner command binary is on $PATH.
+// checkInnerBinary verifies the resolved inner command binary is on $PATH.
 // Returns ExitOK when found, ExitPrerequisiteMissing when missing, ExitOK
-// when innerCmd is empty (defensive skip). Called by runLaunch and runServe.
+// when empty (defensive skip). Called by runLaunch and runServe.
 //
-// It takes the resolved argv — Harness.ResolveInnerCmd's output — rather than
-// a Harness, because that argv is what the sandbox backend will actually try
-// to resolve. Checking only the harness default left two routes unguarded: a
-// profile-pinned inner_cmd (reached when the harness has no default of its
-// own) and an explicit --inner override, whose call sites skipped the
-// pre-flight outright. Either then fails much further downstream, where the
-// backend's own PATH lookup silently yields no grant and macOS reports the
-// denied in-sandbox lookup as a bare "No such file or directory" that names
-// the wrong cause.
+// Validating the wrong binary is what turns a missing harness into the late,
+// mislabeled "No such file or directory" from inside Seatbelt. Three inputs
+// can steer the check wrong, and all three are unwrapped here: the resolved
+// argv may come from a profile-pinned inner_cmd rather than the harness
+// default (Harness.ResolveInnerCmd), and it may be wrapped in an
+// `env NAME=VALUE ...` prefix (UnwrapEnv) or carry env flags like `-i`
+// (skipped below) — each of which would otherwise make the pre-flight check
+// `env` itself and report ExitOK regardless of whether the real harness is
+// installed.
 func checkInnerBinary(innerCmd []string, prefix string, env *Env) int {
 	if len(innerCmd) == 0 || innerCmd[0] == "" {
 		return ExitOK
 	}
-	if _, err := exec.LookPath(innerCmd[0]); err != nil {
-		fmt.Fprintf(env.Stderr, "%s: harness binary %q not found on $PATH; install it or pass --inner-cmd <path>\n", prefix, innerCmd[0])
+	cmd := sandboxrun.UnwrapEnv(innerCmd)
+	for len(cmd) > 0 && strings.HasPrefix(cmd[0], "-") {
+		cmd = cmd[1:]
+	}
+	if len(cmd) == 0 || cmd[0] == "" {
+		return ExitOK
+	}
+	if _, err := exec.LookPath(cmd[0]); err != nil {
+		fmt.Fprintf(env.Stderr, "%s: harness binary %q not found on $PATH; install it or pass --inner-cmd <path>\n", prefix, cmd[0])
 		return ExitPrerequisiteMissing
 	}
 	return ExitOK
@@ -258,14 +266,10 @@ func runLaunch(env *Env, opts launchOpts) int {
 	prof := plan.Launcher
 
 	// 1b. Pre-flight: inner harness binary must be on $PATH. Checked on the
-	//     RESOLVED argv — profile inner_cmd, else the harness default — which
-	//     is the same argv step 8 hands to the sandbox. Passing the harness
-	//     default instead validated the wrong binary whenever a config pinned
-	//     inner_cmd: it confirmed opencode while the launch ran something
-	//     else, which then failed inside Seatbelt naming the wrong cause.
-	//     An explicit --inner still skips: pointing at an exact binary is a
-	//     deliberate escape hatch. sandboxrun warns non-fatally if it cannot
-	//     be resolved either.
+	//     resolved argv (profile inner_cmd, else harness default) — the same
+	//     argv step 8 hands to the sandbox. An explicit --inner skips: that
+	//     points at an exact binary, which is an escape hatch; sandboxrun
+	//     warns non-fatally if it cannot resolve it either.
 	if innerCmdOverride == "" {
 		if code := checkInnerBinary(harness.ResolveInnerCmd(prof.InnerCmd, ""), prefix, env); code != ExitOK {
 			return code

--- a/internal/sandboxrun/backend_darwin.go
+++ b/internal/sandboxrun/backend_darwin.go
@@ -28,6 +28,12 @@ func CheckPlatform() error {
 // as readable — (deny default) blocks exec otherwise. We resolve the
 // binary on the host PATH and add its dir (and symlink-resolved dir)
 // to ReadPaths before generating the SBPL, mirroring backend_linux.go.
+//
+// argv[0] is handed to sandbox-exec as an absolute path (see
+// absoluteInnerArgv). A bare name would make sandbox-exec's execvp redo
+// the PATH lookup inside the sandbox, where a denied lookup is reported
+// as ENOENT — a second resolution that can disagree with the host-side
+// one this function just used to build the grants.
 func BuildChildArgv(g *Grants, innerArgv []string) ([]string, error) {
 	if err := CheckPlatform(); err != nil {
 		return nil, err
@@ -36,6 +42,6 @@ func BuildChildArgv(g *Grants, innerArgv []string) ([]string, error) {
 	gz.ReadPaths = append(append([]string{}, g.ReadPaths...), resolveInnerBinaryDirs(innerArgv)...)
 	profile := GenerateSBPL(&gz)
 	argv := []string{sandboxExecPath, "-p", profile, "--"}
-	argv = append(argv, innerArgv...)
+	argv = append(argv, absoluteInnerArgv(innerArgv)...)
 	return argv, nil
 }

--- a/internal/sandboxrun/backend_darwin_test.go
+++ b/internal/sandboxrun/backend_darwin_test.go
@@ -1,0 +1,112 @@
+//go:build darwin
+
+package sandboxrun
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sandbox-exec is handed argv after `--` verbatim, so a bare argv[0] leaves it
+// to execvp to walk PATH a second time INSIDE the sandbox — where a denied
+// lookup surfaces as ENOENT and the user is told
+//
+//	sandbox-exec: execvp() of 'opencode' failed: No such file or directory
+//
+// on a machine where `which opencode` resolves fine. The grants are computed
+// from a HOST-side lookup; handing sandbox-exec the path that lookup produced
+// is what keeps the two from disagreeing.
+func TestBuildChildArgvPassesTheInnerBinaryAsAnAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "opencode")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	argv, err := BuildChildArgv(&Grants{Workdir: dir}, []string{"opencode", "--version"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// argv is: sandbox-exec -p <profile> -- <inner...>
+	const innerAt = 4
+	if len(argv) != innerAt+2 {
+		t.Fatalf("argv = %v, want %d elements", argv, innerAt+2)
+	}
+	if argv[innerAt] != exe {
+		t.Errorf("inner argv[0] = %q, want the absolute path %q", argv[innerAt], exe)
+	}
+	if argv[innerAt+1] != "--version" {
+		t.Errorf("inner args not preserved: %v", argv[innerAt:])
+	}
+}
+
+// The rewrite must not silently drop a command the host cannot resolve: argv
+// stays as the caller wrote it so the failure mode is unchanged (and the
+// supervisor's warning, not this function, is what explains it).
+func TestBuildChildArgvKeepsAnUnresolvableInnerCommand(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	argv, err := BuildChildArgv(&Grants{Workdir: t.TempDir()}, []string{"definitely-not-installed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := argv[len(argv)-1]; got != "definitely-not-installed" {
+		t.Errorf("inner argv[0] = %q, want it unchanged", got)
+	}
+}
+
+// Regression guard for the reported failure: a Homebrew install at a custom
+// $HOME-rooted prefix (/Users/<u>/homebrew, not /opt/homebrew) whose bin entry
+// is a relative symlink into Cellar. The darwin baseline hard-codes
+// /opt/homebrew and /usr/local, so nothing but the per-launch resolution
+// covers this layout — both the PATH-entry dir and the Cellar real dir must be
+// granted read AND map-executable, and the emitted argv must be absolute.
+func TestBuildChildArgvHomeRootedHomebrewPrefix(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cellarBin := filepath.Join(home, "homebrew", "Cellar", "opencode", "1.18.15", "bin")
+	if err := os.MkdirAll(cellarBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cellarBin, "opencode"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prefixBin := filepath.Join(home, "homebrew", "bin")
+	if err := os.MkdirAll(prefixBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(prefixBin, "opencode")
+	if err := os.Symlink("../Cellar/opencode/1.18.15/bin/opencode", link); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", prefixBin)
+
+	argv, err := BuildChildArgv(&Grants{Workdir: home}, []string{"opencode"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := argv[2]
+
+	// Assert the canonical form: the resolver feeds GenerateSBPL the
+	// symlink-resolved real dir, so on a host whose temp root sits behind a
+	// symlink (/var -> /private/var) only that form is emitted for it.
+	for _, dir := range []string{prefixBin, cellarBin} {
+		form := canonicalPath(dir)
+		if form == "" {
+			form = dir
+		}
+		for _, op := range []string{"file-read*", "file-map-executable"} {
+			want := "(allow " + op + " (subpath " + sbplQuote(form) + "))"
+			if !strings.Contains(profile, want) {
+				t.Errorf("profile missing %s", want)
+			}
+		}
+	}
+	if got := argv[len(argv)-1]; got != link {
+		t.Errorf("inner argv[0] = %q, want the absolute PATH-entry path %q", got, link)
+	}
+}

--- a/internal/sandboxrun/backend_linux_test.go
+++ b/internal/sandboxrun/backend_linux_test.go
@@ -165,8 +165,8 @@ func TestUnwrapEnv(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := unwrapEnv(tc.in); !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("unwrapEnv(%v) = %v, want %v", tc.in, got, tc.want)
+			if got := UnwrapEnv(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("UnwrapEnv(%v) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
 	}

--- a/internal/sandboxrun/resolve_binary.go
+++ b/internal/sandboxrun/resolve_binary.go
@@ -42,24 +42,19 @@ func resolveInnerBinaryDirs(innerArgv []string) []string {
 }
 
 // resolveCommandBinaryDirs is the core resolution for a single command argv
-// (no env-wrapper handling): PATH-entry dir, symlink-resolved real dir, and
-// shebang interpreter dirs. Returns nil when argv is empty or unresolvable.
+// (no env-wrapper handling): the directory of every hop of the symlink chain
+// from the PATH entry to the real file, plus shebang interpreter dirs.
+// Returns nil when argv is empty or unresolvable.
 func resolveCommandBinaryDirs(argv []string) []string {
-	if len(argv) == 0 || argv[0] == "" {
+	if len(argv) == 0 {
 		return nil
 	}
-	resolved, err := exec.LookPath(argv[0])
-	if err != nil {
+	resolved := lookPathAbs(argv[0])
+	if resolved == "" {
 		return nil
 	}
-	if abs, aerr := filepath.Abs(resolved); aerr == nil {
-		resolved = abs
-	}
-	dirs := []string{filepath.Dir(resolved)}
+	dirs := symlinkChainDirs(resolved)
 	if real, rerr := filepath.EvalSymlinks(resolved); rerr == nil {
-		if d := filepath.Dir(real); d != dirs[0] {
-			dirs = append(dirs, d)
-		}
 		if interp := shebangInterpreter(real); interp != "" {
 			if idirs := resolveInterpreterDirs(interp); len(idirs) > 0 {
 				dirs = append(dirs, idirs...)
@@ -67,6 +62,159 @@ func resolveCommandBinaryDirs(argv []string) []string {
 		}
 	}
 	return withPrefixSupportDirs(dirs)
+}
+
+// maxSymlinkHops bounds the chain walk. Well above any real install layout
+// (Homebrew's deepest is three) and below the kernel's own ELOOP limit, so a
+// cyclic or adversarial chain terminates here rather than spinning.
+const maxSymlinkHops = 32
+
+// symlinkChainDirs returns the directory of every hop of the symlink chain
+// starting at path: the path itself, each intermediate link target, and the
+// real file at the end. Duplicates are removed, order preserved.
+//
+// Granting only the two ENDS of the chain — which is what taking Dir(path)
+// and Dir(EvalSymlinks(path)) amounts to — is not enough, because the kernel
+// resolves the chain one hop at a time and needs read access to each link it
+// reads on the way. Homebrew under a non-default prefix is the case that
+// exposed it (issue #229): with the prefix outside every baseline grant,
+//
+//	<prefix>/bin/opencode
+//	  -> <prefix>/Cellar/opencode/<v>/bin/opencode          <- ungranted hop
+//	  -> <prefix>/Cellar/opencode/<v>/libexec/.../opencode.exe
+//
+// only the first and last directories were granted, so resolution died on the
+// middle link. Measured under a profile granting just the two ends, all three
+// argv[0] forms behave differently — the bare name fails ENOENT ("No such
+// file or directory", naming a binary that is plainly on PATH), the absolute
+// PATH-entry path fails EPERM, and only the fully resolved path runs. Adding
+// the middle directory makes all three work, which is why this walks the
+// chain instead of hardening argv[0] alone: passing an absolute path would
+// only have moved the failure from ENOENT to EPERM.
+//
+// Note it is the DIRECTORIES that are returned, not the links: a subpath
+// grant on the directory is what lets the kernel both read the link and stat
+// its siblings, matching how the rest of this file grants access.
+func symlinkChainDirs(path string) []string {
+	var dirs []string
+	seen := map[string]bool{}
+	add := func(d string) {
+		if !seen[d] {
+			seen[d] = true
+			dirs = append(dirs, d)
+		}
+	}
+	cur := path
+	for range maxSymlinkHops {
+		add(filepath.Dir(cur))
+		fi, err := os.Lstat(cur)
+		if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+			break
+		}
+		target, terr := os.Readlink(cur)
+		if terr != nil {
+			break
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(cur), target)
+		}
+		cur = filepath.Clean(target)
+	}
+	// A symlinked ancestor (e.g. a version dir that is itself a link) means
+	// the kernel matches the resolved spelling, which the per-hop walk above
+	// never produces. EvalSymlinks on the end of the chain closes that gap;
+	// it is a no-op for the common all-real-directories case.
+	if real, rerr := filepath.EvalSymlinks(path); rerr == nil {
+		add(filepath.Dir(real))
+	}
+	return dirs
+}
+
+// lookPathAbs resolves name against the host PATH and returns it as an
+// absolute path, WITHOUT following symlinks. Returns "" when the command
+// cannot be resolved.
+//
+// Not following symlinks is deliberate, for two reasons.
+//
+// The link itself is what a PATH lookup finds, and shim-style installs
+// (Homebrew's <prefix>/bin, mise/asdf) rely on the harness seeing the link
+// path rather than the store path behind it.
+//
+// More importantly, resolving would silently defeat the profile. Under a
+// deny covering the harness's tree (e.g. filesystem.deny: ["~"] with a
+// $HOME-rooted Homebrew prefix) all three argv[0] forms were measured:
+// the bare name fails ENOENT, this absolute link path fails EPERM, and
+// the EvalSymlinks-resolved path RUNS — even though the resolved file is
+// itself inside the denied tree and reading it is refused (cat → EPERM).
+// It runs only because exec of a main image consults (allow process-exec*)
+// and never the file-read rules, whereas resolving a symlink must read the
+// link in the denied directory. So the resolved form succeeds by bypassing
+// the user's stated policy, not by being more correct. omac reports that
+// conflict instead — see protectedInnerBinaryWarning. Linux's backend does
+// resolve (backend_linux.go), which gives it the same bypass property;
+// that inconsistency wants fixing on the Linux side, not copying here.
+func lookPathAbs(name string) string {
+	if name == "" {
+		return ""
+	}
+	resolved, err := exec.LookPath(name)
+	if err != nil {
+		return ""
+	}
+	if abs, aerr := filepath.Abs(resolved); aerr == nil {
+		return abs
+	}
+	return resolved
+}
+
+// absoluteInnerArgv returns innerArgv with every executable token replaced
+// by the absolute path the HOST PATH lookup resolves it to: argv[0], and —
+// when argv is an `env NAME=VALUE ... <cmd>` wrapper — the wrapped <cmd>
+// as well.
+//
+// Without this the harness is resolved twice: once here, on the host, to
+// compute the sandbox grants (resolveInnerBinaryDirs), and a second time
+// INSIDE the sandbox, because a bare command name makes the PATH search
+// happen there — by sandbox-exec's execvp for argv[0], or by `env` itself
+// for the wrapped command. Whenever that second lookup fails, Seatbelt
+// reports it as ENOENT, so the user is told
+//
+//	sandbox-exec: execvp() of 'opencode' failed: No such file or directory
+//
+// on a machine where `which opencode` resolves fine — an error naming
+// neither the real cause nor the path involved.
+//
+// Passing absolute paths removes the second lookup entirely, which makes
+// the launch independent of the child's PATH. That matters concretely:
+// deny_vars is applied last and wins over BaseAllowVars, so a profile can
+// strip PATH from the child, after which execvp falls back to libc's
+// /usr/bin:/bin and cannot find the harness at all. An absolute argv[0]
+// is the only form that survives it. Linux has never had the exposure —
+// backend_linux.go rewrites argv[0] for its own reasons — so this is
+// platform parity as well.
+//
+// The env-wrapper form is not hypothetical: a launcher profile may set
+// NPM_CONFIG_* before launching the harness, in which case argv[0] is
+// `env` and rewriting it alone would leave the wrapped harness lookup
+// exactly as exposed as before.
+//
+// Tokens that cannot be resolved are left alone, so the caller's error
+// surface is unchanged.
+func absoluteInnerArgv(innerArgv []string) []string {
+	out := append([]string(nil), innerArgv...)
+	idx := []int{0}
+	if cmd := envWrapperEnd(out); cmd > 0 {
+		idx = append(idx, cmd)
+	}
+	for _, i := range idx {
+		if i >= len(out) {
+			continue
+		}
+		if abs := lookPathAbs(out[i]); abs != "" {
+			out[i] = abs
+		}
+	}
+	return out
 }
 
 // unwrapEnv strips a leading `env NAME=VALUE ...` wrapper and returns the
@@ -77,20 +225,111 @@ func resolveCommandBinaryDirs(argv []string) []string {
 // to resolve and is safely ignored by the caller. Returns argv unchanged when
 // there is no env wrapper.
 func unwrapEnv(argv []string) []string {
-	for len(argv) >= 2 && filepath.Base(argv[0]) == "env" {
-		i := 1
-		for i < len(argv) && isEnvAssignment(argv[i]) {
-			i++
+	return argv[envWrapperEnd(argv):]
+}
+
+// envWrapperEnd returns the index at which the real command begins after any
+// leading `env NAME=VALUE ...` wrapper — 0 when there is none. Split out of
+// unwrapEnv so callers that must REWRITE the wrapped command token (rather
+// than just read it) know where it sits; see absoluteInnerArgv.
+func envWrapperEnd(argv []string) int {
+	i := 0
+	for len(argv)-i >= 2 && filepath.Base(argv[i]) == "env" {
+		j := i + 1
+		for j < len(argv) && isEnvAssignment(argv[j]) {
+			j++
 		}
-		argv = argv[i:]
+		i = j
 	}
-	return argv
+	return i
 }
 
 // isEnvAssignment reports whether tok is a NAME=VALUE assignment (not a flag).
 func isEnvAssignment(tok string) bool {
 	eq := strings.IndexByte(tok, '=')
 	return eq > 0 && !strings.HasPrefix(tok, "-")
+}
+
+// unresolvedInnerCommandWarning returns the operator-facing warning for an
+// inner command that cannot be found on the host PATH, or "" when it can.
+//
+// Resolution failure is otherwise silent — resolveCommandBinaryDirs just
+// returns nil — and the launch proceeds to fail deep inside the sandbox
+// with an error that names the wrong cause (ENOENT on a command the user
+// can see on their PATH). Saying it once, up front, at the point where
+// the host lookup happened, is the difference between a one-line fix and
+// a Seatbelt investigation.
+func unresolvedInnerCommandWarning(innerArgv []string) string {
+	cmd := unwrapEnv(innerArgv)
+	if len(cmd) == 0 || cmd[0] == "" {
+		return ""
+	}
+	if lookPathAbs(cmd[0]) != "" {
+		return ""
+	}
+	return "omac sandbox: warning: " + cmd[0] + " is not on PATH as seen by this process — " +
+		"the sandbox cannot be granted access to it and the launch will fail with " +
+		"\"No such file or directory\". Check that the directory holding it is on PATH here, " +
+		"not only in your interactive shell."
+}
+
+// protectedInnerBinaryWarning returns the operator-facing warning for a
+// protected-path deny that covers a directory the inner command must be read
+// from, or "" when none does.
+//
+// Protected denies are emitted AFTER the read allows and Seatbelt is
+// last-match-wins (GenerateSBPL), so a deny over a tree containing the
+// harness defeats the per-launch grant this package just computed for it.
+// The user sees only
+//
+//	sandbox-exec: execvp() of 'opencode' failed: No such file or directory
+//
+// which names neither the deny nor the directory. A deny broad enough to
+// swallow the harness is nearly always a mistake rather than intent — but it
+// IS the user's stated policy, so this reports the conflict instead of
+// quietly routing around it. Silently resolving the binary out of the denied
+// tree would launch it in defiance of the profile, which is not omac's call
+// to make in a security boundary.
+func protectedInnerBinaryWarning(innerArgv []string, protected []string) string {
+	for _, dir := range resolveInnerBinaryDirs(innerArgv) {
+		for _, p := range protected {
+			if pathCoveredBy(dir, p) {
+				return "omac sandbox: warning: this profile denies " + p +
+					", which contains the harness binary directory " + dir + ". The deny is applied" +
+					" after the grants, so the harness cannot be read and the launch will fail with" +
+					" \"No such file or directory\". Narrow the deny (filesystem.deny / --deny) or" +
+					" move the harness outside it."
+			}
+		}
+	}
+	return ""
+}
+
+// pathCoveredBy reports whether path lies at or under root, comparing every
+// combination of their literal and symlink-resolved forms.
+//
+// Both sides need canonicalizing: a deny is stored as the user wrote it while
+// a binary dir arrives from EvalSymlinks (or vice versa), so a single-sided
+// comparison misses a match whenever either has a symlinked ancestor —
+// /var/folders vs /private/var/folders being the everyday case. Seatbelt
+// itself matches on the resolved form, so this mirrors what the kernel will
+// actually do rather than what the strings happen to look like.
+func pathCoveredBy(path, root string) bool {
+	forms := func(p string) []string {
+		out := []string{filepath.Clean(p)}
+		if c := canonicalPath(p); c != "" && c != out[0] {
+			out = append(out, c)
+		}
+		return out
+	}
+	for _, d := range forms(path) {
+		for _, r := range forms(root) {
+			if d == r || strings.HasPrefix(d, r+string(filepath.Separator)) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // resolveInnerBinaryPath resolves the inner command's executable to its
@@ -169,13 +408,11 @@ func resolveInterpreterDirs(interp string) []string {
 	if abs, aerr := filepath.Abs(resolved); aerr == nil {
 		resolved = abs
 	}
-	dirs := []string{filepath.Dir(resolved)}
-	if real, rerr := filepath.EvalSymlinks(resolved); rerr == nil {
-		if d := filepath.Dir(real); d != dirs[0] {
-			dirs = append(dirs, d)
-		}
-	}
-	return withPrefixSupportDirs(dirs)
+	// Chain-walked for the same reason the harness itself is: an interpreter
+	// reached through a version manager (nvm, mise, asdf) is a multi-hop
+	// symlink, and a middle hop left ungranted fails the exec of every script
+	// that names it — see symlinkChainDirs.
+	return withPrefixSupportDirs(symlinkChainDirs(resolved))
 }
 
 // prefixBinDirNames are the conventional executable subdirectories of a Unix

--- a/internal/sandboxrun/resolve_binary.go
+++ b/internal/sandboxrun/resolve_binary.go
@@ -35,7 +35,7 @@ import (
 // Returns nil when the command cannot be found or resolved.
 func resolveInnerBinaryDirs(innerArgv []string) []string {
 	dirs := resolveCommandBinaryDirs(innerArgv)
-	if cmd := unwrapEnv(innerArgv); len(cmd) > 0 && cmd[0] != innerArgv[0] {
+	if cmd := UnwrapEnv(innerArgv); len(cmd) > 0 && cmd[0] != innerArgv[0] {
 		dirs = append(dirs, resolveCommandBinaryDirs(cmd)...)
 	}
 	return dirs
@@ -217,20 +217,18 @@ func absoluteInnerArgv(innerArgv []string) []string {
 	return out
 }
 
-// unwrapEnv strips a leading `env NAME=VALUE ...` wrapper and returns the
-// argv that begins with the real command. It skips `env` and any following
-// NAME=VALUE assignment tokens; the first non-assignment token is the
-// command. `env` flags (e.g. -i, -u) are not used by omac's profiles and are
-// left in place, so an argv like `env -i cmd` yields `-i cmd` — which fails
-// to resolve and is safely ignored by the caller. Returns argv unchanged when
-// there is no env wrapper.
-func unwrapEnv(argv []string) []string {
+// UnwrapEnv strips a leading `env NAME=VALUE ...` wrapper and returns the
+// argv that begins with the real command: it skips `env` and any following
+// NAME=VALUE assignment tokens. `env` flags (e.g. -i, -u) are left in place,
+// so `env -i cmd` yields `-i cmd`. Returns argv unchanged when there is no
+// wrapper.
+func UnwrapEnv(argv []string) []string {
 	return argv[envWrapperEnd(argv):]
 }
 
 // envWrapperEnd returns the index at which the real command begins after any
 // leading `env NAME=VALUE ...` wrapper — 0 when there is none. Split out of
-// unwrapEnv so callers that must REWRITE the wrapped command token (rather
+// UnwrapEnv so callers that must REWRITE the wrapped command token (rather
 // than just read it) know where it sits; see absoluteInnerArgv.
 func envWrapperEnd(argv []string) int {
 	i := 0
@@ -260,7 +258,7 @@ func isEnvAssignment(tok string) bool {
 // the host lookup happened, is the difference between a one-line fix and
 // a Seatbelt investigation.
 func unresolvedInnerCommandWarning(innerArgv []string) string {
-	cmd := unwrapEnv(innerArgv)
+	cmd := UnwrapEnv(innerArgv)
 	if len(cmd) == 0 || cmd[0] == "" {
 		return ""
 	}

--- a/internal/sandboxrun/resolve_binary_argv_test.go
+++ b/internal/sandboxrun/resolve_binary_argv_test.go
@@ -1,0 +1,217 @@
+package sandboxrun
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// writeExecutable creates an executable file at <dir>/<name> and returns its
+// path. The content is irrelevant — nothing here execs it.
+func writeExecutable(t *testing.T, dir, name string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// A bare argv[0] makes the macOS backend hand sandbox-exec a name rather than
+// a path, and sandbox-exec's execvp then walks PATH a SECOND time — inside the
+// sandbox, where a denied lookup is reported as ENOENT. That second lookup can
+// disagree with the host-side one used to build the grants, and the user sees
+//
+//	sandbox-exec: execvp() of 'opencode' failed: No such file or directory
+//
+// on a machine where `which opencode` resolves. Resolving argv[0] on the host
+// removes the second lookup entirely.
+func TestAbsoluteInnerArgvResolvesBareCommandToAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	exe := writeExecutable(t, dir, "opencode")
+	t.Setenv("PATH", dir)
+
+	got := absoluteInnerArgv([]string{"opencode", "--version"})
+
+	want := []string{exe, "--version"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("absoluteInnerArgv = %v, want %v", got, want)
+	}
+}
+
+// The rewrite must not follow symlinks. A Homebrew-style <prefix>/bin entry is
+// a symlink into Cellar, and a shim install (mise/asdf) is a symlink into a
+// version store; the link path is what a PATH lookup finds and what the
+// harness expects to see as argv[0].
+//
+// It also keeps omac from defeating the profile: under a deny covering the
+// harness's tree the EvalSymlinks-resolved path EXECS while the link path is
+// refused, because exec of a main image never consults the file-read rules.
+// Substituting the resolved path would launch a binary out of a tree the user
+// explicitly denied. See lookPathAbs.
+func TestAbsoluteInnerArgvKeepsTheSymlinkPathNotItsTarget(t *testing.T) {
+	root := t.TempDir()
+	cellarBin := filepath.Join(root, "homebrew", "Cellar", "opencode", "1.18.15", "bin")
+	writeExecutable(t, cellarBin, "opencode")
+	prefixBin := filepath.Join(root, "homebrew", "bin")
+	if err := os.MkdirAll(prefixBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(prefixBin, "opencode")
+	if err := os.Symlink("../Cellar/opencode/1.18.15/bin/opencode", link); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", prefixBin)
+
+	got := absoluteInnerArgv([]string{"opencode"})
+
+	if !reflect.DeepEqual(got, []string{link}) {
+		t.Errorf("absoluteInnerArgv = %v, want %v", got, []string{link})
+	}
+}
+
+// A launcher profile may wrap the harness in `env NAME=VALUE ... <cmd>` to
+// set NPM_CONFIG_* before launching it. Rewriting only argv[0] would resolve
+// `env` and leave `env` to do its own PATH search for the harness inside the
+// sandbox — the same second lookup, just moved one process along. Both
+// executable tokens must be resolved.
+func TestAbsoluteInnerArgvResolvesTheEnvWrappedCommandToo(t *testing.T) {
+	dir := t.TempDir()
+	envExe := writeExecutable(t, dir, "env")
+	exe := writeExecutable(t, dir, "opencode")
+	t.Setenv("PATH", dir)
+
+	argv := []string{"env", "NPM_CONFIG_USERCONFIG=/x/npmrc", "npm_config_cache=/x/cache", "opencode", "--version"}
+	got := absoluteInnerArgv(argv)
+
+	want := []string{envExe, "NPM_CONFIG_USERCONFIG=/x/npmrc", "npm_config_cache=/x/cache", exe, "--version"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("absoluteInnerArgv = %v, want %v", got, want)
+	}
+}
+
+// `env` flags are not used by omac's profiles and are deliberately left in
+// place by unwrapEnv, which makes the following token a flag rather than a
+// command. It must not be rewritten or otherwise disturbed.
+func TestAbsoluteInnerArgvLeavesEnvFlagFormAlone(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, dir, "opencode")
+	t.Setenv("PATH", dir)
+
+	argv := []string{"env", "-i", "opencode"}
+	got := absoluteInnerArgv(argv)
+
+	if got[1] != "-i" || got[2] != "opencode" {
+		t.Errorf("absoluteInnerArgv = %v, want the flag form untouched after argv[0]", got)
+	}
+}
+
+// envWrapperEnd is the index unwrapEnv slices at; the two must not drift.
+func TestEnvWrapperEndMatchesUnwrapEnv(t *testing.T) {
+	for _, argv := range [][]string{
+		nil,
+		{"opencode"},
+		{"env", "A=1", "opencode", "--x"},
+		{"env", "A=1", "env", "B=2", "opencode"},
+		{"env", "-i", "opencode"},
+		{"env"},
+		{"env", "A=1"},
+	} {
+		want := unwrapEnv(argv)
+		got := argv[envWrapperEnd(argv):]
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("argv %v: envWrapperEnd slice = %v, unwrapEnv = %v", argv, got, want)
+		}
+	}
+}
+
+// An unresolvable command must pass through untouched: the caller's error
+// surface (and any launcher that resolves the command by other means) stays
+// exactly as it was.
+func TestAbsoluteInnerArgvLeavesUnresolvableCommandAlone(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	argv := []string{"definitely-not-installed", "--flag"}
+	if got := absoluteInnerArgv(argv); !reflect.DeepEqual(got, argv) {
+		t.Errorf("absoluteInnerArgv = %v, want it unchanged %v", got, argv)
+	}
+}
+
+// An empty argv must not panic — Grants can carry no inner command at all.
+func TestAbsoluteInnerArgvHandlesEmptyArgv(t *testing.T) {
+	if got := absoluteInnerArgv(nil); len(got) != 0 {
+		t.Errorf("absoluteInnerArgv(nil) = %v, want empty", got)
+	}
+}
+
+// The rewrite must not mutate the caller's slice: BuildChildArgv passes the
+// launch flags' InnerArgv, which the supervisor still reads afterwards (e.g.
+// harnessName for the audit record).
+func TestAbsoluteInnerArgvDoesNotMutateInput(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, dir, "tool")
+	t.Setenv("PATH", dir)
+
+	argv := []string{"tool", "run"}
+	absoluteInnerArgv(argv)
+
+	if argv[0] != "tool" {
+		t.Errorf("input argv mutated: argv[0] = %q, want %q", argv[0], "tool")
+	}
+}
+
+// A profile deny broad enough to cover the harness's own directory defeats
+// the per-launch grant, because protected denies are emitted after the read
+// allows and Seatbelt is last-match-wins. The only user-visible symptom is
+// an ENOENT that names neither the deny nor the directory, so the conflict
+// must be reported before launch.
+func TestProtectedInnerBinaryWarning(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "homebrew", "bin")
+	writeExecutable(t, binDir, "opencode")
+	t.Setenv("PATH", binDir)
+
+	warn := protectedInnerBinaryWarning([]string{"opencode"}, []string{home})
+	if warn == "" {
+		t.Fatal("a deny covering the harness binary dir did not warn")
+	}
+	if !strings.Contains(warn, home) {
+		t.Errorf("warning does not name the deny %q: %s", home, warn)
+	}
+
+	// A deny elsewhere must stay quiet — this fires on every launch, so a
+	// false positive trains users to ignore it.
+	if w := protectedInnerBinaryWarning([]string{"opencode"}, []string{filepath.Join(home, ".ssh")}); w != "" {
+		t.Errorf("unrelated deny warned: %s", w)
+	}
+	if w := protectedInnerBinaryWarning([]string{"opencode"}, nil); w != "" {
+		t.Errorf("no denies at all warned: %s", w)
+	}
+}
+
+// A command the host cannot resolve produces no grant at all and the launch
+// dies inside the sandbox naming the wrong cause. Warn once, up front.
+func TestUnresolvedInnerCommandWarning(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, dir, "present")
+	t.Setenv("PATH", dir)
+
+	if w := unresolvedInnerCommandWarning([]string{"present"}); w != "" {
+		t.Errorf("resolvable command warned: %q", w)
+	}
+	if w := unresolvedInnerCommandWarning([]string{"absent"}); w == "" {
+		t.Error("unresolvable command did not warn")
+	}
+	if w := unresolvedInnerCommandWarning(nil); w != "" {
+		t.Errorf("empty argv warned: %q", w)
+	}
+	// The wrapped command, not the `env` wrapper, is what must be checked.
+	if w := unresolvedInnerCommandWarning([]string{"env", "FOO=1", "absent"}); w == "" {
+		t.Error("env-wrapped unresolvable command did not warn")
+	}
+}

--- a/internal/sandboxrun/resolve_binary_argv_test.go
+++ b/internal/sandboxrun/resolve_binary_argv_test.go
@@ -111,7 +111,7 @@ func TestAbsoluteInnerArgvLeavesEnvFlagFormAlone(t *testing.T) {
 	}
 }
 
-// envWrapperEnd is the index unwrapEnv slices at; the two must not drift.
+// envWrapperEnd is the index UnwrapEnv slices at; the two must not drift.
 func TestEnvWrapperEndMatchesUnwrapEnv(t *testing.T) {
 	for _, argv := range [][]string{
 		nil,
@@ -122,10 +122,10 @@ func TestEnvWrapperEndMatchesUnwrapEnv(t *testing.T) {
 		{"env"},
 		{"env", "A=1"},
 	} {
-		want := unwrapEnv(argv)
+		want := UnwrapEnv(argv)
 		got := argv[envWrapperEnd(argv):]
 		if !reflect.DeepEqual(got, want) {
-			t.Errorf("argv %v: envWrapperEnd slice = %v, unwrapEnv = %v", argv, got, want)
+			t.Errorf("argv %v: envWrapperEnd slice = %v, UnwrapEnv = %v", argv, got, want)
 		}
 	}
 }

--- a/internal/sandboxrun/resolve_binary_chain_test.go
+++ b/internal/sandboxrun/resolve_binary_chain_test.go
@@ -1,0 +1,145 @@
+package sandboxrun
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// writeHomebrewChain builds the layout a Homebrew-installed harness has under
+// a non-default prefix, where no baseline grant covers the tree:
+//
+//	<root>/bin/opencode
+//	  -> <root>/Cellar/opencode/1.18.15/bin/opencode
+//	  -> <root>/Cellar/opencode/1.18.15/libexec/lib/node_modules/opencode-ai/bin/opencode.exe
+//
+// Returns the PATH-entry path (the first link).
+func writeHomebrewChain(t *testing.T, root string) string {
+	t.Helper()
+	cellar := filepath.Join(root, "Cellar", "opencode", "1.18.15")
+	realDir := filepath.Join(cellar, "libexec", "lib", "node_modules", "opencode-ai", "bin")
+	for _, d := range []string{filepath.Join(root, "bin"), filepath.Join(cellar, "bin"), realDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	real := filepath.Join(realDir, "opencode.exe")
+	if err := os.WriteFile(real, []byte("\xcf\xfa\xed\xfe-not-really"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mid := filepath.Join(cellar, "bin", "opencode")
+	if err := os.Symlink(real, mid); err != nil {
+		t.Fatal(err)
+	}
+	head := filepath.Join(root, "bin", "opencode")
+	if err := os.Symlink(mid, head); err != nil {
+		t.Fatal(err)
+	}
+	return head
+}
+
+// The kernel resolves a symlink chain one hop at a time and needs read access
+// to each link on the way, so granting only the two ENDS of the chain — the
+// PATH-entry dir and the fully resolved dir — leaves the middle link
+// unreadable and the launch dies there.
+//
+// Homebrew under a non-default prefix (issue #229) is the layout that exposes
+// it: the middle hop sits in <cellar>/bin while the real file sits in
+// <cellar>/libexec/..., so neither end's grant covers it. macOS then reports
+// the failed in-sandbox lookup of a bare argv[0] as
+// "execvp() of 'opencode' failed: No such file or directory" — an error that
+// names neither the deny nor the path, on a machine where `which opencode`
+// answers fine.
+func TestResolveInnerBinaryDirsGrantsEverySymlinkHop(t *testing.T) {
+	root := t.TempDir()
+	head := writeHomebrewChain(t, root)
+
+	got := resolveInnerBinaryDirs([]string{head})
+
+	cellar := filepath.Join(root, "Cellar", "opencode", "1.18.15")
+	for _, want := range []string{
+		filepath.Join(root, "bin"),
+		filepath.Join(cellar, "bin"), // the hop both ends' grants miss
+		filepath.Join(cellar, "libexec", "lib", "node_modules", "opencode-ai", "bin"),
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("missing symlink-chain dir %s in %v", want, got)
+		}
+	}
+}
+
+// The same chain reached the way a user actually launches it: a bare command
+// name found on PATH rather than an absolute path.
+func TestResolveInnerBinaryDirsGrantsEverySymlinkHopViaPATH(t *testing.T) {
+	root := t.TempDir()
+	writeHomebrewChain(t, root)
+	t.Setenv("PATH", filepath.Join(root, "bin"))
+
+	got := resolveInnerBinaryDirs([]string{"opencode"})
+
+	want := filepath.Join(root, "Cellar", "opencode", "1.18.15", "bin")
+	if !slices.Contains(got, want) {
+		t.Errorf("missing intermediate hop %s in %v", want, got)
+	}
+}
+
+// A cyclic chain must terminate rather than spin: the walk is fed paths from
+// the host filesystem, so a loop is a hostile-input case, not a theoretical
+// one. The dirs seen before the cycle closes are still returned — they are
+// legitimate grants regardless of how the chain ends.
+func TestSymlinkChainDirsTerminatesOnCycle(t *testing.T) {
+	root := t.TempDir()
+	a, b := filepath.Join(root, "a", "link"), filepath.Join(root, "b", "link")
+	for _, d := range []string{filepath.Join(root, "a"), filepath.Join(root, "b")} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(b, a); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(a, b); err != nil {
+		t.Fatal(err)
+	}
+
+	got := symlinkChainDirs(a)
+
+	for _, want := range []string{filepath.Join(root, "a"), filepath.Join(root, "b")} {
+		if !slices.Contains(got, want) {
+			t.Errorf("missing %s in %v", want, got)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("cycle produced %d dirs, want the 2 distinct ones: %v", len(got), got)
+	}
+}
+
+// A plain, unlinked binary must yield its own directory and nothing beyond
+// the spellings of that one directory. The chain walk replaced the previous
+// Dir()/EvalSymlinks() pair, so the no-symlink case has to stay as narrow as
+// it was — the temp root sits under the /var → /private/var link on macOS, so
+// both spellings of the same directory are expected and neither widens the
+// grant.
+func TestSymlinkChainDirsPlainBinary(t *testing.T) {
+	root := t.TempDir()
+	exe := filepath.Join(root, "tool")
+	if err := os.WriteFile(exe, nil, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := symlinkChainDirs(exe)
+
+	if !slices.Contains(got, root) {
+		t.Errorf("symlinkChainDirs(%s) = %v, missing %s", exe, got, root)
+	}
+	for _, d := range got {
+		if d != root && d != canonical {
+			t.Errorf("symlinkChainDirs(%s) granted unrelated dir %s: %v", exe, d, got)
+		}
+	}
+}

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -222,6 +222,13 @@ func Run(opts Options) int {
 	}
 	defer markerCleanup()
 
+	if warn := unresolvedInnerCommandWarning(opts.Flags.InnerArgv); warn != "" {
+		fmt.Fprintln(stderr, warn)
+	}
+	if warn := protectedInnerBinaryWarning(opts.Flags.InnerArgv, grants.ProtectedPaths); warn != "" {
+		fmt.Fprintln(stderr, warn)
+	}
+
 	childArgv, err := BuildChildArgv(grants, opts.Flags.InnerArgv)
 	if err != nil {
 		return fail("%v", err)


### PR DESCRIPTION
**Issue:** Closes #229

## What

- `resolveCommandBinaryDirs` walks the symlink chain and grants the directory of every hop, not just the two ends (`symlinkChainDirs`, `internal/sandboxrun/resolve_binary.go`)
- Same walk for interpreter resolution, so multi-hop nvm/mise/asdf shims stop failing the exec of every script naming them
- `BuildChildArgv` hands `sandbox-exec` an absolute `argv[0]`, including the wrapped command of an `env NAME=VALUE …` prefix
- The pre-flight validates the *resolved* argv; two non-fatal warnings name the cause before the launch dies inside Seatbelt

## Why

Bug report + full diagnosis in #229. Short version: the middle directory of a three-hop chain was never granted, so path resolution died there and macOS reported it as ENOENT on a binary that is plainly on `$PATH`.

## How

- The chain walk is `Lstat`/`Readlink` per hop, capped at 32 hops so a cycle terminates, plus the `EvalSymlinks` spelling of the end for symlinked ancestor dirs. Directories are granted, not links — a subpath grant is what lets the kernel read the link and stat its siblings, matching how the rest of the file grants access.
- `lookPathAbs` deliberately does **not** follow symlinks. Under a deny covering the harness's tree all three `argv[0]` forms were measured, and only the `EvalSymlinks`-resolved one runs — because exec of a main image consults `(allow process-exec*)` and never the file-read rules. Substituting it would launch a binary out of a tree the user's profile denies, so `protectedInnerBinaryWarning` reports the conflict instead. Grant order is unchanged (read allows → protected denies → write allows), so denies still win over the new grants.
- Absolute `argv[0]` is not redundant with the chain grant: it also makes the launch independent of the child's `PATH`, which `deny_vars` can strip since it is applied after `BaseAllowVars`.

## Verification

Fixture reproducing the report: `$HOME` outside `/tmp` (a `/tmp`-rooted one is masked by the baseline `/tmp` grant), Homebrew prefix at `$HOME/homebrew`, three-hop chain to the real opencode 1.18.6 binary, profile with neither a `filesystem.deny` nor a grant for the prefix.

```
$ omac-v0.7.1 start opencode -- --version
sandbox-exec: execvp() of 'opencode' failed: No such file or directory   exit 71
$ omac-this-branch start opencode -- --version
1.18.6                                                                   exit 0
```

Kernel behaviour isolated from omac with a hand-written SBPL granting exactly the two ends of the chain — the three-form table in #229. Adding the middle directory takes all three forms to rc 0.

```
$ gofmt -l internal/ cmd/     # clean
$ go build ./...              # ok
$ go test ./...               # EXIT=0, all packages ok
$ go test ./internal/sandboxrun/ -run 'SymlinkHop|SymlinkChainDirs' -v
--- PASS: TestResolveInnerBinaryDirsGrantsEverySymlinkHop
--- PASS: TestResolveInnerBinaryDirsGrantsEverySymlinkHopViaPATH
--- PASS: TestSymlinkChainDirsTerminatesOnCycle
--- PASS: TestSymlinkChainDirsPlainBinary
```

macOS only, by hand — the Linux backend execs the resolved path directly, so it never traversed the chain, but it shares `resolveCommandBinaryDirs` and picks the wider ro-bind set up.

## Follow-up

The report's log also carried `sandbox profile "builtin" could not be resolved … GET /sandbox/denied disabled`. Unrelated, already fixed on `main` by #219, absent from this build — noted here only so it is not re-reported off the same transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
