### PR TITLE
fix(config,cli,skillsource): honor a relocated harness config home

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,23 @@ The project file **replaces** the global one; omac does not merge the two. Any o
 
 The launcher config changes only *how omac launches* in the project: the sandbox runtime it selects, the cache scope, and the facade and audit settings. It does **not** change what the agent is allowed to access. Those grants (filesystem paths, network hosts, open ports) come from the user-global sandbox grants file described below and **currently have no per-project equivalent**.
 
+## Harness config home
+
+Each harness can relocate its configuration directory (its "config home") via an environment variable — typically to keep two logins side by side, for example a personal and a work `~/.claude`. omac follows the redirect: the redirected directory is granted to the sandbox instead of the default one and created if it does not exist yet, the variable is passed through to the harness, and global skills and resumable sessions are read from the redirected directory.
+
+| Harness | Variable | Default |
+|---|---|---|
+| claude-code | `CLAUDE_CONFIG_DIR` | `~/.claude` |
+| codex | `CODEX_HOME` | `~/.codex` |
+| copilot | `COPILOT_HOME` | `~/.copilot` |
+| pi | `PI_CODING_AGENT_DIR` | `~/.pi/agent` |
+| codewhale | `CODEWHALE_HOME` | `~/.codewhale` |
+| opencode | *(none)* — relocate with `$XDG_CONFIG_HOME` | `~/.config/opencode` |
+
+Example: `CLAUDE_CONFIG_DIR=~/.work-claude omac start claude` runs Claude Code with the work login instead of prompting for a fresh one.
+
+A redirect also **hides** the skills installed under the default home: omac scans only the redirected directory for global skills. After switching homes, run `omac setup` to provision the built-in skills there too.
+
 ## Sandbox grants
 
 The sandbox grants file (`~/.config/omac/sandbox-profiles/default.json`) controls what the agent is actually allowed to access — filesystem paths, network mode, and environment variables. This is separate from the launcher config above, which only selects which sandboxing technology to use.

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -345,6 +345,28 @@ func TestLaunchOpenCodeCreatesAndGrantsRuntimeDirs(t *testing.T) {
 	t.Fatalf("start argv missing opentui read/write grant: %v", capture.args)
 }
 
+// A redirect at a not-yet-existing home must be created before grant
+// resolution, or its read+write grant is dropped.
+func TestLaunchCreatesRedirectedConfigHome(t *testing.T) {
+	// The target deliberately does not exist yet; it sits outside the
+	// helper's faked $HOME, whose path the helper picks itself.
+	base := t.TempDir()
+	redirected := filepath.Join(base, ".work-claude")
+	t.Setenv("CLAUDE_CONFIG_DIR", redirected)
+
+	capture := launchCacheCaptureForHarness(t, "claude", false, false, false)
+	if info, err := os.Stat(redirected); err != nil || !info.IsDir() {
+		t.Fatalf("redirected config home was not created before start: info=%v err=%v", info, err)
+	}
+
+	for i := 0; i+1 < len(capture.args); i++ {
+		if capture.args[i] == "--allow" && capture.args[i+1] == redirected {
+			return
+		}
+	}
+	t.Fatalf("start argv missing redirected config home grant: %v", capture.args)
+}
+
 func TestLaunchCacheNoSandboxPreservesHostEnvironment(t *testing.T) {
 	capture := launchCacheCapture(t, true, false, false)
 	for key := range toolcache.Environment("ignored", toolcache.ModePersistent) {

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -693,7 +693,7 @@ func writeClaudeSessionFile(t *testing.T, home, workdir, id, ts string) {
 // created — not the sibling.
 func TestContinueHintSkipsSiblingSession(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("CLAUDE_HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", home)
 	h, ok := config.LookupHarness("claude-code")
 	if !ok {
 		t.Fatal("claude-code harness not registered")

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/zalando/go-keyring"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
 )
 
 // TestMain installs go-keyring's in-memory mock provider for the whole
@@ -17,7 +19,20 @@ import (
 //
 // The mock returns ErrNotFound for absent keys and stores Set values in
 // memory, which is exactly the deterministic behavior these tests assume.
+//
+// It also clears every harness config-home override (CLAUDE_CONFIG_DIR and
+// friends). Tests here fake $HOME but cannot fake a variable that names an
+// absolute path, so an ambient override kept pointing at the developer's real
+// config home.
 func TestMain(m *testing.M) {
 	keyring.MockInit()
+	clearHarnessHomeEnvs()
 	os.Exit(m.Run())
+}
+
+// clearHarnessHomeEnvs unsets every harness HomeEnv for the whole test binary.
+func clearHarnessHomeEnvs() {
+	for _, name := range config.HomeEnvNames() {
+		os.Unsetenv(name)
+	}
 }

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -21,16 +21,14 @@ import (
 // memory, which is exactly the deterministic behavior these tests assume.
 //
 // It also clears every harness config-home override (CLAUDE_CONFIG_DIR and
-// friends). Tests here fake $HOME but cannot fake a variable that names an
-// absolute path, so an ambient override kept pointing at the developer's real
-// config home.
+// friends): tests fake $HOME, but an ambient override names an absolute
+// path and would survive the fake.
 func TestMain(m *testing.M) {
 	keyring.MockInit()
 	clearHarnessHomeEnvs()
 	os.Exit(m.Run())
 }
 
-// clearHarnessHomeEnvs unsets every harness HomeEnv for the whole test binary.
 func clearHarnessHomeEnvs() {
 	for _, name := range config.HomeEnvNames() {
 		os.Unsetenv(name)

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/zalando/go-keyring"
 
-	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/TNG/oh-my-agentic-coder/internal/config"
 )
 
 // TestMain installs go-keyring's in-memory mock provider for the whole

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -707,7 +707,7 @@ func sandboxServeArgv(prof config.SandboxProfile, in sandbox.Inputs, controlPort
 		argv = injectOpenPort(argv, controlPort)
 	}
 	argv = injectServerListenPort(argv, h)
-	argv = injectSandboxDirs(argv, h.SandboxDirs)
+	argv = injectSandboxDirs(argv, h.ResolvedSandboxDirs())
 	return argv, nil
 }
 
@@ -817,9 +817,13 @@ func forwardHarnessEnv(env *Env, argv []string, harness config.Harness, plan san
 		fmt.Fprintln(env.Stderr, "      Continuing shortly…")
 		time.Sleep(emptyAllowVarsWarnDelay)
 		// Seed only the operational minimum; do NOT auto-forward auth vars.
-		return injectSandboxEnvAllow(argv, sandboxprofile.DefaultAllowVars(), plan)
+		// HomeEnv goes through: it
+		// is a path rather than a credential, and omac has already granted the
+		// config home it names (harness.ResolvedSandboxDirs), so withholding it
+		// would point the harness at a directory the sandbox denies.
+		return injectSandboxEnvAllow(argv, append(sandboxprofile.DefaultAllowVars(), harness.HomeEnv), plan)
 	}
-	return injectSandboxEnvAllow(argv, harness.SandboxEnvAllow, plan)
+	return injectSandboxEnvAllow(argv, harness.ForwardedEnvVars(), plan)
 }
 
 // planAllowVarsEmpty reports whether the launch's resolved policy profile

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -528,9 +528,9 @@ func runServe(args []string, env *Env) int {
 	if noSandbox {
 		argv = inner
 	} else {
-		// Create before omac sandbox run resolves and existence-filters the
-		// selected harness's read+write grants.
-		if err := prepareSandboxDirs(harness.SandboxCreateDirs); err != nil {
+		// Create the harness's runtime dirs (plus a redirected config home)
+		// before grant resolution existence-filters them.
+		if err := prepareSandboxDirs(harness.ResolvedCreateDirs()); err != nil {
 			fmt.Fprintln(env.Stderr, "omac serve: harness runtime dirs:", err)
 			return ExitIOError
 		}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -817,10 +817,8 @@ func forwardHarnessEnv(env *Env, argv []string, harness config.Harness, plan san
 		fmt.Fprintln(env.Stderr, "      Continuing shortly…")
 		time.Sleep(emptyAllowVarsWarnDelay)
 		// Seed only the operational minimum; do NOT auto-forward auth vars.
-		// HomeEnv goes through: it
-		// is a path rather than a credential, and omac has already granted the
-		// config home it names (harness.ResolvedSandboxDirs), so withholding it
-		// would point the harness at a directory the sandbox denies.
+		// HomeEnv goes through: it is a path, not a credential, and
+		// ResolvedSandboxDirs already granted the config home it names.
 		return injectSandboxEnvAllow(argv, append(sandboxprofile.DefaultAllowVars(), harness.HomeEnv), plan)
 	}
 	return injectSandboxEnvAllow(argv, harness.ForwardedEnvVars(), plan)

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -609,6 +609,79 @@ func TestForwardHarnessEnvNonEmptyProfileInjects(t *testing.T) {
 	}
 }
 
+// The launch path must forward the harness's config-home override, for every
+// harness that has one.
+func TestForwardHarnessEnvForwardsHomeEnv(t *testing.T) {
+	for _, h := range config.AllHarnesses() {
+		if h.HomeEnv == "" {
+			continue
+		}
+		t.Run(h.Name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			stageProfile(t, home, `{"meta": {"name": "default"}, "environment": {"allow_vars": ["HOME"]}}`)
+
+			env, _, _, drain := newPipeEnv(t, "")
+			argv := []string{"/usr/bin/omac", "sandbox", "run", "--profile", "default", "--", "x"}
+			got := forwardHarnessEnv(env, argv, h, nativePlanForTest(t))
+			drain()
+
+			want := "--allow-env " + h.HomeEnv
+			if !strings.Contains(strings.Join(got, " "), want) {
+				t.Errorf("expected %q; got %v", want, got)
+			}
+		})
+	}
+}
+
+// Even the fail-closed empty-allow_vars branch forwards HomeEnv.
+func TestForwardHarnessEnvEmptyProfileStillForwardsHomeEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stageProfile(t, home, `{"meta": {"name": "default"}}`)
+
+	old := emptyAllowVarsWarnDelay
+	emptyAllowVarsWarnDelay = 0
+	defer func() { emptyAllowVarsWarnDelay = old }()
+
+	env, _, _, drain := newPipeEnv(t, "")
+	h, ok := config.LookupHarness("claude-code")
+	if !ok {
+		t.Fatal("claude-code harness not registered")
+	}
+	argv := []string{"/usr/bin/omac", "sandbox", "run", "--profile", "default", "--", "x"}
+	got := forwardHarnessEnv(env, argv, h, nativePlanForTest(t))
+	drain()
+
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "--allow-env CLAUDE_CONFIG_DIR") {
+		t.Errorf("empty profile should still forward CLAUDE_CONFIG_DIR; got %v", got)
+	}
+	// The fail-closed guarantee itself must hold: still no provider auth.
+	if strings.Contains(joined, "ANTHROPIC_API_KEY") {
+		t.Errorf("empty profile must not auto-forward provider-auth vars; got %v", got)
+	}
+}
+
+// A harness with no HomeEnv must not gain a stray empty --allow-env.
+func TestForwardHarnessEnvNoHomeEnvAddsNothing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stageProfile(t, home, `{"meta": {"name": "default"}, "environment": {"allow_vars": ["HOME"]}}`)
+
+	env, _, _, drain := newPipeEnv(t, "")
+	harness := config.Harness{Name: "test", SandboxEnvAllow: []string{"ANTHROPIC_API_KEY"}}
+	argv := []string{"/usr/bin/omac", "sandbox", "run", "--profile", "default", "--", "x"}
+	got := forwardHarnessEnv(env, argv, harness, nativePlanForTest(t))
+	drain()
+
+	for i, a := range got {
+		if a == "--allow-env" && (i+1 >= len(got) || got[i+1] == "") {
+			t.Errorf("dangling --allow-env with no value: %v", got)
+		}
+	}
+}
+
 // nativePlanForTest resolves the launch plan for a minimal native launcher
 // profile, so a test's staged policy file (stageProfile) is what the plan's
 // policy-derived behaviour is read from.

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -609,8 +609,6 @@ func TestForwardHarnessEnvNonEmptyProfileInjects(t *testing.T) {
 	}
 }
 
-// The launch path must forward the harness's config-home override, for every
-// harness that has one.
 func TestForwardHarnessEnvForwardsHomeEnv(t *testing.T) {
 	for _, h := range config.AllHarnesses() {
 		if h.HomeEnv == "" {
@@ -634,7 +632,6 @@ func TestForwardHarnessEnvForwardsHomeEnv(t *testing.T) {
 	}
 }
 
-// Even the fail-closed empty-allow_vars branch forwards HomeEnv.
 func TestForwardHarnessEnvEmptyProfileStillForwardsHomeEnv(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -657,13 +654,12 @@ func TestForwardHarnessEnvEmptyProfileStillForwardsHomeEnv(t *testing.T) {
 	if !strings.Contains(joined, "--allow-env CLAUDE_CONFIG_DIR") {
 		t.Errorf("empty profile should still forward CLAUDE_CONFIG_DIR; got %v", got)
 	}
-	// The fail-closed guarantee itself must hold: still no provider auth.
+	// The fail-closed guarantee still holds: no provider auth.
 	if strings.Contains(joined, "ANTHROPIC_API_KEY") {
 		t.Errorf("empty profile must not auto-forward provider-auth vars; got %v", got)
 	}
 }
 
-// A harness with no HomeEnv must not gain a stray empty --allow-env.
 func TestForwardHarnessEnvNoHomeEnvAddsNothing(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -775,9 +775,9 @@ func runLaunch(env *Env, opts launchOpts) int {
 				argv = injectOpenPort(argv, port)
 			}
 		}
-		// Create declared runtime dirs before omac sandbox run resolves and
-		// existence-filters the selected harness's read+write grants.
-		if err := prepareSandboxDirs(harness.SandboxCreateDirs); err != nil {
+		// Create the harness's runtime dirs (plus a redirected config home)
+		// before grant resolution existence-filters them.
+		if err := prepareSandboxDirs(harness.ResolvedCreateDirs()); err != nil {
 			fmt.Fprintln(env.Stderr, prefix+": harness runtime dirs:", err)
 			return ExitIOError
 		}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -777,13 +777,11 @@ func runLaunch(env *Env, opts launchOpts) int {
 		}
 		// Create declared runtime dirs before omac sandbox run resolves and
 		// existence-filters the selected harness's read+write grants.
-		// Resolved, so a relocated config home (CLAUDE_CONFIG_DIR
-		// and friends) is granted instead of the default one.
 		if err := prepareSandboxDirs(harness.SandboxCreateDirs); err != nil {
 			fmt.Fprintln(env.Stderr, prefix+": harness runtime dirs:", err)
 			return ExitIOError
 		}
-		argv = injectSandboxDirs(argv, harness.ResolvedSandboxDirs()
+		argv = injectSandboxDirs(argv, harness.ResolvedSandboxDirs())
 		if cacheScope != nil {
 			argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)
 		}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -777,11 +777,13 @@ func runLaunch(env *Env, opts launchOpts) int {
 		}
 		// Create declared runtime dirs before omac sandbox run resolves and
 		// existence-filters the selected harness's read+write grants.
+		// Resolved, so a relocated config home (CLAUDE_CONFIG_DIR
+		// and friends) is granted instead of the default one.
 		if err := prepareSandboxDirs(harness.SandboxCreateDirs); err != nil {
 			fmt.Fprintln(env.Stderr, prefix+": harness runtime dirs:", err)
 			return ExitIOError
 		}
-		argv = injectSandboxDirs(argv, harness.SandboxDirs)
+		argv = injectSandboxDirs(argv, harness.ResolvedSandboxDirs()
 		if cacheScope != nil {
 			argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)
 		}

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -110,6 +110,8 @@ type Harness struct {
 	// SandboxDirs are directories the selected harness needs at runtime
 	// for configuration, authentication, state, and session storage.
 	// omac grants them read+write only for that selected harness.
+	// Declared against the default config home; launch call sites grant
+	// ResolvedSandboxDirs so a HomeEnv redirect is honored.
 	SandboxDirs []string
 	// SandboxCreateDirs is the subset of SandboxDirs that omac must create
 	// before grant resolution so a dependency can populate it on first use.
@@ -285,12 +287,15 @@ func harnessRegistry() []Harness {
 			// Claude Code's config home is ~/.claude, not ~/.config/claude,
 			// so its global skills live in ~/.claude/skills.
 			UserConfigHome: ".claude",
-			HomeEnv:        "CLAUDE_HOME",
+			HomeEnv:        "CLAUDE_CONFIG_DIR",
 			// Claude stores configuration, authentication, and sessions in ~/.claude; runtime state is in ~/.local/share/claude.
+			// The config-home entry follows CLAUDE_CONFIG_DIR via ResolvedSandboxDirs.
 			SandboxDirs: []string{"~/.claude", "~/.local/share/claude"},
-			// Interactive login credentials live in ~/.claude (SandboxDirs);
-			// these are the documented env vars for API-key / custom-endpoint
-			// auth (Anthropic-compatible gateway).
+			// Interactive login credentials live in the config home
+			// (SandboxDirs). CLAUDE_CONFIG_DIR is NOT listed here: every
+			// harness's HomeEnv is forwarded generically by ForwardedEnvVars.
+			// These are the documented env vars for API-key /
+			// custom-endpoint auth (Anthropic-compatible gateway).
 			SandboxEnvAllow: []string{
 				"ANTHROPIC_API_KEY",
 				"ANTHROPIC_AUTH_TOKEN",
@@ -618,12 +623,21 @@ func (h Harness) WorkdirSkillsDir() string {
 // (opencode), this is $XDG_CONFIG_HOME/<base> or ~/.config/<base> by
 // default. When HomeEnv is set and non-empty, its value replaces the
 // default entirely. Returns "" when no home can be resolved.
+//
+// The returned path is normalized (see normalizeHomePath), so a value that
+// merely spells the default home differently is not mistaken for a redirect.
 func (h Harness) ConfigHome() string {
 	if h.HomeEnv != "" {
 		if dir := os.Getenv(h.HomeEnv); dir != "" {
-			return dir
+			return normalizeHomePath(dir)
 		}
 	}
+	return h.defaultConfigHome()
+}
+
+// defaultConfigHome resolves the config home the harness uses when HomeEnv is
+// unset.
+func (h Harness) defaultConfigHome() string {
 	base := h.SkillsBase
 	if base == "" {
 		base = SharedSkillsBase
@@ -640,6 +654,116 @@ func (h Harness) ConfigHome() string {
 		return ""
 	}
 	return filepath.Join(root, base)
+}
+
+// ResolvedSandboxDirs returns SandboxDirs with the entry naming the harness's
+// default config home swapped for ConfigHome(), so a HomeEnv redirect grants
+// the directory the harness actually reads instead of the default one.
+//
+// The swap is only sound because ForwardedEnvVars passes HomeEnv into the
+// sandbox: the harness has to agree with omac about where its config home is,
+// or omac grants one directory while the harness reads another.
+func (h Harness) ResolvedSandboxDirs() []string {
+	def, cur := h.defaultConfigHome(), h.ConfigHome()
+	if def == "" || cur == "" || def == cur {
+		return h.SandboxDirs
+	}
+	out := make([]string, 0, len(h.SandboxDirs)+1)
+	swapped := false
+	for _, d := range h.SandboxDirs {
+		if normalizeHomePath(d) == def {
+			out = append(out, cur)
+			swapped = true
+			continue
+		}
+		out = append(out, d)
+	}
+	if !swapped {
+		// No entry names the config home, so there is nothing to replace: pi
+		// declares ~/.pi while its config home is the nested ~/.pi/agent. The
+		// redirect target still has to be granted — the harness reads it, since
+		// HomeEnv is forwarded — so add it.
+		out = append(out, cur)
+	}
+	return out
+}
+
+// DefaultGlobalSkillsDir returns the user-global skills dir the harness uses
+// when HomeEnv is unset.
+//
+// It returns "" when no home/config directory can be resolved.
+func (h Harness) DefaultGlobalSkillsDir() string {
+	home := h.defaultConfigHome()
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, "skills")
+}
+
+// ForwardedEnvVars returns the env vars omac forwards into the sandbox for this
+// harness: the declared SandboxEnvAllow plus HomeEnv, if it has one.
+//
+// HomeEnv must be forwarded whenever it is set, because omac grants
+// ResolvedSandboxDirs — the REDIRECTED config home. A harness that cannot see
+// its own HomeEnv falls back to the default home, which omac just stopped
+// granting, so it finds no credentials in a directory it is also denied.
+func (h Harness) ForwardedEnvVars() []string {
+	if h.HomeEnv == "" {
+		return h.SandboxEnvAllow
+	}
+	for _, v := range h.SandboxEnvAllow {
+		if v == h.HomeEnv {
+			return h.SandboxEnvAllow
+		}
+	}
+	return append(append(make([]string, 0, len(h.SandboxEnvAllow)+1), h.SandboxEnvAllow...), h.HomeEnv)
+}
+
+// HomeEnvNames returns every harness's HomeEnv — the variables that relocate a
+// harness's config home (CLAUDE_CONFIG_DIR, CODEX_HOME, …) — deduplicated, in
+// registry order. Diagnostics use it to report which overrides are active;
+// tests use it to clear the ambient ones so a faked $HOME is authoritative
+// (otherwise a developer who genuinely uses CLAUDE_CONFIG_DIR gets failures
+// nobody sees in CI).
+func HomeEnvNames() []string {
+	reg := harnessRegistry()
+	seen := make(map[string]bool, len(reg))
+	out := make([]string, 0, len(reg))
+	for _, h := range reg {
+		if h.HomeEnv == "" || seen[h.HomeEnv] {
+			continue
+		}
+		seen[h.HomeEnv] = true
+		out = append(out, h.HomeEnv)
+	}
+	return out
+}
+
+// normalizeHomePath makes a config-home value comparable and usable as a
+// sandbox grant: a leading ~ is expanded against $HOME and the result is
+// cleaned and absolutized (a relative value resolves against omac's working
+// directory). Comparing raw strings instead would treat a value that merely
+// SPELLS the default home differently — "~/.claude/", ".claude/../.claude" —
+// as a redirect, and a redirect "away from" the default home to itself makes
+// discovery drop that home as superseded by itself.
+func normalizeHomePath(p string) string {
+	if p == "" {
+		return ""
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
+			if p == "~" {
+				p = home
+			} else {
+				p = filepath.Join(home, p[2:])
+			}
+		}
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	return abs
 }
 
 // GlobalBridgeDir returns the absolute, user-global directory where this

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -660,10 +660,11 @@ func (h Harness) defaultConfigHome() string {
 // ForwardedEnvVars, which forwards HomeEnv into the sandbox so the harness
 // agrees with omac on where its config home is.
 func (h Harness) ResolvedSandboxDirs() []string {
-	def, cur := h.defaultConfigHome(), h.ConfigHome()
-	if def == "" || cur == "" || def == cur {
+	cur := h.redirectedConfigHome()
+	if cur == "" {
 		return h.SandboxDirs
 	}
+	def := h.defaultConfigHome()
 	out := make([]string, 0, len(h.SandboxDirs)+1)
 	swapped := false
 	for _, d := range h.SandboxDirs {
@@ -679,6 +680,31 @@ func (h Harness) ResolvedSandboxDirs() []string {
 		// config home is the nested ~/.pi/agent), so grant the redirect
 		// target in addition.
 		out = append(out, cur)
+	}
+	return out
+}
+
+// redirectedConfigHome returns the config home a HomeEnv redirect points
+// at, or "" when no redirect is active (HomeEnv unset or a different
+// spelling of the default home).
+func (h Harness) redirectedConfigHome() string {
+	if h.HomeEnv == "" {
+		return ""
+	}
+	def, cur := h.defaultConfigHome(), h.ConfigHome()
+	if def == "" || cur == "" || def == cur {
+		return ""
+	}
+	return cur
+}
+
+// ResolvedCreateDirs returns the directories omac must create before grant
+// resolution, which drops missing paths: the declared SandboxCreateDirs plus,
+// under an active HomeEnv redirect, the redirected config home.
+func (h Harness) ResolvedCreateDirs() []string {
+	out := append([]string(nil), h.SandboxCreateDirs...)
+	if dir := h.redirectedConfigHome(); dir != "" {
+		out = append(out, dir)
 	}
 	return out
 }

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -65,7 +65,10 @@ type Harness struct {
 	// HomeEnv, when non-empty, names an environment variable whose value
 	// replaces the harness's full config home directory. When the env var
 	// is unset or empty, the harness falls back to its default config home
-	// (UserConfigHome under $HOME, or XDG for opencode).
+	// (UserConfigHome under $HOME, or XDG for opencode). A harness whose
+	// upstream exposes no such variable leaves this EMPTY — an override omac
+	// invents is worse than none, because ResolvedSandboxDirs would grant the
+	// relocated home while the harness kept reading the default one (#233).
 	HomeEnv string
 
 	// Session, when non-nil, declares how omac re-enters prior sessions of
@@ -248,7 +251,16 @@ func harnessRegistry() []Harness {
 			ServerLaunch: &ServerLaunch{Subcommand: "serve", ListenPort: 4096, AuthEnvVar: "OPENCODE_SERVER_PASSWORD"},
 			BridgeDir:    filepath.Join(".opencode", "plugins"),
 			SkillsBase:   "opencode",
-			HomeEnv:      "OPENCODE_HOME",
+			// Deliberately NO HomeEnv: OpenCode has no config-home override.
+			// OPENCODE_CONFIG_DIR is not one — it ADDS a directory searched
+			// after the global config (opencode.ai/docs/config#custom-directory),
+			// and credentials live outside it entirely
+			// ($XDG_DATA_HOME/opencode/auth.json). Declaring it would be
+			// harmful, because HomeEnv REPLACES the config home: ConfigHome
+			// would move the session store and the skills install dir, and
+			// ResolvedSandboxDirs would swap ~/.config/opencode OUT of the
+			// grants while OpenCode kept reading it. $XDG_CONFIG_HOME is the
+			// supported way to move it, and is already forwarded (#233).
 			Session: &HarnessSession{
 				ContinueArgs:   []string{"--continue"},
 				ResumeByIDArgs: func(id string) []string { return []string{"--session", id} },

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -65,10 +65,9 @@ type Harness struct {
 	// HomeEnv, when non-empty, names an environment variable whose value
 	// replaces the harness's full config home directory. When the env var
 	// is unset or empty, the harness falls back to its default config home
-	// (UserConfigHome under $HOME, or XDG for opencode). A harness whose
-	// upstream exposes no such variable leaves this EMPTY — an override omac
-	// invents is worse than none, because ResolvedSandboxDirs would grant the
-	// relocated home while the harness kept reading the default one (#233).
+	// (UserConfigHome under $HOME, or XDG for opencode). Leave it empty when
+	// upstream exposes no such variable: an invented override would make
+	// ResolvedSandboxDirs grant a directory the harness never reads (#233).
 	HomeEnv string
 
 	// Session, when non-nil, declares how omac re-enters prior sessions of
@@ -112,8 +111,8 @@ type Harness struct {
 
 	// SandboxDirs are directories the selected harness needs at runtime
 	// for configuration, authentication, state, and session storage.
-	// omac grants them read+write only for that selected harness.
-	// Declared against the default config home; launch call sites grant
+	// omac grants them read+write only for that selected harness. They are
+	// declared against the default config home; launch call sites grant
 	// ResolvedSandboxDirs so a HomeEnv redirect is honored.
 	SandboxDirs []string
 	// SandboxCreateDirs is the subset of SandboxDirs that omac must create
@@ -251,16 +250,10 @@ func harnessRegistry() []Harness {
 			ServerLaunch: &ServerLaunch{Subcommand: "serve", ListenPort: 4096, AuthEnvVar: "OPENCODE_SERVER_PASSWORD"},
 			BridgeDir:    filepath.Join(".opencode", "plugins"),
 			SkillsBase:   "opencode",
-			// Deliberately NO HomeEnv: OpenCode has no config-home override.
-			// OPENCODE_CONFIG_DIR is not one — it ADDS a directory searched
-			// after the global config (opencode.ai/docs/config#custom-directory),
-			// and credentials live outside it entirely
-			// ($XDG_DATA_HOME/opencode/auth.json). Declaring it would be
-			// harmful, because HomeEnv REPLACES the config home: ConfigHome
-			// would move the session store and the skills install dir, and
-			// ResolvedSandboxDirs would swap ~/.config/opencode OUT of the
-			// grants while OpenCode kept reading it. $XDG_CONFIG_HOME is the
-			// supported way to move it, and is already forwarded (#233).
+			// No HomeEnv: OpenCode has no config-home override. OPENCODE_CONFIG_DIR
+			// only adds a config-search dir (credentials live elsewhere), so wiring
+			// it here would move omac's grants away from the dirs OpenCode reads.
+			// $XDG_CONFIG_HOME is the supported redirect (#233).
 			Session: &HarnessSession{
 				ContinueArgs:   []string{"--continue"},
 				ResumeByIDArgs: func(id string) []string { return []string{"--session", id} },
@@ -301,12 +294,9 @@ func harnessRegistry() []Harness {
 			UserConfigHome: ".claude",
 			HomeEnv:        "CLAUDE_CONFIG_DIR",
 			// Claude stores configuration, authentication, and sessions in ~/.claude; runtime state is in ~/.local/share/claude.
-			// The config-home entry follows CLAUDE_CONFIG_DIR via ResolvedSandboxDirs.
 			SandboxDirs: []string{"~/.claude", "~/.local/share/claude"},
 			// Interactive login credentials live in the config home
-			// (SandboxDirs). CLAUDE_CONFIG_DIR is NOT listed here: every
-			// harness's HomeEnv is forwarded generically by ForwardedEnvVars.
-			// These are the documented env vars for API-key /
+			// (SandboxDirs); these are the documented env vars for API-key /
 			// custom-endpoint auth (Anthropic-compatible gateway).
 			SandboxEnvAllow: []string{
 				"ANTHROPIC_API_KEY",
@@ -633,11 +623,9 @@ func (h Harness) WorkdirSkillsDir() string {
 // the HomeEnv override. For UserConfigHome harnesses (claude, codex,
 // copilot, pi), this is $HOME/<UserConfigHome> by default. For XDG harnesses
 // (opencode), this is $XDG_CONFIG_HOME/<base> or ~/.config/<base> by
-// default. When HomeEnv is set and non-empty, its value replaces the
-// default entirely. Returns "" when no home can be resolved.
-//
-// The returned path is normalized (see normalizeHomePath), so a value that
-// merely spells the default home differently is not mistaken for a redirect.
+// default. When HomeEnv is set and non-empty, its normalized value (see
+// normalizeHomePath) replaces the default entirely. Returns "" when no
+// home can be resolved.
 func (h Harness) ConfigHome() string {
 	if h.HomeEnv != "" {
 		if dir := os.Getenv(h.HomeEnv); dir != "" {
@@ -647,8 +635,6 @@ func (h Harness) ConfigHome() string {
 	return h.defaultConfigHome()
 }
 
-// defaultConfigHome resolves the config home the harness uses when HomeEnv is
-// unset.
 func (h Harness) defaultConfigHome() string {
 	base := h.SkillsBase
 	if base == "" {
@@ -670,11 +656,9 @@ func (h Harness) defaultConfigHome() string {
 
 // ResolvedSandboxDirs returns SandboxDirs with the entry naming the harness's
 // default config home swapped for ConfigHome(), so a HomeEnv redirect grants
-// the directory the harness actually reads instead of the default one.
-//
-// The swap is only sound because ForwardedEnvVars passes HomeEnv into the
-// sandbox: the harness has to agree with omac about where its config home is,
-// or omac grants one directory while the harness reads another.
+// the directory the harness actually reads. Sound only together with
+// ForwardedEnvVars, which forwards HomeEnv into the sandbox so the harness
+// agrees with omac on where its config home is.
 func (h Harness) ResolvedSandboxDirs() []string {
 	def, cur := h.defaultConfigHome(), h.ConfigHome()
 	if def == "" || cur == "" || def == cur {
@@ -691,19 +675,17 @@ func (h Harness) ResolvedSandboxDirs() []string {
 		out = append(out, d)
 	}
 	if !swapped {
-		// No entry names the config home, so there is nothing to replace: pi
-		// declares ~/.pi while its config home is the nested ~/.pi/agent. The
-		// redirect target still has to be granted — the harness reads it, since
-		// HomeEnv is forwarded — so add it.
+		// No entry names the config home (pi declares ~/.pi while its
+		// config home is the nested ~/.pi/agent), so grant the redirect
+		// target in addition.
 		out = append(out, cur)
 	}
 	return out
 }
 
-// DefaultGlobalSkillsDir returns the user-global skills dir the harness uses
-// when HomeEnv is unset.
-//
-// It returns "" when no home/config directory can be resolved.
+// DefaultGlobalSkillsDir returns GlobalSkillsDir for the default config home,
+// ignoring any HomeEnv redirect. Discovery uses it to tell which candidate
+// root a redirect supersedes.
 func (h Harness) DefaultGlobalSkillsDir() string {
 	home := h.defaultConfigHome()
 	if home == "" {
@@ -712,13 +694,8 @@ func (h Harness) DefaultGlobalSkillsDir() string {
 	return filepath.Join(home, "skills")
 }
 
-// ForwardedEnvVars returns the env vars omac forwards into the sandbox for this
-// harness: the declared SandboxEnvAllow plus HomeEnv, if it has one.
-//
-// HomeEnv must be forwarded whenever it is set, because omac grants
-// ResolvedSandboxDirs — the REDIRECTED config home. A harness that cannot see
-// its own HomeEnv falls back to the default home, which omac just stopped
-// granting, so it finds no credentials in a directory it is also denied.
+// ForwardedEnvVars returns the env vars omac forwards into the sandbox for
+// this harness: the declared SandboxEnvAllow plus HomeEnv, if it has one.
 func (h Harness) ForwardedEnvVars() []string {
 	if h.HomeEnv == "" {
 		return h.SandboxEnvAllow
@@ -733,10 +710,7 @@ func (h Harness) ForwardedEnvVars() []string {
 
 // HomeEnvNames returns every harness's HomeEnv — the variables that relocate a
 // harness's config home (CLAUDE_CONFIG_DIR, CODEX_HOME, …) — deduplicated, in
-// registry order. Diagnostics use it to report which overrides are active;
-// tests use it to clear the ambient ones so a faked $HOME is authoritative
-// (otherwise a developer who genuinely uses CLAUDE_CONFIG_DIR gets failures
-// nobody sees in CI).
+// registry order.
 func HomeEnvNames() []string {
 	reg := harnessRegistry()
 	seen := make(map[string]bool, len(reg))
@@ -751,13 +725,9 @@ func HomeEnvNames() []string {
 	return out
 }
 
-// normalizeHomePath makes a config-home value comparable and usable as a
-// sandbox grant: a leading ~ is expanded against $HOME and the result is
-// cleaned and absolutized (a relative value resolves against omac's working
-// directory). Comparing raw strings instead would treat a value that merely
-// SPELLS the default home differently — "~/.claude/", ".claude/../.claude" —
-// as a redirect, and a redirect "away from" the default home to itself makes
-// discovery drop that home as superseded by itself.
+// normalizeHomePath expands a leading ~ against $HOME and absolutizes the
+// result, so config-home values are comparable and usable as grants: a value
+// that merely spells the default home differently is not a redirect.
 func normalizeHomePath(p string) string {
 	if p == "" {
 		return ""

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -517,6 +517,176 @@ func TestSandboxDirsClaude(t *testing.T) {
 	}
 }
 
+// Without a redirect the grants are the declared ones, untouched.
+func TestResolvedSandboxDirsClaudeNoOverride(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	h, _ := LookupHarness("claude-code")
+	want := []string{"~/.claude", "~/.local/share/claude"}
+	if got := h.ResolvedSandboxDirs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("ResolvedSandboxDirs() = %v; want %v", got, want)
+	}
+}
+
+// A CLAUDE_CONFIG_DIR redirect must move the config-home grant with it —
+// otherwise the sandbox denies the credentials the harness actually reads and
+// Claude Code prompts for a fresh login.
+func TestResolvedSandboxDirsClaudeFollowsConfigDirOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".work-claude"))
+	h, _ := LookupHarness("claude-code")
+
+	want := []string{filepath.Join(home, ".work-claude"), "~/.local/share/claude"}
+	if got := h.ResolvedSandboxDirs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("ResolvedSandboxDirs() = %v; want %v", got, want)
+	}
+}
+
+// The redirected home replaces the default rather than joining it: granting
+// both would expose the very login the user separated out.
+func TestResolvedSandboxDirsClaudeDropsDefaultHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".work-claude"))
+	h, _ := LookupHarness("claude-code")
+
+	for _, d := range h.ResolvedSandboxDirs() {
+		if d == "~/.claude" || d == filepath.Join(home, ".claude") {
+			t.Errorf("ResolvedSandboxDirs() still grants the default config home %q", d)
+		}
+	}
+}
+
+// A value that merely SPELLS the default home differently is not a redirect.
+// Treating it as one made discovery supersede the default skills root with
+// itself and drop it (see TestSources_TrailingSlashKeepsDefaultRoot).
+func TestResolvedSandboxDirsClaudeIgnoresNonCanonicalDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	want := []string{"~/.claude", "~/.local/share/claude"}
+	for _, spelling := range []string{
+		filepath.Join(home, ".claude") + "/",
+		filepath.Join(home, ".config", "..", ".claude"),
+		"~/.claude",
+	} {
+		t.Run(spelling, func(t *testing.T) {
+			t.Setenv("CLAUDE_CONFIG_DIR", spelling)
+			h, _ := LookupHarness("claude-code")
+			if got := h.ResolvedSandboxDirs(); !reflect.DeepEqual(got, want) {
+				t.Errorf("ResolvedSandboxDirs() = %v; want %v (not a redirect)", got, want)
+			}
+		})
+	}
+}
+
+// EVERY harness with a HomeEnv must forward it. ResolvedSandboxDirs is generic,
+// so it swaps the grant for all of them; a harness that then cannot see its own
+// HomeEnv reads the default home omac just stopped granting — i.e. declaring the
+// swap without the forward is worse than not swapping at all.
+func TestForwardedEnvVarsCarryHomeEnv(t *testing.T) {
+	for _, h := range AllHarnesses() {
+		if h.HomeEnv == "" {
+			continue
+		}
+		fwd := h.ForwardedEnvVars()
+		found := false
+		for _, v := range fwd {
+			if v == h.HomeEnv {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s ForwardedEnvVars() = %v; want it to carry %s", h.Name, fwd, h.HomeEnv)
+		}
+		// The declared auth vars must survive alongside it.
+		for _, want := range h.SandboxEnvAllow {
+			if !slices.Contains(fwd, want) {
+				t.Errorf("%s ForwardedEnvVars() = %v; dropped declared var %s", h.Name, fwd, want)
+			}
+		}
+	}
+}
+
+// ForwardedEnvVars must not mutate the descriptor's own slice — the registry is
+// rebuilt per call, but a caller appending into shared backing storage is the
+// kind of bug that only shows up under a second harness lookup.
+func TestForwardedEnvVarsDoesNotMutateSandboxEnvAllow(t *testing.T) {
+	h, _ := LookupHarness("claude-code")
+	before := append([]string(nil), h.SandboxEnvAllow...)
+	_ = h.ForwardedEnvVars()
+	if !reflect.DeepEqual(h.SandboxEnvAllow, before) {
+		t.Errorf("SandboxEnvAllow mutated: %v -> %v", before, h.SandboxEnvAllow)
+	}
+}
+
+// Codex is the regression case: its config home IS its only declared sandbox
+// dir, so the generic swap drops ~/.codex. Without CODEX_HOME forwarded, codex
+// would read ~/.codex — now denied — and lose a login that used to work.
+func TestResolvedSandboxDirsCodexFollowsHomeEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".work-codex"))
+	h, _ := LookupHarness("codex")
+
+	want := []string{filepath.Join(home, ".work-codex")}
+	if got := h.ResolvedSandboxDirs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("ResolvedSandboxDirs() = %v; want %v", got, want)
+	}
+	if !slices.Contains(h.ForwardedEnvVars(), "CODEX_HOME") {
+		t.Errorf("ForwardedEnvVars() = %v; want CODEX_HOME so codex reads the granted dir", h.ForwardedEnvVars())
+	}
+}
+
+// pi declares ~/.pi while its config home is the nested ~/.pi/agent, so no
+// entry matches and there is nothing to swap. The redirect target must still be
+// granted: PI_CODING_AGENT_DIR is forwarded, so pi reads it.
+func TestResolvedSandboxDirsPiAppendsRedirectTarget(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PI_CODING_AGENT_DIR", filepath.Join(home, ".work-pi"))
+	h, _ := LookupHarness("pi")
+
+	want := []string{"~/.pi", filepath.Join(home, ".work-pi")}
+	if got := h.ResolvedSandboxDirs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("ResolvedSandboxDirs() = %v; want %v", got, want)
+	}
+}
+
+// DefaultGlobalSkillsDir stays on the default home so discovery can tell which
+// candidate root a redirect supersedes.
+func TestDefaultGlobalSkillsDirIgnoresRedirect(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".work-claude"))
+	h, _ := LookupHarness("claude-code")
+
+	if want := filepath.Join(home, ".claude", "skills"); h.DefaultGlobalSkillsDir() != want {
+		t.Errorf("DefaultGlobalSkillsDir() = %q; want %q", h.DefaultGlobalSkillsDir(), want)
+	}
+	if want := filepath.Join(home, ".work-claude", "skills"); h.GlobalSkillsDir() != want {
+		t.Errorf("GlobalSkillsDir() = %q; want %q", h.GlobalSkillsDir(), want)
+	}
+}
+
+// HomeEnvNames must cover every declared override, since tests neutralize the
+// ambient environment through it — a missing name is a silently leaky test.
+func TestHomeEnvNamesCoversRegistry(t *testing.T) {
+	names := HomeEnvNames()
+	for _, h := range AllHarnesses() {
+		if h.HomeEnv != "" && !slices.Contains(names, h.HomeEnv) {
+			t.Errorf("HomeEnvNames() = %v; missing %s (%s)", names, h.HomeEnv, h.Name)
+		}
+	}
+	seen := map[string]bool{}
+	for _, n := range names {
+		if seen[n] {
+			t.Errorf("HomeEnvNames() = %v; contains duplicate %s", names, n)
+		}
+		seen[n] = true
+	}
+}
+
 // --- Codex + Copilot harness descriptors -------------------------------------
 
 func TestLookupCodexHarness(t *testing.T) {
@@ -695,7 +865,7 @@ func TestConfigHomeEnvOverrideUnset(t *testing.T) {
 
 func TestConfigHomeEnvOverrideClaude(t *testing.T) {
 	h, _ := LookupHarness("claude-code")
-	t.Setenv("CLAUDE_HOME", "/tmp/claude-home")
+	t.Setenv("CLAUDE_CONFIG_DIR", "/tmp/claude-home")
 	if got := h.ConfigHome(); got != "/tmp/claude-home" {
 		t.Errorf("ConfigHome() = %q, want /tmp/claude-home", got)
 	}
@@ -720,7 +890,7 @@ func TestGlobalSkillsDirEnvOverride(t *testing.T) {
 
 func TestGlobalSkillsDirEnvOverrideClaude(t *testing.T) {
 	h, _ := LookupHarness("claude-code")
-	t.Setenv("CLAUDE_HOME", "/tmp/claude-skills")
+	t.Setenv("CLAUDE_CONFIG_DIR", "/tmp/claude-skills")
 	want := "/tmp/claude-skills/skills"
 	if got := h.GlobalSkillsDir(); got != want {
 		t.Errorf("GlobalSkillsDir() = %q, want %q", got, want)

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -517,7 +517,6 @@ func TestSandboxDirsClaude(t *testing.T) {
 	}
 }
 
-// Without a redirect the grants are the declared ones, untouched.
 func TestResolvedSandboxDirsClaudeNoOverride(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	h, _ := LookupHarness("claude-code")
@@ -527,9 +526,6 @@ func TestResolvedSandboxDirsClaudeNoOverride(t *testing.T) {
 	}
 }
 
-// A CLAUDE_CONFIG_DIR redirect must move the config-home grant with it —
-// otherwise the sandbox denies the credentials the harness actually reads and
-// Claude Code prompts for a fresh login.
 func TestResolvedSandboxDirsClaudeFollowsConfigDirOverride(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -543,7 +539,7 @@ func TestResolvedSandboxDirsClaudeFollowsConfigDirOverride(t *testing.T) {
 }
 
 // The redirected home replaces the default rather than joining it: granting
-// both would expose the very login the user separated out.
+// both would expose the login the user deliberately separated out.
 func TestResolvedSandboxDirsClaudeDropsDefaultHome(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -557,9 +553,7 @@ func TestResolvedSandboxDirsClaudeDropsDefaultHome(t *testing.T) {
 	}
 }
 
-// A value that merely SPELLS the default home differently is not a redirect.
-// Treating it as one made discovery supersede the default skills root with
-// itself and drop it (see TestSources_TrailingSlashKeepsDefaultRoot).
+// A value that merely spells the default home differently is not a redirect.
 func TestResolvedSandboxDirsClaudeIgnoresNonCanonicalDefault(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -579,10 +573,9 @@ func TestResolvedSandboxDirsClaudeIgnoresNonCanonicalDefault(t *testing.T) {
 	}
 }
 
-// EVERY harness with a HomeEnv must forward it. ResolvedSandboxDirs is generic,
-// so it swaps the grant for all of them; a harness that then cannot see its own
-// HomeEnv reads the default home omac just stopped granting — i.e. declaring the
-// swap without the forward is worse than not swapping at all.
+// Every harness with a HomeEnv must forward it: ResolvedSandboxDirs swaps its
+// grant, so a harness that cannot see its own HomeEnv reads a home omac no
+// longer grants.
 func TestForwardedEnvVarsCarryHomeEnv(t *testing.T) {
 	for _, h := range AllHarnesses() {
 		if h.HomeEnv == "" {
@@ -599,7 +592,6 @@ func TestForwardedEnvVarsCarryHomeEnv(t *testing.T) {
 		if !found {
 			t.Errorf("%s ForwardedEnvVars() = %v; want it to carry %s", h.Name, fwd, h.HomeEnv)
 		}
-		// The declared auth vars must survive alongside it.
 		for _, want := range h.SandboxEnvAllow {
 			if !slices.Contains(fwd, want) {
 				t.Errorf("%s ForwardedEnvVars() = %v; dropped declared var %s", h.Name, fwd, want)
@@ -608,9 +600,7 @@ func TestForwardedEnvVarsCarryHomeEnv(t *testing.T) {
 	}
 }
 
-// ForwardedEnvVars must not mutate the descriptor's own slice — the registry is
-// rebuilt per call, but a caller appending into shared backing storage is the
-// kind of bug that only shows up under a second harness lookup.
+// ForwardedEnvVars must not mutate the descriptor's own slice.
 func TestForwardedEnvVarsDoesNotMutateSandboxEnvAllow(t *testing.T) {
 	h, _ := LookupHarness("claude-code")
 	before := append([]string(nil), h.SandboxEnvAllow...)
@@ -620,9 +610,8 @@ func TestForwardedEnvVarsDoesNotMutateSandboxEnvAllow(t *testing.T) {
 	}
 }
 
-// Codex is the regression case: its config home IS its only declared sandbox
-// dir, so the generic swap drops ~/.codex. Without CODEX_HOME forwarded, codex
-// would read ~/.codex — now denied — and lose a login that used to work.
+// Codex's config home is its only declared sandbox dir — the minimal case
+// for the swap.
 func TestResolvedSandboxDirsCodexFollowsHomeEnv(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -638,9 +627,8 @@ func TestResolvedSandboxDirsCodexFollowsHomeEnv(t *testing.T) {
 	}
 }
 
-// pi declares ~/.pi while its config home is the nested ~/.pi/agent, so no
-// entry matches and there is nothing to swap. The redirect target must still be
-// granted: PI_CODING_AGENT_DIR is forwarded, so pi reads it.
+// pi declares ~/.pi while its config home is the nested ~/.pi/agent, so the
+// redirect target is appended rather than swapped in.
 func TestResolvedSandboxDirsPiAppendsRedirectTarget(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -653,8 +641,6 @@ func TestResolvedSandboxDirsPiAppendsRedirectTarget(t *testing.T) {
 	}
 }
 
-// DefaultGlobalSkillsDir stays on the default home so discovery can tell which
-// candidate root a redirect supersedes.
 func TestDefaultGlobalSkillsDirIgnoresRedirect(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -669,8 +655,6 @@ func TestDefaultGlobalSkillsDirIgnoresRedirect(t *testing.T) {
 	}
 }
 
-// HomeEnvNames must cover every declared override, since tests neutralize the
-// ambient environment through it — a missing name is a silently leaky test.
 func TestHomeEnvNamesCoversRegistry(t *testing.T) {
 	names := HomeEnvNames()
 	for _, h := range AllHarnesses() {
@@ -871,11 +855,8 @@ func TestConfigHomeEnvOverrideClaude(t *testing.T) {
 	}
 }
 
-// OpenCode declares no HomeEnv, so nothing may relocate its config home.
-// OPENCODE_CONFIG_DIR is the plausible mis-wiring: it is only an ADDITIONAL
-// config-search dir, so honoring it would move omac's session store, skills
-// install dir, and sandbox grants away from the dirs OpenCode actually reads
-// (#233).
+// OpenCode declares no HomeEnv; OPENCODE_CONFIG_DIR is only an additional
+// config-search dir and must not relocate the config home (#233).
 func TestConfigHomeOpenCodeHasNoOverride(t *testing.T) {
 	h, _ := LookupHarness("opencode")
 	if h.HomeEnv != "" {
@@ -899,8 +880,7 @@ func TestConfigHomeOpenCodeHasNoOverride(t *testing.T) {
 	}
 }
 
-// $XDG_CONFIG_HOME does move OpenCode's config home — that is the supported
-// mechanism, and it is already forwarded into the sandbox.
+// $XDG_CONFIG_HOME is the supported way to move OpenCode's config home.
 func TestConfigHomeOpenCodeFollowsXDG(t *testing.T) {
 	h, _ := LookupHarness("opencode")
 	t.Setenv("HOME", t.TempDir())
@@ -928,8 +908,6 @@ func TestGlobalSkillsDirEnvOverrideClaude(t *testing.T) {
 	}
 }
 
-// OpenCode's global skills dir follows $XDG_CONFIG_HOME, not a HomeEnv
-// override (see TestConfigHomeOpenCodeHasNoOverride).
 func TestGlobalSkillsDirOpenCodeFollowsXDG(t *testing.T) {
 	h, _ := LookupHarness("opencode")
 	t.Setenv("HOME", t.TempDir())

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -641,6 +641,49 @@ func TestResolvedSandboxDirsPiAppendsRedirectTarget(t *testing.T) {
 	}
 }
 
+// A redirected config home must be created before grant resolution, which
+// drops missing paths.
+func TestResolvedCreateDirsFollowsRedirect(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".work-claude"))
+	h, _ := LookupHarness("claude-code")
+
+	want := []string{filepath.Join(home, ".work-claude")}
+	if got := h.ResolvedCreateDirs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("ResolvedCreateDirs() = %v; want %v", got, want)
+	}
+}
+
+// Without an active redirect, create-dirs are just the declared ones.
+func TestResolvedCreateDirsNoRedirectKeepsDeclared(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	for _, h := range AllHarnesses() {
+		if got, want := h.ResolvedCreateDirs(), h.SandboxCreateDirs; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s ResolvedCreateDirs() = %v; want %v", h.Name, got, want)
+		}
+	}
+}
+
+// A different spelling of the default home is not a redirect.
+func TestResolvedCreateDirsIgnoresNonCanonicalDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, spelling := range []string{
+		filepath.Join(home, ".claude") + "/",
+		filepath.Join(home, ".config", "..", ".claude"),
+		"~/.claude",
+	} {
+		t.Run(spelling, func(t *testing.T) {
+			t.Setenv("CLAUDE_CONFIG_DIR", spelling)
+			h, _ := LookupHarness("claude-code")
+			if got, want := h.ResolvedCreateDirs(), h.SandboxCreateDirs; !reflect.DeepEqual(got, want) {
+				t.Errorf("ResolvedCreateDirs() = %v; want %v (not a redirect)", got, want)
+			}
+		})
+	}
+}
+
 func TestDefaultGlobalSkillsDirIgnoresRedirect(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -871,11 +871,42 @@ func TestConfigHomeEnvOverrideClaude(t *testing.T) {
 	}
 }
 
-func TestConfigHomeEnvOverrideOpenCode(t *testing.T) {
+// OpenCode declares no HomeEnv, so nothing may relocate its config home.
+// OPENCODE_CONFIG_DIR is the plausible mis-wiring: it is only an ADDITIONAL
+// config-search dir, so honoring it would move omac's session store, skills
+// install dir, and sandbox grants away from the dirs OpenCode actually reads
+// (#233).
+func TestConfigHomeOpenCodeHasNoOverride(t *testing.T) {
 	h, _ := LookupHarness("opencode")
-	t.Setenv("OPENCODE_HOME", "/tmp/oc-home")
-	if got := h.ConfigHome(); got != "/tmp/oc-home" {
-		t.Errorf("ConfigHome() = %q, want /tmp/oc-home", got)
+	if h.HomeEnv != "" {
+		t.Fatalf("opencode HomeEnv = %q; want empty (OpenCode has no config-home override)", h.HomeEnv)
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("OPENCODE_CONFIG_DIR", filepath.Join(home, ".other-opencode"))
+	want := filepath.Join(home, ".config", "opencode")
+
+	if got := h.ConfigHome(); got != want {
+		t.Errorf("ConfigHome() = %q; want %q — OPENCODE_CONFIG_DIR must not relocate it", got, want)
+	}
+	if got, wantSkills := h.GlobalSkillsDir(), filepath.Join(want, "skills"); got != wantSkills {
+		t.Errorf("GlobalSkillsDir() = %q; want %q", got, wantSkills)
+	}
+	// The grants must keep naming the dirs OpenCode really reads.
+	if got := h.ResolvedSandboxDirs(); !reflect.DeepEqual(got, h.SandboxDirs) {
+		t.Errorf("ResolvedSandboxDirs() = %v; want the declared %v", got, h.SandboxDirs)
+	}
+}
+
+// $XDG_CONFIG_HOME does move OpenCode's config home — that is the supported
+// mechanism, and it is already forwarded into the sandbox.
+func TestConfigHomeOpenCodeFollowsXDG(t *testing.T) {
+	h, _ := LookupHarness("opencode")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg-oc")
+	if got, want := h.ConfigHome(), filepath.Join("/tmp/xdg-oc", "opencode"); got != want {
+		t.Errorf("ConfigHome() = %q, want %q", got, want)
 	}
 }
 
@@ -897,10 +928,13 @@ func TestGlobalSkillsDirEnvOverrideClaude(t *testing.T) {
 	}
 }
 
-func TestGlobalSkillsDirEnvOverrideOpenCode(t *testing.T) {
+// OpenCode's global skills dir follows $XDG_CONFIG_HOME, not a HomeEnv
+// override (see TestConfigHomeOpenCodeHasNoOverride).
+func TestGlobalSkillsDirOpenCodeFollowsXDG(t *testing.T) {
 	h, _ := LookupHarness("opencode")
-	t.Setenv("OPENCODE_HOME", "/tmp/oc-skills")
-	want := "/tmp/oc-skills/skills"
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/oc-skills")
+	want := "/tmp/oc-skills/opencode/skills"
 	if got := h.GlobalSkillsDir(); got != want {
 		t.Errorf("GlobalSkillsDir() = %q, want %q", got, want)
 	}

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain clears every harness config-home override (CLAUDE_CONFIG_DIR and
+// friends) for the whole package test binary. Tests here fake $HOME to assert
+// the DEFAULT config home, but cannot fake a variable that names an absolute
+// path, so an ambient override kept winning over the faked $HOME.
+func TestMain(m *testing.M) {
+	for _, name := range HomeEnvNames() {
+		os.Unsetenv(name)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -6,9 +6,8 @@ import (
 )
 
 // TestMain clears every harness config-home override (CLAUDE_CONFIG_DIR and
-// friends) for the whole package test binary. Tests here fake $HOME to assert
-// the DEFAULT config home, but cannot fake a variable that names an absolute
-// path, so an ambient override kept winning over the faked $HOME.
+// friends) for the whole test binary: tests fake $HOME, but an ambient
+// override names an absolute path and would win over the fake.
 func TestMain(m *testing.M) {
 	for _, name := range HomeEnvNames() {
 		os.Unsetenv(name)

--- a/internal/session/main_test.go
+++ b/internal/session/main_test.go
@@ -1,0 +1,22 @@
+package session
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+// TestMain clears every harness config-home override (CLAUDE_CONFIG_DIR and
+// friends) for the whole package test binary. Session listing resolves its
+// store from Harness.ConfigHome(), so an ambient override would point a test at
+// the developer's real session history instead of the temp dir it staged. CI
+// has none of these set, so such failures only appear locally. Tests that want
+// a redirect set it themselves with t.Setenv, which still overrides and
+// restores normally after this.
+func TestMain(m *testing.M) {
+	for _, name := range config.HomeEnvNames() {
+		os.Unsetenv(name)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/session/main_test.go
+++ b/internal/session/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/TNG/oh-my-agentic-coder/internal/config"
 )
 
 // TestMain clears every harness config-home override (CLAUDE_CONFIG_DIR and

--- a/internal/session/main_test.go
+++ b/internal/session/main_test.go
@@ -8,12 +8,9 @@ import (
 )
 
 // TestMain clears every harness config-home override (CLAUDE_CONFIG_DIR and
-// friends) for the whole package test binary. Session listing resolves its
-// store from Harness.ConfigHome(), so an ambient override would point a test at
-// the developer's real session history instead of the temp dir it staged. CI
-// has none of these set, so such failures only appear locally. Tests that want
-// a redirect set it themselves with t.Setenv, which still overrides and
-// restores normally after this.
+// friends) for the whole test binary: session stores resolve from
+// Harness.ConfigHome(), so an ambient override would point tests at the
+// developer's real session history instead of their staged temp dirs.
 func TestMain(m *testing.M) {
 	for _, name := range config.HomeEnvNames() {
 		os.Unsetenv(name)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -261,7 +261,7 @@ func listOpenCodeCLI(workdir string, run runner) []Session {
 
 // --- Claude Code backend ----------------------------------------------------
 
-// claudeProjectsRoot returns the claude projects dir, honoring CLAUDE_HOME.
+// claudeProjectsRoot returns the claude projects dir, honoring CLAUDE_CONFIG_DIR.
 // Returns "" when no home dir resolves (best-effort: an empty root yields no sessions).
 func claudeProjectsRoot(h config.Harness) string {
 	home := h.ConfigHome()

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -643,7 +643,7 @@ func claudeHarness(t *testing.T) config.Harness {
 
 func TestKnownIDsClaudeEnumeratesFilenames(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("CLAUDE_HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", home)
 	root := filepath.Join(home, "projects")
 	const wd = "/home/u/proj"
 
@@ -668,7 +668,7 @@ func TestKnownIDsClaudeEnumeratesFilenames(t *testing.T) {
 }
 
 func TestKnownIDsClaudeMissingDirIsEmpty(t *testing.T) {
-	t.Setenv("CLAUDE_HOME", t.TempDir()) // no projects/ subtree written
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir()) // no projects/ subtree written
 	got := KnownIDs(claudeHarness(t), "/home/u/proj")
 	if got == nil || len(got) != 0 {
 		t.Errorf("missing project dir should yield an empty (non-nil) set, got %v", got)

--- a/internal/skillsource/main_test.go
+++ b/internal/skillsource/main_test.go
@@ -1,0 +1,20 @@
+package skillsource
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+)
+
+// TestMain clears every harness config-home override (CLAUDE_CONFIG_DIR and
+// friends) for the whole package test binary. withFakeHome fakes $HOME, but a
+// config-home override names an absolute path and so survived it: with an
+// ambient CLAUDE_CONFIG_DIR, Discover in claude scope scanned the developer's
+// real skills dir and returned host skills the test never staged.
+func TestMain(m *testing.M) {
+	for _, name := range config.HomeEnvNames() {
+		os.Unsetenv(name)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/skillsource/main_test.go
+++ b/internal/skillsource/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/tngtech/oh-my-agentic-coder/internal/config"
+	"github.com/TNG/oh-my-agentic-coder/internal/config"
 )
 
 // TestMain clears every harness config-home override (CLAUDE_CONFIG_DIR and

--- a/internal/skillsource/main_test.go
+++ b/internal/skillsource/main_test.go
@@ -8,10 +8,9 @@ import (
 )
 
 // TestMain clears every harness config-home override (CLAUDE_CONFIG_DIR and
-// friends) for the whole package test binary. withFakeHome fakes $HOME, but a
-// config-home override names an absolute path and so survived it: with an
-// ambient CLAUDE_CONFIG_DIR, Discover in claude scope scanned the developer's
-// real skills dir and returned host skills the test never staged.
+// friends) for the whole test binary: withFakeHome fakes $HOME, but an
+// ambient override names an absolute path and survives it, so discovery
+// would scan the developer's real skills dirs.
 func TestMain(m *testing.M) {
 	for _, name := range config.HomeEnvNames() {
 		os.Unsetenv(name)

--- a/internal/skillsource/skillsource.go
+++ b/internal/skillsource/skillsource.go
@@ -90,7 +90,7 @@ func Sources(workdir string, harness config.Harness) []Source {
 		})
 	}
 	// User-global layer, in base priority order; only existing dirs.
-	for _, root := range userGlobalRoots(bases) {
+	for _, root := range userGlobalRoots(bases, harness) {
 		if info, err := os.Stat(root); err == nil && info.IsDir() {
 			out = append(out, Source{Root: root, Kind: "user-global"})
 		}
@@ -115,7 +115,11 @@ func Sources(workdir string, harness config.Harness) []Source {
 //	  $HOME/.opencode/skills,           $HOME/.agents/skills
 //
 // dedupe() drops duplicates that arise when $XDG_CONFIG_HOME == $HOME/.config.
-func userGlobalRoots(bases []string) []string {
+//
+// withConfigHomeRoot then reconciles the list with the harness's actual config
+// home, which is what makes a relocated config home (CLAUDE_CONFIG_DIR and
+// friends) discoverable.
+func userGlobalRoots(bases []string, h config.Harness) []string {
 	var out []string
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		for _, base := range bases {
@@ -124,13 +128,54 @@ func userGlobalRoots(bases []string) []string {
 	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
-		return dedupe(out)
+		return withConfigHomeRoot(dedupe(out), h)
 	}
 	for _, base := range bases {
 		out = append(out, filepath.Join(home, ".config", base, "skills"))
 	}
 	for _, base := range bases {
 		out = append(out, filepath.Join(home, "."+base, "skills"))
+	}
+	return withConfigHomeRoot(dedupe(out), h)
+}
+
+// withConfigHomeRoot guarantees the harness's own config-home skills dir —
+// GlobalSkillsDir(), which is where `omac setup` and launch-time provisioning
+// install built-in skills, and where the harness's own loader reads them — is
+// among the candidate roots, and that a HomeEnv redirect MOVES it rather than
+// adding a second one.
+//
+// The redirected root is substituted for the default one IN PLACE, so a
+// redirect changes which config home is scanned without reordering the rest of
+// the ladder. The default root drops out: a user who points a harness at a
+// second config home is separating two setups, and omac grants only the
+// redirected one into the sandbox (config.Harness.ResolvedSandboxDirs).
+//
+// When the config home is not itself one of the "<base>/skills" roots there is
+// nothing to substitute, so it is appended: pi keeps its skills in
+// ~/.pi/agent/skills, and codewhale in ~/.codewhale/skills while owning the
+// shared "agents" base, so neither dir was reachable from the bases above —
+// even though `omac setup` installs into exactly those dirs.
+func withConfigHomeRoot(in []string, h config.Harness) []string {
+	cur := h.GlobalSkillsDir()
+	if cur == "" {
+		return in
+	}
+	def := h.DefaultGlobalSkillsDir()
+	out := make([]string, 0, len(in)+1)
+	substituted := false
+	for _, p := range in {
+		if p == def {
+			// A no-op when unredirected (cur == def), which keeps the default
+			// candidate list byte-identical.
+			out = append(out, cur)
+			substituted = true
+			continue
+		}
+		out = append(out, p)
+	}
+	if !substituted {
+		out = append(out, cur)
 	}
 	return dedupe(out)
 }

--- a/internal/skillsource/skillsource.go
+++ b/internal/skillsource/skillsource.go
@@ -115,10 +115,6 @@ func Sources(workdir string, harness config.Harness) []Source {
 //	  $HOME/.opencode/skills,           $HOME/.agents/skills
 //
 // dedupe() drops duplicates that arise when $XDG_CONFIG_HOME == $HOME/.config.
-//
-// withConfigHomeRoot then reconciles the list with the harness's actual config
-// home, which is what makes a relocated config home (CLAUDE_CONFIG_DIR and
-// friends) discoverable.
 func userGlobalRoots(bases []string, h config.Harness) []string {
 	var out []string
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
@@ -139,23 +135,13 @@ func userGlobalRoots(bases []string, h config.Harness) []string {
 	return withConfigHomeRoot(dedupe(out), h)
 }
 
-// withConfigHomeRoot guarantees the harness's own config-home skills dir —
-// GlobalSkillsDir(), which is where `omac setup` and launch-time provisioning
-// install built-in skills, and where the harness's own loader reads them — is
-// among the candidate roots, and that a HomeEnv redirect MOVES it rather than
-// adding a second one.
-//
-// The redirected root is substituted for the default one IN PLACE, so a
-// redirect changes which config home is scanned without reordering the rest of
-// the ladder. The default root drops out: a user who points a harness at a
-// second config home is separating two setups, and omac grants only the
-// redirected one into the sandbox (config.Harness.ResolvedSandboxDirs).
-//
-// When the config home is not itself one of the "<base>/skills" roots there is
-// nothing to substitute, so it is appended: pi keeps its skills in
-// ~/.pi/agent/skills, and codewhale in ~/.codewhale/skills while owning the
-// shared "agents" base, so neither dir was reachable from the bases above —
-// even though `omac setup` installs into exactly those dirs.
+// withConfigHomeRoot ensures the harness's config-home skills dir
+// (GlobalSkillsDir, where `omac setup` installs built-in skills) is among the
+// candidate roots. A HomeEnv redirect substitutes its root for the default
+// one in place — omac grants only the redirected home (see
+// config.Harness.ResolvedSandboxDirs) — and a config home that no
+// "<base>/skills" root matches (pi's ~/.pi/agent/skills, codewhale's
+// ~/.codewhale/skills) is appended instead.
 func withConfigHomeRoot(in []string, h config.Harness) []string {
 	cur := h.GlobalSkillsDir()
 	if cur == "" {
@@ -166,8 +152,7 @@ func withConfigHomeRoot(in []string, h config.Harness) []string {
 	substituted := false
 	for _, p := range in {
 		if p == def {
-			// A no-op when unredirected (cur == def), which keeps the default
-			// candidate list byte-identical.
+			// No-op when unredirected (cur == def).
 			out = append(out, cur)
 			substituted = true
 			continue

--- a/internal/skillsource/skillsource_test.go
+++ b/internal/skillsource/skillsource_test.go
@@ -381,3 +381,165 @@ func names(es []Entry) []string {
 	}
 	return out
 }
+
+// ---- Sources: redirected config home ----
+
+// A CLAUDE_CONFIG_DIR redirect must move skill discovery with it. `omac setup`
+// already installs into ConfigHome()/skills, so a discovery layer still keyed
+// on $HOME/.claude/skills resolves skills omac cannot grant into the sandbox.
+func TestSources_ClaudeFollowsRedirectedConfigHome(t *testing.T) {
+	home := withFakeHome(t)
+	redirected := filepath.Join(home, ".work-claude")
+	t.Setenv("CLAUDE_CONFIG_DIR", redirected)
+	stageSkill(t, filepath.Join(redirected, "skills"), "marketplace")
+
+	wd := t.TempDir()
+	dir, src, err := Resolve(wd, ccHarness(t), "marketplace")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if want := filepath.Join(redirected, "skills", "marketplace"); dir != want {
+		t.Errorf("Resolve dir = %q, want %q", dir, want)
+	}
+	if src.Kind != "user-global" {
+		t.Errorf("Resolve kind = %q, want user-global", src.Kind)
+	}
+}
+
+// The superseded default root drops out entirely: resolving from ~/.claude
+// would register a path ResolvedSandboxDirs no longer grants, so the sidecar
+// could not be executed from it later.
+func TestSources_RedirectDropsDefaultRoot(t *testing.T) {
+	home := withFakeHome(t)
+	redirected := filepath.Join(home, ".work-claude")
+	t.Setenv("CLAUDE_CONFIG_DIR", redirected)
+	stageSkill(t, filepath.Join(redirected, "skills"), "marketplace")
+	stageSkill(t, filepath.Join(home, ".claude", "skills"), "marketplace")
+
+	wd := t.TempDir()
+	for _, s := range Sources(wd, ccHarness(t)) {
+		if s.Root == filepath.Join(home, ".claude", "skills") {
+			t.Errorf("redirected claude scope must not include the default root; got %+v", s)
+		}
+	}
+}
+
+// A redirect SUBSTITUTES its root for the default one in place; it must not
+// reorder the rest of the ladder. Prepending instead put the redirected root
+// above $XDG_CONFIG_HOME/claude/skills, which the root it replaced ranked below.
+func TestSources_RedirectPreservesRootPriority(t *testing.T) {
+	home := withFakeHome(t)
+	redirected := filepath.Join(home, ".work-claude")
+	t.Setenv("CLAUDE_CONFIG_DIR", redirected)
+
+	// One skill of the same name in every user-global root, so Resolve's answer
+	// is decided purely by candidate order.
+	xdgRoot := filepath.Join(home, ".config", "claude", "skills")
+	stageSkill(t, xdgRoot, "marketplace")
+	stageSkill(t, filepath.Join(redirected, "skills"), "marketplace")
+
+	dir, _, err := Resolve(t.TempDir(), ccHarness(t), "marketplace")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// ~/.claude/skills ranked BELOW ~/.config/claude/skills, so the root that
+	// replaces it must too.
+	if want := filepath.Join(xdgRoot, "marketplace"); dir != want {
+		t.Errorf("Resolve dir = %q, want %q — the redirect must not outrank XDG roots", dir, want)
+	}
+}
+
+// A CLAUDE_CONFIG_DIR that merely SPELLS the default home differently is not a
+// redirect. Comparing raw strings made it one, and since the "redirected" root
+// then equalled the root it superseded, the default skills root was dropped
+// outright: every user-global claude skill became unresolvable.
+func TestSources_TrailingSlashKeepsDefaultRoot(t *testing.T) {
+	home := withFakeHome(t)
+	stageSkill(t, filepath.Join(home, ".claude", "skills"), "marketplace")
+
+	for _, spelling := range []string{
+		filepath.Join(home, ".claude") + "/",
+		filepath.Join(home, ".config", "..", ".claude"),
+		"~/.claude",
+	} {
+		t.Run(spelling, func(t *testing.T) {
+			t.Setenv("CLAUDE_CONFIG_DIR", spelling)
+			dir, _, err := Resolve(t.TempDir(), ccHarness(t), "marketplace")
+			if err != nil {
+				t.Fatalf("skill in the default home became unresolvable: %v", err)
+			}
+			if want := filepath.Join(home, ".claude", "skills", "marketplace"); dir != want {
+				t.Errorf("Resolve dir = %q, want %q", dir, want)
+			}
+		})
+	}
+}
+
+// pi's config home is the nested ~/.pi/agent and codewhale owns the shared
+// "agents" base, so neither harness's config-home skills dir was derivable from
+// the skills bases — yet `omac setup` and launch-time provisioning install built-in
+// skills into exactly those dirs, where discovery never looked.
+func TestSources_ConfigHomeRootScannedForNestedHomes(t *testing.T) {
+	for _, tc := range []struct {
+		harness string
+		rel     []string
+	}{
+		{"pi", []string{".pi", "agent", "skills"}},
+		{"codewhale", []string{".codewhale", "skills"}},
+	} {
+		t.Run(tc.harness, func(t *testing.T) {
+			home := withFakeHome(t)
+			h, ok := config.LookupHarness(tc.harness)
+			if !ok {
+				t.Fatalf("%s harness not registered", tc.harness)
+			}
+			root := filepath.Join(append([]string{home}, tc.rel...)...)
+			if root != h.GlobalSkillsDir() {
+				t.Fatalf("test stages %q but GlobalSkillsDir() is %q", root, h.GlobalSkillsDir())
+			}
+			stageSkill(t, root, "marketplace")
+
+			dir, _, err := Resolve(t.TempDir(), h, "marketplace")
+			if err != nil {
+				t.Fatalf("skill in the harness's own global skills dir not found: %v", err)
+			}
+			if want := filepath.Join(root, "marketplace"); dir != want {
+				t.Errorf("Resolve dir = %q, want %q", dir, want)
+			}
+		})
+	}
+}
+
+// Without a redirect the candidate roots are unchanged — the default install
+// keeps resolving out of ~/.claude/skills.
+func TestSources_NoRedirectKeepsDefaultRoot(t *testing.T) {
+	home := withFakeHome(t)
+	stageSkill(t, filepath.Join(home, ".claude", "skills"), "marketplace")
+
+	wd := t.TempDir()
+	dir, _, err := Resolve(wd, ccHarness(t), "marketplace")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if want := filepath.Join(home, ".claude", "skills", "marketplace"); dir != want {
+		t.Errorf("Resolve dir = %q, want %q", dir, want)
+	}
+}
+
+// Other harnesses are untouched when their own HomeEnv is unset: the redirect
+// is per-harness, so a Claude redirect must not perturb OpenCode discovery.
+func TestSources_OpenCodeUnaffectedByClaudeRedirect(t *testing.T) {
+	home := withFakeHome(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".work-claude"))
+	t.Setenv("OPENCODE_HOME", "")
+	stageSkill(t, filepath.Join(home, ".config", "opencode", "skills"), "marketplace")
+
+	wd := t.TempDir()
+	dir, _, err := Resolve(wd, ocHarness(t), "marketplace")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if want := filepath.Join(home, ".config", "opencode", "skills", "marketplace"); dir != want {
+		t.Errorf("Resolve dir = %q, want %q", dir, want)
+	}
+}

--- a/internal/skillsource/skillsource_test.go
+++ b/internal/skillsource/skillsource_test.go
@@ -526,12 +526,12 @@ func TestSources_NoRedirectKeepsDefaultRoot(t *testing.T) {
 	}
 }
 
-// Other harnesses are untouched when their own HomeEnv is unset: the redirect
-// is per-harness, so a Claude redirect must not perturb OpenCode discovery.
+// The redirect is per-harness: a Claude redirect must not perturb OpenCode
+// discovery. OpenCode declares no HomeEnv at all, so its roots are derived from
+// $XDG_CONFIG_HOME/$HOME alone.
 func TestSources_OpenCodeUnaffectedByClaudeRedirect(t *testing.T) {
 	home := withFakeHome(t)
 	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".work-claude"))
-	t.Setenv("OPENCODE_HOME", "")
 	stageSkill(t, filepath.Join(home, ".config", "opencode", "skills"), "marketplace")
 
 	wd := t.TempDir()

--- a/internal/skillsource/skillsource_test.go
+++ b/internal/skillsource/skillsource_test.go
@@ -384,9 +384,8 @@ func names(es []Entry) []string {
 
 // ---- Sources: redirected config home ----
 
-// A CLAUDE_CONFIG_DIR redirect must move skill discovery with it. `omac setup`
-// already installs into ConfigHome()/skills, so a discovery layer still keyed
-// on $HOME/.claude/skills resolves skills omac cannot grant into the sandbox.
+// `omac setup` installs and the sandbox grants only the redirected skills dir,
+// so discovery must follow the redirect.
 func TestSources_ClaudeFollowsRedirectedConfigHome(t *testing.T) {
 	home := withFakeHome(t)
 	redirected := filepath.Join(home, ".work-claude")
@@ -406,9 +405,9 @@ func TestSources_ClaudeFollowsRedirectedConfigHome(t *testing.T) {
 	}
 }
 
-// The superseded default root drops out entirely: resolving from ~/.claude
-// would register a path ResolvedSandboxDirs no longer grants, so the sidecar
-// could not be executed from it later.
+// The superseded default root drops out entirely: resolving from it would
+// register a path ResolvedSandboxDirs no longer grants, so the sidecar could
+// not be executed from it later.
 func TestSources_RedirectDropsDefaultRoot(t *testing.T) {
 	home := withFakeHome(t)
 	redirected := filepath.Join(home, ".work-claude")
@@ -424,9 +423,8 @@ func TestSources_RedirectDropsDefaultRoot(t *testing.T) {
 	}
 }
 
-// A redirect SUBSTITUTES its root for the default one in place; it must not
-// reorder the rest of the ladder. Prepending instead put the redirected root
-// above $XDG_CONFIG_HOME/claude/skills, which the root it replaced ranked below.
+// A redirect substitutes its root for the default one in place; it must not
+// reorder the rest of the ladder.
 func TestSources_RedirectPreservesRootPriority(t *testing.T) {
 	home := withFakeHome(t)
 	redirected := filepath.Join(home, ".work-claude")
@@ -442,17 +440,15 @@ func TestSources_RedirectPreservesRootPriority(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
-	// ~/.claude/skills ranked BELOW ~/.config/claude/skills, so the root that
+	// ~/.claude/skills ranks below ~/.config/claude/skills, so the root that
 	// replaces it must too.
 	if want := filepath.Join(xdgRoot, "marketplace"); dir != want {
 		t.Errorf("Resolve dir = %q, want %q — the redirect must not outrank XDG roots", dir, want)
 	}
 }
 
-// A CLAUDE_CONFIG_DIR that merely SPELLS the default home differently is not a
-// redirect. Comparing raw strings made it one, and since the "redirected" root
-// then equalled the root it superseded, the default skills root was dropped
-// outright: every user-global claude skill became unresolvable.
+// A CLAUDE_CONFIG_DIR that merely spells the default home differently is not
+// a redirect.
 func TestSources_TrailingSlashKeepsDefaultRoot(t *testing.T) {
 	home := withFakeHome(t)
 	stageSkill(t, filepath.Join(home, ".claude", "skills"), "marketplace")
@@ -475,10 +471,9 @@ func TestSources_TrailingSlashKeepsDefaultRoot(t *testing.T) {
 	}
 }
 
-// pi's config home is the nested ~/.pi/agent and codewhale owns the shared
-// "agents" base, so neither harness's config-home skills dir was derivable from
-// the skills bases — yet `omac setup` and launch-time provisioning install built-in
-// skills into exactly those dirs, where discovery never looked.
+// pi's and codewhale's config-home skills dirs are not derivable from the
+// skills bases, yet `omac setup` installs built-in skills into exactly those
+// dirs.
 func TestSources_ConfigHomeRootScannedForNestedHomes(t *testing.T) {
 	for _, tc := range []struct {
 		harness string
@@ -510,8 +505,6 @@ func TestSources_ConfigHomeRootScannedForNestedHomes(t *testing.T) {
 	}
 }
 
-// Without a redirect the candidate roots are unchanged — the default install
-// keeps resolving out of ~/.claude/skills.
 func TestSources_NoRedirectKeepsDefaultRoot(t *testing.T) {
 	home := withFakeHome(t)
 	stageSkill(t, filepath.Join(home, ".claude", "skills"), "marketplace")
@@ -526,9 +519,8 @@ func TestSources_NoRedirectKeepsDefaultRoot(t *testing.T) {
 	}
 }
 
-// The redirect is per-harness: a Claude redirect must not perturb OpenCode
-// discovery. OpenCode declares no HomeEnv at all, so its roots are derived from
-// $XDG_CONFIG_HOME/$HOME alone.
+// The redirect is per-harness: OpenCode declares no HomeEnv, so a Claude
+// redirect must not perturb its discovery.
 func TestSources_OpenCodeUnaffectedByClaudeRedirect(t *testing.T) {
 	home := withFakeHome(t)
 	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".work-claude"))


### PR DESCRIPTION
<!--
Keep this PR **concise**. See ../COLLABORATION.md for the full spec.
Conventional-Commit title with scope, e.g. fix(sandbox): protect docker.sock by default.
Resolve review comments as you address them (reply required only if you deviated).
-->

**Issue:** Closes #233 

## What
- Claude Code's config-home override now works: `HomeEnv` was declared as
  `CLAUDE_HOME`, a name nothing reads (`CLAUDE_CONFIG_DIR` is the real one).
- Every harness's `HomeEnv` is forwarded into the sandbox, and the sandbox grants
  follow the resolved config home instead of the default one.
- Global skill discovery follows a relocated config home — and now also finds
  pi's and codewhale's config-home skills dirs, which it never scanned.
- OpenCode's `HomeEnv` is **removed**: `OPENCODE_HOME` was omac's invention too,
  and OpenCode has no config-home override to honor.

## Why
Users relocate a harness's config home to keep separate logins side by side
(`~/.claude` personal, `~/.work-claude` work). omac claimed to model this but
honored it nowhere the harness could see, so the redirect was **silently
ignored**: omac resolved every path from the default home, and the sandboxed
harness was never told the redirect existed. With both homes present the user
gets the wrong login; with only the redirect populated, `claude` finds no
credentials in `~/.claude` and prompts a fresh login.

The one profile shape where the var survived — the sanctioned
`allow_vars: ["*"]` — broke the other way: the harness read the relocated home,
which was never granted, so the sandbox denied it.

## How
1. **`5010e06` — config + launch path.** `ConfigHome()` normalizes the value, so a
   different *spelling* of the default home is not read as a redirect.
   `ResolvedSandboxDirs()` swaps the `SandboxDirs` entry naming the default config
   home — appending instead when no entry names it (pi declares `~/.pi`, its home
   is `~/.pi/agent`). `ForwardedEnvVars()` adds `HomeEnv` generically
   (`internal/cli/serve.go:713`); that forwarding is what makes the swap sound,
   since granting the relocated home while the harness reads the default one is
   worse than not swapping at all.
2. **`fc94e08` — discovery.** `withConfigHomeRoot` substitutes the redirected
   skills root for the default one *in place*, so a redirect moves which config
   home is scanned without reordering the rest of the ladder. It also makes
   `GlobalSkillsDir()` always a candidate, closing a pre-existing gap: pi and
   codewhale are `omac setup` targets discovery never looked in.
3. **`b5d2a45` — opencode.** `OPENCODE_CONFIG_DIR` only *adds* a config-search dir
   ([docs](https://opencode.ai/docs/config#custom-directory)) and credentials live
   outside it, so it is no `HomeEnv`: declaring it would swap `~/.config/opencode`
   out of the grants while OpenCode kept reading it. The field doc now carries the
   general rule — no upstream variable ⇒ leave `HomeEnv` empty.

Test isolation came along by necessity: tests fake `$HOME`, but an override names
an absolute path and survives that, so an ambient `CLAUDE_CONFIG_DIR` pointed them
at the developer's real config home — 9 failures locally, 0 in CI. A `TestMain`
per package clears them via the new `config.HomeEnvNames()`.

## Verification
Linux, `go1.26.6`. Every CI lint gate, run locally:

```
gofmt -l .                               # clean
go vet ./...                             # clean
staticcheck ./...                        # clean
python3 scripts/check-docs.py            # ok
python3 scripts/check-workflow-shell.py  # ok
go test ./...                            # same failure set as main
```

- **No regressions:** `go test ./...` fails the same 51 tests as `main` —
  pre-existing loopback/network artifacts of the local sandbox in `cli`, `facade`,
  `intent`, `netprompt/origin`, `netproxy`, `sandboxrun`, `updater` — confirmed by
  diffing both failure lists.
- **Manual:** a build with `CLAUDE_CONFIG_DIR` set reuses that home's login
  instead of prompting — which also confirms it is the name Claude Code reads.
- **Not run:** `go mod verify` (blocked on `proxy.golang.org` locally) and the
  e2e matrix. This touches launch argv and macOS/Seatbelt is untested, so
  `e2e.yml` is the gate.

### Every `HomeEnv` name audited

| Harness | Declared | Evidence |
|---|---|---|
| claude-code | `CLAUDE_CONFIG_DIR` | 147 occurrences in installed claude 2.1.228 (`CLAUDE_HOME`: 0) |
| opencode | *(none, this PR)* | `OPENCODE_HOME`: 0 occurrences; `OPENCODE_CONFIG_DIR` is additive only |
| pi | `PI_CODING_AGENT_DIR` | 3 occurrences in `pi-coding-agent/dist/cli.js` |
| codex | `CODEX_HOME` | `openai/codex`, `codex-rs/utils/home-dir/src/lib.rs`: `find_codex_home()` — "the Codex configuration directory, which can be specified by the `CODEX_HOME` environment variable […] defaults to `~/.codex`" |
| copilot | `COPILOT_HOME` | `github/copilot-cli` changelog: "`--config-dir` is deprecated in favor of `COPILOT_HOME`" |
| codewhale | `CODEWHALE_HOME` | `Hmbown/CodeWhale`, `crates/paths/src/lib.rs`: `codewhale_home_override()`; `codewhale_home_is_explicit()` documents it as an "explicit isolation boundary" |

Three upstream divergences surfaced by the audit — all narrow, none blocking:

- **codex canonicalizes** `CODEX_HOME` (resolves symlinks) and errors if it does
  not exist; `normalizeHomePath` only cleans and absolutizes. A symlinked value
  means omac grants the link path while codex uses the target.
- **codewhale rejects** a relative `CODEWHALE_HOME`; omac absolutizes it against
  its own working directory instead.
- **copilot stops loading `~/.agents/skills`** when `COPILOT_HOME` is set, but omac
  keeps the shared `agents` root in copilot's scope — the same discovery/harness
  mismatch this PR fixes for claude, in a spot it does not reach.

## Follow-up
- **Document it.** `docs/CONFIGURATION.md` has no harness-config-home section —
  `CLAUDE_CONFIG_DIR` and the per-harness overrides belong there, together with
  the behavior change that a redirect **hides** skills installed under the
  default home. Worth a `docs/` commit on this branch or a separate PR.
- **Symlinked / relative override values.** `normalizeHomePath` cleans and
  absolutizes but does not resolve symlinks, so it can disagree with codex
  (canonicalizes) and codewhale (rejects relative values). Worth a follow-up issue
  rather than widening this PR.
- **copilot + the shared `agents` skills root.** `COPILOT_HOME` makes copilot stop
  reading `~/.agents/skills` while omac still treats it as in scope for copilot.


🤖 Generated with Claude Opus 5