### PR TITLE
fix(copilot): forward BYOK provider environment

### DIFF
--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -287,12 +287,13 @@ sandbox:
 >   is not the same as no filtering.
 >
 > Note: with a **non-empty** `allow_vars`, omac injects the selected harness's
-> documented auth vars (`harness.SandboxEnvAllow`) on top at launch — but only
-> for **single-provider** harnesses where the key is unambiguous (claude-code
-> → `ANTHROPIC_*`, codex → `OPENAI_*`, copilot → `GITHUB_TOKEN`). **Multi-provider
-> harnesses (opencode, pi) auto-forward nothing**: omac will not blindly push
-> every third-party provider key into the sandbox, so a user relying on an
-> env-based provider key lists it in `allow_vars` themselves (opencode's primary
+> documented auth/config vars (`harness.SandboxEnvAllow`) on top at launch —
+> but only where the key is unambiguously scoped to that harness (claude-code
+> → `ANTHROPIC_*`, codex → `OPENAI_*`, copilot → `GITHUB_TOKEN` and its native
+> `COPILOT_PROVIDER_*`/`COPILOT_MODEL` BYOK configuration). **Multi-provider
+> harnesses (opencode, pi) auto-forward nothing**: omac will not blindly push every
+> third-party provider key into the sandbox, so a user relying on an env-based
+> provider key lists it in `allow_vars` themselves (opencode's primary
 > `auth.json` login, in its granted dirs, is unaffected). Auto-forwarding is
 > skipped entirely for the empty (misconfigured) case.
 >
@@ -315,4 +316,3 @@ never reads or copies their contents. External nono profiles are opaque
 to these diagnostics and skipped. The warnings are advisory — doctor
 never rewrites the profile. See
 [Installation → Prerequisites](./INSTALLATION.md#prerequisites).
-

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -130,10 +130,11 @@ type Harness struct {
 	// environment.allow_vars at launch (via --allow-env) so they survive
 	// the filter — for the selected harness only.
 	//
-	// Only unambiguous, single-provider auth vars belong here (e.g.
-	// claude-code → ANTHROPIC_*, codex → OPENAI_*). Multi-provider harnesses
-	// (opencode, pi) leave this empty: omac must not blindly forward a
-	// grab-bag of third-party keys regardless of which provider is
+	// Only unambiguous, harness-scoped auth vars belong here (e.g.
+	// claude-code → ANTHROPIC_*, codex → OPENAI_*, Copilot's native BYOK
+	// provider key). Multi-provider harnesses that consume arbitrary
+	// third-party key names (opencode, pi) leave this empty: omac must not
+	// blindly forward a grab-bag of keys regardless of which provider is
 	// configured — the user declares the specific key their setup uses in the
 	// profile's environment.allow_vars. Entries are exact names or trailing-*
 	// prefixes (sandboxprofile.envVarAllowed).
@@ -344,14 +345,19 @@ func harnessRegistry() []Harness {
 			HomeEnv:        "COPILOT_HOME",
 			// Copilot stores configuration, session state, and authentication in ~/.copilot.
 			SandboxDirs: []string{"~/.copilot"},
-			// Copilot authenticates with a GitHub token (both spellings are
-			// accepted by the GitHub toolchain). COPILOT_CUSTOM_INSTRUCTIONS_DIRS
-			// is set by omac's BriefingEnvFunc to point copilot at the
-			// per-launch briefing dir; it must survive the env filter.
+			// Copilot authenticates with a GitHub token or its native BYOK
+			// provider configuration. COPILOT_CUSTOM_INSTRUCTIONS_DIRS is set by
+			// omac's BriefingEnvFunc to point copilot at the per-launch briefing
+			// dir; all of these must survive the env filter.
 			SandboxEnvAllow: []string{
 				"GITHUB_TOKEN",
 				"GH_TOKEN",
 				"COPILOT_CUSTOM_INSTRUCTIONS_DIRS",
+				"COPILOT_PROVIDER_TYPE",
+				"COPILOT_PROVIDER_BASE_URL",
+				"COPILOT_PROVIDER_API_KEY",
+				"COPILOT_MODEL",
+				"COPILOT_PROVIDER_WIRE_API",
 			},
 			Session: &HarnessSession{
 				ContinueArgs:   []string{"--continue"},

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -244,6 +245,25 @@ func TestHarnessAuthForwardPolicy(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("single-provider harness %q should forward %q; got %v", name, want, h.SandboxEnvAllow)
+		}
+	}
+}
+
+func TestCopilotForwardsBYOKProviderEnvironment(t *testing.T) {
+	h, ok := LookupHarness("copilot")
+	if !ok {
+		t.Fatal("copilot harness not found")
+	}
+
+	for _, want := range []string{
+		"COPILOT_PROVIDER_TYPE",
+		"COPILOT_PROVIDER_BASE_URL",
+		"COPILOT_PROVIDER_API_KEY",
+		"COPILOT_MODEL",
+		"COPILOT_PROVIDER_WIRE_API",
+	} {
+		if !slices.Contains(h.SandboxEnvAllow, want) {
+			t.Errorf("copilot SandboxEnvAllow missing %q; got %v", want, h.SandboxEnvAllow)
 		}
 	}
 }


### PR DESCRIPTION
**Issue:** Refs #181

## What
- Forward Copilot native BYOK provider variables only for the Copilot harness.

## Why
- The sandbox stripped installer-provided `COPILOT_*` configuration before Copilot started.

## How
- Add the five exact BYOK variables to `SandboxEnvAllow`.
- Pin the policy with a regression test and update the security documentation.

## Verification
- `go test ./internal/config ./internal/cli ./internal/sandboxprofile`
- `go vet ./internal/config ./internal/cli ./internal/sandboxprofile`
- Focused `internal/e2e` configuration tests