### PR TITLE
fix(config,skilltrust): resolve symlinked skill roots in BundleHash a…

### DIFF
--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -128,7 +128,17 @@ the sandbox:
 
 - `config.BundleHash` deliberately excludes dependency/artifact subtrees
   (`node_modules`, `.venv`, `build`, `dist`, `target`, …) and does not follow
-  symlinks, so the hash alone does not cover everything a skill executes.
+  in-tree symlinks, so the hash alone does not cover everything a skill executes.
+
+  The skill root itself may be a symlink — either the skills directory
+  (~/.config/opencode/skills -> /repo/opencode/skills/) or an individual
+  skill within it (skills/foo -> ../../library/skills/foo/), common for
+  git-versioned skill libraries. Both `config.BundleHash` and the approval
+  snapshot (`skilltrust.copyTree`) resolve the root via
+  `filepath.EvalSymlinks` before walking, so they agree on what they
+  cover, while in-tree symlinks remain dropped/recreated per the rules
+  below.
+
   omac closes this by **executing from an approval snapshot**: at approval
   time the whole skill tree is frozen into a host-only directory the sandbox
   cannot write (`~/.config/omac/skills/<name>/<hash>`), and the sidecar is

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -83,12 +83,12 @@ func TestParseLaunchArgsEphemeralCache(t *testing.T) {
 }
 
 func TestParseLaunchArgsOpenPort(t *testing.T) {
-	opts, ok := parseLaunchArgs("start", []string{
+	opts, code := parseLaunchArgs("start", []string{
 		"--open-port", "3000",
 		"--open-port", "4173",
 	}, devnullEnv(t))
-	if !ok {
-		t.Fatal("parseLaunchArgs() returned false")
+	if code != ExitOK {
+		t.Fatalf("parseLaunchArgs() code = %d, want ExitOK", code)
 	}
 	if len(opts.openPorts) != 2 || opts.openPorts[0] != 3000 || opts.openPorts[1] != 4173 {
 		t.Errorf("openPorts = %v", opts.openPorts)
@@ -96,10 +96,10 @@ func TestParseLaunchArgsOpenPort(t *testing.T) {
 }
 
 func TestParseLaunchArgsRejectsBadOpenPort(t *testing.T) {
-	if _, ok := parseLaunchArgs("start", []string{"--open-port", "0"}, devnullEnv(t)); ok {
+	if _, code := parseLaunchArgs("start", []string{"--open-port", "0"}, devnullEnv(t)); code == ExitOK {
 		t.Error("port 0 should be rejected")
 	}
-	if _, ok := parseLaunchArgs("start", []string{"--open-port", "nope"}, devnullEnv(t)); ok {
+	if _, code := parseLaunchArgs("start", []string{"--open-port", "nope"}, devnullEnv(t)); code == ExitOK {
 		t.Error("non-integer port should be rejected")
 	}
 }

--- a/internal/config/bundle_test.go
+++ b/internal/config/bundle_test.go
@@ -134,6 +134,42 @@ func TestBundleHash_MissingDir(t *testing.T) {
 	}
 }
 
+// TestBundleHash_SymlinkRoot guards that a skill root that is itself a
+// symlink (common for git-versioned skill libraries installed as
+// ~/.config/opencode/skills-> ../../library/skills/) hashes
+// the same as its real target. Without resolving the root, WalkDir
+// Lstats the root, sees ModeSymlink, fires the callback once with
+// rel == "." (skipped), and never descends — yielding the empty
+// sha256:e3b0c44… digest.
+func TestBundleHash_SymlinkRoot(t *testing.T) {
+	realDir := stageSkill(t, t.TempDir(), map[string]string{
+		"omac.yaml":  "name: x\n",
+		"sidecar.py": "# server\n",
+	})
+	symlink := filepath.Join(t.TempDir(), "linked-skill")
+	if err := os.Symlink(realDir, symlink); err != nil {
+		// On platforms without symlink permission, just skip.
+		t.Skipf("symlink: %v", err)
+	}
+
+	realHash, err := BundleHash(realDir)
+	if err != nil {
+		t.Fatalf("BundleHash(realDir): %v", err)
+	}
+	symHash, err := BundleHash(symlink)
+	if err != nil {
+		t.Fatalf("BundleHash(symlink): %v", err)
+	}
+
+	const emptyHash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if symHash == emptyHash {
+		t.Errorf("BundleHash(symlink) is the empty digest %s; symlink root was not resolved/walked", symHash)
+	}
+	if symHash != realHash {
+		t.Errorf("BundleHash must match for symlink root vs real target; got symlink=%s real=%s", symHash, realHash)
+	}
+}
+
 func TestBundleHash_SkipsSymlinks(t *testing.T) {
 	dir := stageSkill(t, t.TempDir(), map[string]string{
 		"omac.yaml":  "name: x\n",

--- a/internal/config/meta.go
+++ b/internal/config/meta.go
@@ -356,10 +356,27 @@ func (s *SidecarMeta) InstallScriptFor(o osinfo.OS) string {
 //
 // Returns an error only if a directory entry can't be stat'd or read;
 // missing dir is reported as a regular fs.PathError.
+//
+// The skill root is resolved via filepath.EvalSymlinks before walking.
+// The root is commonly a symlink — either the skills directory itself
+// (~/.config/opencode/skills -> /repo/opencode/skills/) or an individual
+// skill within it (skills/foo -> ../../library/skills/foo/) — so the tree
+// stays git-versioned in a separate repo. Without resolution, WalkDir
+// Lstats the root, sees ModeSymlink, fires the callback once with
+// rel == "." (skipped below), and never descends — yielding the empty
+// sha256:e3b0c44… digest. On any error (including a not-exist target),
+// the walk proceeds against the unresolved abs so the missing-dir
+// contract still gets its fs.PathError from the walk, not from
+// EvalSymlinks. In-tree symlinks remain skipped per the per-entry rule
+// below.
 func BundleHash(skillDir string) (string, error) {
 	abs, err := filepath.Abs(skillDir)
 	if err != nil {
 		return "", fmt.Errorf("bundle hash: abs: %w", err)
+	}
+	root := abs
+	if resolved, evalErr := filepath.EvalSymlinks(abs); evalErr == nil {
+		root = resolved
 	}
 	type item struct {
 		rel string
@@ -367,11 +384,11 @@ func BundleHash(skillDir string) (string, error) {
 	}
 	var items []item
 
-	err = filepath.WalkDir(abs, func(p string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		rel, relErr := filepath.Rel(abs, p)
+		rel, relErr := filepath.Rel(root, p)
 		if relErr != nil {
 			return relErr
 		}
@@ -390,7 +407,7 @@ func BundleHash(skillDir string) (string, error) {
 			return nil
 		}
 		if !d.Type().IsRegular() {
-			// Skip symlinks, sockets, devices. Hashing through symlinks
+			// Skip in-tree symlinks, sockets, devices. Hashing through symlinks
 			// would let a target replacement silently change the bundle
 			// without tripping detection.
 			return nil

--- a/internal/skilltrust/snapshot.go
+++ b/internal/skilltrust/snapshot.go
@@ -12,8 +12,8 @@ import (
 // host-only directory the sandbox cannot write, and omac spawns the sidecar
 // from that copy. This makes the executed bytes exactly the approved bytes:
 // it closes the gap that the bundle hash (config.BundleHash) leaves open —
-// dependency/artifact subtrees (node_modules, .venv, dist, …) and symlinks
-// are excluded from the hash, so an agent could otherwise rewrite code under
+// dependency/artifact subtrees (node_modules, .venv, dist, …) and in-tree
+// symlinks are excluded from the hash, so an agent could otherwise rewrite code under
 // them after approval without changing the hash. A snapshot also removes the
 // check-then-exec TOCTOU: the gate verifies a hash, but exec then runs the
 // frozen copy, not the still-mutable workdir.
@@ -121,13 +121,26 @@ func removeSnapshot(name, bundleHash string) {
 
 // copyTree recursively copies src into dst, which must already exist. It
 // captures a self-contained, immutable image of a skill:
+//   - the skill root itself is resolved via filepath.EvalSymlinks before
+//     walking: the root is commonly a symlink — either the skills
+//     directory itself (~/.config/opencode/skills ->
+//     /repo/opencode/skills/) or an individual skill within it
+//     (skills/foo -> ../../library/skills/foo/) — so the tree stays
+//     git-versioned in a separate repo. Such a root must hash and
+//     snapshot the same as its real target. WalkDir Lstats the root, so
+//     walking an unresolved symlink fires the callback once with
+//     rel == "." (skipped below) and never descends — yielding an empty
+//     snapshot. EvalSymlinks collapses the chain to the real dir. On a
+//     not-exist / any error, the walk falls through against
+//     filepath.Clean(src) so the missing-dir contract still surfaces a
+//     walk-style error.
 //   - directories are recreated (VCS metadata under .git is skipped),
 //   - regular files are copied with their mode bits (execute bits preserved),
 //   - symlinks are NEVER dereferenced into content. A symlink whose target
 //     resolves INSIDE the skill tree and whose link text is relative is
 //     recreated verbatim (self-contained; e.g. node_modules/.bin entries).
 //     Any symlink that escapes the tree, is absolute, or is unresolvable is
-//     dropped. This mirrors config.BundleHash (which skips symlinks) so the
+//     dropped. This mirrors config.BundleHash (which skips in-tree symlinks) so the
 //     snapshot hashes identically to the workdir, and — crucially — prevents
 //     baking a host file the link points at (e.g. ~/.ssh/id_rsa) into the
 //     snapshot or letting it be read back through the skill.
@@ -136,11 +149,11 @@ func copyTree(src, dst string) error {
 	if err != nil {
 		srcReal = filepath.Clean(src)
 	}
-	return filepath.WalkDir(src, func(p string, d os.DirEntry, err error) error {
+	return filepath.WalkDir(srcReal, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		rel, rerr := filepath.Rel(src, p)
+		rel, rerr := filepath.Rel(srcReal, p)
 		if rerr != nil {
 			return rerr
 		}

--- a/internal/skilltrust/snapshot_symlink_test.go
+++ b/internal/skilltrust/snapshot_symlink_test.go
@@ -1,0 +1,98 @@
+package skilltrust
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSnapshot_SymlinkRootMatchesRealTree guards that snapshotting a skill
+// root that is itself a symlink (common for git-versioned skill libraries
+// installed as ~/.config/opencode/skills/foo -> ../../library/skills/foo/)
+// resolves the root and freezes the real tree, exactly as snapshotting the
+// real dir would. copyTree (internal/skilltrust/snapshot.go:135) already
+// calls filepath.EvalSymlinks on the root; this test is a regression guard
+// for that behavior so a future change can't silently drop it.
+//
+// Symlink roots are the skilltrust analogue of the config.BundleHash
+// symlink-root case (TestBundleHash_SymlinkRoot). If snapshot regressed to
+// walking the link itself, the snapshot would be empty (the walk fires
+// once with rel == "." and is skipped) and the sidecar spawn would fail
+// with connection refused — the exact failure mode BundleHash had.
+func TestSnapshot_SymlinkRootMatchesRealTree(t *testing.T) {
+	isolate(t)
+
+	// Stage a real skill dir with omac.yaml, a sidecar file, and a nested
+	// helper file — the same shape real skills take.
+	realDir := t.TempDir()
+	files := map[string]string{
+		"omac.yaml":       "name: s\n",
+		"sidecar.py":      "# server sidecar\n",
+		"helpers/util.py": "def f(): return 1\n",
+	}
+	for rel, body := range files {
+		full := filepath.Join(realDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+
+	// Create a symlink to the real dir. Skip on platforms without symlink
+	// permission, mirroring the pattern at skilltrust_test.go:215-217 and
+	// config/bundle_test.go:149-151.
+	symlink := filepath.Join(t.TempDir(), "linked-skill")
+	if err := os.Symlink(realDir, symlink); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+
+	// Use distinct hashes for the symlink vs real snapshot so they land in
+	// different content-addressed dirs (snapshot is keyed by (name, hash)).
+	// The FILE CONTENTS must match even though the keys differ.
+	snapSym, err := snapshot("s", "sha256:via-symlink", symlink)
+	if err != nil {
+		t.Fatalf("snapshot(via symlink): %v", err)
+	}
+	snapReal, err := snapshot("s", "sha256:via-real", realDir)
+	if err != nil {
+		t.Fatalf("snapshot(via real): %v", err)
+	}
+
+	// Assert non-empty: each staged file must be present in the symlink
+	// snapshot and identical in body to the original.
+	for rel, want := range files {
+		got, err := os.ReadFile(filepath.Join(snapSym, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("snapshot(via symlink) missing %s: %v", rel, err)
+		}
+		if string(got) != want {
+			t.Errorf("snapshot(via symlink) %s = %q; want %q", rel, got, want)
+		}
+	}
+
+	// Assert the snapshot contents equal those produced by snapshotting
+	// the real tree — guarding the copyTree/BundleHash consistency on
+	// symlink roots. Compare the file set body-for-body.
+	for rel, want := range files {
+		got, err := os.ReadFile(filepath.Join(snapReal, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("snapshot(via real) missing %s: %v", rel, err)
+		}
+		if string(got) != want {
+			t.Errorf("snapshot(via real) %s = %q; want %q", rel, got, want)
+		}
+		// Cross-compare the two snapshots.
+		gotSym, _ := os.ReadFile(filepath.Join(snapSym, filepath.FromSlash(rel)))
+		if string(gotSym) != string(got) {
+			t.Errorf("snapshot mismatch on %s: symlink=%q real=%q", rel, gotSym, got)
+		}
+	}
+
+	// The symlink snapshot must NOT contain the link itself baked in as a
+	// directory entry pointing nowhere (root resolution, not link copy).
+	if _, err := os.Lstat(filepath.Join(snapSym, "linked-skill")); err == nil {
+		t.Error("symlink snapshot should not contain a baked-in copy of the link entry")
+	}
+}


### PR DESCRIPTION
…nd copyTree

<!--
Keep this PR **concise**. See ../COLLABORATION.md for the full spec.
Conventional-Commit title with scope, e.g. fix(sandbox): protect docker.sock by default.
Resolve review comments as you address them (reply required only if you deviated).
-->

**Issue:** Closes #247 

## What
Resolve symlinks of skill root folders before hashing.

## Why
See #247

## How
- resolve root symlinks in `BundleHash`.

## Verification
~~~
go test ./internal/config/ ./internal/skilltrust/

ok  	github.com/tngtech/oh-my-agentic-coder/internal/config	(cached)
ok  	github.com/tngtech/oh-my-agentic-coder/internal/skilltrust	(cached)
~~~
