### PR TITLE
fix(opencode): grant opentui grammar cache

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -70,7 +70,7 @@ cannot access.
 | Path or variable | Access | Why |
 |---|---|---|
 | `<workdir>` | read + write | Your project files |
-| Harness config dirs (e.g. `~/.claude`, `~/.local/share/opencode`) | read + write | The harness stores its state and credentials here |
+| Harness config dirs (e.g. `~/.claude`, `~/.local/share/opencode`, `~/.local/share/opentui`) | read + write | The harness stores its state and credentials here; omac pre-creates declared first-use dirs (e.g. OpenCode's `opentui` tree-sitter grammar cache) before sandbox grant resolution |
 | omac-managed tool cache (isolated from `~/.cache`; see [Cache](./advanced/cache.md)) | read + write | Build artifacts and downloaded packages; isolated from your host caches |
 | Language toolchain binaries (`~/.cargo/bin`, `~/go/bin`, `~/.nvm`, `~/.bun/bin`, `~/.rustup`) | read-only | So installed compilers and build tools can run |
 | Shared skills dirs (`~/.config/agents/skills`, `~/.agents/skills`) | read-only | So the agent can read skill descriptions (`SKILL.md`) |

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -389,6 +389,7 @@ func launchCacheCaptureForHarness(t *testing.T, harnessName string, noSandbox, e
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", "")
 	for key := range toolcache.Environment("ignored", toolcache.ModePersistent) {
 		value := "host-" + key
 		if harnessName == "opencode" {

--- a/internal/cli/continue_resume_test.go
+++ b/internal/cli/continue_resume_test.go
@@ -330,6 +330,21 @@ func TestLaunchCacheOmitsVerboseOutputWithoutVerbose(t *testing.T) {
 	}
 }
 
+func TestLaunchOpenCodeCreatesAndGrantsRuntimeDirs(t *testing.T) {
+	capture := launchCacheCaptureForHarness(t, "opencode", false, false, false)
+	opentuiDir := filepath.Join(capture.home, ".local", "share", "opentui")
+	if info, err := os.Stat(opentuiDir); err != nil || !info.IsDir() {
+		t.Fatalf("opentui runtime dir was not created before start: info=%v err=%v", info, err)
+	}
+
+	for i := 0; i+1 < len(capture.args); i++ {
+		if capture.args[i] == "--allow" && capture.args[i+1] == "~/.local/share/opentui" {
+			return
+		}
+	}
+	t.Fatalf("start argv missing opentui read/write grant: %v", capture.args)
+}
+
 func TestLaunchCacheNoSandboxPreservesHostEnvironment(t *testing.T) {
 	capture := launchCacheCapture(t, true, false, false)
 	for key := range toolcache.Environment("ignored", toolcache.ModePersistent) {
@@ -360,6 +375,10 @@ type cacheCapture struct {
 }
 
 func launchCacheCapture(t *testing.T, noSandbox, ephemeral, verbose bool) cacheCapture {
+	return launchCacheCaptureForHarness(t, "claude", noSandbox, ephemeral, verbose)
+}
+
+func launchCacheCaptureForHarness(t *testing.T, harnessName string, noSandbox, ephemeral, verbose bool) cacheCapture {
 	t.Helper()
 	shortTmp, err := os.MkdirTemp("/tmp", "omac-cli-")
 	if err != nil {
@@ -371,7 +390,11 @@ func launchCacheCapture(t *testing.T, noSandbox, ephemeral, verbose bool) cacheC
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	for key := range toolcache.Environment("ignored", toolcache.ModePersistent) {
-		t.Setenv(key, "host-"+key)
+		value := "host-" + key
+		if harnessName == "opencode" {
+			value = filepath.Join(shortTmp, key)
+		}
+		t.Setenv(key, value)
 	}
 
 	workdir := t.TempDir()
@@ -395,9 +418,9 @@ func launchCacheCapture(t *testing.T, noSandbox, ephemeral, verbose bool) cacheC
 	}
 
 	env, stderr := launchTestEnv(t, workdir)
-	harness, ok := config.LookupHarness("claude")
+	harness, ok := config.LookupHarness(harnessName)
 	if !ok {
-		t.Fatal("claude harness missing")
+		t.Fatalf("%s harness missing", harnessName)
 	}
 	inner := "/bin/true"
 	if noSandbox {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -528,6 +528,8 @@ func runServe(args []string, env *Env) int {
 	if noSandbox {
 		argv = inner
 	} else {
+		// Create before omac sandbox run resolves and existence-filters the
+		// selected harness's read+write grants.
 		if err := prepareSandboxDirs(harness.SandboxCreateDirs); err != nil {
 			fmt.Fprintln(env.Stderr, "omac serve: harness runtime dirs:", err)
 			return ExitIOError
@@ -691,7 +693,8 @@ func controlPortOf(ln net.Listener) string {
 //   - the harness server daemon's own listen port, so its bind() is permitted
 //     (issue #115 — otherwise a restrictive profile denies the bind and the
 //     daemon crashes on startup).
-//   - the selected harness's runtime dirs (config/state/sessions) read+write.
+//   - the selected harness's existing runtime dirs (config/state/sessions)
+//     read+write; runServe pre-creates the declared first-use dirs.
 //
 // Kept as one pure function so the grant sequence stays unit-testable without
 // launching the control plane.

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -528,6 +528,10 @@ func runServe(args []string, env *Env) int {
 	if noSandbox {
 		argv = inner
 	} else {
+		if err := prepareSandboxDirs(harness.SandboxCreateDirs); err != nil {
+			fmt.Fprintln(env.Stderr, "omac serve: harness runtime dirs:", err)
+			return ExitIOError
+		}
 		argv, err = sandboxServeArgv(prof, sandbox.Inputs{
 			Workdir:  env.Workdir,
 			Socket:   socketPath,
@@ -738,6 +742,24 @@ func serverExposureWarning(h config.Harness, getenv func(string) string) string 
 // sandboxed inner command may connect to that loopback port.
 func injectOpenPort(argv []string, port string) []string {
 	return injectSandboxFlag(argv, "--open-port", port)
+}
+
+// prepareSandboxDirs creates harness-declared runtime directories before grant
+// resolution, which skips nonexistent paths.
+func prepareSandboxDirs(dirs []string) error {
+	for _, d := range dirs {
+		if d == "" {
+			continue
+		}
+		expanded, err := sandboxprofile.ExpandPath(d)
+		if err != nil {
+			return fmt.Errorf("expand %q: %w", d, err)
+		}
+		if err := os.MkdirAll(expanded, 0o700); err != nil {
+			return fmt.Errorf("create %s: %w", expanded, err)
+		}
+	}
+	return nil
 }
 
 // injectSandboxDirs splices --allow flags (read+write) for each

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -285,6 +285,7 @@ func TestSandboxServeArgvInjectsListenPort(t *testing.T) {
 func TestPrepareAndGrantOpenCodeRuntimeDirs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "")
 	oc, _ := config.LookupHarness("opencode")
 	prof := config.SandboxProfile{
 		Command:  []string{"omac", "sandbox", "run", "--", "{{inner_cmd}}", "{{inner_args}}"},
@@ -308,6 +309,45 @@ func TestPrepareAndGrantOpenCodeRuntimeDirs(t *testing.T) {
 	}
 	if !contains(strings.Join(argv, " "), "--allow ~/.local/share/opentui") {
 		t.Fatalf("serve argv missing opentui read/write grant: %v", argv)
+	}
+}
+
+func TestPrepareAndGrantOpenCodeRuntimeDirsUsesXDGDataHome(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	oc, _ := config.LookupHarness("opencode")
+	prof := config.SandboxProfile{
+		Command:  []string{"omac", "sandbox", "run", "--", "{{inner_cmd}}", "{{inner_args}}"},
+		InnerCmd: []string{"opencode"},
+	}
+	in := sandbox.Inputs{Workdir: t.TempDir(), InnerCmd: []string{"opencode", "serve"}}
+
+	if err := prepareSandboxDirs(oc.SandboxCreateDirs); err != nil {
+		t.Fatalf("prepareSandboxDirs: %v", err)
+	}
+	argv, err := sandboxServeArgv(prof, in, "", oc)
+	if err != nil {
+		t.Fatalf("sandboxServeArgv: %v", err)
+	}
+	want := filepath.Join(xdgDataHome, "opentui")
+	if info, err := os.Stat(want); err != nil || !info.IsDir() {
+		t.Fatalf("XDG opentui runtime dir was not created: info=%v err=%v", info, err)
+	}
+	if !contains(strings.Join(argv, " "), "--allow "+want) {
+		t.Fatalf("serve argv missing XDG opentui read/write grant: %v", argv)
+	}
+}
+
+func TestPrepareSandboxDirsRejectsFileTarget(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(target, []byte("file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := prepareSandboxDirs([]string{target})
+	if err == nil || !strings.Contains(err.Error(), "create "+target) {
+		t.Fatalf("prepareSandboxDirs error = %v; want create error", err)
 	}
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -240,6 +240,7 @@ func TestInjectServerListenPort(t *testing.T) {
 // injectServerListenPort helper in isolation. It guards against the #115 bind
 // grant being dropped from the pipeline during a refactor.
 func TestSandboxServeArgvInjectsListenPort(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	oc, _ := config.LookupHarness("opencode")
 	prof := config.SandboxProfile{
 		Command:  []string{"omac", "sandbox", "run", "--", "{{inner_cmd}}", "{{inner_args}}"},
@@ -278,6 +279,35 @@ func TestSandboxServeArgvInjectsListenPort(t *testing.T) {
 	}
 	if !contains(nj, "--listen-port 4096") {
 		t.Errorf("listen-port grant must still apply without a control port: %s", nj)
+	}
+}
+
+func TestPrepareAndGrantOpenCodeRuntimeDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oc, _ := config.LookupHarness("opencode")
+	prof := config.SandboxProfile{
+		Command:  []string{"omac", "sandbox", "run", "--", "{{inner_cmd}}", "{{inner_args}}"},
+		InnerCmd: []string{"opencode"},
+	}
+	in := sandbox.Inputs{Workdir: t.TempDir(), InnerCmd: []string{"opencode", "serve"}}
+
+	if err := prepareSandboxDirs(oc.SandboxCreateDirs); err != nil {
+		t.Fatalf("prepareSandboxDirs: %v", err)
+	}
+	argv, err := sandboxServeArgv(prof, in, "", oc)
+	if err != nil {
+		t.Fatalf("sandboxServeArgv: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(home, ".local", "share", "opentui"))
+	if err != nil {
+		t.Fatalf("opentui runtime dir was not created before sandbox launch: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Errorf("opentui runtime dir mode = %o; want 700", got)
+	}
+	if !contains(strings.Join(argv, " "), "--allow ~/.local/share/opentui") {
+		t.Fatalf("serve argv missing opentui read/write grant: %v", argv)
 	}
 }
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -778,6 +778,10 @@ func runLaunch(env *Env, opts launchOpts) int {
 		// Grant the selected harness's runtime dirs (config, state,
 		// sessions) read+write — only for the selected harness, not all
 		// harnesses.
+		if err := prepareSandboxDirs(harness.SandboxCreateDirs); err != nil {
+			fmt.Fprintln(env.Stderr, prefix+": harness runtime dirs:", err)
+			return ExitIOError
+		}
 		argv = injectSandboxDirs(argv, harness.SandboxDirs)
 		if cacheScope != nil {
 			argv = injectSandboxFlag(argv, "--allow", cacheScope.Dir)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -775,9 +775,8 @@ func runLaunch(env *Env, opts launchOpts) int {
 				argv = injectOpenPort(argv, port)
 			}
 		}
-		// Grant the selected harness's runtime dirs (config, state,
-		// sessions) read+write — only for the selected harness, not all
-		// harnesses.
+		// Create declared runtime dirs before omac sandbox run resolves and
+		// existence-filters the selected harness's read+write grants.
 		if err := prepareSandboxDirs(harness.SandboxCreateDirs); err != nil {
 			fmt.Fprintln(env.Stderr, prefix+": harness runtime dirs:", err)
 			return ExitIOError

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -237,6 +237,7 @@ const defaultHarnessName = "opencode"
 // Order is significant only for the human-readable list in error messages
 // (canonical names are sorted there).
 func harnessRegistry() []Harness {
+	opentuiDataDir := xdgDataDir("opentui")
 	return []Harness{
 		{
 			Name:         "opencode",
@@ -255,12 +256,12 @@ func harnessRegistry() []Harness {
 			// Its opentui dependency caches tree-sitter grammars under the XDG data dir.
 			SandboxDirs: []string{
 				"~/.local/share/opencode",
-				"~/.local/share/opentui",
+				opentuiDataDir,
 				"~/.local/state/opencode",
 				"~/.config/opencode",
 				"~/.opencode",
 			},
-			SandboxCreateDirs: []string{"~/.local/share/opentui"},
+			SandboxCreateDirs: []string{opentuiDataDir},
 			// OpenCode authenticates primarily via auth.json (in SandboxDirs,
 			// granted read+write). It also supports several providers'
 			// env-var API keys, but omac does NOT auto-forward them: pushing
@@ -701,6 +702,15 @@ func userConfigRoot() string {
 		return ""
 	}
 	return filepath.Join(home, ".config")
+}
+
+// xdgDataDir returns an application's XDG data directory while preserving the
+// compact home-relative form used in sandbox profiles for the default root.
+func xdgDataDir(name string) string {
+	if root := os.Getenv("XDG_DATA_HOME"); root != "" {
+		return filepath.Join(root, name)
+	}
+	return filepath.Join("~", ".local", "share", name)
 }
 
 // ApplyServerLaunch ensures the inner command launches this harness's server

--- a/internal/config/harness.go
+++ b/internal/config/harness.go
@@ -111,6 +111,9 @@ type Harness struct {
 	// for configuration, authentication, state, and session storage.
 	// omac grants them read+write only for that selected harness.
 	SandboxDirs []string
+	// SandboxCreateDirs is the subset of SandboxDirs that omac must create
+	// before grant resolution so a dependency can populate it on first use.
+	SandboxCreateDirs []string
 
 	// NeedsPluginBootstrap is true for harnesses that require omac to
 	// idempotently provision a client-side bridge plugin on launch.
@@ -249,12 +252,15 @@ func harnessRegistry() []Harness {
 				ListKind:       SessionListOpenCodeCLI,
 			},
 			// OpenCode stores configuration and runtime state under XDG dirs and ~/.opencode.
+			// Its opentui dependency caches tree-sitter grammars under the XDG data dir.
 			SandboxDirs: []string{
 				"~/.local/share/opencode",
+				"~/.local/share/opentui",
 				"~/.local/state/opencode",
 				"~/.config/opencode",
 				"~/.opencode",
 			},
+			SandboxCreateDirs: []string{"~/.local/share/opentui"},
 			// OpenCode authenticates primarily via auth.json (in SandboxDirs,
 			// granted read+write). It also supports several providers'
 			// env-var API keys, but omac does NOT auto-forward them: pushing

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -473,9 +473,26 @@ func TestSandboxDirsOpenCode(t *testing.T) {
 	if !ok {
 		t.Fatal("opencode harness not found")
 	}
-	want := []string{"~/.local/share/opencode", "~/.local/state/opencode", "~/.config/opencode", "~/.opencode"}
+	want := []string{
+		"~/.local/share/opencode",
+		"~/.local/share/opentui",
+		"~/.local/state/opencode",
+		"~/.config/opencode",
+		"~/.opencode",
+	}
 	if !reflect.DeepEqual(h.SandboxDirs, want) {
 		t.Errorf("opencode SandboxDirs = %v; want %v", h.SandboxDirs, want)
+	}
+	if !reflect.DeepEqual(h.SandboxCreateDirs, []string{"~/.local/share/opentui"}) {
+		t.Errorf("opencode SandboxCreateDirs = %v; want [~/.local/share/opentui]", h.SandboxCreateDirs)
+	}
+}
+
+func TestSandboxCreateDirsAreOpenCodeOnly(t *testing.T) {
+	for _, h := range AllHarnesses() {
+		if h.Name != "opencode" && len(h.SandboxCreateDirs) != 0 {
+			t.Errorf("%s SandboxCreateDirs = %v; want none", h.Name, h.SandboxCreateDirs)
+		}
 	}
 }
 

--- a/internal/config/harness_test.go
+++ b/internal/config/harness_test.go
@@ -469,6 +469,7 @@ func TestSandboxDirsCopilot(t *testing.T) {
 }
 
 func TestSandboxDirsOpenCode(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "")
 	h, ok := LookupHarness("opencode")
 	if !ok {
 		t.Fatal("opencode harness not found")
@@ -488,8 +489,17 @@ func TestSandboxDirsOpenCode(t *testing.T) {
 	}
 }
 
-func TestSandboxCreateDirsAreOpenCodeOnly(t *testing.T) {
+func TestSandboxCreateDirsAreGranted(t *testing.T) {
 	for _, h := range AllHarnesses() {
+		granted := make(map[string]bool, len(h.SandboxDirs))
+		for _, dir := range h.SandboxDirs {
+			granted[dir] = true
+		}
+		for _, dir := range h.SandboxCreateDirs {
+			if !granted[dir] {
+				t.Errorf("%s SandboxCreateDirs contains ungranted path %q", h.Name, dir)
+			}
+		}
 		if h.Name != "opencode" && len(h.SandboxCreateDirs) != 0 {
 			t.Errorf("%s SandboxCreateDirs = %v; want none", h.Name, h.SandboxCreateDirs)
 		}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -92,9 +92,9 @@ func runE2E(t *testing.T, h harnessConfig) {
 	home := t.TempDir()
 	workdir := t.TempDir()
 
-	// Pre-create the runtime dirs harnesses expect to write to. The
-	// sandbox's ExpandExisting step skips nonexistent allow paths, so
-	// these must exist before the sandbox starts. The tool cache itself
+	// Stage runtime dirs used by harness installation and provider setup.
+	// omac also creates declared first-use dirs before sandbox grant resolution.
+	// The tool cache itself
 	// (~/.cache/omac, exposed as XDG_CACHE_HOME / OMAC_CACHE_DIR inside
 	// the sandbox) is created by omac at launch via PreparePersistent —
 	// it is NOT pre-created here, so the test exercises the real cache

--- a/internal/e2e/plugin_briefing_test.go
+++ b/internal/e2e/plugin_briefing_test.go
@@ -112,9 +112,8 @@ func TestOpenCodeSingleSystemMessage(t *testing.T) {
 
 	home := t.TempDir()
 	workdir := t.TempDir()
-	// Runtime dirs OpenCode expects to exist; the sandbox skips
-	// nonexistent allow paths, so create them before launch (mirrors
-	// smoke_test.go).
+	// Stage cache and runtime dirs used during OpenCode installation.
+	// omac also creates declared first-use dirs before sandbox launch.
 	for _, dir := range []string{
 		".cache", ".cache/opencode",
 		".local/share/opencode", ".local/state/opencode/locks",

--- a/internal/e2e/smoke_test.go
+++ b/internal/e2e/smoke_test.go
@@ -152,8 +152,8 @@ func TestHarnessLaunchProbe(t *testing.T) {
 			home := t.TempDir()
 			workdir := t.TempDir()
 
-			// Runtime dirs some harnesses expect; the sandbox skips nonexistent
-			// allow paths, so create them before launch (mirrors runE2E).
+			// Stage cache and runtime dirs used during harness installation.
+			// omac also creates declared first-use dirs before sandbox launch.
 			for _, dir := range []string{".cache", ".cache/opencode", ".local/share/opencode", ".local/state/opencode/locks"} {
 				if err := os.MkdirAll(filepath.Join(home, dir), 0o755); err != nil {
 					t.Fatal(err)
@@ -244,8 +244,8 @@ func TestHarnessServeProbe(t *testing.T) {
 			workdir := t.TempDir()
 			cwd := t.TempDir()
 
-			// Runtime dirs the harness expects; the sandbox skips nonexistent
-			// allow paths, so create them before launch (mirrors the launch probe).
+			// Stage cache and runtime dirs used during harness installation.
+			// omac also creates declared first-use dirs before sandbox launch.
 			for _, dir := range []string{".cache", ".cache/opencode", ".local/share/opencode", ".local/state/opencode/locks"} {
 				if err := os.MkdirAll(filepath.Join(home, dir), 0o755); err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
**Issue:** Closes #244

## What
- Restores OpenCode markdown rendering outside `$HOME`, including first-use grammar cache setup under default and custom XDG data roots.

## Why
- OpenTUI caches tree-sitter grammars outside OpenCode’s existing sandbox grants, so rendering silently fell back to raw text.

## How
- Resolve OpenTUI’s cache from `$XDG_DATA_HOME`, falling back to `~/.local/share/opentui`.
- Create the cache before `start` and `serve` grant resolution, then grant it read/write only for OpenCode.
- Enforce that pre-created directories are also sandbox-granted and document the new grant.

## Verification
- `go test -buildvcs=false ./... -skip ^TestIntegration -count=1` — pass
- `go build -buildvcs=false ./...` — pass
- `go vet ./internal/config ./internal/cli ./internal/sandboxprofile` — pass
- `go test -buildvcs=false -tags=e2e ./internal/e2e -run ^$ -count=1` — pass (compile check)
- `git diff --check` — pass

## Follow-up
- Full macOS kernel-sandbox integration is covered by CI; nested local Seatbelt application is denied by the active sandbox.

🤖 Generated with OpenCode (GPT-5.6 Sol).