### PR TITLE
feat(netproxy,diagnose): record network prompts nobody answered in time

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,7 +170,9 @@ omac cannot pass on your access token, so packages that require login still fail
 
 ## Audit trail
 
-omac logs every security-relevant action to an append-only file: process launches, network decisions, secret injections. The file is outside the sandbox so the agent cannot tamper with it.
+omac logs every security-relevant action to an append-only, structured (JSON Lines) file the agent cannot tamper with: the sandboxed inner command and each sidecar it spawns (`process.exec` / `process.exit`), outbound network allow/deny decisions and their source (`net.decision`), network prompts raised but never answered in time (`net.prompt_abandoned`), facade requests (`facade.request`), control-plane mutations (`control.mutation`), secret injection by name (`secret.inject`), non-ready routes (`route.state`), and session lifecycle (`session.start` / `session.stop`).
+
+A prompt-sourced `net.decision` also carries `waited_ms`, how long the dialog was open before it was answered. This distinguishes "allowed promptly" from "allowed after the requesting tool had already timed out" (see [Short-timeout clients](#short-timeout-clients)); `omac diagnose` flags the latter.
 
 | Platform | Default path |
 |---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,6 +144,12 @@ Java (Maven/Gradle) and Node/npm do not reliably route their package downloads t
 
 Node injection requires Node ≥ 22.21.0 (22.x line) or ≥ 24.5.0; on older versions it is skipped and downloads may still fail.
 
+### Short-timeout clients
+
+While a network prompt is open the connection is held, and the requesting tool is subject to *its own* timeout — some are only a few seconds (the opencode Skainet plugin aborts model discovery after 3s). Answering a dialog reliably takes longer than that, so the tool can give up before your click lands: the fetch fails silently, and the allow you then grant applies to a request nobody is waiting for any more. Put hosts that short-timeout tools depend on in `network.allow_domain` so no prompt is raised. Under `omac serve` or any non-TTY launch there is no dialog at all and `on_unavailable: deny` (the default) makes this deterministic.
+
+`omac diagnose` reports these as abandoned prompts — a run whose prompt was never answered in time no longer reads as "nothing was blocked".
+
 ### Private package registries
 
 If your company hosts its own npm packages, `~/.npmrc` says where to find them. A line like `@acme:registry=https://npm.acme.test` means "packages starting with `@acme/` come from that server".

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -246,7 +246,7 @@ func TestFailOpenWarnsOnce(t *testing.T) {
 
 func TestValidJSONPerLine(t *testing.T) {
 	a, path := newTestAuditor(t, Config{})
-	a.Emit(NetDecision("example.com", 443, true, "host", "prompt", true))
+	a.Emit(NetDecision("example.com", 443, true, "host", "prompt", true, 0))
 	a.Emit(SecretInject("s", "tok", []string{"A", "B"}, []string{"C"}))
 	a.Emit(RouteStateEvent("s", "tok", "broken", "boom"))
 	_ = a.Close()
@@ -293,7 +293,7 @@ func TestInheritedRunIDPreservesCorrelation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("child New: %v", err)
 	}
-	child.Emit(NetDecision("host.example", 443, true, "host", "prompt", false)) // seq 1
+	child.Emit(NetDecision("host.example", 443, true, "host", "prompt", false, 0)) // seq 1
 	_ = parent.Close()
 	_ = child.Close()
 

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -34,15 +34,22 @@ const (
 
 // Event types. Dotted namespaces group related actions.
 const (
-	TypeSessionStart    = "session.start"
-	TypeSessionStop     = "session.stop"
-	TypeProcessExec     = "process.exec"
-	TypeProcessExit     = "process.exit"
-	TypeNetDecision     = "net.decision"
-	TypeFacadeRequest   = "facade.request"
-	TypeControlMutation = "control.mutation"
-	TypeSecretInject    = "secret.inject"
-	TypeRouteState      = "route.state"
+	TypeSessionStart = "session.start"
+	TypeSessionStop  = "session.stop"
+	TypeProcessExec  = "process.exec"
+	TypeProcessExit  = "process.exit"
+	TypeNetDecision  = "net.decision"
+	// TypeNetPromptAbandoned records a network prompt that was raised but
+	// never resolved because the requesting tool gave up (its own timeout
+	// is shorter than the human's answer time) or the run ended first.
+	// Without it such a run looks clean: no decision is ever logged, so
+	// `omac diagnose` reports "nothing was blocked" for a launch that in
+	// fact failed. See #257.
+	TypeNetPromptAbandoned = "net.prompt_abandoned"
+	TypeFacadeRequest      = "facade.request"
+	TypeControlMutation    = "control.mutation"
+	TypeSecretInject       = "secret.inject"
+	TypeRouteState         = "route.state"
 )
 
 // Event is one audit record. The envelope fields (Ts, RunID, Seq, Type,
@@ -81,9 +88,13 @@ type Event struct {
 	Sandboxed   *bool    `json:"sandboxed,omitempty"`
 	DurationMS  int64    `json:"duration_ms,omitempty"`
 
-	// --- net.decision ---
-	Host      string `json:"host,omitempty"`
-	Port      int    `json:"port,omitempty"`
+	// --- net.decision / net.prompt_abandoned ---
+	Host string `json:"host,omitempty"`
+	Port int    `json:"port,omitempty"`
+	// WaitedMS is how long a net.prompt_abandoned prompt had been open
+	// when it was abandoned. Compared against the requesting tool's own
+	// timeout, it is what explains the failure.
+	WaitedMS  int64  `json:"waited_ms,omitempty"`
 	Allow     *bool  `json:"allow,omitempty"`
 	Scope     string `json:"scope,omitempty"`  // once|host|suffix
 	Source    string `json:"source,omitempty"` // prompt|learned|allowlist|blocklist|timeout|unavailable|hard-deny|dns|default|session

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -91,9 +91,10 @@ type Event struct {
 	// --- net.decision / net.prompt_abandoned ---
 	Host string `json:"host,omitempty"`
 	Port int    `json:"port,omitempty"`
-	// WaitedMS is how long a net.prompt_abandoned prompt had been open
-	// when it was abandoned. Compared against the requesting tool's own
-	// timeout, it is what explains the failure.
+	// WaitedMS is how long the interactive prompt was open: until it was
+	// abandoned (net.prompt_abandoned) or until the user answered
+	// (net.decision, prompt-sourced only). Compared against the requesting
+	// tool's own timeout, it is what explains a silent failure.
 	WaitedMS  int64  `json:"waited_ms,omitempty"`
 	Allow     *bool  `json:"allow,omitempty"`
 	Scope     string `json:"scope,omitempty"`  // once|host|suffix

--- a/internal/audit/events_ctor.go
+++ b/internal/audit/events_ctor.go
@@ -69,6 +69,19 @@ func NetDecision(host string, port int, allow bool, scope, source string, persis
 	}
 }
 
+// NetPromptAbandoned builds a net.prompt_abandoned event: a prompt was
+// raised for host:port but no verdict was ever reached, because the
+// requesting tool stopped waiting or the run ended. waitedMS is how long
+// the prompt had been open.
+func NetPromptAbandoned(host string, port int, waitedMS int64) Event {
+	return Event{
+		Type:     TypeNetPromptAbandoned,
+		Host:     host,
+		Port:     port,
+		WaitedMS: waitedMS,
+	}
+}
+
 // FacadeRequest builds a facade.request event.
 func FacadeRequest(method, mount, namespace, path string, status int, bytesOut, durationMS int64) Event {
 	return Event{

--- a/internal/audit/events_ctor.go
+++ b/internal/audit/events_ctor.go
@@ -56,8 +56,11 @@ func ProcessExit(skill, namespace string, exitCode int, durationMS int64) Event 
 	}
 }
 
-// NetDecision builds a net.decision event.
-func NetDecision(host string, port int, allow bool, scope, source string, persisted bool) Event {
+// NetDecision builds a net.decision event. waitedMS is how long an
+// interactive prompt was open before the user answered (0 for decisions
+// that did not involve a prompt); it is what lets a later reader see that
+// an "allow" landed after a short-timeout client had already given up.
+func NetDecision(host string, port int, allow bool, scope, source string, persisted bool, waitedMS int64) Event {
 	return Event{
 		Type:      TypeNetDecision,
 		Host:      host,
@@ -66,6 +69,7 @@ func NetDecision(host string, port int, allow bool, scope, source string, persis
 		Scope:     scope,
 		Source:    source,
 		Persisted: bptr(persisted),
+		WaitedMS:  waitedMS,
 	}
 }
 

--- a/internal/audit/read_test.go
+++ b/internal/audit/read_test.go
@@ -62,7 +62,7 @@ func TestReadLogRoundTripsWrittenTrail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	a.Emit(NetDecision("a.example", 443, false, "", "blocklist", false))
+	a.Emit(NetDecision("a.example", 443, false, "", "blocklist", false, 0))
 	if err := a.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}

--- a/internal/cli/diagnose.go
+++ b/internal/cli/diagnose.go
@@ -90,7 +90,8 @@ func runDiagnose(args []string, env *Env) int {
 		runID = audit.LastRunID(events)
 	}
 	decisions := decisionsFromEvents(events, runID)
-	report := diagnose.Build(pol, decisions, netproxy.MatchDomainList)
+	abandoned := abandonedFromEvents(events, runID)
+	report := diagnose.Build(pol, decisions, abandoned, netproxy.MatchDomainList)
 
 	logPath, _ := sandboxrun.DiagLogPath()
 	var exitCode *int
@@ -191,6 +192,27 @@ func decisionsFromEvents(events []audit.Event, runID string) []diagnose.Decision
 	return out
 }
 
+// abandonedFromEvents maps net.prompt_abandoned audit events, scoped to a
+// single run when runID is set. These carry no verdict by definition, so
+// they cannot be folded into decisionsFromEvents.
+func abandonedFromEvents(events []audit.Event, runID string) []diagnose.AbandonedPrompt {
+	var out []diagnose.AbandonedPrompt
+	for _, ev := range events {
+		if ev.Type != audit.TypeNetPromptAbandoned {
+			continue
+		}
+		if runID != "" && ev.RunID != runID {
+			continue
+		}
+		out = append(out, diagnose.AbandonedPrompt{
+			Host:     ev.Host,
+			Port:     ev.Port,
+			WaitedMS: ev.WaitedMS,
+		})
+	}
+	return out
+}
+
 func writeDiagnoseJSON(env *Env, v any) int {
 	enc := json.NewEncoder(env.Stdout)
 	enc.SetIndent("", "  ")
@@ -227,6 +249,12 @@ func writeDiagnoseText(env *Env, v diagnoseView, verbose bool) {
 		status += fmt.Sprintf(" exited %d", *v.ExitCode)
 	}
 	status += fmt.Sprintf(" · %s mode · %d/%d connection(s) blocked", v.Policy.Mode, v.Report.Denied, v.Report.Total)
+	// An abandoned prompt is invisible in the blocked count (no verdict was
+	// ever reached), so the headline must carry it or the run still reads as
+	// clean — the #257 failure mode.
+	if n := len(v.Report.Abandoned); n > 0 {
+		status += fmt.Sprintf(" · %d prompt(s) abandoned", n)
+	}
 	fmt.Fprintln(w, status)
 	fmt.Fprintln(w)
 

--- a/internal/cli/diagnose.go
+++ b/internal/cli/diagnose.go
@@ -183,10 +183,11 @@ func decisionsFromEvents(events []audit.Event, runID string) []diagnose.Decision
 			continue
 		}
 		out = append(out, diagnose.Decision{
-			Host:    ev.Host,
-			Port:    ev.Port,
-			Allowed: ev.Allow != nil && *ev.Allow,
-			Source:  ev.Source,
+			Host:     ev.Host,
+			Port:     ev.Port,
+			Allowed:  ev.Allow != nil && *ev.Allow,
+			Source:   ev.Source,
+			WaitedMS: ev.WaitedMS,
 		})
 	}
 	return out

--- a/internal/cli/diagnose_abandoned_test.go
+++ b/internal/cli/diagnose_abandoned_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestDiagnoseSurfacesAbandonedPrompt reproduces the run shape from #257: the
+// only network activity was an allowed fetch plus a prompt the requesting tool
+// stopped waiting for. Before this, diagnose reported "0/1 blocked · nothing
+// was blocked" for a run that had silently failed.
+func TestDiagnoseSurfacesAbandonedPrompt(t *testing.T) {
+	isolateHome(t)
+	writeProfileFixture(t, `{"meta":{"name":"default"},"network":{"mode":"filtered","network_prompt":{"enabled":true}}}`)
+	writeAuditFixture(t,
+		`{"ts":"2026-08-24T09:58:11Z","run_id":"r1","type":"session.start"}`,
+		`{"ts":"2026-08-24T09:58:12Z","run_id":"r1","type":"net.decision","host":"registry.npmjs.org","port":443,"allow":true,"source":"allowlist"}`,
+		`{"ts":"2026-08-24T09:58:16Z","run_id":"r1","type":"net.prompt_abandoned","host":"models.dev","port":443,"waited_ms":4800}`,
+		`{"ts":"2026-08-24T09:58:17Z","run_id":"r1","type":"session.stop","exit_code":0}`,
+	)
+
+	env, out, _, drain := newPipeEnv(t, "")
+	env.Workdir = t.TempDir()
+	if code := runDiagnose(nil, env); code != ExitOK {
+		t.Fatalf("code=%d, want ExitOK", code)
+	}
+	drain()
+	s := out.String()
+
+	if !strings.Contains(s, "1 prompt(s) abandoned") {
+		t.Errorf("status line does not carry the abandoned count:\n%s", s)
+	}
+	if !strings.Contains(s, "models.dev:443") {
+		t.Errorf("abandoned host not named:\n%s", s)
+	}
+	if !strings.Contains(s, "4.8s") {
+		t.Errorf("time the tool waited not reported:\n%s", s)
+	}
+	// The core regression: the reassuring note must be gone.
+	if strings.Contains(s, "Nothing was blocked by the network policy") {
+		t.Errorf("still reported 'nothing was blocked' for a run with an abandoned prompt:\n%s", s)
+	}
+	if strings.Contains(s, "No problems detected") {
+		t.Errorf("still reported 'no problems detected':\n%s", s)
+	}
+}
+
+// TestDiagnoseJSONCarriesAbandonedPrompts keeps the machine-readable view in
+// step with the text one, so automation can detect this class too.
+func TestDiagnoseJSONCarriesAbandonedPrompts(t *testing.T) {
+	isolateHome(t)
+	writeProfileFixture(t, `{"meta":{"name":"default"},"network":{"mode":"filtered","network_prompt":{"enabled":true}}}`)
+	writeAuditFixture(t,
+		`{"ts":"2026-08-24T09:58:11Z","run_id":"r1","type":"session.start"}`,
+		`{"ts":"2026-08-24T09:58:16Z","run_id":"r1","type":"net.prompt_abandoned","host":"models.dev","port":443,"waited_ms":4800}`,
+	)
+
+	env, out, _, drain := newPipeEnv(t, "")
+	env.Workdir = t.TempDir()
+	if code := runDiagnose([]string{"--json"}, env); code != ExitOK {
+		t.Fatalf("code=%d, want ExitOK", code)
+	}
+	drain()
+
+	var view struct {
+		Report struct {
+			Abandoned []struct {
+				Host     string `json:"host"`
+				Port     int    `json:"port"`
+				WaitedMS int64  `json:"waited_ms"`
+			} `json:"abandoned"`
+		} `json:"report"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &view); err != nil {
+		t.Fatalf("decode --json output: %v\n%s", err, out.String())
+	}
+	if len(view.Report.Abandoned) != 1 {
+		t.Fatalf("report.abandoned = %+v, want 1 entry", view.Report.Abandoned)
+	}
+	got := view.Report.Abandoned[0]
+	if got.Host != "models.dev" || got.Port != 443 || got.WaitedMS != 4800 {
+		t.Errorf("abandoned entry = %+v, want models.dev:443 waited 4800ms", got)
+	}
+}
+
+// TestDiagnoseUnaffectedWithoutAbandonedPrompts guards against the new axis
+// leaking into ordinary runs.
+func TestDiagnoseUnaffectedWithoutAbandonedPrompts(t *testing.T) {
+	isolateHome(t)
+	writeProfileFixture(t, `{"meta":{"name":"default"},"network":{"mode":"filtered","network_prompt":{"enabled":true}}}`)
+	writeAuditFixture(t,
+		`{"ts":"2026-08-24T09:58:11Z","run_id":"r1","type":"session.start"}`,
+		`{"ts":"2026-08-24T09:58:12Z","run_id":"r1","type":"net.decision","host":"registry.npmjs.org","port":443,"allow":true,"source":"allowlist"}`,
+	)
+
+	env, out, _, drain := newPipeEnv(t, "")
+	env.Workdir = t.TempDir()
+	runDiagnose(nil, env)
+	drain()
+	s := out.String()
+
+	if strings.Contains(s, "abandoned") {
+		t.Errorf("mentioned abandoned prompts for a run with none:\n%s", s)
+	}
+	if !strings.Contains(s, "Nothing was blocked by the network policy") {
+		t.Errorf("expected the all-allowed note to still fire:\n%s", s)
+	}
+}

--- a/internal/diagnose/abandoned_test.go
+++ b/internal/diagnose/abandoned_test.go
@@ -1,6 +1,7 @@
 package diagnose
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -61,6 +62,85 @@ func TestNoAbandonedPromptsNoHint(t *testing.T) {
 	}
 	if h := findHint(r.Hints, "never answered in time"); h != nil {
 		t.Errorf("emitted an abandoned-prompt hint with none recorded: %q", h.Title)
+	}
+}
+
+// TestSlowPromptReported covers the answered-but-too-late half of #257: a
+// decision exists and reads as "allowed", so only the recorded wait shows the
+// requesting tool had already timed out.
+func TestSlowPromptReported(t *testing.T) {
+	decisions := []Decision{
+		{Host: "models.dev", Port: 443, Allowed: true, Source: "prompt", WaitedMS: 5200},
+	}
+	r := Build(filtered(), decisions, nil, realMatch)
+
+	h := findHint(r.Hints, "may have failed anyway")
+	if h == nil {
+		t.Fatalf("no slow-prompt hint; hints = %+v", r.Hints)
+	}
+	if h.Kind != KindProblem {
+		t.Errorf("hint kind = %q, want %q", h.Kind, KindProblem)
+	}
+	joined := h.Title + " " + strings.Join(h.Detail, " ")
+	if !strings.Contains(joined, "models.dev:443") || !strings.Contains(joined, "5.2s") {
+		t.Errorf("hint does not name host and wait: %q", joined)
+	}
+	// It must also displace the reassuring note, which is the actual misreport.
+	if n := findHint(r.Hints, "can be invisible to this report"); n != nil {
+		t.Errorf("still emitted 'nothing was blocked' alongside a slow prompt: %q", n.Title)
+	}
+}
+
+// TestFastPromptNotReported keeps the threshold from firing on ordinary
+// pre-allowlisted or promptly answered traffic.
+func TestFastPromptNotReported(t *testing.T) {
+	for _, d := range []Decision{
+		{Host: "a.test", Allowed: true, Source: "prompt", WaitedMS: 800},
+		{Host: "b.test", Allowed: true, Source: "allowlist", WaitedMS: 0},
+		// A non-prompt source must never be flagged even with a stale wait.
+		{Host: "c.test", Allowed: true, Source: "allowlist", WaitedMS: 9000},
+	} {
+		r := Build(filtered(), []Decision{d}, nil, realMatch)
+		if h := findHint(r.Hints, "may have failed anyway"); h != nil {
+			t.Errorf("flagged %+v as a slow prompt: %q", d, h.Title)
+		}
+	}
+}
+
+// TestAbandonedPromptsAggregatedAndCapped guards the focused view: one line
+// per host, capped, rather than one line per occurrence across the log.
+func TestAbandonedPromptsAggregatedAndCapped(t *testing.T) {
+	var abandoned []AbandonedPrompt
+	// One host repeated many times, plus more distinct hosts than the cap.
+	for i := 0; i < 5; i++ {
+		abandoned = append(abandoned, AbandonedPrompt{Host: "noisy.test", Port: 443, WaitedMS: int64(1000 + i)})
+	}
+	for i := 0; i < maxPromptHostsShown+3; i++ {
+		abandoned = append(abandoned, AbandonedPrompt{Host: fmt.Sprintf("h%d.test", i), Port: 443, WaitedMS: 2000})
+	}
+
+	h := findHint(Build(filtered(), nil, abandoned, realMatch).Hints, "never answered in time")
+	if h == nil {
+		t.Fatal("no abandoned-prompt hint")
+	}
+	noisyLines := 0
+	for _, d := range h.Detail {
+		if strings.Contains(d, "noisy.test") {
+			noisyLines++
+		}
+	}
+	if noisyLines != 1 {
+		t.Errorf("noisy.test appears on %d detail line(s), want 1 aggregated line", noisyLines)
+	}
+	if !strings.Contains(strings.Join(h.Detail, " "), "×5") {
+		t.Errorf("aggregated line does not report the repeat count: %v", h.Detail)
+	}
+	// Cap: host lines + the "and N more" line + the two closing lines.
+	if len(h.Detail) > maxPromptHostsShown+3 {
+		t.Errorf("detail has %d lines, want at most %d", len(h.Detail), maxPromptHostsShown+3)
+	}
+	if !strings.Contains(strings.Join(h.Detail, " "), "more host(s)") {
+		t.Errorf("no truncation notice despite exceeding the cap: %v", h.Detail)
 	}
 }
 

--- a/internal/diagnose/abandoned_test.go
+++ b/internal/diagnose/abandoned_test.go
@@ -1,0 +1,90 @@
+package diagnose
+
+import (
+	"strings"
+	"testing"
+)
+
+func filtered() Policy { return Policy{Mode: "filtered", PromptEnabled: true} }
+
+// TestAbandonedPromptReported is the #257 headline: an abandoned prompt must
+// surface as a problem, not vanish because no verdict exists.
+func TestAbandonedPromptReported(t *testing.T) {
+	abandoned := []AbandonedPrompt{{Host: "models.dev", Port: 443, WaitedMS: 4800}}
+	r := Build(filtered(), nil, abandoned, realMatch)
+
+	if len(r.Abandoned) != 1 {
+		t.Fatalf("Report.Abandoned = %v, want 1 entry", r.Abandoned)
+	}
+	h := findHint(r.Hints, "never answered in time")
+	if h == nil {
+		t.Fatalf("no abandoned-prompt hint; hints = %+v", r.Hints)
+	}
+	if h.Kind != KindProblem {
+		t.Errorf("hint kind = %q, want %q", h.Kind, KindProblem)
+	}
+	joined := h.Title + " " + strings.Join(h.Detail, " ")
+	if !strings.Contains(joined, "models.dev:443") {
+		t.Errorf("hint does not name the host: %q", joined)
+	}
+	if !strings.Contains(joined, "4.8s") {
+		t.Errorf("hint does not report how long the tool waited: %q", joined)
+	}
+	if !strings.Contains(joined, "network.allow_domain") {
+		t.Errorf("hint does not name the remedy: %q", joined)
+	}
+}
+
+// TestAbandonedPromptSuppressesNothingBlockedNote is the regression guard for
+// the actual misreport in #257: with an abandoned prompt on record, diagnose
+// must not also claim nothing was blocked.
+func TestAbandonedPromptSuppressesNothingBlockedNote(t *testing.T) {
+	allowed := []Decision{{Host: "registry.npmjs.org", Port: 443, Allowed: true, Source: "prompt"}}
+
+	withAbandoned := Build(filtered(), allowed,
+		[]AbandonedPrompt{{Host: "models.dev", Port: 443, WaitedMS: 5000}}, realMatch)
+	if h := findHint(withAbandoned.Hints, "can be invisible to this report"); h != nil {
+		t.Errorf("still emitted the 'nothing was blocked' note alongside an abandoned prompt: %q", h.Title)
+	}
+
+	// Control: without an abandoned prompt the note is still the right call.
+	clean := Build(filtered(), allowed, nil, realMatch)
+	if h := findHint(clean.Hints, "can be invisible to this report"); h == nil {
+		t.Error("expected the 'nothing was blocked' note for an all-allowed run")
+	}
+}
+
+func TestNoAbandonedPromptsNoHint(t *testing.T) {
+	r := Build(filtered(), []Decision{{Host: "a.test", Allowed: true}}, nil, realMatch)
+	if len(r.Abandoned) != 0 {
+		t.Errorf("Report.Abandoned = %v, want empty", r.Abandoned)
+	}
+	if h := findHint(r.Hints, "never answered in time"); h != nil {
+		t.Errorf("emitted an abandoned-prompt hint with none recorded: %q", h.Title)
+	}
+}
+
+func TestWaitedForUnits(t *testing.T) {
+	for _, tt := range []struct {
+		ms   int64
+		want string
+	}{
+		{0, "0ms"},
+		{999, "999ms"},
+		{1000, "1.0s"},
+		{4800, "4.8s"},
+	} {
+		if got := waitedFor(tt.ms); got != tt.want {
+			t.Errorf("waitedFor(%d) = %q, want %q", tt.ms, got, tt.want)
+		}
+	}
+}
+
+func TestHostPortOmitsZeroPort(t *testing.T) {
+	if got := hostPort("a.test", 0); got != "a.test" {
+		t.Errorf("hostPort with no port = %q, want %q", got, "a.test")
+	}
+	if got := hostPort("a.test", 443); got != "a.test:443" {
+		t.Errorf("hostPort = %q, want a.test:443", got)
+	}
+}

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -29,6 +29,12 @@ type Decision struct {
 	// | hard-deny | prompt | learned | dns | unavailable | default. Treated
 	// as an opaque contract string.
 	Source string
+	// WaitedMS is how long an interactive prompt was open before the user
+	// answered (prompt-sourced decisions only). A large value on an allowed
+	// decision means the connection was held that long, so any client with
+	// a shorter timeout had already failed — the decision says "allowed",
+	// the tool saw a timeout. See #257.
+	WaitedMS int64
 }
 
 // AbandonedPrompt is a network prompt that was raised but never resolved:
@@ -182,6 +188,7 @@ func Analyze(p Policy, decisions []Decision, abandoned []AbandonedPrompt, match 
 	}
 
 	hints = append(hints, abandonedPromptHints(abandoned)...)
+	hints = append(hints, slowPromptHints(decisions)...)
 	hints = append(hints, deadAllowRuleHints(p, decisions, match)...)
 	hints = append(hints, overBroadAllowHints(p)...)
 	hints = append(hints, sourceHints(decisions)...)
@@ -358,8 +365,11 @@ func invisibleFailureHint(p Policy, decisions []Decision, abandoned []AbandonedP
 	if p.Mode != "filtered" {
 		return nil
 	}
-	if len(abandoned) > 0 {
-		return nil // an abandoned prompt IS the concrete finding; see abandonedPromptHints
+	if len(abandoned) > 0 || len(slowPrompts(decisions)) > 0 {
+		// An abandoned or late-answered prompt IS the concrete finding, and
+		// claiming "nothing was blocked" alongside it is the misreport #257
+		// is about.
+		return nil
 	}
 	for _, d := range decisions {
 		if !d.Allowed {
@@ -378,6 +388,12 @@ func invisibleFailureHint(p Policy, decisions []Decision, abandoned []AbandonedP
 	}}
 }
 
+// maxPromptHostsShown caps how many hosts an abandoned/late-prompt hint
+// enumerates, mirroring maxBlockedShown in the renderer. Under --run all the
+// raw entry count spans the whole persistent log, so without aggregation a
+// single noisy host could fill the focused view.
+const maxPromptHostsShown = 8
+
 // abandonedPromptHints explains a prompt nobody answered in time. This is
 // the failure that otherwise leaves no trace at all: the tool gave up before
 // a verdict existed, so no decision was ever recorded and the report would
@@ -390,17 +406,125 @@ func abandonedPromptHints(abandoned []AbandonedPrompt) []Hint {
 	if len(abandoned) == 0 {
 		return nil
 	}
-	detail := make([]string, 0, len(abandoned)+2)
+	// Aggregate per host:port — one line per host, not per occurrence.
+	type agg struct {
+		key    string
+		count  int
+		maxWMS int64
+	}
+	idx := map[string]*agg{}
+	var order []string
 	for _, a := range abandoned {
-		detail = append(detail, fmt.Sprintf("%s gave up after %s — the prompt was still open when the request was abandoned.",
-			hostPort(a.Host, a.Port), waitedFor(a.WaitedMS)))
+		k := hostPort(a.Host, a.Port)
+		e := idx[k]
+		if e == nil {
+			e = &agg{key: k}
+			idx[k] = e
+			order = append(order, k)
+		}
+		e.count++
+		if a.WaitedMS > e.maxWMS {
+			e.maxWMS = a.WaitedMS
+		}
+	}
+	sort.SliceStable(order, func(i, j int) bool { return idx[order[i]].count > idx[order[j]].count })
+
+	shown := order
+	if len(shown) > maxPromptHostsShown {
+		shown = shown[:maxPromptHostsShown]
+	}
+	detail := make([]string, 0, len(shown)+3)
+	for _, k := range shown {
+		e := idx[k]
+		times := ""
+		if e.count > 1 {
+			times = fmt.Sprintf(" ×%d", e.count)
+		}
+		detail = append(detail, fmt.Sprintf("%s%s gave up after %s — the prompt was still open when the request was abandoned.",
+			e.key, times, waitedFor(e.maxWMS)))
+	}
+	if n := len(order) - len(shown); n > 0 {
+		detail = append(detail, fmt.Sprintf("… and %d more host(s).", n))
 	}
 	detail = append(detail,
 		"The tool's own HTTP timeout is shorter than the time it took to answer the dialog, so allowing it afterwards came too late — the fetch had already failed, silently.",
 		"Fix: add the host to network.allow_domain so no prompt is raised. Answering faster is not a reliable remedy.")
 	return []Hint{{
-		Kind:   KindProblem,
-		Title:  fmt.Sprintf("%d network prompt(s) were raised but never answered in time — the requesting tool stopped waiting", len(abandoned)),
+		Kind: KindProblem,
+		Title: fmt.Sprintf("%d network prompt(s) across %d host(s) were raised but never answered in time — the requesting tool stopped waiting",
+			len(abandoned), len(order)),
+		Detail: detail,
+	}}
+}
+
+// promptLatencyThresholdMS is the dialog-open time above which an allowed
+// prompt decision is reported as a likely silent failure. 3s is the shortest
+// client budget observed in the wild (the opencode Skainet plugin's model
+// discovery), so an answer slower than this can already have missed it.
+const promptLatencyThresholdMS = 3000
+
+// slowPrompts returns prompt-sourced decisions the user answered so slowly
+// that a short-timeout client had probably already given up.
+func slowPrompts(decisions []Decision) []Decision {
+	var out []Decision
+	for _, d := range decisions {
+		if d.Source == "prompt" && d.WaitedMS >= promptLatencyThresholdMS {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// slowPromptHints covers the other half of #257: the prompt WAS answered, so
+// a decision exists and nothing looks wrong, but the answer landed after the
+// requesting tool's own timeout had expired. The tool saw a failure; the
+// audit trail says "allowed". Only the wait time reveals it.
+func slowPromptHints(decisions []Decision) []Hint {
+	slow := slowPrompts(decisions)
+	if len(slow) == 0 {
+		return nil
+	}
+	type agg struct {
+		key    string
+		count  int
+		maxWMS int64
+	}
+	idx := map[string]*agg{}
+	var order []string
+	for _, d := range slow {
+		k := hostPort(d.Host, d.Port)
+		e := idx[k]
+		if e == nil {
+			e = &agg{key: k}
+			idx[k] = e
+			order = append(order, k)
+		}
+		e.count++
+		if d.WaitedMS > e.maxWMS {
+			e.maxWMS = d.WaitedMS
+		}
+	}
+	sort.SliceStable(order, func(i, j int) bool { return idx[order[i]].maxWMS > idx[order[j]].maxWMS })
+
+	shown := order
+	if len(shown) > maxPromptHostsShown {
+		shown = shown[:maxPromptHostsShown]
+	}
+	detail := make([]string, 0, len(shown)+3)
+	for _, k := range shown {
+		e := idx[k]
+		detail = append(detail, fmt.Sprintf("%s was held for %s before the prompt was answered.", e.key, waitedFor(e.maxWMS)))
+	}
+	if n := len(order) - len(shown); n > 0 {
+		detail = append(detail, fmt.Sprintf("… and %d more host(s).", n))
+	}
+	detail = append(detail,
+		"The connection is held while the dialog is open, so a tool whose own timeout is shorter than that already failed — the decision reads as allowed, the tool saw a timeout.",
+		"Fix: add these hosts to network.allow_domain so no prompt is raised.")
+	return []Hint{{
+		Kind: KindProblem,
+		Title: fmt.Sprintf("%d prompt(s) were answered after %s or more — a short-timeout tool may have failed anyway",
+			len(slow), waitedFor(promptLatencyThresholdMS)),
 		Detail: detail,
 	}}
 }

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -31,6 +31,18 @@ type Decision struct {
 	Source string
 }
 
+// AbandonedPrompt is a network prompt that was raised but never resolved:
+// the requesting tool stopped waiting (its own HTTP timeout is shorter than
+// the time it takes to answer a dialog) or the run ended first. No Decision
+// is ever produced for such a request, which is exactly why it has to be
+// carried separately — otherwise the run reads as "nothing was blocked".
+type AbandonedPrompt struct {
+	Host string `json:"host"`
+	Port int    `json:"port,omitempty"`
+	// WaitedMS is how long the prompt had been open when it was abandoned.
+	WaitedMS int64 `json:"waited_ms,omitempty"`
+}
+
 // Policy is the effective network policy in force, decoupled from
 // sandboxprofile. Only the fields the analysis needs are carried.
 type Policy struct {
@@ -95,11 +107,17 @@ type Report struct {
 	Total   int           `json:"total"`
 	Denied  int           `json:"denied"`
 	Blocked []BlockedHost `json:"blocked,omitempty"`
-	Hints   []Hint        `json:"hints,omitempty"`
+	// Abandoned lists prompts that were raised but never answered in time
+	// to matter. They are not Decisions — no verdict exists — so they are
+	// reported on their own axis.
+	Abandoned []AbandonedPrompt `json:"abandoned,omitempty"`
+	Hints     []Hint            `json:"hints,omitempty"`
 }
 
 // Build analyzes decisions against the policy and returns a full Report.
-func Build(p Policy, decisions []Decision, match DomainMatcher) Report {
+// abandoned may be empty; when it is not, it suppresses the
+// "nothing was blocked" note, because something concrete did go wrong.
+func Build(p Policy, decisions []Decision, abandoned []AbandonedPrompt, match DomainMatcher) Report {
 	denied := 0
 	for _, d := range decisions {
 		if !d.Allowed {
@@ -107,10 +125,11 @@ func Build(p Policy, decisions []Decision, match DomainMatcher) Report {
 		}
 	}
 	return Report{
-		Total:   len(decisions),
-		Denied:  denied,
-		Blocked: Blocked(decisions),
-		Hints:   Analyze(p, decisions, match),
+		Total:     len(decisions),
+		Denied:    denied,
+		Blocked:   Blocked(decisions),
+		Abandoned: abandoned,
+		Hints:     Analyze(p, decisions, abandoned, match),
 	}
 }
 
@@ -142,7 +161,7 @@ func Blocked(decisions []Decision) []BlockedHost {
 
 // Analyze correlates observed decisions against the policy and returns
 // actionable hints, warnings before informational notes.
-func Analyze(p Policy, decisions []Decision, match DomainMatcher) []Hint {
+func Analyze(p Policy, decisions []Decision, abandoned []AbandonedPrompt, match DomainMatcher) []Hint {
 	if match == nil {
 		match = func(string, []string) bool { return false }
 	}
@@ -162,10 +181,11 @@ func Analyze(p Policy, decisions []Decision, match DomainMatcher) []Hint {
 		hints = append(hints, blockedHostHint(p, b, match))
 	}
 
+	hints = append(hints, abandonedPromptHints(abandoned)...)
 	hints = append(hints, deadAllowRuleHints(p, decisions, match)...)
 	hints = append(hints, overBroadAllowHints(p)...)
 	hints = append(hints, sourceHints(decisions)...)
-	hints = append(hints, invisibleFailureHint(p, decisions)...)
+	hints = append(hints, invisibleFailureHint(p, decisions, abandoned)...)
 	hints = append(hints, environmentHints(p)...)
 
 	// Problems before advisories (stable) so -v and --json list the
@@ -334,9 +354,12 @@ func environmentHints(p Policy) []Hint {
 // filesystem/socket or loopback access denial. It fires only when nothing was
 // blocked — so it never competes with a concrete blocked-host finding — and
 // steers toward the narrowest fix rather than widening the network policy.
-func invisibleFailureHint(p Policy, decisions []Decision) []Hint {
+func invisibleFailureHint(p Policy, decisions []Decision, abandoned []AbandonedPrompt) []Hint {
 	if p.Mode != "filtered" {
 		return nil
+	}
+	if len(abandoned) > 0 {
+		return nil // an abandoned prompt IS the concrete finding; see abandonedPromptHints
 	}
 	for _, d := range decisions {
 		if !d.Allowed {
@@ -353,6 +376,50 @@ func invisibleFailureHint(p Policy, decisions []Decision) []Hint {
 			"Either way, prefer the narrowest grant; do not widen the network policy.",
 		},
 	}}
+}
+
+// abandonedPromptHints explains a prompt nobody answered in time. This is
+// the failure that otherwise leaves no trace at all: the tool gave up before
+// a verdict existed, so no decision was ever recorded and the report would
+// have said "nothing was blocked" (#257).
+//
+// The remedy is to pre-allow the host, not to answer faster: the requesting
+// tool's timeout is its own, and some are far shorter than a human dialog
+// round-trip.
+func abandonedPromptHints(abandoned []AbandonedPrompt) []Hint {
+	if len(abandoned) == 0 {
+		return nil
+	}
+	detail := make([]string, 0, len(abandoned)+2)
+	for _, a := range abandoned {
+		detail = append(detail, fmt.Sprintf("%s gave up after %s — the prompt was still open when the request was abandoned.",
+			hostPort(a.Host, a.Port), waitedFor(a.WaitedMS)))
+	}
+	detail = append(detail,
+		"The tool's own HTTP timeout is shorter than the time it took to answer the dialog, so allowing it afterwards came too late — the fetch had already failed, silently.",
+		"Fix: add the host to network.allow_domain so no prompt is raised. Answering faster is not a reliable remedy.")
+	return []Hint{{
+		Kind:   KindProblem,
+		Title:  fmt.Sprintf("%d network prompt(s) were raised but never answered in time — the requesting tool stopped waiting", len(abandoned)),
+		Detail: detail,
+	}}
+}
+
+// hostPort renders host:port, omitting a zero port.
+func hostPort(host string, port int) string {
+	if port == 0 {
+		return host
+	}
+	return fmt.Sprintf("%s:%d", host, port)
+}
+
+// waitedFor renders an abandoned prompt's open duration, in the unit that
+// makes the comparison against a client timeout obvious.
+func waitedFor(ms int64) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	return fmt.Sprintf("%.1fs", float64(ms)/1000)
 }
 
 func anyDeniedSource(decisions []Decision, source string) bool {

--- a/internal/diagnose/diagnose_test.go
+++ b/internal/diagnose/diagnose_test.go
@@ -60,7 +60,7 @@ func TestAllowlistedButDeniedIsFlaggedAsClash(t *testing.T) {
 	pol := Policy{Mode: "filtered", AllowDomains: []string{"repo.corp"}}
 	decisions := []Decision{dec("repo.corp", false, "blocklist")}
 
-	hints := Analyze(pol, decisions, realMatch)
+	hints := Analyze(pol, decisions, nil, realMatch)
 	h := findHint(hints, "repo.corp is in allow_domain but was still DENIED")
 	if h == nil {
 		t.Fatalf("clash hint missing.\n%s", hintTitles(hints))
@@ -77,7 +77,7 @@ func TestAllowAndDenyOverlapReportsClashNamingDenyDomain(t *testing.T) {
 	pol := Policy{AllowDomains: []string{"repo.corp"}, DenyDomains: []string{"repo.corp"}}
 	decisions := []Decision{dec("repo.corp", false, "blocklist")}
 
-	hints := Analyze(pol, decisions, realMatch)
+	hints := Analyze(pol, decisions, nil, realMatch)
 	h := findHint(hints, "repo.corp is in allow_domain but was still DENIED")
 	if h == nil {
 		t.Fatalf("clash must outrank the deny_domain note.\n%s", hintTitles(hints))
@@ -94,7 +94,7 @@ func TestBlockedNotInAnyRuleSuggestsAllowlist(t *testing.T) {
 	pol := Policy{Mode: "filtered", PromptEnabled: false}
 	decisions := []Decision{dec("registry.npmjs.org", false, "allowlist")}
 
-	hints := Analyze(pol, decisions, realMatch)
+	hints := Analyze(pol, decisions, nil, realMatch)
 	h := findHint(hints, "registry.npmjs.org was blocked and is not in any allow rule")
 	if h == nil {
 		t.Fatalf("missing hint.\n%s", hintTitles(hints))
@@ -126,7 +126,7 @@ func TestSessionDenyShadowingAllowIsNamed(t *testing.T) {
 	pol := Policy{Mode: "filtered", PromptEnabled: true, AllowDomains: []string{"api.github.com"}}
 	decisions := []Decision{dec("api.github.com", false, "session")}
 
-	hints := Analyze(pol, decisions, realMatch)
+	hints := Analyze(pol, decisions, nil, realMatch)
 	h := findHint(hints, "api.github.com is in allow_domain but was still DENIED")
 	if h == nil {
 		t.Fatalf("missing hint.\n%s", hintTitles(hints))
@@ -144,7 +144,7 @@ func TestSessionDenyShadowingAllowIsNamed(t *testing.T) {
 
 func TestOverBroadAllowRuleFlagged(t *testing.T) {
 	pol := Policy{AllowDomains: []string{"*.com", "*.example.com"}}
-	hints := Analyze(pol, nil, realMatch)
+	hints := Analyze(pol, nil, nil, realMatch)
 	h := findHint(hints, `allow_domain "*.com" is very broad`)
 	if h == nil {
 		t.Fatalf("whole-TLD wildcard not flagged.\n%s", hintTitles(hints))
@@ -164,7 +164,7 @@ func TestWildcardAllowMatchesSubdomain(t *testing.T) {
 	pol := Policy{AllowDomains: []string{"*.tngtech.com"}}
 	decisions := []Decision{dec("chat.tngtech.com", false, "learned")}
 
-	hints := Analyze(pol, decisions, realMatch)
+	hints := Analyze(pol, decisions, nil, realMatch)
 	if findHint(hints, "is in allow_domain but was still DENIED") == nil {
 		t.Fatalf("wildcard allow not honored.\n%s", hintTitles(hints))
 	}
@@ -174,7 +174,7 @@ func TestDeadAllowRuleDetected(t *testing.T) {
 	pol := Policy{AllowDomains: []string{"used.example", "typo.exmaple"}}
 	decisions := []Decision{dec("used.example", true, "allowlist")}
 
-	hints := Analyze(pol, decisions, realMatch)
+	hints := Analyze(pol, decisions, nil, realMatch)
 	if findHint(hints, `allow_domain "typo.exmaple" matched no traffic`) == nil {
 		t.Fatalf("dead-rule hint missing.\n%s", hintTitles(hints))
 	}
@@ -186,7 +186,7 @@ func TestDeadAllowRuleDetected(t *testing.T) {
 func TestNoDeadRuleHintWithoutObservedTraffic(t *testing.T) {
 	// With no decisions we cannot know a rule is unused; stay silent.
 	pol := Policy{AllowDomains: []string{"whatever.example"}}
-	if h := findHint(Analyze(pol, nil, realMatch), "matched no traffic"); h != nil {
+	if h := findHint(Analyze(pol, nil, nil, realMatch), "matched no traffic"); h != nil {
 		t.Fatalf("should not flag dead rules with zero observations: %q", h.Title)
 	}
 }
@@ -198,7 +198,7 @@ func TestNoDeadRuleHintWithoutObservedTraffic(t *testing.T) {
 func TestInvisibleFailureHintFiresWhenNothingBlocked(t *testing.T) {
 	pol := Policy{Mode: "filtered", AllowDomains: []string{"example.com"}}
 	decisions := []Decision{dec("example.com", true, "allowlist")} // all allowed
-	h := findHint(Analyze(pol, decisions, realMatch), "can be invisible to this report")
+	h := findHint(Analyze(pol, decisions, nil, realMatch), "can be invisible to this report")
 	if h == nil {
 		t.Fatalf("invisible-failure hint should fire when nothing was blocked")
 	}
@@ -217,7 +217,7 @@ func TestInvisibleFailureHintFiresWhenNothingBlocked(t *testing.T) {
 func TestInvisibleFailureHintSuppressedWhenSomethingBlocked(t *testing.T) {
 	pol := Policy{Mode: "filtered"}
 	decisions := []Decision{dec("blocked.example", false, "allowlist")}
-	if findHint(Analyze(pol, decisions, realMatch), "can be invisible to this report") != nil {
+	if findHint(Analyze(pol, decisions, nil, realMatch), "can be invisible to this report") != nil {
 		t.Fatalf("blind-spot note must stay quiet when a concrete block exists")
 	}
 }
@@ -225,7 +225,7 @@ func TestInvisibleFailureHintSuppressedWhenSomethingBlocked(t *testing.T) {
 func TestDNSDenialSurfaced(t *testing.T) {
 	pol := Policy{}
 	decisions := []Decision{dec("nope.invalid", false, "dns")}
-	if findHint(Analyze(pol, decisions, realMatch), "failed DNS resolution") == nil {
+	if findHint(Analyze(pol, decisions, nil, realMatch), "failed DNS resolution") == nil {
 		t.Fatal("dns-source denial should surface a hint")
 	}
 }
@@ -237,7 +237,7 @@ func TestEnvironmentHintsAreOrderedAfterWarnings(t *testing.T) {
 		AllowVars:     []string{"HOME"},
 	}
 	decisions := []Decision{dec("blocked.example", false, "allowlist")}
-	hints := Analyze(pol, decisions, realMatch)
+	hints := Analyze(pol, decisions, nil, realMatch)
 	if len(hints) < 2 {
 		t.Fatalf("expected a problem + advisories, got %d", len(hints))
 	}
@@ -255,7 +255,7 @@ func TestBuildCountsDenied(t *testing.T) {
 		dec("b", true, "allowlist"),
 		dec("c", false, "blocklist"),
 	}
-	r := Build(Policy{}, decisions, realMatch)
+	r := Build(Policy{}, decisions, nil, realMatch)
 	if r.Total != 3 || r.Denied != 2 {
 		t.Fatalf("Build counts wrong: total=%d denied=%d", r.Total, r.Denied)
 	}

--- a/internal/netproxy/abandoned_prompt_test.go
+++ b/internal/netproxy/abandoned_prompt_test.go
@@ -1,0 +1,110 @@
+package netproxy
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
+)
+
+// eventsOfType filters a capturingAuditor's record by event type.
+func eventsOfType(c *capturingAuditor, typ string) []audit.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []audit.Event
+	for _, ev := range c.events {
+		if ev.Type == typ {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// stubResolve pins any host to a routable address so Check reaches the
+// prompt stage instead of failing DNS.
+func stubResolve(context.Context, string) ([]netip.Addr, error) {
+	return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+}
+
+// TestDrainAbandonedPromptsEmitsEventForOpenPrompt is the #257 core: a prompt
+// still open at shutdown must leave a record, because no net.decision will
+// ever be written for it.
+func TestDrainAbandonedPromptsEmitsEventForOpenPrompt(t *testing.T) {
+	rec := &capturingAuditor{}
+	prompter := &blockingPrompter{block: make(chan struct{}), res: PromptResult{Allow: true}}
+	f := NewFilter(FilterConfig{
+		PromptEnabled: true,
+		Prompter:      prompter,
+		Auditor:       rec,
+		Resolve:       stubResolve,
+	})
+
+	// A request that reaches the prompt and never gets an answer.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f.Check(context.Background(), "models.dev", 443)
+	}()
+	waitUntil(t, func() bool { return prompter.started.Load() == 1 })
+
+	if n := f.DrainAbandonedPrompts(); n != 1 {
+		t.Fatalf("drained %d prompt(s), want 1", n)
+	}
+	evs := eventsOfType(rec, audit.TypeNetPromptAbandoned)
+	if len(evs) != 1 {
+		t.Fatalf("emitted %d abandoned event(s), want 1", len(evs))
+	}
+	if evs[0].Host != "models.dev" || evs[0].Port != 443 {
+		t.Errorf("event = %s:%d, want models.dev:443", evs[0].Host, evs[0].Port)
+	}
+
+	// Release the parked prompt so the goroutine can finish.
+	close(prompter.block)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("prompt goroutine did not finish")
+	}
+}
+
+// TestDrainAbandonedPromptsIgnoresAnsweredPrompt asserts a prompt that WAS
+// answered produces a net.decision and no abandoned event — otherwise every
+// normal run would report a phantom failure.
+func TestDrainAbandonedPromptsIgnoresAnsweredPrompt(t *testing.T) {
+	rec := &capturingAuditor{}
+	f := NewFilter(FilterConfig{
+		PromptEnabled: true,
+		Prompter:      &fakePrompter{res: PromptResult{Allow: true}},
+		Auditor:       rec,
+		Resolve:       stubResolve,
+	})
+
+	if v, _ := f.Check(context.Background(), "example.test", 443); v.Decision != Allow {
+		t.Fatalf("verdict = %v, want Allow", v.Decision)
+	}
+	if n := f.DrainAbandonedPrompts(); n != 0 {
+		t.Errorf("drained %d prompt(s) after an answered prompt, want 0", n)
+	}
+	if evs := eventsOfType(rec, audit.TypeNetPromptAbandoned); len(evs) != 0 {
+		t.Errorf("emitted %d abandoned event(s) for an answered prompt, want 0", len(evs))
+	}
+	if evs := eventsOfType(rec, audit.TypeNetDecision); len(evs) != 1 {
+		t.Errorf("emitted %d decision(s), want 1", len(evs))
+	}
+}
+
+func TestDrainAbandonedPromptsIsIdempotent(t *testing.T) {
+	rec := &capturingAuditor{}
+	f := NewFilter(FilterConfig{Auditor: rec})
+	if n := f.DrainAbandonedPrompts(); n != 0 {
+		t.Errorf("drained %d with no prompts in flight, want 0", n)
+	}
+	if n := f.DrainAbandonedPrompts(); n != 0 {
+		t.Errorf("second drain returned %d, want 0", n)
+	}
+	if evs := eventsOfType(rec, audit.TypeNetPromptAbandoned); len(evs) != 0 {
+		t.Errorf("emitted %d event(s) with nothing in flight", len(evs))
+	}
+}

--- a/internal/netproxy/abandoned_prompt_test.go
+++ b/internal/netproxy/abandoned_prompt_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tngtech/oh-my-agentic-coder/internal/audit"
+	"github.com/TNG/oh-my-agentic-coder/internal/audit"
 )
 
 // eventsOfType filters a capturingAuditor's record by event type.
@@ -92,6 +92,93 @@ func TestDrainAbandonedPromptsIgnoresAnsweredPrompt(t *testing.T) {
 	}
 	if evs := eventsOfType(rec, audit.TypeNetDecision); len(evs) != 1 {
 		t.Errorf("emitted %d decision(s), want 1", len(evs))
+	}
+}
+
+// TestPromptWaitRecordedOnDecision covers the other half of #257: the prompt
+// IS answered, but late. A decision exists (so nothing looks wrong) and only
+// the recorded wait reveals that a short-timeout client had already failed.
+func TestPromptWaitRecordedOnDecision(t *testing.T) {
+	rec := &capturingAuditor{}
+	prompter := &blockingPrompter{block: make(chan struct{}), res: PromptResult{Allow: true}}
+	f := NewFilter(FilterConfig{
+		PromptEnabled: true,
+		Prompter:      prompter,
+		Auditor:       rec,
+		Resolve:       stubResolve,
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f.Check(context.Background(), "models.dev", 443)
+	}()
+	waitUntil(t, func() bool { return prompter.started.Load() == 1 })
+	time.Sleep(30 * time.Millisecond) // let the dialog be "open" measurably
+	close(prompter.block)
+	<-done
+
+	evs := eventsOfType(rec, audit.TypeNetDecision)
+	if len(evs) != 1 {
+		t.Fatalf("emitted %d decision(s), want 1", len(evs))
+	}
+	if evs[0].WaitedMS <= 0 {
+		t.Errorf("decision WaitedMS = %d, want > 0 for a prompt-sourced decision", evs[0].WaitedMS)
+	}
+}
+
+// TestNonPromptDecisionHasNoWait keeps the new field out of decisions that
+// never involved a dialog, so a diagnose threshold cannot false-positive.
+func TestNonPromptDecisionHasNoWait(t *testing.T) {
+	rec := &capturingAuditor{}
+	f := NewFilter(FilterConfig{
+		AllowDomains: []string{"allowed.test"},
+		Auditor:      rec,
+		Resolve:      stubResolve,
+	})
+	f.Check(context.Background(), "allowed.test", 443)
+
+	evs := eventsOfType(rec, audit.TypeNetDecision)
+	if len(evs) != 1 {
+		t.Fatalf("emitted %d decision(s), want 1", len(evs))
+	}
+	if evs[0].WaitedMS != 0 {
+		t.Errorf("WaitedMS = %d for an allowlist decision, want 0", evs[0].WaitedMS)
+	}
+}
+
+// TestDrainedPromptAnsweredLateEmitsNoDecision guards against one request
+// being reported twice with contradictory outcomes: once as abandoned, then
+// again as an ordinary allow when the dialog is finally answered.
+func TestDrainedPromptAnsweredLateEmitsNoDecision(t *testing.T) {
+	rec := &capturingAuditor{}
+	prompter := &blockingPrompter{block: make(chan struct{}), res: PromptResult{Allow: true}}
+	f := NewFilter(FilterConfig{
+		PromptEnabled: true,
+		Prompter:      prompter,
+		Auditor:       rec,
+		Resolve:       stubResolve,
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f.Check(context.Background(), "models.dev", 443)
+	}()
+	waitUntil(t, func() bool { return prompter.started.Load() == 1 })
+
+	if n := f.DrainAbandonedPrompts(); n != 1 {
+		t.Fatalf("drained %d, want 1", n)
+	}
+	// The user answers after the drain — too late to matter.
+	close(prompter.block)
+	<-done
+
+	if evs := eventsOfType(rec, audit.TypeNetPromptAbandoned); len(evs) != 1 {
+		t.Errorf("abandoned events = %d, want 1", len(evs))
+	}
+	if evs := eventsOfType(rec, audit.TypeNetDecision); len(evs) != 0 {
+		t.Errorf("emitted %d decision(s) for an already-abandoned prompt, want 0", len(evs))
 	}
 }
 

--- a/internal/netproxy/filter.go
+++ b/internal/netproxy/filter.go
@@ -45,6 +45,17 @@ type Verdict struct {
 	// without a follow-up GET /sandbox/intent. Body-only: never a header value
 	// (it is agent-supplied and unsanitized).
 	IntentReason string
+	// PromptWaitMS is how long the dialog was open before the user answered
+	// (prompt decisions only; 0 otherwise). It is what makes a *silent*
+	// failure visible after the fact: the connection is held while the
+	// dialog is up, so any client whose own timeout is shorter than this
+	// had already given up by the time the allow was granted. See #257.
+	PromptWaitMS int64
+	// PromptAbandoned marks a verdict whose prompt had already been recorded
+	// as abandoned (the proxy shut down while it was open). The answer
+	// arrived too late to be acted on, so emitting it as an ordinary
+	// decision would contradict the abandoned record for the same request.
+	PromptAbandoned bool
 }
 
 // hardDenyHosts can never be allowed, even interactively (nono parity).
@@ -147,6 +158,10 @@ type promptWait struct {
 	// the requesting goroutine may have gone.
 	port      int
 	startedAt time.Time
+	// drained is set by DrainAbandonedPrompts when this prompt was still
+	// open at shutdown. Read by the resolution path so a late answer is
+	// not also emitted as an ordinary decision. Guarded by promptMu.
+	drained bool
 }
 
 // NewFilter builds a Filter.
@@ -184,6 +199,10 @@ func (f *Filter) DrainAbandonedPrompts() int {
 	f.promptMu.Lock()
 	abandoned := make(map[string]*promptWait, len(f.inflight))
 	for host, w := range f.inflight {
+		// Mark before releasing the lock: the dialog may still be up, and
+		// its resolution path checks this to avoid emitting a decision
+		// that would contradict the abandoned record.
+		w.drained = true
 		abandoned[host] = w
 		delete(f.inflight, host)
 	}
@@ -339,7 +358,7 @@ func (f *Filter) recordDecision(s DecisionStore, host string, res PromptResult, 
 // as deny).
 func (f *Filter) defaultDecision(ctx context.Context, host string, port int) (Verdict, bool) {
 	if f.cfg.PromptEnabled {
-		res, prompted := f.promptCoalesced(ctx, host, port)
+		res, waited, drained, prompted := f.promptCoalesced(ctx, host, port)
 		if !prompted {
 			if f.cfg.OnUnavailableAllow {
 				return Verdict{Decision: Allow, Reason: "prompt unavailable: on_unavailable=allow"}, true
@@ -359,12 +378,12 @@ func (f *Filter) defaultDecision(ctx context.Context, host string, port int) (Ve
 			scope = "once"
 		}
 		if res.NeedsIntent {
-			return Verdict{Decision: Deny, Reason: "prompt:needs_intent", Scope: scope, Persisted: res.Persist, IntentReason: res.PriorReason}, true
+			return Verdict{Decision: Deny, Reason: "prompt:needs_intent", Scope: scope, Persisted: res.Persist, IntentReason: res.PriorReason, PromptWaitMS: waited, PromptAbandoned: drained}, true
 		}
 		if res.Allow {
-			return Verdict{Decision: Allow, Reason: "prompt:allow", Scope: scope, Persisted: res.Persist}, true
+			return Verdict{Decision: Allow, Reason: "prompt:allow", Scope: scope, Persisted: res.Persist, PromptWaitMS: waited, PromptAbandoned: drained}, true
 		}
-		return Verdict{Decision: Deny, Reason: "prompt:deny", Scope: scope, Persisted: res.Persist, IntentReason: res.PriorReason}, true
+		return Verdict{Decision: Deny, Reason: "prompt:deny", Scope: scope, Persisted: res.Persist, IntentReason: res.PriorReason, PromptWaitMS: waited, PromptAbandoned: drained}, true
 	}
 	if len(f.cfg.AllowDomains) > 0 {
 		return Verdict{Decision: Deny, Reason: "not in allowlist"}, true
@@ -375,9 +394,15 @@ func (f *Filter) defaultDecision(ctx context.Context, host string, port int) (Ve
 
 // promptCoalesced ensures concurrent requests for the same host share
 // one dialog. prompted=false means no prompter is available.
-func (f *Filter) promptCoalesced(ctx context.Context, host string, port int) (PromptResult, bool) {
+//
+// waitedMS is how long the dialog was open, and drained reports whether it
+// had already been recorded as abandoned (see DrainAbandonedPrompts) by the
+// time it was answered. Both travel onto the Verdict so the audit trail can
+// distinguish "allowed promptly" from "allowed long after the requesting
+// tool gave up".
+func (f *Filter) promptCoalesced(ctx context.Context, host string, port int) (res PromptResult, waitedMS int64, drained bool, prompted bool) {
 	if f.cfg.Prompter == nil {
-		return PromptResult{}, false
+		return PromptResult{}, 0, false, false
 	}
 	f.promptMu.Lock()
 	if w, ok := f.inflight[host]; ok {
@@ -386,7 +411,10 @@ func (f *Filter) promptCoalesced(ctx context.Context, host string, port int) (Pr
 			f.cfg.onCoalesceWait()
 		}
 		<-w.done
-		return w.res, true
+		f.promptMu.Lock()
+		wasDrained := w.drained
+		f.promptMu.Unlock()
+		return w.res, time.Since(w.startedAt).Milliseconds(), wasDrained, true
 	}
 	w := &promptWait{done: make(chan struct{}), port: port, startedAt: time.Now()}
 	f.inflight[host] = w
@@ -395,10 +423,11 @@ func (f *Filter) promptCoalesced(ctx context.Context, host string, port int) (Pr
 	w.res = f.cfg.Prompter.Prompt(ctx, host, port)
 
 	f.promptMu.Lock()
+	wasDrained := w.drained
 	delete(f.inflight, host)
 	f.promptMu.Unlock()
 	close(w.done)
-	return w.res, true
+	return w.res, time.Since(w.startedAt).Milliseconds(), wasDrained, true
 }
 
 func (f *Filter) log(host string, port int, v Verdict) Verdict {
@@ -407,10 +436,19 @@ func (f *Filter) log(host string, port int, v Verdict) Verdict {
 		word = "ALLOW"
 	}
 	f.cfg.Logf("omac sandbox: net %s %s:%d (%s)", word, host, port, v.Reason)
+	if v.PromptAbandoned {
+		// Already recorded as abandoned at shutdown. Emitting a decision now
+		// would put two contradictory records in the trail for one request,
+		// and the abandoned one is the accurate account: the requester was
+		// gone before this answer existed.
+		f.cfg.Logf("omac sandbox: net %s %s:%d answered %dms after the prompt was abandoned — not recorded as a decision",
+			word, host, port, v.PromptWaitMS)
+		return v
+	}
 	source := classifyReason(v.Reason)
 	scope := v.Scope
 	persisted := v.Persisted
-	f.cfg.Auditor.Emit(audit.NetDecision(host, port, v.Decision == Allow, scope, source, persisted))
+	f.cfg.Auditor.Emit(audit.NetDecision(host, port, v.Decision == Allow, scope, source, persisted, v.PromptWaitMS))
 	return v
 }
 

--- a/internal/netproxy/filter.go
+++ b/internal/netproxy/filter.go
@@ -16,6 +16,7 @@ import (
 	"net/netip"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/TNG/oh-my-agentic-coder/internal/audit"
 )
@@ -141,6 +142,11 @@ type Filter struct {
 type promptWait struct {
 	done chan struct{}
 	res  PromptResult
+	// port and startedAt describe the prompt for the abandoned-prompt
+	// audit event, which is emitted from DrainAbandonedPrompts long after
+	// the requesting goroutine may have gone.
+	port      int
+	startedAt time.Time
 }
 
 // NewFilter builds a Filter.
@@ -158,6 +164,38 @@ func NewFilter(cfg FilterConfig) *Filter {
 		cfg.Auditor = audit.Nop()
 	}
 	return &Filter{cfg: cfg, inflight: map[string]*promptWait{}}
+}
+
+// DrainAbandonedPrompts records every prompt that is still open, as an
+// abandoned prompt, and forgets it.
+//
+// A prompt outlives the request that raised it on purpose: the dialog runs
+// on a detached context (see internal/netprompt, which builds its timeout
+// from context.Background()) so a transient client does not kill a dialog
+// the user is already reading. The cost is that a tool with a short HTTP
+// timeout — the opencode skainet plugin aborts model discovery after 3s,
+// while answering a dialog measurably takes longer — gives up before the
+// verdict exists. No net.decision is ever logged, so the run reads as
+// clean while having silently failed.
+//
+// Called at proxy shutdown, when any remaining prompt is by definition
+// unresolved. Returns the number of prompts drained. See #257.
+func (f *Filter) DrainAbandonedPrompts() int {
+	f.promptMu.Lock()
+	abandoned := make(map[string]*promptWait, len(f.inflight))
+	for host, w := range f.inflight {
+		abandoned[host] = w
+		delete(f.inflight, host)
+	}
+	f.promptMu.Unlock()
+
+	for host, w := range abandoned {
+		waited := time.Since(w.startedAt).Milliseconds()
+		f.cfg.Logf("omac sandbox: net ABANDONED %s:%d (prompt raised %dms ago, no verdict — the requesting tool stopped waiting)",
+			host, w.port, waited)
+		f.cfg.Auditor.Emit(audit.NetPromptAbandoned(host, w.port, waited))
+	}
+	return len(abandoned)
 }
 
 // Check runs the full decision pipeline for host:port and returns the
@@ -350,7 +388,7 @@ func (f *Filter) promptCoalesced(ctx context.Context, host string, port int) (Pr
 		<-w.done
 		return w.res, true
 	}
-	w := &promptWait{done: make(chan struct{})}
+	w := &promptWait{done: make(chan struct{}), port: port, startedAt: time.Now()}
 	f.inflight[host] = w
 	f.promptMu.Unlock()
 

--- a/internal/netproxy/server.go
+++ b/internal/netproxy/server.go
@@ -289,13 +289,6 @@ func (s *Server) EnvVars() map[string]string {
 
 // Close stops the listener and tears down active tunnels.
 func (s *Server) Close() {
-	// Any prompt still open at shutdown was never answered in time to
-	// matter: record it so the run does not read as "nothing was blocked"
-	// (#257). Done before tearing down connections, while the filter's
-	// in-flight set is still intact.
-	if s.filter != nil {
-		s.filter.DrainAbandonedPrompts()
-	}
 	s.mu.Lock()
 	s.closed = true
 	conns := make([]net.Conn, 0, len(s.conns))
@@ -308,6 +301,15 @@ func (s *Server) Close() {
 	}
 	for _, c := range conns {
 		_ = c.Close()
+	}
+	// Any prompt still open now was never answered in time to matter:
+	// record it so the run does not read as "nothing was blocked" (#257).
+	// Deliberately last — draining before the listener and connections are
+	// gone would clear the in-flight set while requests can still arrive,
+	// so a follow-up request for the same host would raise a second dialog
+	// (the coalescing map is what prevents that) and go unrecorded.
+	if s.filter != nil {
+		s.filter.DrainAbandonedPrompts()
 	}
 }
 

--- a/internal/netproxy/server.go
+++ b/internal/netproxy/server.go
@@ -289,6 +289,13 @@ func (s *Server) EnvVars() map[string]string {
 
 // Close stops the listener and tears down active tunnels.
 func (s *Server) Close() {
+	// Any prompt still open at shutdown was never answered in time to
+	// matter: record it so the run does not read as "nothing was blocked"
+	// (#257). Done before tearing down connections, while the filter's
+	// in-flight set is still intact.
+	if s.filter != nil {
+		s.filter.DrainAbandonedPrompts()
+	}
 	s.mu.Lock()
 	s.closed = true
 	conns := make([]net.Conn, 0, len(s.conns))


### PR DESCRIPTION
**Issue:** Closes #257 · Refs #241

## What

- New `net.prompt_abandoned` audit event for a network prompt that was raised but never resolved.
- Prompt-sourced `net.decision` events now carry `waited_ms` — how long the dialog was open before it was answered.
- `omac diagnose` reports both, and no longer claims *"Nothing was blocked by the network policy"* for a run where either happened.

## Why

While a prompt is open the connection is held, and the requesting tool is subject to **its own** timeout. The opencode Skainet plugin aborts model discovery after 3s; answering a GUI dialog measurably takes longer (5s measured here, with the dialog already in focus). So the tool gives up, the fetch fails silently, and the allow you then grant applies to a request nobody is waiting for.

Both halves of that were invisible:

- If the run ends with the dialog still open, **no** `net.decision` is ever written. `omac diagnose` reported `0/1 connection(s) blocked · Nothing was blocked by the network policy` for a run that had silently failed.
- If the dialog *is* answered, just too late, a perfectly ordinary allow is recorded and nothing looks wrong at all.

This is not an edge case: the compiled-in default profile (`internal/sandboxprofile/resolve.go:23`) has no `allow_domain`, so on a fresh install every host prompts on first contact.

## How

- The dialog deliberately runs on a detached context (`internal/netprompt/prompt.go:312` builds its timeout from `context.Background()`), so an open prompt outlives the request that raised it and dies with the process. Detection therefore belongs at teardown: `Filter.DrainAbandonedPrompts` records whatever is still in flight when the proxy closes. It runs **last** in `Server.Close`, after the listener and connections are gone — draining earlier clears the coalescing map while requests can still arrive, which would raise a second dialog for a host already being asked about.
- Nothing in the proxy can observe the requester leaving (`clientSourceCtx` is also `context.Background()`-derived), so for the answered-too-late case the prompt's open duration is recorded on the decision instead, and diagnose flags anything ≥3s (`promptLatencyThresholdMS` — the shortest client budget observed in the wild).
- A prompt already recorded as abandoned does not also emit a decision: `promptWait` carries a `drained` flag so one request cannot appear as both abandoned and allowed.
- Abandoned entries are aggregated per `host:port` with a repeat count and capped at 8, mirroring `maxBlockedShown` — otherwise `--run all` emits one line per occurrence across the whole persistent log.

## Verification

`go build ./...`, `go vet ./internal/...` clean. `go test ./internal/netproxy/ -race` clean. `go test ./...` passes except `TestIntegrationWorktreeKnownLimitations` and `TestIntegrationWorkflowInterpretersRunnable`, which fail identically on clean `main` on this host (local toolchain paths absent from the default profile).

Drain path, end to end, **no human interaction** (the client times out on its own):

```
omac sandbox run --profile <prompt-enabled> --audit-log /tmp/a.jsonl \
  -- curl -s --max-time 1 https://example.com          # exit 28

diag:  net ABANDONED example.com:443 (prompt raised 967ms ago, no verdict —
       the requesting tool stopped waiting)
audit: net.prompt_abandoned example.com 443 waited_ms=967
omac diagnose:
       last run · filtered mode · 0/0 connection(s) blocked · 1 prompt(s) abandoned
       • 1 network prompt(s) … were raised but never answered in time
```

Late-answer path (the case the first commit missed — a `waited_ms=5200` prompt-sourced allow):

```
• 1 prompt(s) were answered after 3.0s or more — a short-timeout tool may have failed anyway
  chat.model.tngtech.com:443 was held for 5.2s before the prompt was answered.
  Fix: add these hosts to network.allow_domain so no prompt is raised.
```

…and no *"Nothing was blocked"* in either case. Runs with neither condition are unchanged (regression test asserts the note still fires).

The second commit is review fixes; the late-answer detection, the `Close` ordering, the double-report suppression and the detail cap each have a test.

## Follow-up

- **Correction to #257 as filed:** the issue implies a cancelled request context. The dialog is actually detached and dies with the process, so detection had to move to teardown plus a recorded wait. Worth a comment on the issue.
- Deliberately not included (#257 checklist item 4): making a bare `omac sandbox run` write the central audit trail. It only gets an auditor when the parent passes `--audit-log` (`internal/sandboxrun/run.go:144`), and wiring it would couple `sandboxrun` to launcher-config loading — worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
