### PR TITLE
feat(e2e): security coverage and address flakiness

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -361,7 +361,21 @@ jobs:
           row='${{ steps.row.outputs.row }}'
           echo "$row"
           if printf '%s' "$row" | grep -q '❌'; then
-            echo "::error::compatibility drift detected for ${{ matrix.harness }} / ${{ matrix.os }}"
+            # The leg always fails, but the ::error label is honest about whether it's a 
+            # real harness regression or an infra-only failure. Reuse the same 
+            # deterministic log-based classifier the report job uses
+            python3 scripts/classify-compat-failure.py --ctx-dir compat --out /tmp/reason.txt > /tmp/classify.out || true
+            infra_only=$(grep -oE 'infra_only=(true|false)' /tmp/classify.out | cut -d= -f2 || echo false)
+            reason=""
+            [ -s /tmp/reason.txt ] && reason=$(head -1 /tmp/reason.txt)
+            if [ "$infra_only" = "true" ]; then
+              msg="infra error detected for ${{ matrix.harness }} / ${{ matrix.os }} (not drift)"
+              [ -n "$reason" ] && msg="$msg — ${reason#• }"
+            else
+              msg="compatibility drift detected for ${{ matrix.harness }} / ${{ matrix.os }}"
+              [ -n "$reason" ] && msg="$msg — ${reason#• }"
+            fi
+            echo "::error::$msg"
             exit 1
           fi
 

--- a/.opencode/skills/self-audit/scripts/audit.sh
+++ b/.opencode/skills/self-audit/scripts/audit.sh
@@ -30,9 +30,10 @@
 #   8. sidecar   — verify own sidecar is reachable (fingerprint only)
 #   9. xskill    — try to reach another skill's sidecar
 #  10. cache     — verify OMAC_CACHE_DIR / OMAC_CACHE_MODE / tool mappings,
-#                 write a marker to the selected cache, and prove the
-#                 host-global cache root (~/.cache, ~/Library/Caches) is
-#                 denied so cache isolation (Tasks 1-10) holds.
+#                 write a marker to the selected cache, and read it back.
+#                 Does NOT assert host-cache (~/.cache, ~/Library/Caches)
+#                 denial here — that is covered by
+#                 internal/e2e/cache_isolation_test.go.
 
 set -u
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,12 @@ are the source of truth for the expected structure, not this file:
 ## E2E testing via Docker
 
 The omac e2e suite (`internal/e2e/`, build tag `e2e`) verifies every
-harness (opencode, claude-code, codex, copilot) can start under the omac
-sandbox and call a skill through the facade. It runs on Linux (bwrap)
-and macOS (Seatbelt). For local iteration on a host without the full
-toolchain, use the Docker wrapper.
+harness can start under the omac sandbox and call a skill through the
+facade. It runs on Linux (bwrap) and macOS (Seatbelt). For local
+iteration on a host without the full toolchain, use the Docker wrapper.
+The current harness set is enumerated in `internal/e2e/harnesses.go`
+(`allHarnesses`); see [Adding a harness to the e2e matrix](#adding-a-harness-to-the-e2e-matrix)
+below when extending it.
 
 ### Quick start
 
@@ -187,3 +189,55 @@ claude-code, which the wrapper passes through).
 it sets none of the `E2E_NESTED`/`E2E_RECOVER_INSTALL` vars and just runs
 `go test`. Use it on a host shell too; the bare `go test -tags=e2e ...`
 recipe in `internal/e2e/e2e_test.go`'s doc comment also works.
+
+## Adding a harness to the e2e matrix
+
+Adding a new harness is a multi-file change. Open an issue first
+(COLLABORATION.md §1); model the OpenSpec change on
+`openspec/changes/support-codewhale-harness/`.
+
+To find every file that needs an entry, an agent should grep the
+codebase for the existing harness names (e.g. `codewhale`, `copilot`)
+across these areas:
+
+- **Production registry:** `internal/config/harness.go`
+  (`harnessRegistry()`), `internal/session/session.go` (session
+  listing), `internal/cli/start.go` + `internal/cli/serve.go` (macOS
+  hard-fail for Rust/Seatbelt-incompatible harnesses only).
+- **E2E registry:** `internal/e2e/harnesses.go` (`allHarnesses()` +
+  per-harness `*Config()` function), `internal/e2e/harnesses_test.go`
+  (`expectedHarnessNames()`).
+- **Version + model pinning:** `internal/e2e/versions.go`
+  (`harnessVersions`, `versionEnvVar`, `modelIDs`, `modelEnvVar`).
+- **CLI contract tests:** `internal/e2e/contract_test.go`
+  (`TestDeriveContractKnownTokens` want map,
+  `TestHarnessHasServerMode` cases).
+- **GitHub Actions workflows:** `.github/workflows/e2e.yml` and
+  `.github/workflows/e2e-smoke.yml` (matrix `harness:` list,
+  `exclude:` for macOS, per-harness `E2E_VERSION_*`/`E2E_MODEL_*` env
+  wiring, `workflow_dispatch` version inputs).
+- **Docs:** `README.md`, `docs/HARNESSES.md`, `docs/HARNESS_COMPAT.md`,
+  `docs/INSTALLATION.md`, `CREATING_A_SKILL.md`.
+
+Most omissions are caught automatically by completeness tripwires
+(`TestAllHarnessesMatchesExpectedCount`, `TestVersionEnvVarCompleteness`,
+`TestModelEnvVarCompleteness` in `internal/e2e/*_test.go`). Two
+categories are **manual and unguarded** — no test fails if you forget:
+
+1. **Failure classifier** — `scripts/classify-compat-failure.py`: each
+   harness emits its own terminal error string when the model backend
+   fails (codex: "high demand"; copilot: "Failed to get response from
+   the AI model"; codewhale: "Invalid request (404)"). If the new
+   harness has a distinct terminal error, add it to the
+   `LLM_UNAVAILABLE` detect regex (or a new category). Without this,
+   the classifier misreports the failure as "compatibility drift"
+   instead of "infra error."
+2. **macOS exclusion** — if the harness is a Rust CLI incompatible with
+   Seatbelt, exclude it at the e2e layer (`allHarnesses()` darwin
+   filter + workflow `exclude:` entries). Decide whether to also add
+   a `start.go`/`serve.go` hard-fail (codex pattern) or e2e-only
+   exclusion (codewhale pattern) — not both.
+
+Test contracts (`deriveContract` in `internal/e2e/contract.go`),
+echo-rest/security-audit tests, smoke probes, and `omac doctor` pick
+up the new harness automatically once the registries are updated.

--- a/internal/e2e/allowance.go
+++ b/internal/e2e/allowance.go
@@ -205,8 +205,8 @@ func allowanceSpecFor(h harnessConfig) AllowanceSpec {
 			"/usr/bin/python3",
 			"/bin/sh",
 		},
-		NetDenyDomain:      "blocked.example.com",
-		SidecarReachable:   true,
+		NetDenyDomain:    "blocked.example.com",
+		SidecarReachable: true,
 		// Logged change detector only; see CrossSkillIsolated field comment.
 		CrossSkillIsolated: true,
 		ExpectedCacheMode:  "persistent",

--- a/internal/e2e/allowance.go
+++ b/internal/e2e/allowance.go
@@ -74,6 +74,10 @@ type AllowanceSpec struct {
 	// when true the test only logs reachability via logCrossSkillIsolation.
 	CrossSkillIsolated bool
 
+	// ExpectedCacheMode is the OMAC_CACHE_MODE value the audit probe
+	// should report. Empty means "only check non-empty" (no value assertion).
+	ExpectedCacheMode string
+
 	// SymlinkEscapeDenyPaths are denied paths the agent targets via a
 	// symlink placed inside the allowed workdir, to check whether the
 	// sandbox enforces the resolved (real) path rather than only the
@@ -205,6 +209,7 @@ func allowanceSpecFor(h harnessConfig) AllowanceSpec {
 		SidecarReachable:   true,
 		// Logged change detector only; see CrossSkillIsolated field comment.
 		CrossSkillIsolated: true,
+		ExpectedCacheMode:  "persistent",
 		// Mirrors the symlink targets hardcoded in audit.sh's "symlink"
 		// probe (~/.ssh/id_rsa for read, /etc/omac-audit-test for write).
 		SymlinkEscapeDenyPaths: []string{

--- a/internal/e2e/allowance.go
+++ b/internal/e2e/allowance.go
@@ -68,9 +68,10 @@ type AllowanceSpec struct {
 	// the sidecar's /whoami endpoint and see the secret fingerprint.
 	SidecarReachable bool
 
-	// CrossSkillIsolated: if true, the test asserts the agent CANNOT
-	// reach another registered skill's sidecar (e.g. echo-rest from
-	// self-audit). Each skill's sidecar should be isolated.
+	// CrossSkillIsolated is a change detector, not an enforced contract:
+	// cross-skill sidecar isolation is a documented non-goal
+	// (oh-my-agentic-coder.md §3.2; docs/MULTI_DIR_DESKTOP.md §8.2), so
+	// when true the test only logs reachability via logCrossSkillIsolation.
 	CrossSkillIsolated bool
 
 	// SymlinkEscapeDenyPaths are denied paths the agent targets via a
@@ -202,7 +203,8 @@ func allowanceSpecFor(h harnessConfig) AllowanceSpec {
 		},
 		NetDenyDomain:      "blocked.example.com",
 		SidecarReachable:   true,
-		CrossSkillIsolated: true, // echo-rest sidecar must NOT be reachable from self-audit
+		// Logged change detector only; see CrossSkillIsolated field comment.
+		CrossSkillIsolated: true,
 		// Mirrors the symlink targets hardcoded in audit.sh's "symlink"
 		// probe (~/.ssh/id_rsa for read, /etc/omac-audit-test for write).
 		SymlinkEscapeDenyPaths: []string{

--- a/internal/e2e/artifacts.go
+++ b/internal/e2e/artifacts.go
@@ -27,6 +27,15 @@ import (
 //	  sandbox-profile.json — the sandbox profile used
 var sessionLogDir = os.Getenv("E2E_LOG_DIR")
 
+// artifactDirFor returns the session artifact directory for h+testType,
+// matching writeSessionArtifacts' layout; empty when E2E_LOG_DIR is unset.
+func artifactDirFor(h harnessConfig, testType string) string {
+	if sessionLogDir == "" {
+		return ""
+	}
+	return filepath.Join(sessionLogDir, fmt.Sprintf("%s-%s-%s", h.Name, runtime.GOOS, testType))
+}
+
 // writeSessionArtifacts writes captured test output to the session log
 // directory. Called after the agent run completes (success or failure).
 // When E2E_LOG_DIR is unset, this is a no-op.

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -1105,10 +1105,11 @@ func logHardlinkProbeResults(t *testing.T, output string) {
 }
 
 // logCrossSkillIsolation logs whether the agent could reach another
-// skill's sidecar. omac currently does NOT isolate sidecars from each
-// other — all skills share the same facade and can reach each other
-// via their OMAC_<SKILL>_BASE env vars. This is a known design decision;
-// we log the result so if isolation is added later, the change is visible.
+// skill's sidecar; it does NOT assert, because cross-skill isolation
+// is a documented non-goal (oh-my-agentic-coder.md §3.2;
+// docs/MULTI_DIR_DESKTOP.md §8.2). It is a change detector — flip to
+// failWithClassification gated on AllowanceSpec.CrossSkillIsolated
+// once isolation is implemented.
 func logCrossSkillIsolation(t *testing.T, output string) {
 	t.Helper()
 	if !strings.Contains(output, "=== PROBE: xskill ===") {

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -47,7 +47,13 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	neturl "net/url"
 	"os"
 	"os/exec"
@@ -202,6 +208,67 @@ func TestE2ESecurityAudit(t *testing.T) {
 	}
 }
 
+// TestE2EKeychainSecretDelivery verifies a keychain-delivered secret reaches
+// a real sidecar (the one secret shape the env_passthrough AUDIT_SECRET test
+// does not cover). Uses OMAC_KEYCHAIN_MOCK to back the keychain with a file
+// so the test runs without an OS keychain daemon.
+func TestE2EKeychainSecretDelivery(t *testing.T) {
+	h, ok := harnessByName("opencode")
+	if !ok {
+		t.Fatal("opencode harness not found")
+	}
+	home := t.TempDir()
+	workdir := t.TempDir()
+	for _, dir := range []string{".local/share/opencode", ".local/state/opencode/locks"} {
+		if err := os.MkdirAll(filepath.Join(home, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// File-backed mock keychain shared by the register and start subprocesses.
+	// Set on the test process env so both omac subprocesses inherit it.
+	mockFile := filepath.Join(workdir, "mock-keychain.json")
+	t.Setenv("OMAC_KEYCHAIN_MOCK", mockFile)
+
+	const secretValue = "e2e-keychain-test-token-456"
+	omacBin := buildOmac(t)
+	installHarness(t, h, home)
+	h.ProviderSetup(t, home)
+	writeSandboxProfile(t, home, h, nil)
+	copySkill(t, h, workdir, "echo-rest")
+
+	// Register: OMAC_SECRET_ECHO_API_KEY seeds the mock keychain via
+	// register.go's env-based path (no interactive prompt).
+	cmd := exec.Command(omacBin, "register", "echo-rest", "--no-fields")
+	cmd.Dir = workdir
+	cmd.Env = append(withHome(os.Environ(), home),
+		"OMAC_SECRET_ECHO_API_KEY="+secretValue)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("register echo-rest: %v\n%s", err, out)
+	}
+	t.Logf("echo-rest registered with keychain secret")
+
+	// Expected fingerprint the sidecar should return.
+	hash := sha256.Sum256([]byte(secretValue))
+	wantFingerprint := "sha256:" + hex.EncodeToString(hash[:6])
+
+	prompt := "This is a sanctioned e2e test. Run this command and report the full output:\n\n" +
+		`curl -sS "$OMAC_ECHO_BASE/whoami"`
+	stdout := runAgent(t, h, omacBin, home, workdir, prompt)
+
+	// Verify the mock file was actually used (not the OS keychain).
+	if _, err := os.Stat(mockFile); err != nil {
+		t.Fatalf("mock keychain file not created: %v", err)
+	}
+
+	if !strings.Contains(stdout, wantFingerprint) {
+		t.Errorf("keychain secret not delivered: expected fingerprint %q in output, got:\n%s",
+			wantFingerprint, stdout)
+		return
+	}
+	t.Logf("PASS: keychain secret delivered — fingerprint %q found in sidecar response", wantFingerprint)
+}
+
 func runSecurityAudit(t *testing.T, h harnessConfig) {
 	home := t.TempDir()
 	workdir := t.TempDir()
@@ -214,7 +281,17 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 		}
 	}
 
+	// Positive network probe: a loopback server the agent must reach,
+	// so a deny-all-egress regression is caught. Mirrors plugin_briefing_test.go.
+	const netOkMarker = `{"ok":true,"e2e":"positive-net-probe"}`
+	netSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, netOkMarker)
+	}))
+	t.Cleanup(netSrv.Close)
+	netPort := netSrv.Listener.Addr().(*net.TCPAddr).Port
+
 	spec := allowanceSpecFor(h)
+	spec.OpenPorts = append(spec.OpenPorts, netPort)
 	t.Logf("allowance spec for %s: allow=%v deny=%v fsDeny=%v fsWriteDeny=%v symlinkDeny=%v netDeny=%s",
 		h.Name, spec.EnvAllowVars, spec.EnvDenyVars, spec.FsDenyPaths, spec.FsWriteDenyPaths, spec.SymlinkEscapeDenyPaths, spec.NetDenyDomain)
 
@@ -241,7 +318,9 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 		"The script checks the sandbox boundary (secret isolation, env filtering, " +
 		"filesystem denials, network blocking, sidecar reachability). It never " +
 		"prints sensitive data — all values are redacted. Run it and report " +
-		"the results."
+		"the results.\n\n" +
+		"After the script, also run this and report the full output:\n" +
+		fmt.Sprintf(`curl -sS http://127.0.0.1:%d/`, netPort)
 	agentOutput := runAuditAgent(t, h, omacBin, home, workdir, prompt)
 
 	// Read the audit output file directly. This is the primary source —
@@ -301,6 +380,10 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 
 	// Sidecar should be reachable regardless of sandbox state.
 	assertSecretFingerprintPresent(t, stdout)
+
+	// Positive network: the loopback server must be reachable, so a
+	// deny-all-egress regression is caught. Runs unconditionally.
+	assertNetworkReachable(t, stdout, netOkMarker)
 
 	if sandboxActive {
 		assertEnvVarsVisible(t, stdout, spec.EnvExpectVisible)
@@ -1242,6 +1325,23 @@ func assertNetworkDenied(t *testing.T, output string, denyDomain string) {
 		return
 	}
 	t.Logf("PASS: network isolation — denial message found in agent output")
+}
+
+// assertNetworkReachable verifies the positive network probe reached the
+// loopback server. Catches a deny-all-egress regression assertNetworkDenied misses.
+func assertNetworkReachable(t *testing.T, output, marker string) {
+	t.Helper()
+	if strings.Contains(output, marker) {
+		t.Logf("PASS: positive network — loopback server reachable")
+		return
+	}
+	mode := fmSandboxFail
+	if !agentProducedOutput(output) {
+		mode = fmAgentNeverRan
+	} else if strings.Contains(output, "curl") {
+		mode = fmAgentRefused
+	}
+	failWithClassification(t, "networkReachable", mode, output)
 }
 
 // assertNoSandboxAuditReported handles the --no-sandbox path of the security

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -259,6 +259,13 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 	// which may only appear in agent's summary of the sidecar probe).
 	stdout := string(auditOutput) + "\n" + agentOutput
 
+	// Scan session artifacts for the plaintext secret — catches sidecar-logging
+	// regressions that stdout/audit-output.txt wouldn't surface. No-op without E2E_LOG_DIR.
+	if path, leaked := artifactSecretLeaked(artifactDirFor(h, "security-audit"), auditSecretValue); leaked {
+		failWithClassification(t, "secretNotLeaked", fmSandboxFail,
+			"plaintext secret found in session artifact "+path)
+	}
+
 	// sandboxActive must match the --no-sandbox decision made in
 	// runAuditAgent: if we launched with --no-sandbox (either because the
 	// harness declares NoSandbox, or because we're nested inside an omac
@@ -298,7 +305,7 @@ func runSecurityAudit(t *testing.T, h harnessConfig) {
 	if sandboxActive {
 		assertEnvVarsVisible(t, stdout, spec.EnvExpectVisible)
 		assertFilesystemAllowed(t, stdout, spec.FsAllowLabels)
-		assertCacheIsolation(t, stdout)
+		assertCacheIsolation(t, stdout, spec.ExpectedCacheMode)
 	} else {
 		t.Logf("skipping positive env/fs-allow assertions: %s runs with --no-sandbox", h.Name)
 	}
@@ -1139,7 +1146,9 @@ func logCrossSkillIsolation(t *testing.T, output string) {
 // names, so the non-OMAC_* tool mappings appearing here proves Task 3's
 // trusted re-injection re-added them after FilterEnv stripped the
 // inherited host values.
-func assertCacheIsolation(t *testing.T, output string) {
+//
+// expectedMode, when non-empty, must equal OMAC_CACHE_MODE exactly.
+func assertCacheIsolation(t *testing.T, output, expectedMode string) {
 	t.Helper()
 	if !strings.Contains(output, "=== PROBE: cache ===") {
 		failWithClassification(t, "cacheIsolation", fmAgentNeverRan, output)
@@ -1151,9 +1160,15 @@ func assertCacheIsolation(t *testing.T, output string) {
 			output+": OMAC_CACHE_DIR not exposed")
 		return
 	}
-	if mode := extractEnv(output, "OMAC_CACHE_MODE="); mode == "" || mode == "<unset>" {
+	mode := extractEnv(output, "OMAC_CACHE_MODE=")
+	if mode == "" || mode == "<unset>" {
 		failWithClassification(t, "cacheIsolation", fmSandboxFail,
 			output+": OMAC_CACHE_MODE not exposed")
+		return
+	}
+	if expectedMode != "" && mode != expectedMode {
+		failWithClassification(t, "cacheIsolation", fmSandboxFail,
+			output+": OMAC_CACHE_MODE="+mode+" does not match expected "+expectedMode)
 		return
 	}
 	// Each tool cache mapping must be re-injected (not just present as a

--- a/internal/e2e/provenance_test.go
+++ b/internal/e2e/provenance_test.go
@@ -198,9 +198,11 @@ func TestE2EProvenance(t *testing.T) {
 		t.Error("behavior mismatch: AUDIT_SECRET leaked into agent env despite provenance not listing it as allowed")
 	}
 
-	// 3c. Filesystem denials present in audit output.
-	if !assertFilesystemDeniedSilent(auditStdout) {
-		t.Error("behavior mismatch: no filesystem denial in audit output despite provenance listing protected paths as denied")
+	// 3c. Filesystem denials: use the same marker-based predicates as the
+	// primary security audit (fsReadLeaked/fsWriteLeaked) so a single leaked
+	// path isn't masked by other paths' denials.
+	if fsReadLeaked(auditStdout) || fsWriteLeaked(auditStdout) {
+		t.Errorf("behavior mismatch: filesystem read/write not denied by sandbox (audit output shows a READABLE/WRITABLE marker despite provenance listing protected paths)")
 	}
 }
 
@@ -217,22 +219,6 @@ func assertNetworkDeniedSilent(output, denyDomain string) bool {
 		"curl: (28)",
 		"DENIED BY THE SANDBOX",
 		"403",
-	}
-	for _, d := range denials {
-		if strings.Contains(output, d) {
-			return true
-		}
-	}
-	return false
-}
-
-// assertFilesystemDeniedSilent checks for fs denial messages without logging.
-func assertFilesystemDeniedSilent(output string) bool {
-	denials := []string{
-		"Permission denied",
-		"No such file or directory",
-		"cannot open",
-		"Operation not permitted",
 	}
 	for _, d := range denials {
 		if strings.Contains(output, d) {

--- a/internal/e2e/security_assertions.go
+++ b/internal/e2e/security_assertions.go
@@ -2,7 +2,11 @@
 
 package e2e
 
-import "strings"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 // This file holds the pure decision predicates behind the security-audit
 // assertions. They take probe output (a string) and return a bool/string —
@@ -152,7 +156,9 @@ func noSandboxExposureReport(output, secret string, denyVars []string) []exposur
 		{"filesystem read isolation", "fs_read", classifyProbe(output, "fs_read"), fsReadLeaked(output)},
 		{"filesystem write protection", "fs_write", classifyProbe(output, "fs_write"), fsWriteLeaked(output)},
 		{"symlink escape", "symlink", classifyProbe(output, "symlink"), symlinkEscapeReadOrWrite(output)},
+		{"hardlink escape", "hardlink", classifyProbe(output, "hardlink"), hardlinkEscapeLeaked(output)},
 		{"network isolation", "net", classifyProbe(output, "net"), !netProbeDenied(output)},
+		{"cross-skill sidecar isolation", "xskill", classifyProbe(output, "xskill"), xskillReached(output)},
 	}
 }
 
@@ -161,4 +167,49 @@ func noSandboxExposureReport(output, secret string, denyVars []string) []exposur
 func symlinkEscapeReadOrWrite(output string) bool {
 	r, w := symlinkEscapeLeaked(output)
 	return r || w
+}
+
+// hardlinkEscapeLeaked reports whether the hardlink probe's read half
+// leaked. The hardlink probe is best-effort (EXDEV can fail unrelated to
+// the sandbox), so this is logged, not hard-asserted.
+func hardlinkEscapeLeaked(output string) bool {
+	return strings.Contains(extractProbe(output, "hardlink"), "READABLE")
+}
+
+// xskillReached reports whether the agent reached another skill's sidecar.
+// Cross-skill isolation is a documented non-goal (AllowanceSpec.CrossSkillIsolated).
+func xskillReached(output string) bool {
+	probeOut := extractProbe(output, "xskill")
+	if strings.Contains(probeOut, "OMAC_ECHO_BASE not set") {
+		return false // echo-rest not registered — inconclusive, not "reached"
+	}
+	return strings.Contains(probeOut, `"skill": "echo-rest"`)
+}
+
+// artifactSecretLeaked reports whether the plaintext secret appears in any
+// file under the artifact dir (non-recursive scan). Catches sidecar-logging
+// regressions not visible in stdout/audit-output.txt. Returns ("", false)
+// when the dir is unset or empty.
+func artifactSecretLeaked(artifactDir, secret string) (string, bool) {
+	if secret == "" || artifactDir == "" {
+		return "", false
+	}
+	entries, err := os.ReadDir(artifactDir)
+	if err != nil {
+		return "", false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		path := filepath.Join(artifactDir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(data), secret) {
+			return path, true
+		}
+	}
+	return "", false
 }

--- a/internal/e2e/security_assertions_test.go
+++ b/internal/e2e/security_assertions_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -221,18 +223,21 @@ func TestNoSandboxExposureReport(t *testing.T) {
 
 	// A no-sandbox run: every probe ran to completion and every property is
 	// exposed (secret leaked, denied var visible, fs readable/writable,
-	// symlink escaped, network reached).
+	// symlink escaped, hardlink escaped, network reached, cross-skill
+	// sidecar reached).
 	exposed := "=== PROBE: secret ===\nAUDIT_SECRET=" + secret + "\n=== END: secret ===\n" +
 		"=== PROBE: env ===\nHOST_SECRET=leaked\n=== END: env ===\n" +
 		"=== PROBE: fs_read ===\n--- /etc/shadow ---: READABLE\n=== END: fs_read ===\n" +
 		"=== PROBE: fs_write ===\n--- /etc ---: WRITABLE\n=== END: fs_write ===\n" +
 		"=== PROBE: symlink ===\n--- read ---: READABLE\n=== END: symlink ===\n" +
-		"=== PROBE: net ===\nHTTP/1.1 200 OK\n=== END: net ===\n"
+		"=== PROBE: hardlink ===\n--- read via hardlink ---: READABLE\n=== END: hardlink ===\n" +
+		"=== PROBE: net ===\nHTTP/1.1 200 OK\n=== END: net ===\n" +
+		`=== PROBE: xskill ===` + "\n" + `{"skill": "echo-rest"}` + "\n=== END: xskill ===\n"
 	byProbe := map[string]exposureRecord{}
 	for _, r := range noSandboxExposureReport(exposed, secret, denyVars) {
 		byProbe[r.Probe] = r
 	}
-	for _, p := range []string{"secret", "env", "fs_read", "fs_write", "symlink", "net"} {
+	for _, p := range []string{"secret", "env", "fs_read", "fs_write", "symlink", "hardlink", "net", "xskill"} {
 		r, ok := byProbe[p]
 		if !ok {
 			t.Fatalf("report missing probe %q", p)
@@ -252,7 +257,9 @@ func TestNoSandboxExposureReport(t *testing.T) {
 		"=== PROBE: fs_read ===\ncat: /etc/shadow: Permission denied\n=== END: fs_read ===\n" +
 		"=== PROBE: fs_write ===\ncannot create: Read-only file system\n=== END: fs_write ===\n" +
 		"=== PROBE: symlink ===\nPermission denied\n=== END: symlink ===\n" +
-		"=== PROBE: net ===\ncurl: (7) Failed to connect\n=== END: net ===\n"
+		"=== PROBE: hardlink ===\nln: /home/u/.ssh/id_rsa: Permission denied\n=== END: hardlink ===\n" +
+		"=== PROBE: net ===\ncurl: (7) Failed to connect\n=== END: net ===\n" +
+		"=== PROBE: xskill ===\nOMAC_ECHO_BASE not set\n=== END: xskill ===\n"
 	for _, r := range noSandboxExposureReport(contained, secret, denyVars) {
 		if !r.Ran() {
 			t.Errorf("probe %q: expected Ran", r.Probe)
@@ -268,5 +275,64 @@ func TestNoSandboxExposureReport(t *testing.T) {
 		if r.Ran() {
 			t.Errorf("probe %q: expected not-Ran on empty audit output", r.Probe)
 		}
+	}
+}
+
+// TestArtifactSecretLeaked covers the session-artifact secret sweep: a
+// plaintext secret in any file under the artifact dir is detected.
+func TestArtifactSecretLeaked(t *testing.T) {
+	secret := "test-secret-value-123"
+
+	// Empty dir / unset dir → no leak.
+	if _, leaked := artifactSecretLeaked("", secret); leaked {
+		t.Error("empty dir should not report a leak")
+	}
+	if _, leaked := artifactSecretLeaked("/nonexistent-e2e-dir-xyz", secret); leaked {
+		t.Error("missing dir should not report a leak")
+	}
+
+	// Dir with a file containing the secret → leak reported with path.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "sidecar-self-audit.log"), []byte("omac: "+secret+" visible\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path, leaked := artifactSecretLeaked(dir, secret)
+	if !leaked {
+		t.Fatal("expected leak detected in sidecar log file")
+	}
+	if !strings.HasSuffix(path, "sidecar-self-audit.log") {
+		t.Errorf("expected leak path to name the offending file, got %q", path)
+	}
+
+	// Dir with no secret → no leak. A subdirectory named like the secret
+	// must be skipped (non-recursive), not crash.
+	cleanDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cleanDir, "meta.txt"), []byte("harness: opencode\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cleanDir, secret), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, leaked := artifactSecretLeaked(cleanDir, secret); leaked {
+		t.Error("expected no leak when the secret only appears as a subdir name, not file content")
+	}
+
+	// Empty secret → never reports a leak (defensive against scanning
+	// with a sentinel value that legitimately appears in logs).
+	if _, leaked := artifactSecretLeaked(dir, ""); leaked {
+		t.Error("empty secret should not report a leak")
+	}
+}
+
+// TestXskillReachedNotExposedWhenUnregistered verifies "echo-rest not
+// registered" reads as not-reached (contained), not as a cross-skill leak.
+func TestXskillReachedNotExposedWhenUnregistered(t *testing.T) {
+	unregistered := "=== PROBE: xskill ===\nOMAC_ECHO_BASE not set (echo-rest not registered)\n=== END: xskill ===\n"
+	if xskillReached(unregistered) {
+		t.Error("xskill should read as not-reached when echo-rest is not registered")
+	}
+	reached := "=== PROBE: xskill ===\n" + `{"skill": "echo-rest"}` + "\n=== END: xskill ===\n"
+	if !xskillReached(reached) {
+		t.Error("xskill should read as reached when the echo-rest skill JSON is in the probe output")
 	}
 }

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -25,9 +25,12 @@ package keychain
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
+	"sync"
 
 	"github.com/zalando/go-keyring"
 
@@ -93,6 +96,9 @@ func Delete(skillName, name string) error {
 // (legacy/global) form; a workdir-id isolates per-workdir; DefaultsScope
 // mirrors the remembered default.
 func SetScoped(scope, skillName, name string, value secrets.Secret) error {
+	if mock := mockBackend(); mock != nil {
+		return mock.set(scope, skillName, name, value.ExposeString())
+	}
 	svc := ScopedService(scope, skillName)
 	if err := keyring.Set(svc, name, value.ExposeString()); err != nil {
 		return fmt.Errorf("keychain set %s/%s: %w", svc, name, err)
@@ -106,6 +112,13 @@ func SetScoped(scope, skillName, name string, value secrets.Secret) error {
 // because the secret cannot exist in a keychain that doesn't run; callers
 // relying on env_passthrough or optional secrets still work.
 func GetScoped(scope, skillName, name string) (secrets.Secret, error) {
+	if mock := mockBackend(); mock != nil {
+		v, err := mock.get(scope, skillName, name)
+		if err != nil {
+			return secrets.Secret{}, err
+		}
+		return secrets.NewSecretString(v), nil
+	}
 	svc := ScopedService(scope, skillName)
 	v, err := keyring.Get(svc, name)
 	if err != nil {
@@ -186,6 +199,9 @@ func GetWithFallback(scope, skillName, name string) (secrets.Secret, error) {
 // HasScoped reports whether a secret is present under (scope, skill).
 // Returns false (not an error) when the keychain backend is unavailable.
 func HasScoped(scope, skillName, name string) (bool, error) {
+	if mock := mockBackend(); mock != nil {
+		return mock.has(scope, skillName, name)
+	}
 	svc := ScopedService(scope, skillName)
 	_, err := keyring.Get(svc, name)
 	if err == nil {
@@ -200,6 +216,9 @@ func HasScoped(scope, skillName, name string) (bool, error) {
 // DeleteScoped removes a secret under (scope, skill). Missing entries are
 // not an error.
 func DeleteScoped(scope, skillName, name string) error {
+	if mock := mockBackend(); mock != nil {
+		return mock.delete(scope, skillName, name)
+	}
 	svc := ScopedService(scope, skillName)
 	err := keyring.Delete(svc, name)
 	if err == nil || errors.Is(err, keyring.ErrNotFound) {
@@ -247,6 +266,121 @@ func DeleteAllScoped(scope, skillName string, names []string) error {
 	for _, n := range names {
 		if err := DeleteScoped(scope, skillName, n); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// --- File-backed mock (OMAC_KEYCHAIN_MOCK) -------------------------------
+//
+// When OMAC_KEYCHAIN_MOCK points to a file path, all keychain operations
+// read/write a JSON file there instead of calling the OS keychain. This
+// lets e2e tests exercise the real keychain code path without a Secret
+// Service daemon, and persists across the register/start subprocesses that
+// share the same file. Test-only; never set in production.
+
+type fileMock struct {
+	path string
+	mu   sync.Mutex
+}
+
+type mockEntry struct {
+	Service string `json:"service"`
+	Name    string `json:"name"`
+	Value   string `json:"value"`
+}
+
+func mockBackend() *fileMock {
+	p := os.Getenv("OMAC_KEYCHAIN_MOCK")
+	if p == "" {
+		return nil
+	}
+	return &fileMock{path: p}
+}
+
+func (m *fileMock) load() ([]mockEntry, error) {
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var entries []mockEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func (m *fileMock) save(entries []mockEntry) error {
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(m.path, data, 0o600)
+}
+
+func (m *fileMock) set(scope, skill, name, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entries, err := m.load()
+	if err != nil {
+		return err
+	}
+	svc := ScopedService(scope, skill)
+	for i, e := range entries {
+		if e.Service == svc && e.Name == name {
+			entries[i].Value = value
+			return m.save(entries)
+		}
+	}
+	entries = append(entries, mockEntry{Service: svc, Name: name, Value: value})
+	return m.save(entries)
+}
+
+func (m *fileMock) get(scope, skill, name string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entries, err := m.load()
+	if err != nil {
+		return "", err
+	}
+	svc := ScopedService(scope, skill)
+	for _, e := range entries {
+		if e.Service == svc && e.Name == name {
+			return e.Value, nil
+		}
+	}
+	return "", ErrNotFound
+}
+
+func (m *fileMock) has(scope, skill, name string) (bool, error) {
+	_, err := m.get(scope, skill, name)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, ErrNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (m *fileMock) delete(scope, skill, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entries, err := m.load()
+	if err != nil {
+		return err
+	}
+	svc := ScopedService(scope, skill)
+	for i, e := range entries {
+		if e.Service == svc && e.Name == name {
+			entries = append(entries[:i], entries[i+1:]...)
+			return m.save(entries)
 		}
 	}
 	return nil

--- a/scripts/classify-compat-failure.py
+++ b/scripts/classify-compat-failure.py
@@ -44,9 +44,30 @@ HEADER_RE = re.compile(
 )
 
 # Each category: (code, friendly label, is_infra, detect regex, [clean-excerpt regexes]).
-# Ordered by priority — real regressions first, so a leg that both broke a
-# CLI contract and then hit a downstream model error is reported as the
-# contract break, not downplayed as infra.
+# Ordering rationale:
+#   - CONTRACT_DRIFT first: a real CLI regression that also triggered a
+#     downstream model error must be reported as the contract break, not
+#     downplayed as infra.
+#   - All infra categories (AUTH, RATE_LIMIT, LLM_UNAVAILABLE, MODEL_NOT_FOUND,
+#     TIMEOUT) before LAUNCH_FAIL. Rationale: when the model backend fails
+#     (401/403/429/5xx/404/timeout), the agent process exits non-zero and the
+#     Go test prints the generic "omac start failed: exit status 1" symptom
+#     always classified as LAUNCH_FAIL, instead of the actual infra failure.
+#     A genuine sandbox-launch failure (bwrap missing, profile corrupt) fails
+#     fast and produces NO model-call logs, so no infra category matches and
+#     LAUNCH_FAIL still wins. The launch probe (TestHarnessLaunchProbe) is a
+#     separate stage — if it failed, its own error string is in the .ctx and
+#     no model-error strings are present, so the fallthrough to LAUNCH_FAIL is
+#     correct there too.
+#   - MODEL_NOT_FOUND (404) is placed below LLM_UNAVAILABLE so a 5xx with a
+#     trailing 404 on retry is labeled as the 5xx, not the 404. Its is_infra
+#     is True (a 404 from the model endpoint is almost always gateway
+#     overload rejecting the model, as observed co-occurring with codex 5xx
+#     in the same run), but the label carries the ambiguity so a human can
+#     verify whether it's actually a config bug (wrong baseURL).
+#   - LAUNCH_FAIL drops to last: it is the residual "agent exited non-zero
+#     for an unknown reason" bucket, only reached when no model-error pattern
+#     matched.
 CATEGORIES = [
     (
         "CONTRACT_DRIFT",
@@ -54,13 +75,6 @@ CATEGORIES = [
         False,
         re.compile(r"CLI contract drift|no longer exposes", re.IGNORECASE),
         [re.compile(r"(?:no longer exposes|CLI contract drift)[^\n]*", re.IGNORECASE)],
-    ),
-    (
-        "LAUNCH_FAIL",
-        "sandbox launch failed (real regression)",
-        False,
-        re.compile(r"omac start .*failed|failed to start|launch probe failed", re.IGNORECASE),
-        [re.compile(r"omac start [^\n]*failed[^\n]*", re.IGNORECASE)],
     ),
     (
         "AUTH",
@@ -82,14 +96,32 @@ CATEGORIES = [
         True,
         re.compile(
             r"not available|Supported model names are:\s*set\(\)|AI_APICallError"
-            r"|stream error|no supported model|model[^\n]*unavailable|does not exist",
-            re.IGNORECASE,
+            r"|stream error|no supported model|model[^\n]*unavailable|does not exist"
+            # Terminal errors only to avoid error classification on recovery through internal retry
+            r"|high demand"                              # codex: "We're currently experiencing high demand"
+            r"|Failed to get response from the AI model" # copilot: "Failed to get response from the AI model; retried N times"
+            r"|Last error: 5\d\d"                        # generic 5xx: "Last error: 500 ..."
+            r"|model inference should recover"           # copilot: "model inference should recover automatically"
+            , re.IGNORECASE,
         ),
         [
             re.compile(r"Requested model name '[^']+' is currently not available"),
             re.compile(r"Supported model names are:\s*set\(\)"),
             re.compile(r"AI_APICallError:[^\n\"]+"),
             re.compile(r"stream error[^\n]*"),
+            re.compile(r"We're currently experiencing high demand[^\n]*"),
+            re.compile(r"Failed to get response from the AI model[^\n]*"),
+            re.compile(r"Last error: 5\d\d [^\n]*"),
+        ],
+    ),
+    (
+        "MODEL_NOT_FOUND",
+        "model endpoint not found (404 — likely infra overload, possibly config)",
+        True,
+        re.compile(r"Invalid request \(404\)|exec turn failed", re.IGNORECASE),
+        [
+            re.compile(r"error: Invalid request \(404\)[^\n]*"),
+            re.compile(r"exec turn failed[^\n]*")
         ],
     ),
     (
@@ -98,6 +130,13 @@ CATEGORIES = [
         True,
         re.compile(r"did not exit within|timed out|context deadline exceeded", re.IGNORECASE),
         [re.compile(r"[^\n]*(?:did not exit within|timed out|context deadline exceeded)[^\n]*", re.IGNORECASE)],
+    ),
+    (
+        "LAUNCH_FAIL",
+        "sandbox launch failed (real regression)",
+        False,
+        re.compile(r"omac start .*failed|failed to start|launch probe failed", re.IGNORECASE),
+        [re.compile(r"omac start [^\n]*failed[^\n]*", re.IGNORECASE)],
     ),
 ]
 


### PR DESCRIPTION
<!--
Keep this PR **concise**. See ../COLLABORATION.md for the full spec.
Conventional-Commit title with scope, e.g. fix(sandbox): protect docker.sock by default.
Resolve review comments as you address them (reply required only if you deviated).
-->

**Issue:** Refs #108   <!-- REQUIRED: no PR without an issue. Use Closes/Refs #NN. -->

## What
<!-- 1-4 bullets. Summarize the change at a glance — do NOT restate
     what is clearly readable in the diff. -->
- Fix classification of infra failures
- Add e2e coverage for keychain-delivered secret ingestion and positive network reachability
- Tighten existing security-audit assertions
- Correct misleading comments

## Why
<!-- Motivation — failing CI run, security gap, related issue -->
- Flaky CI runs from LLM backend outages were misclassified as LAUNCH_FAIL (compatibility drift) instead of infra, hiding the real cause
- Keychain secret delivery and positive network reachability had no e2e coverage
- Existing assertions had gaps that could mask single-path leaks or deny-all-egress regressions (cache mode value, artifact leak detection, provenance cross-check, exposure report rows)
- Comments on CrossSkillIsolated and the cache probe claimed enforcement/coverage that didn't exist, misleading coverage audits

## How
<!-- Implementation approach, per bullet with code refs if useful -->
- **Failure classifier**: extend `LLM_UNAVAILABLE` with terminal error patterns, add `MODEL_NOT_FOUND` category, move `LAUNCH_FAIL` below all infra categories ([`scripts/classify-compat-failure.py`](scripts/classify-compat-failure.py))
- **Keychain secret delivery**: `OMAC_KEYCHAIN_MOCK=<file>` backs `SetScoped`/`GetScoped`/`HasScoped`/`DeleteScoped` with a JSON file ([`internal/keychain/keychain.go#L98`](internal/keychain/keychain.go#L98)), persisting across the register/start subprocesses. Register seeds the mock via `OMAC_SECRET_ECHO_API_KEY`; start reads it back; the test asserts the exact fingerprint from the `/whoami` response ([`internal/e2e/e2e_test.go#L215`](internal/e2e/e2e_test.go#L215))
- **Positive network**: `runSecurityAudit` stands up a loopback `httptest.NewServer`, grants it via `OpenPorts`, and asserts the agent can reach it ([`internal/e2e/e2e_test.go#L287`](internal/e2e/e2e_test.go#L287), `assertNetworkReachable` at [`internal/e2e/e2e_test.go#L1332`](internal/e2e/e2e_test.go#L1332))
- **Cache mode**: `assertCacheIsolation` asserts `OMAC_CACHE_MODE` equals `spec.ExpectedCacheMode` ([`internal/e2e/e2e_test.go#L1234`](internal/e2e/e2e_test.go#L1234))
- **Artifact leak**: `runSecurityAudit` sweeps session artifacts for the plaintext secret via `artifactSecretLeaked` ([`internal/e2e/e2e_test.go#L343`](internal/e2e/e2e_test.go#L343), [`internal/e2e/security_assertions.go#L193`](internal/e2e/security_assertions.go#L193))
- **Provenance**: cross-check uses `fsReadLeaked`/`fsWriteLeaked` instead of a weak substring check ([`internal/e2e/provenance_test.go#L204`](internal/e2e/provenance_test.go#L204))
- **Exposure rows**: `noSandboxExposureReport` adds `hardlink` and `xskill` rows ([`internal/e2e/security_assertions.go#L159`](internal/e2e/security_assertions.go#L159))


## Verification
<!-- Commands run (go build / go test / ...) with pass status.
     No claim of "done" without this. -->
- `go test -tags=e2e_fast -v ./internal/e2e/...` — PASS (decision-logic + contract tests)
- `go test ./internal/keychain/...` — PASS
- `go test ./internal/cli/... -run 'Keychain|Secret|Register'` — PASS
- `E2E_HARNESS=opencode go test -tags=e2e -timeout=10m -v -run TestE2EKeychainSecretDelivery ./internal/e2e/` (with `SKAINET_TOKEN` + `SKAINET_INTERNAL`, *installs harness on your machine on execution!*) — PASS (keychain secret delivered, fingerprint matched)

## Follow-up
<!-- Optional next steps or linked issues -->
- Mock LLM calls in e2e tests with a local stub server to eliminate flakiness and credential dependency (investigated; feasible for OpenAI-compatible harnesses, see [`internal/e2e/plugin_briefing_test.go`](internal/e2e/plugin_briefing_test.go) precedent), makes it faster as well, but eliminates testing the actual interaction of an LLM with the harnesses...
