### PR TITLE
fix(cli): clarify custom profile remediation

### DIFF
--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -282,12 +282,17 @@ sandbox:
 > flag an empty allowlist.
 >
 > To resolve an empty profile, either:
-> - add an explicit `allow_vars` list (start from `DefaultAllowVars()` in
->   `internal/sandboxprofile/env.go`, then add the provider/token vars the
+> - for a profile supplied by an installer or another repository, refresh it
+>   from that original source. omac upgrades do not update custom profiles in
+>   `~/.config/omac/sandbox-profiles/`, or
+> - for a manually maintained profile, add an explicit `allow_vars` list
+>   (start from `DefaultAllowVars()` in `internal/sandboxprofile/env.go`, then
+>   add the provider/token vars the
 >   harness reads — e.g. `ANTHROPIC_API_KEY`, or a custom `SKAINET_*`); back up
 >   + delete a scaffolded `default.json` to have omac re-scaffold the full list
 >   (it is not auto-migrated), or
-> - set `allow_vars: ["*"]` to forward **every** ambient var — the danger
+> - as a deliberately broad fallback, set `allow_vars: ["*"]` to forward
+>   **every** ambient var — the danger
 >   blocklist (`LD_*`, `NODE_OPTIONS`, 1Password tokens, …) still wins, so this
 >   is not the same as no filtering.
 >

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -296,20 +296,26 @@ func doctorSandboxProfileWarnings(env *Env, lc config.LauncherConfig) {
 			// doctor can't see into its profile, so skip silently.
 			continue
 		}
-		p, _, err := sandboxprofile.Resolve(ref)
+		p, path, err := sandboxprofile.Resolve(ref)
 		if err != nil {
 			fmt.Fprintf(env.Stdout, "  [warn] sandbox profile %q: %v\n", profName, err)
 			continue
 		}
 		if len(p.Environment.AllowVars) == 0 {
 			fmt.Fprintf(env.Stdout, "  [warn] sandbox profile %q has an empty environment.allow_vars\n", profName)
+			if path != "" {
+				fmt.Fprintf(env.Stdout, "         source:      %s\n", path)
+			}
 			fmt.Fprintln(env.Stdout, "         impact:      at launch omac forwards only the operational minimum (HOME, PATH,")
 			fmt.Fprintln(env.Stdout, "                      TERM, locale, …); all other ambient env vars — including provider")
 			fmt.Fprintln(env.Stdout, "                      tokens and secrets — are NOT passed through, and omac does not")
 			fmt.Fprintln(env.Stdout, "                      auto-forward auth vars. This differs from the pre-#102 inherit-")
 			fmt.Fprintln(env.Stdout, "                      everything behavior; the harness starts but will not authenticate.")
-			fmt.Fprintln(env.Stdout, `         remediation: add the vars the harness needs to allow_vars (see`)
-			fmt.Fprintln(env.Stdout, `                      sandboxprofile.DefaultAllowVars), or set allow_vars: ["*"] to forward`)
+			fmt.Fprintln(env.Stdout, "         remediation: custom profiles are not updated by omac upgrades; refresh this profile")
+			fmt.Fprintln(env.Stdout, "                      from its installer or original source. If you maintain it manually,")
+			fmt.Fprintln(env.Stdout, "                      add the vars the harness needs to allow_vars (see")
+			fmt.Fprintln(env.Stdout, "                      sandboxprofile.DefaultAllowVars).")
+			fmt.Fprintln(env.Stdout, `                      allow_vars: ["*"] is not recommended because it forwards almost`)
 			fmt.Fprintln(env.Stdout, "                      every ambient var (minus the danger blocklist).")
 		}
 		if denied := sandboxprofile.DeniedBaseVars(p.Environment.DenyVars); len(denied) > 0 {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -509,6 +509,17 @@ func TestDoctorEmptyAllowVarsWarned(t *testing.T) {
 		!strings.Contains(strings.ToLower(output), "remediation") {
 		t.Errorf("doctor output missing impact/remediation; got:\n%s", output)
 	}
+	profilePath := filepath.Join(home, ".config", "omac", "sandbox-profiles", "default.json")
+	for _, want := range []string{
+		profilePath,
+		"not updated by omac upgrades",
+		"installer or original source",
+		`["*"] is not recommended`,
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("doctor output missing %q; got:\n%s", want, output)
+		}
+	}
 }
 
 // TestDoctorNonEmptyAllowVarsNotWarned asserts the empty-allow_vars warning

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -711,10 +711,15 @@ func forwardHarnessEnv(env *Env, argv []string, harness config.Harness, plan san
 	}
 	if planAllowVarsEmpty(plan) {
 		fmt.Fprintf(env.Stderr, "omac: sandbox profile %q has an empty environment.allow_vars.\n", plan.PolicyRef)
+		if plan.PolicyPath != "" {
+			fmt.Fprintf(env.Stderr, "      Profile source: %s\n", plan.PolicyPath)
+		}
 		fmt.Fprintln(env.Stderr, "      Forwarding only the operational minimum (HOME, PATH, TERM, locale, …).")
 		fmt.Fprintln(env.Stderr, "      No provider-auth or other ambient env vars are passed through (previously every")
-		fmt.Fprintln(env.Stderr, "      var was inherited). The harness starts but will not authenticate until you add")
-		fmt.Fprintln(env.Stderr, `      the vars it needs to allow_vars (see "omac doctor"), or set allow_vars: ["*"].`)
+		fmt.Fprintln(env.Stderr, "      var was inherited). Custom profiles are not updated by omac upgrades. Refresh")
+		fmt.Fprintln(env.Stderr, `      this profile from its installer or original source, then run "omac doctor".`)
+		fmt.Fprintln(env.Stderr, "      If you maintain it manually, add the vars the harness needs to allow_vars.")
+		fmt.Fprintln(env.Stderr, `      allow_vars: ["*"] is not recommended because it forwards almost every ambient var.`)
 		fmt.Fprintln(env.Stderr, "      Continuing shortly…")
 		time.Sleep(emptyAllowVarsWarnDelay)
 		// Seed only the operational minimum; do NOT auto-forward auth vars.

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -499,8 +499,17 @@ func TestForwardHarnessEnvEmptyProfileForwardsOperationalMinimum(t *testing.T) {
 	if strings.Contains(joined, "ANTHROPIC_API_KEY") {
 		t.Errorf("empty profile must not auto-forward provider-auth vars; got %v", got)
 	}
-	if !strings.Contains(errBuf.String(), "allow_vars") {
-		t.Errorf("expected empty-allow_vars warning on stderr; got:\n%s", errBuf.String())
+	warning := errBuf.String()
+	for _, want := range []string{
+		"allow_vars",
+		plan.PolicyPath,
+		"not updated by omac upgrades",
+		"installer or original source",
+		`["*"] is not recommended`,
+	} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("empty-allow-vars warning missing %q; got:\n%s", want, warning)
+		}
 	}
 }
 

--- a/internal/profileaudit/check.go
+++ b/internal/profileaudit/check.go
@@ -47,7 +47,7 @@ func checkEnvironment(profile *sandboxprofile.Profile) []Finding {
 		Category: CatEnvironment,
 		Field:    "environment.allow_vars",
 		Value:    "(empty)",
-		Message:  `fails closed to the operational defaults, so the harness starts but cannot authenticate; add the vars it needs to allow_vars, or ["*"] to inherit every non-blocklisted var`,
+		Message:  `fails closed to the operational defaults, so the harness starts but cannot authenticate; custom profiles are not updated by omac upgrades, so refresh the profile from its installer or original source, or add explicit allow_vars manually; ["*"] is not recommended because it inherits every non-blocklisted var`,
 	}}
 }
 

--- a/internal/profileaudit/check_test.go
+++ b/internal/profileaudit/check_test.go
@@ -40,6 +40,11 @@ func TestCheck_EmptyAllowVarsIsMedium(t *testing.T) {
 			if f.Severity != SeverityMedium {
 				t.Errorf("empty allow_vars severity = %q, want medium", f.Severity)
 			}
+			for _, want := range []string{"installer or original source", `["*"] is not recommended`} {
+				if !strings.Contains(f.Message, want) {
+					t.Errorf("empty allow_vars finding missing %q: %s", want, f.Message)
+				}
+			}
 		}
 	}
 	if !found {

--- a/internal/sandboxrun/run.go
+++ b/internal/sandboxrun/run.go
@@ -51,8 +51,10 @@ func warnEmptyAllowVars(stderr io.Writer, allowVars []string) {
 	fmt.Fprintln(stderr, "omac sandbox: warning: empty environment.allow_vars — forwarding only the")
 	fmt.Fprintln(stderr, "  operational defaults (HOME, PATH, TERM, locale, …). Every other ambient var,")
 	fmt.Fprintln(stderr, "  including provider tokens, is stripped: a harness started this way will not")
-	fmt.Fprintln(stderr, "  authenticate. Add what it needs to allow_vars, pass --allow-env <name>, or set")
-	fmt.Fprintln(stderr, `  allow_vars: ["*"] to inherit every non-blocklisted var.`)
+	fmt.Fprintln(stderr, "  authenticate. Custom profiles are not updated by omac upgrades; refresh this")
+	fmt.Fprintln(stderr, "  profile from its installer or original source. If you maintain it manually, add")
+	fmt.Fprintln(stderr, "  what it needs to allow_vars or pass --allow-env <name>.")
+	fmt.Fprintln(stderr, `  allow_vars: ["*"] is not recommended because it inherits every non-blocklisted var.`)
 }
 
 // Run is the `omac sandbox run` supervisor: resolve profile + flags,

--- a/internal/sandboxrun/run_test.go
+++ b/internal/sandboxrun/run_test.go
@@ -180,7 +180,15 @@ func TestWarnEmptyAllowVars(t *testing.T) {
 		if got == "" {
 			t.Fatal("empty allow_vars produced no warning")
 		}
-		for _, want := range []string{"empty environment.allow_vars", "will not", "authenticate", "--allow-env"} {
+		for _, want := range []string{
+			"empty environment.allow_vars",
+			"will not",
+			"authenticate",
+			"--allow-env",
+			"not updated by omac upgrades",
+			"installer or original source",
+			`["*"] is not recommended`,
+		} {
 			if !strings.Contains(got, want) {
 				t.Errorf("warning lacks %q:\n%s", want, got)
 			}


### PR DESCRIPTION
**Issue:** Refs #256

## What
- Make empty-allowlist diagnostics point to the resolved custom profile.
- Direct users to refresh installer-managed profiles and flag wildcard inheritance as broad.
- Align launch, doctor, profile audit, direct sandbox warnings, tests, and docs.

## Why
Custom sandbox profiles survive omac upgrades. A stale profile can therefore keep an empty allowlist without telling users that the original installer is the correct remediation path.

## How
- Reuse the resolved policy path in launch and doctor output.
- Preserve fail-closed behavior and provider credential isolation.

## Verification
- `go test ./... -skip ^TestIntegration -count=1` - pass
- `go vet ./...` - pass
- `gofmt -l .` - clean
- `git diff --check` - pass
- Full `go test ./...` is blocked only by nested macOS Seatbelt `TestIntegration*` cases (`sandbox_apply: Operation not permitted`).

## Follow-up
- Confirm the reporter startup timing after refreshing `tng-default.json`.

🤖 Generated with OpenCode