### PR TITLE
feat(cli): expose workdir-derived hashes via `omac diagnose --hash`

### DIFF
--- a/docs/skills/authoring.md
+++ b/docs/skills/authoring.md
@@ -242,14 +242,18 @@ curl "$OMAC_MY_SKILL_BASE/status"
 
 `--no-sandbox` skips the OS sandbox and runs your command directly. `--inner bash` replaces the agent with a shell, so you can call the skill by hand. Your sidecar and the facade still start normally.
 
-If a call returns HTTP `503` with the header `X-Omac-Reason: sidecar-down`, your sidecar failed to start or crashed. Its output (stdout and stderr) is captured in a per-project runtime directory under `$TMPDIR`:
+If a call returns HTTP `503` with the header `X-Omac-Reason: sidecar-down`, your sidecar failed to start or crashed. Its output (stdout and stderr) is captured in a per-project runtime directory:
 
 ```bash
-# omac creates one omac-<hash> directory per project; if only one is running:
+# On the host — omac creates one omac-<hash> directory per project; if only one is running:
 cat $TMPDIR/omac-*/logs/<skill>.log
+
+# Inside the sandbox, $TMPDIR is remapped to the per-launch sandbox temp dir,
+# so resolve the runtime dir from the socket instead:
+ls "$(dirname "$OMAC_SOCKET")/logs"
 ```
 
-Resolve `<hash>` for the current workdir exactly with `omac diagnose --hash=runtime` (see [CLI reference](../usage/cli.md#workdir-hashes-omac-diagnose---hash)).
+`omac diagnose --hash=runtime` resolves the runtime dir for the current workdir from either side — omac reads `$OMAC_SOCKET` when it is set (see [CLI reference](../usage/cli.md#workdir-hashes-omac-diagnose---hash)).
 
 Because omac runs the skill from the copy made at register time (see above), re-run `omac register` after editing the skill so your changes take effect.
 

--- a/docs/skills/authoring.md
+++ b/docs/skills/authoring.md
@@ -249,6 +249,8 @@ If a call returns HTTP `503` with the header `X-Omac-Reason: sidecar-down`, your
 cat $TMPDIR/omac-*/logs/<skill>.log
 ```
 
+Resolve `<hash>` for the current workdir exactly with `omac diagnose --hash=runtime` (see [CLI reference](../usage/cli.md#workdir-hashes-omac-diagnose---hash)).
+
 Because omac runs the skill from the copy made at register time (see above), re-run `omac register` after editing the skill so your changes take effect.
 
 ## Pre-shipping checklist

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -169,6 +169,33 @@ omac diagnose
 
 Requires the audit trail from a previous `omac start` or `omac serve` run. The audit trail is written automatically unless `--no-audit` was passed.
 
+#### Workdir hashes (`omac diagnose --hash`)
+
+omac derives four different identifiers from a workdir, each hashed differently. `omac diagnose --hash` prints them so you don't have to reverse-engineer a log path or a cache directory:
+
+| Kind | Hashed input | Digest | Names |
+|---|---|---|---|
+| `runtime` | absolute workdir | `sha256[:6]` | `$TMPDIR/omac-<hash>/` — `omac start`'s `logs/`, `pids/`, `bridge.sock` |
+| `serve` | `"serve:"` + absolute workdir | `sha256[:6]` | `$TMPDIR/omac-serve-<hash>/` — `omac serve`'s `logs/` |
+| `keychain` | absolute workdir | full `sha256` | the secret scope a workdir's keychain entries live under (not a path) |
+| `cache` | `"v1:<domain>:<canonical>"` | full `sha256` | `~/.cache/omac/<hash>/` — the persistent tool-cache scope |
+
+```bash
+omac diagnose --hash                 # all four kinds
+omac diagnose --hash=runtime         # one kind (attached '=', not a space)
+omac --workdir /path/to/proj diagnose --hash=cache
+
+# Find a run's logs:
+ls "$(omac diagnose --hash=runtime --json | jq -r '.entries[0].path')/logs"
+```
+
+Two things the output makes explicit, because both are easy to get wrong:
+
+- The `runtime` and `serve` paths are relative to `$TMPDIR`, so a shell with a different `TMPDIR` than the running agent resolves a different (equally correct) path. The reported `tmpdir` is the one that produced the output.
+- `runtime`, `serve` and `keychain` hash the **absolute** workdir, while `cache` hashes the **symlink-resolved** path. On macOS, where `/tmp` is a symlink to `/private/tmp`, those are different strings — the per-kind `input` field shows exactly what was hashed.
+
+The `cache` kind honors the configured `cache.scope` (`global`, `config`, or `workdir` — see [Cache](../advanced/cache.md)), so it reports the cache this workdir actually gets. It always agrees with `omac provenance`'s `cache.path`.
+
 ### omac update
 
 ```bash

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -178,7 +178,15 @@ omac derives four different identifiers from a workdir, each hashed differently.
 | `runtime` | absolute workdir | `sha256[:6]` | `$TMPDIR/omac-<hash>/` — `omac start`'s `logs/`, `pids/`, `bridge.sock` |
 | `serve` | `"serve:"` + absolute workdir | `sha256[:6]` | `$TMPDIR/omac-serve-<hash>/` — `omac serve`'s `logs/` |
 | `keychain` | absolute workdir | full `sha256` | the secret scope a workdir's keychain entries live under (not a path) |
-| `cache` | `"v1:<domain>:<canonical>"` | full `sha256` | `~/.cache/omac/<hash>/` — the persistent tool-cache scope |
+| `cache` | depends on the scope (below) | full `sha256` | `~/.cache/omac/<hash>/` — the persistent tool-cache scope |
+
+The `cache` input depends on the configured `cache.scope`, so it is **not** always workdir-derived:
+
+| `cache.scope` | Hashed input |
+|---|---|
+| `global` (default) | the constant `v1:shared` — identical for every workdir |
+| `workdir` | `v1:workdir:<symlink-resolved workdir>` |
+| `config` | `v1:config:<symlink-resolved launcher config path>`, or `v1:shared` when no config file is on disk |
 
 ```bash
 omac diagnose --hash                 # all four kinds
@@ -189,12 +197,13 @@ omac --workdir /path/to/proj diagnose --hash=cache
 ls "$(omac diagnose --hash=runtime --json | jq -r '.entries[0].path')/logs"
 ```
 
-Two things the output makes explicit, because both are easy to get wrong:
+Three things the output makes explicit, because all three are easy to get wrong:
 
-- The `runtime` and `serve` paths are relative to `$TMPDIR`, so a shell with a different `TMPDIR` than the running agent resolves a different (equally correct) path. The reported `tmpdir` is the one that produced the output.
-- `runtime`, `serve` and `keychain` hash the **absolute** workdir, while `cache` hashes the **symlink-resolved** path. On macOS, where `/tmp` is a symlink to `/private/tmp`, those are different strings — the per-kind `input` field shows exactly what was hashed.
+- The `runtime` and `serve` paths are joined onto `$TMPDIR`, so a shell with a different `TMPDIR` than the run resolves a different path. The reported `tmpdir` is the one that produced the output. **Inside the sandbox `TMPDIR` is deliberately remapped** to the per-launch sandbox temp dir, which would make a naively joined path point at nothing; when `$OMAC_SOCKET` is set and belongs to the workdir being reported, the command reads the live runtime dir from it instead and says so in the entry's `note`.
+- `runtime`, `serve` and `keychain` hash the **absolute** workdir, while `cache` hashes a **symlink-resolved** path (when it hashes a path at all). On macOS, where `/tmp` is a symlink to `/private/tmp`, those are different strings — the per-kind `input` field shows exactly what was hashed.
+- Digests are always derivable; paths may not exist yet. The command only *describes* directories — it never creates them, and never removes them.
 
-The `cache` kind honors the configured `cache.scope` (`global`, `config`, or `workdir` — see [Cache](../advanced/cache.md)), so it reports the cache this workdir actually gets. It always agrees with `omac provenance`'s `cache.path`.
+The `cache` kind reports the scope resolved from `cache.scope` in the launcher config (see [Cache](../advanced/cache.md)), and always agrees with `omac provenance`'s `cache.path`. Like `provenance`, it reports the **config-resolved** scope: it does not know about a specific launch's `--cache-scope` override, `--ephemeral-cache` (a per-launch dir under the sandbox temp dir), or `--no-sandbox` (no persistent scope is prepared at all).
 
 ### omac update
 

--- a/internal/cli/diagnose.go
+++ b/internal/cli/diagnose.go
@@ -62,7 +62,13 @@ func runDiagnose(args []string, env *Env) int {
 		// the stdlib cannot tell `--hash runtime` from `--hash` plus a
 		// positional. Reject it rather than silently printing every kind.
 		if fs.NArg() > 0 {
-			fmt.Fprintf(env.Stderr, "omac diagnose: use --hash=%s (attached), not --hash %s\n", fs.Arg(0), fs.Arg(0))
+			// Only suggest the attached form when the stray token really is a
+			// kind — otherwise "use --hash=bogus" is advice that fails again.
+			if hashSel.kind == hashKindAll && validHashKind(fs.Arg(0)) {
+				fmt.Fprintf(env.Stderr, "omac diagnose: use --hash=%s (attached), not --hash %s\n", fs.Arg(0), fs.Arg(0))
+			} else {
+				fmt.Fprintf(env.Stderr, "omac diagnose: unexpected argument %q (--hash takes no positional; use --hash=%s)\n", fs.Arg(0), hashKindList())
+			}
 			return ExitMisuse
 		}
 		if !validHashKind(hashSel.kind) {

--- a/internal/cli/diagnose.go
+++ b/internal/cli/diagnose.go
@@ -35,10 +35,14 @@ func runDiagnose(args []string, env *Env) int {
 	profileRef := fs.String("profile", "", "Sandbox profile ref (path or name); default resolves like `omac start`.")
 	runSel := fs.String("run", "last", "Which run(s) to analyze: last|all.")
 	probe := fs.String("probe", "", "Statically check whether host[:port] would be admitted, then exit.")
+	var hashSel hashKindFlag
+	// No backquoted word in the usage text: flag.PrintDefaults would take it
+	// as this flag's value placeholder and render "-hash --hash".
+	fs.Var(&hashSel, "hash", "Print the identifiers derived from the workdir, then exit. Bare --hash prints all; --hash="+hashKindList()+" selects one.")
 	verbose := fs.Bool("verbose", false, "Show every hint and the full effective config, not just the focused view.")
 	fs.BoolVar(verbose, "v", false, "Alias for --verbose.")
 	fs.Usage = func() {
-		fmt.Fprintln(fs.Output(), "Usage: omac diagnose [--json] [--profile <ref>] [--run last|all] [--probe host[:port]] [-v]")
+		fmt.Fprintln(fs.Output(), "Usage: omac diagnose [--json] [--profile <ref>] [--run last|all] [--probe host[:port]] [--hash[=kind]] [-v]")
 		fs.PrintDefaults()
 	}
 	if code, ok := parseFlags(fs, args, env); !ok {
@@ -47,6 +51,25 @@ func runDiagnose(args []string, env *Env) int {
 	if *runSel != "last" && *runSel != "all" {
 		fmt.Fprintln(env.Stderr, "omac diagnose: --run must be last|all")
 		return ExitMisuse
+	}
+
+	// --hash runs before the profile resolves and before the audit trail is
+	// read: the derivations depend on nothing but the workdir, the launcher
+	// config, and $TMPDIR, so they must stay answerable in a workdir that has
+	// never been started and has no profile on disk.
+	if hashSel.set {
+		// --hash is a bool-style flag (so bare `--hash` works), which means
+		// the stdlib cannot tell `--hash runtime` from `--hash` plus a
+		// positional. Reject it rather than silently printing every kind.
+		if fs.NArg() > 0 {
+			fmt.Fprintf(env.Stderr, "omac diagnose: use --hash=%s (attached), not --hash %s\n", fs.Arg(0), fs.Arg(0))
+			return ExitMisuse
+		}
+		if !validHashKind(hashSel.kind) {
+			fmt.Fprintf(env.Stderr, "omac diagnose: unknown --hash kind %q (want %s)\n", hashSel.kind, hashKindList())
+			return ExitMisuse
+		}
+		return runDiagnoseHash(env, hashSel.kind, *asJSON)
 	}
 
 	profile, profPath, err := sandboxprofile.Resolve(*profileRef)

--- a/internal/cli/hash.go
+++ b/internal/cli/hash.go
@@ -1,0 +1,249 @@
+// Package cli diagnose hash: `omac diagnose --hash[=<kind>]` prints the
+// identifiers omac derives from a workdir — the start/serve runtime-dir
+// hashes, the keychain secret-scope id, and the tool-cache scope digest.
+//
+// Everything here READS existing producers; it never recomputes a digest.
+// Each kind calls the same function the runtime calls (runtimeDirPath /
+// serveRuntimeDirPath in runtimedir.go, keychain.WorkdirID,
+// describeCacheScope → toolcache.Describe*), so a printed hash cannot drift
+// from the one omac actually uses. See issue #156.
+//
+// Split from diagnose.go for the same reason diagnose_probe.go is: this is a
+// standalone compute-and-exit path, independent of the audit-trail analysis.
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/TNG/oh-my-agentic-coder/internal/config"
+	"github.com/TNG/oh-my-agentic-coder/internal/keychain"
+)
+
+// Hash kinds. "all" is the default when --hash is passed bare.
+const (
+	hashKindRuntime  = "runtime"
+	hashKindServe    = "serve"
+	hashKindKeychain = "keychain"
+	hashKindCache    = "cache"
+	hashKindAll      = "all"
+)
+
+// hashKinds is the emission order for --hash=all, and the list shown when an
+// unknown kind is rejected.
+var hashKinds = []string{hashKindRuntime, hashKindServe, hashKindKeychain, hashKindCache}
+
+// hashEntry is one derivation. Input is the exact string that was hashed,
+// which is what makes the canonicalization differences visible: runtime,
+// serve and keychain hash the ABSOLUTE workdir, while cache hashes the
+// EvalSymlinks'd path behind a "v1:<domain>:" prefix — on macOS, where
+// /tmp is a symlink to /private/tmp, those are different strings.
+type hashEntry struct {
+	Kind   string `json:"kind"`
+	Input  string `json:"input"`
+	Digest string `json:"digest"`
+	// Path is the directory the digest names, when it names one. The
+	// keychain id is a namespace, not a path, so it has none.
+	Path string `json:"path,omitempty"`
+	// Note carries kind-specific context, e.g. the resolved cache scope.
+	Note string `json:"note,omitempty"`
+	// Error is set instead of Digest when this kind could not be derived.
+	// In --hash=all mode one failing kind never suppresses the others.
+	Error string `json:"error,omitempty"`
+}
+
+// hashView is the --json payload. The envelope is emitted even for a single
+// kind so the shape is stable for scripts (`jq -r '.entries[0].path'`).
+//
+// TmpDir is reported because it is a real footgun: the runtime and serve
+// paths are relative to os.TempDir(), so a shell whose TMPDIR differs from
+// the one the running agent had resolves a different — equally correct —
+// path. Seeing the TMPDIR that produced the output makes that mismatch
+// diagnosable instead of mysterious.
+type hashView struct {
+	Workdir string      `json:"workdir"`
+	TmpDir  string      `json:"tmpdir"`
+	Entries []hashEntry `json:"entries"`
+}
+
+// hashKindFlag backs --hash. It is a flag.Value with IsBoolFlag so the
+// stdlib accepts both the bare form (--hash) and the attached form
+// (--hash=runtime); a plain string flag would reject the former.
+type hashKindFlag struct {
+	set  bool
+	kind string
+}
+
+func (h *hashKindFlag) String() string {
+	if h == nil {
+		return ""
+	}
+	return h.kind
+}
+
+func (h *hashKindFlag) Set(v string) error {
+	switch v {
+	case "false":
+		// --hash=false: an explicit opt-out, treated as absent.
+		h.set, h.kind = false, ""
+	case "", "true":
+		// Bare --hash arrives here as "true".
+		h.set, h.kind = true, hashKindAll
+	default:
+		h.set, h.kind = true, v
+	}
+	return nil
+}
+
+// IsBoolFlag lets `--hash` stand alone. Its consequence is that
+// `--hash runtime` (space-separated) parses as bare --hash followed by a
+// positional; runDiagnose rejects that explicitly rather than silently
+// printing every kind.
+func (h *hashKindFlag) IsBoolFlag() bool { return true }
+
+// validHashKind reports whether kind is one this command can emit.
+func validHashKind(kind string) bool {
+	if kind == hashKindAll {
+		return true
+	}
+	for _, k := range hashKinds {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// runDiagnoseHash builds and renders the requested derivations. It reads
+// nothing but the workdir, the launcher config (for the cache scope) and
+// $TMPDIR — no audit trail, no sandbox profile — so it works in a fresh
+// checkout and cannot be broken by an unresolvable profile.
+func runDiagnoseHash(env *Env, kind string, asJSON bool) int {
+	view := buildHashView(env.Workdir, kind)
+
+	// A single explicitly requested kind that failed is a hard error: the
+	// user asked for one value and there is none to print. In "all" mode the
+	// failure is reported inline and the other kinds still print.
+	if kind != hashKindAll && len(view.Entries) == 1 && view.Entries[0].Error != "" {
+		fmt.Fprintf(env.Stderr, "omac diagnose --hash=%s: %s\n", kind, view.Entries[0].Error)
+		return ExitIOError
+	}
+
+	if asJSON {
+		return writeDiagnoseJSON(env, view)
+	}
+	return writeHashText(env, view)
+}
+
+// buildHashView derives the requested kinds. Every entry comes from the
+// producer the runtime itself uses; nothing here hashes anything.
+func buildHashView(workdir, kind string) hashView {
+	view := hashView{Workdir: workdir, TmpDir: os.TempDir()}
+	for _, k := range hashKinds {
+		if kind != hashKindAll && kind != k {
+			continue
+		}
+		view.Entries = append(view.Entries, buildHashEntry(workdir, k))
+	}
+	return view
+}
+
+func buildHashEntry(workdir, kind string) hashEntry {
+	switch kind {
+	case hashKindRuntime:
+		return hashEntry{
+			Kind:   kind,
+			Input:  workdir,
+			Digest: runtimeDirDigest(workdir),
+			Path:   runtimeDirPath(workdir),
+			Note:   "omac start runtime dir (logs, pids, bridge.sock)",
+		}
+	case hashKindServe:
+		return hashEntry{
+			Kind:   kind,
+			Input:  "serve:" + workdir,
+			Digest: serveRuntimeDirDigest(workdir),
+			Path:   serveRuntimeDirPath(workdir),
+			Note:   "omac serve runtime dir, keyed on the server root",
+		}
+	case hashKindKeychain:
+		return hashEntry{
+			Kind:   kind,
+			Input:  workdir,
+			Digest: keychain.WorkdirID(workdir),
+			Note:   "secret scope id (not a path)",
+		}
+	case hashKindCache:
+		return buildCacheHashEntry(workdir)
+	}
+	return hashEntry{Kind: kind, Error: "unknown kind"}
+}
+
+// buildCacheHashEntry resolves the cache scope the way the launcher does —
+// load the config, resolve global/config/workdir, then hand it to the shared
+// describeCacheScope (provenance.go) — so it reports the cache this workdir
+// would actually get, matching `omac provenance`'s cache.path exactly.
+func buildCacheHashEntry(workdir string) hashEntry {
+	entry := hashEntry{Kind: hashKindCache, Input: workdir}
+	lc, cfgPath, err := config.LoadLauncher(workdir)
+	if err != nil {
+		entry.Error = err.Error()
+		return entry
+	}
+	cacheScope, err := lc.Cache.Resolve()
+	if err != nil {
+		entry.Error = err.Error()
+		return entry
+	}
+	scope, err := describeCacheScope(cacheScope, workdir, cfgPath)
+	if err != nil {
+		// Most likely EvalSymlinks on a workdir that does not exist, or an
+		// unset HOME. Say which scope was being resolved — the bare error
+		// ("no such file or directory") is otherwise unattributable.
+		entry.Error = fmt.Sprintf("resolve %s cache scope: %v", cacheScope, err)
+		return entry
+	}
+	entry.Input = scope.Identity
+	entry.Digest = scope.Digest
+	entry.Path = scope.Dir
+	entry.Note = fmt.Sprintf("cache scope %q (config: %s)", cacheScope, cacheScopeOrigin(cfgPath))
+	return entry
+}
+
+func cacheScopeOrigin(cfgPath string) string {
+	if cfgPath == "" {
+		return "no config file; defaults"
+	}
+	return cfgPath
+}
+
+// writeHashText renders a stanza per kind. Deliberately not a table: the
+// keychain and cache digests are full 64-hex sha256s, so a KIND/DIGEST/PATH
+// table pads every row out past 140 columns and wraps in a normal terminal.
+// Stanzas stay readable at any width and keep each digest on its own line,
+// where it can be double-clicked or copied whole.
+func writeHashText(env *Env, view hashView) int {
+	fmt.Fprintf(env.Stdout, "workdir  %s\nTMPDIR   %s\n", view.Workdir, view.TmpDir)
+	for _, e := range view.Entries {
+		fmt.Fprintln(env.Stdout)
+		if e.Error != "" {
+			fmt.Fprintf(env.Stdout, "%s\n  error  %s\n", e.Kind, e.Error)
+			continue
+		}
+		fmt.Fprintf(env.Stdout, "%s\n  digest %s\n", e.Kind, e.Digest)
+		if e.Path != "" {
+			fmt.Fprintf(env.Stdout, "  path   %s\n", e.Path)
+		}
+		fmt.Fprintf(env.Stdout, "  input  %s\n", e.Input)
+		if e.Note != "" {
+			fmt.Fprintf(env.Stdout, "  note   %s\n", e.Note)
+		}
+	}
+	return ExitOK
+}
+
+// hashKindList renders the accepted kinds for error messages and usage.
+func hashKindList() string {
+	return strings.Join(append(append([]string{}, hashKinds...), hashKindAll), "|")
+}

--- a/internal/cli/hash.go
+++ b/internal/cli/hash.go
@@ -15,6 +15,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/TNG/oh-my-agentic-coder/internal/config"
@@ -152,20 +153,22 @@ func buildHashView(workdir, kind string) hashView {
 func buildHashEntry(workdir, kind string) hashEntry {
 	switch kind {
 	case hashKindRuntime:
+		path, live := resolveRuntimePath(runtimeDirPath(workdir))
 		return hashEntry{
 			Kind:   kind,
 			Input:  workdir,
 			Digest: runtimeDirDigest(workdir),
-			Path:   runtimeDirPath(workdir),
-			Note:   "omac start runtime dir (logs, pids, bridge.sock)",
+			Path:   path,
+			Note:   annotateLive("omac start runtime dir (logs, pids, bridge.sock)", live),
 		}
 	case hashKindServe:
+		path, live := resolveRuntimePath(serveRuntimeDirPath(workdir))
 		return hashEntry{
 			Kind:   kind,
 			Input:  "serve:" + workdir,
 			Digest: serveRuntimeDirDigest(workdir),
-			Path:   serveRuntimeDirPath(workdir),
-			Note:   "omac serve runtime dir, keyed on the server root",
+			Path:   path,
+			Note:   annotateLive("omac serve runtime dir, keyed on the server root", live),
 		}
 	case hashKindKeychain:
 		return hashEntry{
@@ -178,6 +181,45 @@ func buildHashEntry(workdir, kind string) hashEntry {
 		return buildCacheHashEntry(workdir)
 	}
 	return hashEntry{Kind: kind, Error: "unknown kind"}
+}
+
+// liveRuntimeDir returns the runtime dir of the omac session this process is
+// running inside, or "" when it is not inside one.
+//
+// This exists because os.TempDir() is the wrong answer in the one place the
+// answer matters most. Inside the sandbox, TMPDIR is remapped to the
+// per-launch sandbox temp dir (start.go, serve.go both export it), so joining
+// os.TempDir() with the derived name yields a directory that does not exist —
+// exactly what an agent debugging a sidecar from inside the sandbox would be
+// handed. $OMAC_SOCKET is unaffected: start and serve both set it to
+// <runtimeDir>/bridge.sock on the HOST, so its parent is the live runtime dir,
+// read rather than re-derived.
+func liveRuntimeDir() string {
+	sock := os.Getenv("OMAC_SOCKET")
+	if sock == "" {
+		return ""
+	}
+	return filepath.Dir(sock)
+}
+
+// resolveRuntimePath prefers the live runtime dir over the $TMPDIR-derived
+// one, but only when the two carry the same directory NAME — that is, when the
+// ambient session belongs to the workdir being reported. A --workdir pointing
+// at some other directory, or a serve session while asking for the start kind,
+// keeps the derived path.
+func resolveRuntimePath(derived string) (path string, fromSocket bool) {
+	live := liveRuntimeDir()
+	if live == "" || live == derived || filepath.Base(live) != filepath.Base(derived) {
+		return derived, false
+	}
+	return live, true
+}
+
+func annotateLive(note string, fromSocket bool) string {
+	if !fromSocket {
+		return note
+	}
+	return note + "; path read from $OMAC_SOCKET ($TMPDIR is remapped inside the sandbox)"
 }
 
 // buildCacheHashEntry resolves the cache scope the way the launcher does —
@@ -226,11 +268,15 @@ func cacheScopeOrigin(cfgPath string) string {
 func writeHashText(env *Env, view hashView) int {
 	fmt.Fprintf(env.Stdout, "workdir  %s\nTMPDIR   %s\n", view.Workdir, view.TmpDir)
 	for _, e := range view.Entries {
-		fmt.Fprintln(env.Stdout)
+		// A kind that could not be derived goes to stderr, so a caller
+		// scraping stdout for paths never picks up an error stanza as if it
+		// were one. (In --json the failure is a structured `error` field and
+		// stays in the payload.)
 		if e.Error != "" {
-			fmt.Fprintf(env.Stdout, "%s\n  error  %s\n", e.Kind, e.Error)
+			fmt.Fprintf(env.Stderr, "omac diagnose --hash: %s: %s\n", e.Kind, e.Error)
 			continue
 		}
+		fmt.Fprintln(env.Stdout)
 		fmt.Fprintf(env.Stdout, "%s\n  digest %s\n", e.Kind, e.Digest)
 		if e.Path != "" {
 			fmt.Fprintf(env.Stdout, "  path   %s\n", e.Path)

--- a/internal/cli/hash_test.go
+++ b/internal/cli/hash_test.go
@@ -245,6 +245,112 @@ func TestDiagnoseHashTextMode(t *testing.T) {
 	}
 }
 
+// TestDiagnoseHashRuntimeInsideSandbox: inside the sandbox TMPDIR is remapped
+// to the per-launch sandbox temp dir, so joining it with the derived name
+// names a directory that does not exist. $OMAC_SOCKET still points at the
+// host runtime dir, and must win.
+func TestDiagnoseHashRuntimeInsideSandbox(t *testing.T) {
+	wd := hashSandbox(t)
+
+	// The host runtime dir, created before TMPDIR is remapped.
+	hostDir, err := createRuntimeDir(wd)
+	if err != nil {
+		t.Fatalf("createRuntimeDir: %v", err)
+	}
+	// Now stand where the inner agent stands: TMPDIR points at the sandbox
+	// temp dir, OMAC_SOCKET still carries the host path.
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("OMAC_SOCKET", filepath.Join(hostDir, "bridge.sock"))
+
+	view, code, errOut := runHash(t, wd, "--hash=runtime")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	got := onlyEntry(t, view, "runtime")
+	if got.Path != hostDir {
+		t.Errorf("path = %q, want the live runtime dir %q", got.Path, hostDir)
+	}
+	if _, err := os.Stat(got.Path); err != nil {
+		t.Errorf("reported path does not exist: %v", err)
+	}
+	if !strings.Contains(got.Note, "OMAC_SOCKET") {
+		t.Errorf("note does not disclose the path source: %q", got.Note)
+	}
+}
+
+// TestDiagnoseHashIgnoresForeignSocket: an ambient session belonging to a
+// DIFFERENT workdir must not hijack the reported path — only a same-named
+// runtime dir is trusted.
+func TestDiagnoseHashIgnoresForeignSocket(t *testing.T) {
+	wd := hashSandbox(t)
+	other := t.TempDir()
+
+	t.Setenv("OMAC_SOCKET", filepath.Join(t.TempDir(), filepath.Base(runtimeDirPath(other)), "bridge.sock"))
+
+	view, code, errOut := runHash(t, wd, "--hash=runtime")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	got := onlyEntry(t, view, "runtime")
+	if want := runtimeDirPath(wd); got.Path != want {
+		t.Errorf("path = %q, want the derived path %q (foreign session hijacked it)", got.Path, want)
+	}
+	if strings.Contains(got.Note, "OMAC_SOCKET") {
+		t.Errorf("note claims a socket source it did not use: %q", got.Note)
+	}
+}
+
+// TestDiagnoseHashServeIgnoresStartSocket: a live `omac start` session must
+// not be reported as the serve runtime dir — the two names differ by prefix.
+func TestDiagnoseHashServeIgnoresStartSocket(t *testing.T) {
+	wd := hashSandbox(t)
+
+	t.Setenv("OMAC_SOCKET", filepath.Join(runtimeDirPath(wd), "bridge.sock"))
+
+	view, code, errOut := runHash(t, wd, "--hash=serve")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	if got, want := onlyEntry(t, view, "serve").Path, serveRuntimeDirPath(wd); got != want {
+		t.Errorf("path = %q, want %q (a start session was mistaken for serve)", got, want)
+	}
+}
+
+// TestDiagnoseHashFailedKindGoesToStderr: in --hash=all a kind that cannot be
+// derived must not write into the stream a caller scrapes paths from.
+func TestDiagnoseHashFailedKindGoesToStderr(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	// Force the workdir cache scope against a workdir that does not exist, so
+	// DescribePersistent's EvalSymlinks fails.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfgDir := filepath.Join(home, ".config", "omac")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte("cache:\n  scope: workdir\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(t.TempDir(), "gone")
+
+	env, read := captureEnv(t, missing)
+	code := runDiagnose([]string{"--hash"}, env)
+	out, errOut := read()
+	if code != ExitOK {
+		t.Fatalf("code = %d, want ExitOK (other kinds still derive); stderr=%q", code, errOut)
+	}
+	if !strings.Contains(errOut, "cache") {
+		t.Errorf("cache failure not reported on stderr: %q", errOut)
+	}
+	if strings.Contains(out, "error") {
+		t.Errorf("error text leaked into stdout: %q", out)
+	}
+	if !strings.Contains(out, "runtime") {
+		t.Errorf("a failing kind suppressed the others: %q", out)
+	}
+}
+
 // TestDiagnoseHashUnknownKind: a typo is rejected loudly, with the valid
 // kinds listed, rather than silently printing everything.
 func TestDiagnoseHashUnknownKind(t *testing.T) {
@@ -279,6 +385,25 @@ func TestDiagnoseHashRejectsSpaceForm(t *testing.T) {
 	_, errOut := read()
 	if !strings.Contains(errOut, "--hash=runtime") {
 		t.Errorf("stderr does not suggest the attached form: %q", errOut)
+	}
+}
+
+// TestDiagnoseHashStrayNonKindArg: a stray token that is NOT a kind must not
+// be echoed back as "use --hash=<that token>" — following that advice would
+// just fail again with "unknown kind".
+func TestDiagnoseHashStrayNonKindArg(t *testing.T) {
+	wd := hashSandbox(t)
+
+	env, read := captureEnv(t, wd)
+	if code := runDiagnose([]string{"--hash", "wat"}, env); code != ExitMisuse {
+		t.Fatalf("code = %d, want ExitMisuse", code)
+	}
+	_, errOut := read()
+	if strings.Contains(errOut, "--hash=wat") {
+		t.Errorf("stderr suggests advice that would fail again: %q", errOut)
+	}
+	if !strings.Contains(errOut, "unexpected argument") {
+		t.Errorf("stderr does not name the problem: %q", errOut)
 	}
 }
 

--- a/internal/cli/hash_test.go
+++ b/internal/cli/hash_test.go
@@ -1,0 +1,331 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/TNG/oh-my-agentic-coder/internal/keychain"
+	"github.com/TNG/oh-my-agentic-coder/internal/toolcache"
+)
+
+// These tests are the drift guard issue #156 asks for: each one asserts the
+// value `omac diagnose --hash` prints against the REAL producer the runtime
+// uses, never against a hardcoded digest. If someone re-inlines a sha256 in
+// start.go/serve.go, or changes a cache identity, these fail.
+
+// hashSandbox isolates HOME/XDG and points TMPDIR at a temp dir, then returns
+// a fresh workdir. TMPDIR isolation matters: createRuntimeDir os.RemoveAll's
+// its target, and these tests call it for real — without this it could delete
+// a developer's live `omac start` runtime dir.
+func hashSandbox(t *testing.T) string {
+	t.Helper()
+	isolateHome(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	return t.TempDir()
+}
+
+// runHash invokes the real CLI entry point and decodes the JSON payload.
+func runHash(t *testing.T, wd string, args ...string) (hashView, int, string) {
+	t.Helper()
+	env, read := captureEnv(t, wd)
+	code := runDiagnose(append(args, "--json"), env)
+	out, errOut := read()
+	var view hashView
+	if code == ExitOK {
+		if err := json.Unmarshal([]byte(out), &view); err != nil {
+			t.Fatalf("decode --hash JSON: %v; stdout=%q stderr=%q", err, out, errOut)
+		}
+	}
+	return view, code, errOut
+}
+
+func onlyEntry(t *testing.T, view hashView, kind string) hashEntry {
+	t.Helper()
+	if len(view.Entries) != 1 {
+		t.Fatalf("--hash=%s: got %d entries, want 1: %+v", kind, len(view.Entries), view.Entries)
+	}
+	if view.Entries[0].Kind != kind {
+		t.Fatalf("--hash=%s: got kind %q", kind, view.Entries[0].Kind)
+	}
+	return view.Entries[0]
+}
+
+// TestDiagnoseHashRuntimeMatchesCreateRuntimeDir: the reported runtime path is
+// byte-for-byte the directory createRuntimeDir actually creates.
+func TestDiagnoseHashRuntimeMatchesCreateRuntimeDir(t *testing.T) {
+	wd := hashSandbox(t)
+
+	want, err := createRuntimeDir(wd)
+	if err != nil {
+		t.Fatalf("createRuntimeDir: %v", err)
+	}
+
+	view, code, errOut := runHash(t, wd, "--hash=runtime")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	got := onlyEntry(t, view, "runtime")
+	if got.Path != want {
+		t.Errorf("path = %q, want %q (createRuntimeDir drifted from runtimeDirPath)", got.Path, want)
+	}
+	if got.Digest != filepath.Base(want)[len("omac-"):] {
+		t.Errorf("digest = %q, not the suffix of %q", got.Digest, want)
+	}
+	if got.Input != wd {
+		t.Errorf("input = %q, want the absolute workdir %q", got.Input, wd)
+	}
+}
+
+// TestDiagnoseHashServeMatchesCreateRuntimeDirServe: same guard for serve,
+// whose identity carries the "serve:" prefix so it never collides with start's.
+func TestDiagnoseHashServeMatchesCreateRuntimeDirServe(t *testing.T) {
+	wd := hashSandbox(t)
+
+	want, err := createRuntimeDirServe(wd)
+	if err != nil {
+		t.Fatalf("createRuntimeDirServe: %v", err)
+	}
+
+	view, code, errOut := runHash(t, wd, "--hash=serve")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	got := onlyEntry(t, view, "serve")
+	if got.Path != want {
+		t.Errorf("path = %q, want %q (createRuntimeDirServe drifted from serveRuntimeDirPath)", got.Path, want)
+	}
+	if got.Input != "serve:"+wd {
+		t.Errorf("input = %q, want %q", got.Input, "serve:"+wd)
+	}
+	if got.Path == runtimeDirPath(wd) {
+		t.Error("serve and start runtime dirs collide")
+	}
+}
+
+// TestDiagnoseHashKeychainMatchesWorkdirID: the keychain kind is exactly what
+// register/start/serve scope secrets under.
+func TestDiagnoseHashKeychainMatchesWorkdirID(t *testing.T) {
+	wd := hashSandbox(t)
+
+	view, code, errOut := runHash(t, wd, "--hash=keychain")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	got := onlyEntry(t, view, "keychain")
+	if want := keychain.WorkdirID(wd); got.Digest != want {
+		t.Errorf("digest = %q, want keychain.WorkdirID = %q", got.Digest, want)
+	}
+	if got.Path != "" {
+		t.Errorf("keychain id is a namespace, not a path; got path %q", got.Path)
+	}
+}
+
+// TestDiagnoseHashCacheWorkdirScope: with cache.scope=workdir configured, the
+// reported cache matches toolcache's own description of the workdir scope.
+func TestDiagnoseHashCacheWorkdirScope(t *testing.T) {
+	wd := hashSandbox(t)
+	writeWorkdirScopeConfig(t, wd)
+
+	want, err := toolcache.DescribePersistent(toolcache.DomainWorkdir, wd)
+	if err != nil {
+		t.Fatalf("DescribePersistent: %v", err)
+	}
+
+	view, code, errOut := runHash(t, wd, "--hash=cache")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	got := onlyEntry(t, view, "cache")
+	if got.Digest != want.Digest {
+		t.Errorf("digest = %q, want %q", got.Digest, want.Digest)
+	}
+	if got.Path != want.Dir {
+		t.Errorf("path = %q, want %q", got.Path, want.Dir)
+	}
+	if got.Input != want.Identity {
+		t.Errorf("input = %q, want the hashed identity %q", got.Input, want.Identity)
+	}
+}
+
+// TestDiagnoseHashCacheDefaultsToShared: with no launcher config on disk the
+// scope resolves to global/shared, i.e. the same cache for every workdir.
+func TestDiagnoseHashCacheDefaultsToShared(t *testing.T) {
+	wd := hashSandbox(t)
+
+	want, err := toolcache.DescribeShared()
+	if err != nil {
+		t.Fatalf("DescribeShared: %v", err)
+	}
+
+	view, code, errOut := runHash(t, wd, "--hash=cache")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	got := onlyEntry(t, view, "cache")
+	if got.Digest != want.Digest {
+		t.Errorf("digest = %q, want the shared scope %q", got.Digest, want.Digest)
+	}
+	if got.Path != want.Dir {
+		t.Errorf("path = %q, want %q", got.Path, want.Dir)
+	}
+}
+
+// TestDiagnoseHashAgreesWithProvenance: `--hash=cache` and the already-shipped
+// `omac provenance` cache view must name the same directory — they share
+// describeCacheScope, and this pins that they keep sharing it.
+func TestDiagnoseHashAgreesWithProvenance(t *testing.T) {
+	wd := hashSandbox(t)
+	writeWorkdirScopeConfig(t, wd)
+
+	view, code, errOut := runHash(t, wd, "--hash=cache")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+
+	pv, err := buildProvenanceView(wd, "")
+	if err != nil {
+		t.Fatalf("buildProvenanceView: %v", err)
+	}
+	if got := onlyEntry(t, view, "cache").Path; got != pv.Cache.Path {
+		t.Errorf("--hash=cache path %q != provenance cache.path %q", got, pv.Cache.Path)
+	}
+}
+
+// TestDiagnoseHashAllKinds: bare --hash emits every kind, in a stable order,
+// and reports the TMPDIR the paths were resolved against.
+func TestDiagnoseHashAllKinds(t *testing.T) {
+	wd := hashSandbox(t)
+
+	view, code, errOut := runHash(t, wd, "--hash")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	var kinds []string
+	for _, e := range view.Entries {
+		if e.Error != "" {
+			t.Errorf("kind %s errored: %s", e.Kind, e.Error)
+		}
+		kinds = append(kinds, e.Kind)
+	}
+	if want := strings.Join(hashKinds, ","); strings.Join(kinds, ",") != want {
+		t.Errorf("kinds = %v, want %v", kinds, hashKinds)
+	}
+	if view.Workdir != wd {
+		t.Errorf("workdir = %q, want %q", view.Workdir, wd)
+	}
+	if view.TmpDir == "" {
+		t.Error("tmpdir is empty; the runtime/serve paths are unattributable without it")
+	}
+}
+
+// TestDiagnoseHashTextMode: the default (non-JSON) rendering names every kind
+// and its digest.
+func TestDiagnoseHashTextMode(t *testing.T) {
+	wd := hashSandbox(t)
+
+	env, read := captureEnv(t, wd)
+	if code := runDiagnose([]string{"--hash"}, env); code != ExitOK {
+		_, errOut := read()
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	out, _ := read()
+	for _, kind := range hashKinds {
+		if !strings.Contains(out, kind) {
+			t.Errorf("text output missing kind %q; got:\n%s", kind, out)
+		}
+	}
+	if !strings.Contains(out, runtimeDirPath(wd)) {
+		t.Errorf("text output missing the runtime path; got:\n%s", out)
+	}
+	if !strings.Contains(out, keychain.WorkdirID(wd)) {
+		t.Errorf("text output missing the keychain id; got:\n%s", out)
+	}
+}
+
+// TestDiagnoseHashUnknownKind: a typo is rejected loudly, with the valid
+// kinds listed, rather than silently printing everything.
+func TestDiagnoseHashUnknownKind(t *testing.T) {
+	wd := hashSandbox(t)
+
+	env, read := captureEnv(t, wd)
+	if code := runDiagnose([]string{"--hash=bogus"}, env); code != ExitMisuse {
+		t.Fatalf("code = %d, want ExitMisuse", code)
+	}
+	_, errOut := read()
+	if !strings.Contains(errOut, "bogus") {
+		t.Errorf("stderr does not name the bad kind: %q", errOut)
+	}
+	for _, kind := range hashKinds {
+		if !strings.Contains(errOut, kind) {
+			t.Errorf("stderr does not list valid kind %q: %q", kind, errOut)
+		}
+	}
+}
+
+// TestDiagnoseHashRejectsSpaceForm: --hash is a bool-style flag so bare
+// `--hash` works, which means `--hash runtime` parses as bare --hash plus a
+// positional. That must fail loudly — silently printing all four kinds when
+// the user asked for one is the trap this guards.
+func TestDiagnoseHashRejectsSpaceForm(t *testing.T) {
+	wd := hashSandbox(t)
+
+	env, read := captureEnv(t, wd)
+	if code := runDiagnose([]string{"--hash", "runtime"}, env); code != ExitMisuse {
+		t.Fatalf("code = %d, want ExitMisuse", code)
+	}
+	_, errOut := read()
+	if !strings.Contains(errOut, "--hash=runtime") {
+		t.Errorf("stderr does not suggest the attached form: %q", errOut)
+	}
+}
+
+// TestDiagnoseHashNeedsNoProfileOrAuditTrail: --hash must answer in a workdir
+// that has never been started — no audit log, no sandbox profile. This pins
+// the short-circuit ahead of sandboxprofile.Resolve in runDiagnose.
+func TestDiagnoseHashNeedsNoProfileOrAuditTrail(t *testing.T) {
+	wd := hashSandbox(t)
+
+	env, read := captureEnv(t, wd)
+	if code := runDiagnose([]string{"--hash=runtime", "--profile", "/nonexistent/profile.json"}, env); code != ExitOK {
+		_, errOut := read()
+		t.Fatalf("code = %d, want ExitOK; stderr=%q", code, errOut)
+	}
+}
+
+// TestDiagnoseHashCreatesNothing: --hash is a read-only debugging aid. It must
+// never create (or, worse, RemoveAll) the directories it names — reporting the
+// runtime dir of a LIVE session must not wipe that session's logs and pids.
+func TestDiagnoseHashCreatesNothing(t *testing.T) {
+	wd := hashSandbox(t)
+
+	// Stage a live-looking runtime dir with a log in it.
+	live, err := createRuntimeDir(wd)
+	if err != nil {
+		t.Fatalf("createRuntimeDir: %v", err)
+	}
+	marker := filepath.Join(live, "logs", "skill.log")
+	if err := os.WriteFile(marker, []byte("live session output"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	view, code, errOut := runHash(t, wd, "--hash")
+	if code != ExitOK {
+		t.Fatalf("code = %d; stderr=%q", code, errOut)
+	}
+	got, err := os.ReadFile(marker)
+	if err != nil || string(got) != "live session output" {
+		t.Fatalf("--hash destroyed the live runtime dir; read = %q, err = %v", got, err)
+	}
+	// The cache scope dir is likewise only described, never created.
+	for _, e := range view.Entries {
+		if e.Kind != "cache" {
+			continue
+		}
+		if _, err := os.Stat(e.Path); err == nil {
+			t.Errorf("--hash created the cache scope dir %q", e.Path)
+		}
+	}
+}

--- a/internal/cli/provenance.go
+++ b/internal/cli/provenance.go
@@ -148,22 +148,7 @@ func buildProvenanceView(workdir, profileRef string) (*provenanceView, error) {
 // ephemeral or serve-process scope. An error from the describe call (e.g.
 // HOME unset) is returned to the caller rather than swallowed.
 func buildCacheView(cacheScope config.CacheScope, workdir, cfgPath string) (cacheView, error) {
-	var (
-		scope toolcache.Scope
-		err   error
-	)
-	switch cacheScope {
-	case config.CacheScopeWorkdir:
-		scope, err = toolcache.DescribePersistent(toolcache.DomainWorkdir, workdir)
-	case config.CacheScopeConfig:
-		if cfgPath != "" {
-			scope, err = toolcache.DescribePersistent(toolcache.DomainConfig, cfgPath)
-		} else {
-			scope, err = toolcache.DescribeShared()
-		}
-	default:
-		scope, err = toolcache.DescribeShared()
-	}
+	scope, err := describeCacheScope(cacheScope, workdir, cfgPath)
 	if err != nil {
 		return cacheView{}, err
 	}
@@ -173,6 +158,31 @@ func buildCacheView(cacheScope config.CacheScope, workdir, cfgPath string) (cach
 		Path:        scope.Dir,
 		Environment: toolcache.Environment(scope.Dir, scope.Mode),
 	}, nil
+}
+
+// describeCacheScope maps a config-resolved cache scope onto the toolcache
+// scope it names, without creating or locking the directory. It is the single
+// source of truth for the scope→domain mapping: both buildCacheView
+// (`omac provenance`) and buildHashView (`omac diagnose --hash`) call it, so
+// the two surfaces cannot disagree about which cache a workdir resolves to.
+//
+// Note `config` falls back to the shared scope when no launcher config file is
+// on disk, matching what start/serve do.
+//
+// (`omac cache clear` has a structurally similar switch in cache.go, but it
+// dispatches to toolcache.Clear*, not Describe*, so it is not folded in here.)
+func describeCacheScope(cacheScope config.CacheScope, workdir, cfgPath string) (toolcache.Scope, error) {
+	switch cacheScope {
+	case config.CacheScopeWorkdir:
+		return toolcache.DescribePersistent(toolcache.DomainWorkdir, workdir)
+	case config.CacheScopeConfig:
+		if cfgPath != "" {
+			return toolcache.DescribePersistent(toolcache.DomainConfig, cfgPath)
+		}
+		return toolcache.DescribeShared()
+	default:
+		return toolcache.DescribeShared()
+	}
 }
 
 // classifyProfilePath attributes a profile path to a config layer.

--- a/internal/cli/runtimedir.go
+++ b/internal/cli/runtimedir.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+)
+
+// Runtime-dir name derivation, kept separate from the functions that create
+// those directories.
+//
+// createRuntimeDir (start.go) and createRuntimeDirServe (serve.go) both
+// os.RemoveAll their target before recreating it, so nothing that merely wants
+// to KNOW the path may call them — `omac diagnose --hash` would wipe a running
+// session's logs/ and pids/. The pure derivations therefore live here, and the
+// creating functions call them. That is the single source of truth: there is
+// exactly one sha256 of a workdir in the CLI package, and both the runtime and
+// the reporting path go through it, so the printed hash cannot drift from the
+// one omac actually uses.
+//
+// Note the digest is over the ABSOLUTE workdir with no symlink resolution
+// (cli.Run absolutizes but does not EvalSymlinks) — unlike the tool cache,
+// which hashes the EvalSymlinks'd path. See internal/toolcache/cache.go.
+
+// shortDigest returns the first 6 bytes of sha256(input) as hex — the
+// truncation both runtime-dir names use.
+func shortDigest(input string) string {
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:6])
+}
+
+// runtimeDirDigest is the hash embedded in a start-mode runtime dir name.
+func runtimeDirDigest(workdir string) string { return shortDigest(workdir) }
+
+// runtimeDirPath returns ${TMPDIR}/omac-<digest> for a workdir, without
+// creating, touching, or removing anything.
+func runtimeDirPath(workdir string) string {
+	return filepath.Join(os.TempDir(), "omac-"+runtimeDirDigest(workdir))
+}
+
+// serveRuntimeDirDigest is the hash embedded in a serve-mode runtime dir name.
+// The "serve:" prefix is what keeps a serve run's dir distinct from a start
+// run's dir for the same directory.
+func serveRuntimeDirDigest(serverRoot string) string { return shortDigest("serve:" + serverRoot) }
+
+// serveRuntimeDirPath returns ${TMPDIR}/omac-serve-<digest> for a server root,
+// without creating, touching, or removing anything.
+func serveRuntimeDirPath(serverRoot string) string {
+	return filepath.Join(os.TempDir(), "omac-serve-"+serveRuntimeDirDigest(serverRoot))
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -1973,11 +1972,10 @@ func mintToken() string {
 }
 
 // createRuntimeDirServe creates ${TMPDIR}/omac-serve-<hash>/{logs}.
+// The name comes from serveRuntimeDirPath (runtimedir.go) so
+// `omac diagnose --hash` reports exactly the directory this creates.
 func createRuntimeDirServe(serverRoot string) (string, error) {
-	tmp := os.TempDir()
-	sum := sha256.Sum256([]byte("serve:" + serverRoot))
-	name := "omac-serve-" + hex.EncodeToString(sum[:6])
-	dir := filepath.Join(tmp, name)
+	dir := serveRuntimeDirPath(serverRoot)
 	if _, err := os.Stat(dir); err == nil {
 		_ = os.RemoveAll(dir)
 	}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -1395,11 +1393,10 @@ func startAutoRegisterOne(workdir string, ent skillsource.Entry) (*registry.Entr
 }
 
 // createRuntimeDir creates ${TMPDIR}/omac-<workdir-hash>/{logs,pids}.
+// The name comes from runtimeDirPath (runtimedir.go) so `omac diagnose --hash`
+// reports exactly the directory this creates.
 func createRuntimeDir(workdir string) (string, error) {
-	tmp := os.TempDir()
-	sum := sha256.Sum256([]byte(workdir))
-	name := "omac-" + hex.EncodeToString(sum[:6])
-	dir := filepath.Join(tmp, name)
+	dir := runtimeDirPath(workdir)
 	// Clean stale directory if present.
 	if _, err := os.Stat(dir); err == nil {
 		_ = os.RemoveAll(dir)


### PR DESCRIPTION
**Issue:** Closes #156

## What

- `omac diagnose --hash[=runtime|serve|keychain|cache|all]` prints the four identifiers omac derives from a workdir, in text or `--json`.
- The hashing that `createRuntimeDir`/`createRuntimeDirServe` inlined moves to `internal/cli/runtimedir.go`; both creators now call it. One `sha256` of a workdir left in the package.
- `describeCacheScope` lifted out of provenance's `buildCacheView`, so `--hash=cache` and `omac provenance` cannot disagree.

## Why

Four different workdir-derived identifiers, none reachable from the CLI — debugging a run meant reverse-engineering a log path or a cache directory by hand. `internal/cli/controlinfo.go:18-20` states the gap outright.

Shape follows the [comment on #156](https://github.com/TNG/oh-my-agentic-coder/issues/156#issuecomment-3489493906) (a debugging flag, not a new top-level verb) rather than the issue body's `omac hash`. It mirrors the existing `--probe` compute-and-exit precedent.

## How

The issue's hard requirement is single-source-of-truth, and that is what forced the refactors:

- `createRuntimeDir` / `createRuntimeDirServe` **`os.RemoveAll` their target**, so a reporting path that called them would wipe a live session's `logs/` and `pids/`. Only the pure derivation moved out; the creators keep their side effects.
- Every value is read from the producer the runtime uses — `runtimeDirPath`, `serveRuntimeDirPath`, `keychain.WorkdirID`, `describeCacheScope` → `toolcache.Describe*`. Nothing here recomputes a digest.

Sandbox correctness (2nd commit, from self-review): `start.go:1011` / `serve.go:1499` export `TMPDIR=<sandboxTmp>` to the inner agent, so joining `os.TempDir()` handed an in-sandbox agent a path that does not exist — precisely the audience `docs/NONO_SANDBOX.md` points at. `$OMAC_SOCKET` is unaffected (`socketPath = filepath.Join(rtDir, "bridge.sock")`, `start.go:713`), so its parent is read as the live runtime dir when it names the same directory as the derived one. Guarded on the dir name, so another workdir's session — or a `start` session while asking for `serve` — cannot hijack the answer.

Two deliberate deviations from the issue body, both worth a look:
- **JSON is a stable envelope** (`{workdir, tmpdir, entries[]}`), not the issue's flat `{...,"dir":...}`. Single-kind scripting is `jq -r '.entries[0].path'`. `tmpdir` is load-bearing given the remap above.
- **Text output is stanzas, not a table** — the keychain and cache digests are full 64-hex, which pads a `KIND/DIGEST/PATH` table past 140 columns.

## Verification

```
$ gofmt -l . && go vet ./... && python3 scripts/check-docs.py
[ok] README.md 233/400 lines; all doc links resolve

$ go test -race -count=1 ./internal/cli/ ./internal/toolcache/ ./internal/keychain/
ok  github.com/tngtech/oh-my-agentic-coder/internal/cli        7.276s
ok  github.com/tngtech/oh-my-agentic-coder/internal/toolcache  2.108s
ok  github.com/tngtech/oh-my-agentic-coder/internal/keychain   1.012s
```

17 tests in `hash_test.go`, all passing. They assert against the **real producers**, not hardcoded digests — the drift guard the issue asks for. Mutation-checked: re-inlining a different hash inside `createRuntimeDir` fails `TestDiagnoseHashRuntimeMatchesCreateRuntimeDir` with a clear message. (Mutating the *shared* helper correctly does not fail; both sides move together, which is the point.)

Manual, against the built binary:

```
# cache path agrees with the already-shipped provenance surface (default and workdir scope)
$ diff <(omac diagnose --hash=cache --json | jq -r '.entries[0].path') \
       <(omac provenance --json | jq -r '.cache.path')          # MATCH

# in-sandbox case: TMPDIR remapped, OMAC_SOCKET set -> live dir, and the doc's command resolves
$ TMPDIR=/tmp/omac-sandbox-tmp-fake OMAC_SOCKET="$REAL/bridge.sock" \
    sh -c 'ls "$(omac diagnose --hash=runtime --json | jq -r .entries[0].path)/logs"'
echo-rest.log
```

Error paths exercised by hand and by test: unknown kind, the `--hash runtime` space form, a stray non-kind argument, and an unresolvable cache scope in both `all` mode (stderr + other kinds survive, exit 0) and single-kind mode (stderr, exit 5).

**Not green locally, and not from this branch:** `TestIntegrationWorktreeKnownLimitations` (git `packed-refs: Device or resource busy`) and `TestIntegrationWorkflowInterpretersRunnable` (`bwrap: execvp node`, node at a non-standard path) fail in `internal/sandboxrun`. Confirmed via `git stash` that both fail identically on a clean `main`. `sandboxrun` does not import `internal/cli`.

## Follow-up

- Two commits kept separate so the self-review trail is legible — squash on merge if you prefer one.
- `clearActiveScope` (`internal/cli/cache.go:86-96`) has a structurally similar scope switch, but it dispatches to `toolcache.Clear*` rather than `Describe*`; folding it in would mean changing `toolcache`'s public API, so it is deliberately left alone.
- #143 may split the cache into two scopes; `--hash=cache` should then expose both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)