### PR TITLE
Re-structure information on env vars (not) passing to the agent, upda…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ omac runs the agent inside an OS sandbox that enforces three boundaries:
 
 The result: a capable coding agent with a clear boundary.
 
+Want to try it? See the [Quick start](./getting-started/quick-start.md) to install omac, set up prerequisites, and launch your first session.
+
 ## Architecture
 
 ```mermaid

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,17 +106,19 @@ You can also open a port for a single session with `omac start --open-port 3000`
 
 ### Passing an environment variable into the sandbox
 
-The sandbox passes through only the variables named in `environment.allow_vars`, plus a small set of operational defaults (such as `PATH` and `HOME`). Everything else, including any token, is stripped unless configured otherwise.
+By default, the sandbox strips every variable from your shell except a small set of operational defaults (`PATH`, `HOME`, `LANG`, …). Ambient secrets like cloud tokens never reach the agent.
 
-If a tool inside the sandbox needs a variable from your shell, for example an API token, add its name to the list:
+If a program running inside the sandbox needs one of your shell's variables — for example an API token a build tool or MCP server reads — add its name to `environment.allow_vars`:
 
 ```json
 "environment": { "allow_vars": ["MY_API_TOKEN"] }
 ```
 
-Only the *name* goes here. The value still comes from your shell at start time. There is no CLI flag for this on `omac start`.
+Only the *name* goes here; the value comes from your shell when you run `omac start`, so export it first.
 
-Note that this is separate from a skill's secrets: skill credentials are injected on the host and never enter the sandbox (see [Security model](./security.md)). `allow_vars` is for variables that a program *inside* the sandbox reads directly. Those variables can then also be accessed by the agent.
+A few things to know:
+- For safety, a few variables that let a program load extra code (LD_*, NODE_OPTIONS, PYTHONPATH, …) are always stripped, even if you add them to `allow_vars`.
+- An empty `allow_vars` means "operational defaults only", not "pass everything through".
 
 ### Running an MCP server the harness launches
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,7 @@ You can also open a port for a single session with `omac start --open-port 3000`
 
 By default, the sandbox strips every variable from your shell except a small set of operational defaults (`PATH`, `HOME`, `LANG`, …). Ambient secrets like cloud tokens never reach the agent.
 
-If a program running inside the sandbox needs one of your shell's variables — for example an API token a build tool or MCP server reads — add its name to `environment.allow_vars`:
+If a program running inside the sandbox needs one of your shell's variables — for example an API token a build tool or MCP server reads — add its name to `environment.allow_vars` in the sandbox grants file (`~/.config/omac/sandbox-profiles/default.json`):
 
 ```json
 "environment": { "allow_vars": ["MY_API_TOKEN"] }
@@ -117,8 +117,9 @@ If a program running inside the sandbox needs one of your shell's variables — 
 Only the *name* goes here; the value comes from your shell when you run `omac start`, so export it first.
 
 A few things to know:
-- For safety, a few variables that let a program load extra code (LD_*, NODE_OPTIONS, PYTHONPATH, …) are always stripped, even if you add them to `allow_vars`.
+- For safety, a few variables that let a program load extra code (`LD_*`, `NODE_OPTIONS`, `PYTHONPATH`, …) are always stripped, even if you add them to `allow_vars`. Run `omac provenance` and look at the `environment` section: the always-stripped variables are the rows with action `deny` and source `blocklist`. To list just those, run `omac provenance | grep blocklist`.
 - An empty `allow_vars` means "operational defaults only", not "pass everything through".
+- Do not use this to pass through secrets (e.g. for skills). See the next section and [Security model](./security.md) for secure ways to do so.
 
 ### Running an MCP server the harness launches
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -172,3 +172,11 @@ sha256sum -c checksums.txt --ignore-missing
 ```
 
 Keep each downloaded file under its original release name. `sha256sum -c` matches entries by filename and `--ignore-missing` silently skips any file whose name is not in the list — so a renamed download would verify nothing.
+
+## Further reading
+
+- [CLI](../usage/cli.md): Details on how to use the command line interface.
+- [Configuration](../configuration.md): How to customize configuration regarding environment variables, ports, package registries, etc.
+- [Security model](../security.md): What is and what is not available to your agent inside the sandbox.
+- Skills — [usage](../usage/skills.md) and [authoring](../skills/authoring.md): How to use and create skills that require secrets without exposing them to the agent.
+- [Troubleshooting](../troubleshooting.md): Tips for common problems and instructions on how to report a bug.

--- a/docs/security.md
+++ b/docs/security.md
@@ -116,20 +116,15 @@ omac does not make you re-approve skills you already registered.
 ## Environment filtering
 
 The sandbox does not inherit all environment variables from the shell that
-launched omac. Only variables on an explicit allow list pass through: the
-`OMAC_*` prefix, basic system variables (`HOME`, `PATH`, `LANG`, …), and the
-API key the selected harness needs to call its AI provider. Everything else is
-stripped before the agent starts.
+launched omac. It starts from an explicit allow list — the `OMAC_*` prefix,
+basic system variables (`HOME`, `PATH`, `LANG`, …), and the key the selected
+harness needs to call its AI provider — and strips everything else, including
+any ambient cloud tokens, before the agent starts.
 
-**Note:** the harness's AI provider credentials are always accessible inside
-the sandbox — this is unavoidable, since the harness needs them to function.
-For harnesses like claude-code, the key arrives as an environment variable
-(`ANTHROPIC_API_KEY`). For harnesses like opencode, credentials are stored in
-the harness config directory (`~/.local/share/opencode`), which is mounted
-inside the sandbox. Either way, a sufficiently capable agent could read them.
-This is a known limitation; skill secrets are fully isolated, but harness
-credentials are not.
-
-You can add more variables with `allow_vars` or block specific ones with
-`deny_vars` in the sandbox profile. See [Configuration](./configuration.md)
-for the schema.
+**Known limitation — the harness's AI provider credentials are reachable
+inside the sandbox.** This is unavoidable, since the harness needs them to
+function. For harnesses like claude-code, the key arrives as an environment
+variable (`ANTHROPIC_API_KEY`). For harnesses like opencode, credentials are
+stored in the harness config directory (`~/.local/share/opencode`), which is
+mounted inside the sandbox. Either way, a sufficiently capable agent could read
+them. Skill secrets are fully isolated; harness credentials are not.

--- a/docs/skills/authoring.md
+++ b/docs/skills/authoring.md
@@ -152,7 +152,7 @@ Before forwarding the request, omac strips your skill's mount prefix (`/my-skill
 
 ## Environment variables injected into the sidecar
 
-omac sets these in the sidecar process before spawning it. Your sidecar code reads them like any other env var; they tell it where to bind and what credentials and config it has. You do not set them yourself.
+omac sets the injected variables in the sidecar process before spawning it.
 
 For example, if your `omac.yaml` declares a secret `MY_API_TOKEN` and a config field `API_BASE_URL`, they arrive in your sidecar as plain env vars:
 
@@ -175,7 +175,7 @@ api_url = os.environ["API_BASE_URL"]   # from skill-config.yaml
 
 ## How the agent reaches your skill
 
-The agent runs inside the sandbox, not in your sidecar's process, so it receives a different set of variables. It uses them to reach your skill through the facade:
+The agent uses the variables it receives to reach your skill through the facade:
 
 | Variable | Value |
 |---|---|

--- a/internal/cli/sandbox_cmd.go
+++ b/internal/cli/sandbox_cmd.go
@@ -56,7 +56,9 @@ func printSandboxUsage(env *Env) {
 Usage:
   omac sandbox run [flags] -- <cmd> [args...]
 
-Flags (list flags are repeatable; they merge additively onto the profile):
+Flags apply to this single run only; they layer on top of the chosen profile.
+List flags (--allow, --allow-env, …) are
+repeatable and merge additively onto the profile's grants:
   --profile <ref>            profile name, path, or builtin (default: "default")
   --allow <path>             grant read+write on a directory or file
   --read <path>              grant read-only
@@ -75,6 +77,8 @@ Flags (list flags are repeatable; they merge additively onto the profile):
   --allow-tcp-connect <port> direct outbound TCP to any host on this port (e.g. 22)
   --allow-domain <domain>    add to the proxy allowlist (exact or *.suffix)
   --deny-domain <domain>     add to the proxy blocklist (exact or *.suffix)
+  --allow-env <name>         pass an environment variable into the sandbox for
+                             this run (adds to the profile's allow_vars)
   --block-net                block all network access (overrides profile)
   --workdir-access <level>   none|read|write|readwrite (replaces profile value)`)
 }


### PR DESCRIPTION
**Issue:** Closes #262

## What
Adjust explanations on env var handling (most of it already happened when adjusting the docs).
- Clear explanation for the user in `configuration.md`
- Focus on options that are most relevant to the user (allow_vars in the settings)
- Disregard --allow-env, which is mainly used for testing (since users usually want reproducable settings)
- No adjustment for nono (deprecated, will be removed)

## Why
Users complaining about documentation not clearly specifying env var handling.