### PR TITLE
fix(security-scan): preflight the archive credential and stop hiding a no-op scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -7,11 +7,13 @@
 # redirected straight to a file and never printed to the console, because
 # this is a public repo and both the job log and (if used) upload-artifact
 # would be publicly downloadable. Full reports are pushed to a private
-# companion repo instead, and only aggregate severity/dedupe counts reach
-# the public step summary. A human reviews the private repo and decides
-# what -- if anything -- becomes a public GitHub issue. The private artifact
-# repo is named by the SECURITY_ARCHIVE_REPO secret (kept out of public
-# source); see it for the artifact history.
+# companion repo instead, and only aggregate severity/dedupe counts -- plus
+# the scan's exit code, duration and log size, which are numbers about the
+# run rather than anything it found -- reach the public step summary. A human
+# reviews the private repo and decides what -- if anything -- becomes a public
+# GitHub issue. The private artifact repo is named by the
+# SECURITY_ARCHIVE_REPO secret (kept out of public source); see it for the
+# artifact history.
 name: Security Scan
 
 on:
@@ -60,6 +62,56 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: target
+
+      - name: Preflight archive credential
+        id: archive
+        # The whole point of this job is the report it pushes to the private
+        # archive repo, so a credential that cannot write there makes the scan
+        # below wasted compute -- and until 2026-09 it failed exactly that way
+        # every week, three hours in, with nothing but "exit code 128" against a
+        # redacted URL to explain it. Check first, and say what to fix.
+        #
+        # GitHub authorizes the ref advertisement, so asking for the
+        # git-receive-pack advertisement is a read-only probe of *write* access:
+        # 200 means the push will be allowed, 403 means the token is valid but
+        # read-only on that repo, 401 means it is expired or malformed, and 404
+        # means it cannot see the repo at all. `git ls-remote` cannot tell these
+        # apart -- it only ever exercises upload-pack.
+        env:
+          SECURITY_SCAN_PAT: ${{ secrets.SECURITY_SCAN_PAT }}
+          ARCHIVE_REPO: ${{ secrets.SECURITY_ARCHIVE_REPO }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ARCHIVE_REPO:-}" ] || [ -z "${SECURITY_SCAN_PAT:-}" ]; then
+            echo "::warning::SECURITY_ARCHIVE_REPO or SECURITY_SCAN_PAT secret missing — the scan will run but its report cannot be archived"
+            exit 0
+          fi
+          # -u keeps the token out of the URL, so it stays out of any error curl
+          # prints. Only the status code is captured.
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -u "x-access-token:${SECURITY_SCAN_PAT}" \
+            "https://github.com/${ARCHIVE_REPO}.git/info/refs?service=git-receive-pack" || echo 000)
+          case "$code" in
+            200)
+              echo "archive repo is writable"
+              ;;
+            403)
+              echo "::error title=Archive repo is read-only::SECURITY_SCAN_PAT can read the private archive repo but not write it, so this scan's report has nowhere to go. Grant the token Contents: read and write on the archive repo (a fine-grained PAT also has to list that repo explicitly), then re-run. Same secret, same symptom in e2e-smoke.yml's Record & report job."
+              exit 1
+              ;;
+            401)
+              echo "::error title=Archive credential rejected::SECURITY_SCAN_PAT was refused by GitHub (401) -- it is expired or malformed. Rotate it and re-run."
+              exit 1
+              ;;
+            404)
+              echo "::error title=Archive repo not reachable::SECURITY_SCAN_PAT cannot see the repo named by SECURITY_ARCHIVE_REPO (404). Either the repo name is wrong or the token has no access to it at all."
+              exit 1
+              ;;
+            *)
+              echo "::error title=Archive preflight inconclusive::Probing the archive repo returned HTTP ${code}. Not starting a three-hour scan whose report may be undeliverable."
+              exit 1
+              ;;
+          esac
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -166,9 +218,21 @@ jobs:
           # Redirected to a file, NEVER printed to this (public) job log --
           # strix's console output includes full vulnerability detail and
           # working PoCs once findings surface.
+          #
+          # The exit code is recorded rather than discarded. It used to be
+          # thrown away with `|| true`, which meant a strix that died on
+          # startup was indistinguishable from one that ran for hours and found
+          # nothing -- every scheduled run from 2026-08-15 to 2026-09-05
+          # "succeeded" after ~105 seconds without writing a findings file. It
+          # is not asserted on here on its own, because a non-zero exit from an
+          # otherwise complete scan should not discard the findings; the check
+          # below combines it with whether a result was actually produced.
+          started=$SECONDS
+          rc=0
           strix -n --target "$PWD/target" \
             --scan-mode "${{ inputs.scan_mode || 'deep' }}" \
-            > strix_scan.log 2>&1 || true
+            > strix_scan.log 2>&1 || rc=$?
+          elapsed=$(( SECONDS - started ))
 
           # strix_runs/ lands relative to strix's OWN invocation cwd (this
           # job's default workspace root), as a sibling of target/ -- NOT
@@ -201,6 +265,28 @@ jobs:
             exit 1
           fi
 
+          # How long the scan ran and how much it wrote. Both are counts, not
+          # content, so they are safe on this public summary -- and they are the
+          # cheapest way to spot a scan that did not really happen: a `deep`
+          # scan of this repo takes hours and writes megabytes, so two minutes
+          # and a few kilobytes means something went wrong even when every
+          # guard above is satisfied. Published here because the log that would
+          # explain it only ever reaches the private archive repo.
+          log_bytes=$(wc -c < strix_scan.log)
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+          echo "elapsed=$elapsed" >> "$GITHUB_OUTPUT"
+          echo "log_bytes=$log_bytes" >> "$GITHUB_OUTPUT"
+          echo "strix exited $rc after ${elapsed}s, wrote ${log_bytes} bytes of log"
+
+          # A non-zero exit AND no findings file means there is no evidence the
+          # scan produced a result at all -- fail, rather than triaging an empty
+          # run as a clean bill of health. A findings-free scan that exits 0 is
+          # still allowed through (#194): that is a real result.
+          if [ "$rc" -ne 0 ] && [ ! -f "${run_dirs[-1]}vulnerabilities.json" ]; then
+            echo "::error::strix exited $rc after ${elapsed}s and wrote no vulnerabilities.json -- no evidence the scan produced a result, so it is not reported as a clean scan. strix_scan.log in the private artifact repo has the reason; it is never printed here because it can contain scan content."
+            exit 1
+          fi
+
       - name: Dedupe against open issues + build triage report
         if: steps.scan.outcome == 'success'
         env:
@@ -218,6 +304,8 @@ jobs:
           cat step-summary.md >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Model: \`${{ steps.model.outputs.model }}\` · scan mode: \`${{ inputs.scan_mode || 'deep' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "strix exit code \`${{ steps.scan.outputs.exit_code }}\` · ran for ${{ steps.scan.outputs.elapsed }}s · wrote ${{ steps.scan.outputs.log_bytes }} bytes of log. A \`deep\` scan that finishes in a couple of minutes did not really run, whatever it reports." >> "$GITHUB_STEP_SUMMARY"
           if [ '${{ steps.model.outputs.fallback }}' = 'true' ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "> ⚠️ **Fallback model** — the intended model is not served by the gateway, so this scan's coverage is not comparable to previous ones." >> "$GITHUB_STEP_SUMMARY"
@@ -232,7 +320,12 @@ jobs:
         # way to debug a startup failure, and it must never be printed to
         # this (public) job log -- the private repo is the one place it's
         # safe to look, whether or not the scan actually produced findings.
-        if: always()
+        #
+        # Skipped only when the preflight itself failed. There is nothing to
+        # push in that case -- the scan never started -- and attempting it would
+        # stack a second, misleading error on top of the one that already said
+        # exactly what to fix.
+        if: always() && steps.archive.outcome == 'success'
         env:
           SECURITY_SCAN_PAT: ${{ secrets.SECURITY_SCAN_PAT }}
           # Repo name lives in a secret, not in this public source.
@@ -244,6 +337,16 @@ jobs:
             echo "## Security scan: report push SKIPPED (SECURITY_ARCHIVE_REPO unset)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          # The preflight at the top of the job already established that this
+          # credential can write the archive repo, so anything failing here is
+          # something else -- a protected default branch, a mid-run token
+          # revocation. Name that, instead of leaving a bare "exit code 128"
+          # against a redacted URL for someone to guess at.
+          archive_failed() {
+            echo "::error title=Report archiving failed::The scan itself is not what failed here -- pushing its report to the private archive repo did, after the preflight had confirmed write access. Check the archive repo for a protected default branch, or a token revoked mid-run. The report for this run was NOT stored."
+            exit 1
+          }
+          trap archive_failed ERR
           dest=$(mktemp -d)
           git clone --quiet --depth 1 \
             "https://x-access-token:${SECURITY_SCAN_PAT}@github.com/${ARCHIVE_REPO}.git" \
@@ -266,5 +369,11 @@ jobs:
           git config user.name "strix-ci-bot"
           git config user.email "actions@users.noreply.github.com"
           git add .
+          # Nothing staged means nothing ran -- don't let `git commit`'s "nothing
+          # to commit" exit code surface as an archiving failure.
+          if git diff --cached --quiet; then
+            echo "::warning::nothing to archive for this run"
+            exit 0
+          fi
           git commit --quiet -m "scan: ${{ inputs.reason || 'scheduled' }} [$status] ($(date -u +%F))"
           git push --quiet

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -31,9 +31,9 @@ on:
         options: [quick, standard, deep]
         default: deep
       model:
-        description: 'Model id for the strix agent, for THIS RUN ONLY. Set empty to use each harness''s pin in internal/e2e/versions.go. Whatever is resolved here still goes through the gateway probe, so the -TEE variant flip and the fallback chain apply.'
+        description: 'Model id for the strix agent, for THIS RUN ONLY. Leave it as it comes to use the scan''s own pin (the E2E_MODEL default below — keep the two in step). Whatever is resolved here still goes through the gateway probe, so the -TEE variant flip and the fallback chain apply.'
         type: string
-        default: 'deepseek-ai/DeepSeek-V4-Flash'
+        default: 'zai-org/GLM-5.3'
 
 permissions:
   contents: read
@@ -54,9 +54,14 @@ jobs:
       LLM_API_BASE: ${{ secrets.SKAINET_INTERNAL }}
       LLM_API_KEY: ${{ secrets.SKAINET_TOKEN }}
       GH_TOKEN: ${{ github.token }}
-      # Read by scripts/probe-model.sh below; empty on the scheduled run, so
-      # that run starts from the committed pin.
-      E2E_MODEL: ${{ inputs.model }}
+      # Read by scripts/probe-model.sh below. The scan pins its own model rather
+      # than inheriting opencode's harness pin from internal/e2e/versions.go:
+      # that pin exists to track what the *harnesses* are tested against, and
+      # letting the pentest agent drift along with it meant nobody chose the
+      # model doing the scanning. The literal is repeated in the `model` input's
+      # default above so the dispatch form shows what it is about to run --
+      # change both together.
+      E2E_MODEL: ${{ inputs.model || 'zai-org/GLM-5.3' }}
     steps:
       - name: Checkout target repo
         uses: actions/checkout@v4

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,8 +8,11 @@
 # this is a public repo and both the job log and (if used) upload-artifact
 # would be publicly downloadable. Full reports are pushed to a private
 # companion repo instead, and only aggregate severity/dedupe counts -- plus
-# the scan's exit code, duration and log size, which are numbers about the
-# run rather than anything it found -- reach the public step summary. A human
+# the scan's exit code, duration, log size and finding count, which are numbers
+# about the run rather than anything it found -- reach the public step summary.
+# The finding count is published because it is the one thing that distinguishes
+# a partial scan worth reading from a run that achieved nothing, and the log
+# that would say so is deliberately never printed here. A human
 # reviews the private repo and decides what -- if anything -- becomes a public
 # GitHub issue. The private artifact repo is named by the
 # SECURITY_ARCHIVE_REPO secret (kept out of public source); see it for the
@@ -30,6 +33,10 @@ on:
         type: choice
         options: [quick, standard, deep]
         default: deep
+      scan_budget_minutes:
+        description: 'Minutes strix itself may run before it is stopped. Must stay below the job''s timeout-minutes, so the run still has time to triage and archive what it found. Raise it for a scan you want to reach the end; lower it to cap spend.'
+        type: string
+        default: '300'
       model:
         description: 'Model id for the strix agent, for THIS RUN ONLY. Leave it as it comes to use the scan''s own pin (the E2E_MODEL default below — keep the two in step). Whatever is resolved here still goes through the gateway probe, so the -TEE variant flip and the fallback chain apply.'
         type: string
@@ -47,7 +54,14 @@ jobs:
   scan:
     name: Strix security scan
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    # Sized against the scan budget below, not the other way round: strix is
+    # stopped by its own `timeout` with time to spare, so this ceiling should
+    # never be the thing that ends the job. It used to be 180, which cut the
+    # 2026-09-08 run off mid-scan at exactly 3h -- and a job GitHub cancels
+    # skips straight past the archive step's inputs, so three hours of findings
+    # were left on the runner's disk and thrown away with it. 350 is just under
+    # the 360-minute hosted-runner ceiling.
+    timeout-minutes: 350
     env:
       # SKAINET_INTERNAL is the same secret e2e.yml uses for the model
       # provider base URL — reused here rather than duplicating the URL.
@@ -283,12 +297,39 @@ jobs:
           # It is not asserted on here on its own, because a non-zero exit from an
           # otherwise complete scan should not discard the findings; the check
           # below combines it with whether a result was actually produced.
+          #
+          # Run strix under its OWN deadline, comfortably inside the job's
+          # timeout-minutes, so that a scan which does not finish is stopped by
+          # this step rather than by GitHub. The difference matters: when the
+          # job hits timeout-minutes the runner cancels it, every later step is
+          # skipped or runs with the outputs this one never got to write, and
+          # the run directory is destroyed with the runner. That is exactly how
+          # the 2026-09-08 run lost a scan that had already reported 22
+          # findings. Under `timeout` the same overrun is an ordinary exit code:
+          # the guards, the triage and the archive below all still run.
+          #
+          # -s INT rather than the default TERM: SIGINT is the signal an
+          # interactive strix already handles, so it gets the chance to flush
+          # its run directory. -k gives it two minutes to do that before SIGKILL.
+          # 124 = killed at the deadline, 130 = exited on the SIGINT itself;
+          # both mean "ran out of time", which is a partial scan, not a failure.
+          budget="${{ inputs.scan_budget_minutes || '300' }}"
+          case "$budget" in
+            ''|*[!0-9]*) echo "::error::scan_budget_minutes must be a whole number of minutes, got '$budget'"; exit 1 ;;
+          esac
           started=$SECONDS
           rc=0
-          strix -n --target "$PWD/staging/target" \
+          timeout -s INT -k 120s "${budget}m" \
+            strix -n --target "$PWD/staging/target" \
             --scan-mode "${{ inputs.scan_mode || 'deep' }}" \
             > strix_scan.log 2>&1 || rc=$?
           elapsed=$(( SECONDS - started ))
+          partial=false
+          if [ "$rc" -eq 124 ] || [ "$rc" -eq 130 ]; then
+            partial=true
+            echo "::warning title=Scan stopped at its budget::strix was still working when its ${budget}-minute budget ran out, so this scan is PARTIAL -- it covers only what it had reached. Whatever it did find is archived and triaged as usual. Raise scan_budget_minutes (and timeout-minutes with it) for a run that reaches the end."
+          fi
+          echo "partial=$partial" >> "$GITHUB_OUTPUT"
 
           # strix_runs/ lands relative to strix's OWN invocation cwd (this
           # job's default workspace root), as a sibling of target/ and
@@ -329,22 +370,50 @@ jobs:
           # guard above is satisfied. Published here because the log that would
           # explain it only ever reaches the private archive repo.
           log_bytes=$(wc -c < strix_scan.log)
+
+          # How many findings strix actually reported, counted off the log's own
+          # report banners rather than the findings file. A scan stopped at its
+          # budget often has no vulnerabilities.json -- strix writes that at the
+          # end -- while the log already holds every finding it reported in
+          # full. Publishing the COUNT (a number, not a finding) is what tells a
+          # human whether a partial run is worth reading: "PARTIAL, 22 findings
+          # in the log" is a very different message from "FAILED".
+          vuln_count=$(grep -cE '^╭─ VULN-[0-9]+' strix_scan.log || true)
+          have_vulns=false
+          [ -f "${run_dirs[-1]}vulnerabilities.json" ] && have_vulns=true
+          echo "vuln_count=$vuln_count" >> "$GITHUB_OUTPUT"
+          echo "have_vulns=$have_vulns" >> "$GITHUB_OUTPUT"
           echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
           echo "elapsed=$elapsed" >> "$GITHUB_OUTPUT"
           echo "log_bytes=$log_bytes" >> "$GITHUB_OUTPUT"
-          echo "strix exited $rc after ${elapsed}s, wrote ${log_bytes} bytes of log"
+          echo "strix exited $rc after ${elapsed}s, wrote ${log_bytes} bytes of log, reported ${vuln_count} findings"
 
           # A non-zero exit AND no findings file means there is no evidence the
           # scan produced a result at all -- fail, rather than triaging an empty
           # run as a clean bill of health. A findings-free scan that exits 0 is
           # still allowed through (#194): that is a real result.
-          if [ "$rc" -ne 0 ] && [ ! -f "${run_dirs[-1]}vulnerabilities.json" ]; then
-            echo "::error::strix exited $rc after ${elapsed}s and wrote no vulnerabilities.json -- no evidence the scan produced a result, so it is not reported as a clean scan. strix_scan.log in the private artifact repo has the reason; it is never printed here because it can contain scan content."
-            exit 1
+          #
+          # A scan stopped at its budget is exempt when it reported findings:
+          # those are a real (incomplete) result, and failing the step here
+          # would be the old bug in a new place -- discarding hours of work
+          # because the last file was never written. It still fails when it
+          # reported nothing at all, which is indistinguishable from a scan that
+          # never got going.
+          if [ "$rc" -ne 0 ] && [ "$have_vulns" != true ]; then
+            if [ "$partial" = true ] && [ "$vuln_count" -gt 0 ]; then
+              echo "::notice title=Partial scan kept::stopped at its budget with no vulnerabilities.json, but ${vuln_count} findings are in the log -- archiving as PARTIAL rather than discarding them."
+            else
+              echo "::error::strix exited $rc after ${elapsed}s and wrote no vulnerabilities.json -- no evidence the scan produced a result, so it is not reported as a clean scan. strix_scan.log in the private artifact repo has the reason; it is never printed here because it can contain scan content."
+              exit 1
+            fi
           fi
 
       - name: Dedupe against open issues + build triage report
-        if: steps.scan.outcome == 'success'
+        # Gated on a findings file existing, not on the scan step succeeding.
+        # A scan stopped at its budget still deserves a triage report for what
+        # it did find, and a scan that failed a completeness guard may have
+        # written one too.
+        if: always() && steps.scan.outputs.have_vulns == 'true'
         env:
           STRIX_LLM: ${{ steps.model.outputs.strix_llm }}
         run: |
@@ -355,13 +424,26 @@ jobs:
             --summary-out step-summary.md
 
       - name: Public summary (counts only, no exploit detail)
-        if: steps.scan.outcome == 'success'
+        # Runs whenever the scan step got far enough to publish its numbers, so
+        # a partial or failed run says so here instead of leaving a blank
+        # summary for someone to interpret from a red X.
+        if: always() && steps.scan.outputs.exit_code != ''
         run: |
-          cat step-summary.md >> "$GITHUB_STEP_SUMMARY"
+          if [ -f step-summary.md ]; then
+            cat step-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Security scan: no findings file" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "strix wrote no \`vulnerabilities.json\`, so there is nothing to dedupe against open issues. It reported **${{ steps.scan.outputs.vuln_count }}** findings in its log, which is archived to the private repo." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ '${{ steps.scan.outputs.partial }}' = 'true' ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Partial scan** — strix was stopped at its \`scan_budget_minutes\` budget while still working, so this covers only what it had reached. Findings below are real; their absence is not evidence." >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Model: \`${{ steps.model.outputs.model }}\` · scan mode: \`${{ inputs.scan_mode || 'deep' }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "strix exit code \`${{ steps.scan.outputs.exit_code }}\` · ran for ${{ steps.scan.outputs.elapsed }}s · wrote ${{ steps.scan.outputs.log_bytes }} bytes of log. A \`deep\` scan that finishes in a couple of minutes did not really run, whatever it reports." >> "$GITHUB_STEP_SUMMARY"
+          echo "strix exit code \`${{ steps.scan.outputs.exit_code }}\` · ran for ${{ steps.scan.outputs.elapsed }}s · wrote ${{ steps.scan.outputs.log_bytes }} bytes of log · reported ${{ steps.scan.outputs.vuln_count }} findings. A \`deep\` scan that finishes in a couple of minutes did not really run, whatever it reports." >> "$GITHUB_STEP_SUMMARY"
           if [ '${{ steps.model.outputs.fallback }}' = 'true' ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "> ⚠️ **Fallback model** — the intended model is not served by the gateway, so this scan's coverage is not comparable to previous ones." >> "$GITHUB_STEP_SUMMARY"
@@ -407,10 +489,41 @@ jobs:
           git clone --quiet --depth 1 \
             "https://x-access-token:${SECURITY_SCAN_PAT}@github.com/${ARCHIVE_REPO}.git" \
             "$dest"
-          status="${{ steps.scan.outcome == 'success' && 'ok' || 'FAILED' }}"
-          scan_dir="$dest/scans/${{ steps.scan.outputs.run_label }}-${{ inputs.reason || 'scheduled' }}-${status}"
+          if [ "${{ steps.scan.outcome }}" = success ]; then
+            status="${{ steps.scan.outputs.partial == 'true' && 'PARTIAL' || 'ok' }}"
+          else
+            status=FAILED
+          fi
+          # Fall back to a timestamp: run_label is written at the very top of
+          # the scan step, so it survives almost anything, but an unnamed
+          # directory is still better than a path beginning "-manual-FAILED".
+          run_label="${{ steps.scan.outputs.run_label }}"
+          scan_dir="$dest/scans/${run_label:-$(date -u +%Y%m%d-%H%M%S)}-${{ inputs.reason || 'scheduled' }}-${status}"
           mkdir -p "$scan_dir"
+
+          # Find the run directory on disk rather than trusting the scan step's
+          # output for it.
+          #
+          # This is the fix for the 2026-09-08 loss. run_dir is written to
+          # $GITHUB_OUTPUT only AFTER strix returns, so every way the scan step
+          # can end early -- job timeout, cancellation, a guard's exit 1, the
+          # runner going away -- leaves it empty, and this step then silently
+          # copied nothing while reporting success. The directory was there the
+          # whole time. Anything this step can rediscover for itself, it should:
+          # it is the last thing standing between hours of scanning and an empty
+          # commit.
           run_dir="${{ steps.scan.outputs.run_dir }}"
+          if [ -z "$run_dir" ] || [ ! -d "$run_dir" ]; then
+            shopt -s nullglob
+            found=(strix_runs/*/)
+            shopt -u nullglob
+            if [ ${#found[@]} -gt 0 ]; then
+              run_dir="${found[-1]}"
+              echo "::warning title=Recovered the run directory::The scan step never published its run directory (it ended before it could), so this step found ${run_dir} on disk. Its contents are archived below; without this fallback they would have been discarded."
+            else
+              run_dir=""
+            fi
+          fi
           if [ -n "$run_dir" ] && [ -d "$run_dir" ]; then
             cp -r "$run_dir"/* "$scan_dir"/
           fi

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -214,6 +214,56 @@ jobs:
           set -o pipefail
           run_label="$(date -u +%Y%m%d-%H%M%S)"
           echo "run_label=$run_label" >> "$GITHUB_OUTPUT"
+
+          # Stage a symlink-free copy of the checkout, and scan THAT.
+          #
+          # strix's --target copy walks the tree with O_NOFOLLOW and aborts on
+          # the first symlink it meets -- "symlink_not_supported", raised in
+          # openai-agents' agents/sandbox/entries/artifacts.py. The exception's
+          # message carries only the target path, not the reason or the offending
+          # file, so it surfaces as a bare "failed to read local dir artifact".
+          #
+          # This repo has had exactly one symlink, CLAUDE.md -> AGENTS.md, since
+          # 2026-07-16 -- two days after this workflow was added. Every scan
+          # since has died here, before its first agent turn, having spent zero
+          # tokens.
+          #
+          # Dereferencing rather than deleting the symlink: CLAUDE.md exists so
+          # that tools looking for either name find the same file, the scanner
+          # should see the content those tools actually read, and this way the
+          # next symlink somebody commits does not silently kill the scan again.
+          #
+          # Staged at staging/target, keeping the basename, because strix names
+          # its run directory after it (strix_runs/<basename>_<id>) and the
+          # archive history is easier to read if that stays "target".
+          #
+          # Unresolvable links are checked for first, because cp -L fails on one
+          # with a message about the copy rather than about the repo.
+          #
+          # `find -type l` lists symlinks without stat'ing their targets, then
+          # readlink -e resolves each. Deliberately NOT `find -xtype l`: that
+          # stats the target, so a symlink LOOP makes find exit non-zero having
+          # printed nothing to stdout, and the guard would abort the job with no
+          # message at all. readlink -e reports broken links and loops alike.
+          links=""
+          unresolvable=""
+          while IFS= read -r -d '' link; do
+            links="${links:+$links }${link#target/}"
+            readlink -e "$link" >/dev/null 2>&1 \
+              || unresolvable="${unresolvable:+$unresolvable }${link#target/}"
+          done < <(find target -type l -print0)
+          if [ -n "$unresolvable" ]; then
+            echo "::error title=Unresolvable symlink in the checkout::Cannot stage a symlink-free copy to scan, because these links do not resolve (broken, or a loop): $unresolvable. Fix or remove them."
+            exit 1
+          fi
+          rm -rf staging
+          mkdir -p staging
+          # -L dereferences. A symlink pointing outside the repo would pull that
+          # content into the scan; none does today, which is what the list of
+          # flattened links printed below is for.
+          cp -rL target staging/target
+          echo "staged a symlink-free copy of the checkout; flattened: ${links:-none}"
+
           # --target, not --mount: the PyPI release (strix-agent, pinned
           # below) doesn't have --mount or --max-budget-usd -- those only
           # exist in unreleased commits ahead of the 1.0.4 tag. --target
@@ -228,22 +278,23 @@ jobs:
           # thrown away with `|| true`, which meant a strix that died on
           # startup was indistinguishable from one that ran for hours and found
           # nothing -- every scheduled run from 2026-08-15 to 2026-09-05
-          # "succeeded" after ~105 seconds without writing a findings file. It
-          # is not asserted on here on its own, because a non-zero exit from an
+          # "succeeded" after ~105 seconds without writing a findings file (the
+          # symlink abort above; the ~105 seconds were the docker image pull).
+          # It is not asserted on here on its own, because a non-zero exit from an
           # otherwise complete scan should not discard the findings; the check
           # below combines it with whether a result was actually produced.
           started=$SECONDS
           rc=0
-          strix -n --target "$PWD/target" \
+          strix -n --target "$PWD/staging/target" \
             --scan-mode "${{ inputs.scan_mode || 'deep' }}" \
             > strix_scan.log 2>&1 || rc=$?
           elapsed=$(( SECONDS - started ))
 
           # strix_runs/ lands relative to strix's OWN invocation cwd (this
-          # job's default workspace root), as a sibling of target/ -- NOT
-          # nested inside target/strix_runs/, regardless of --target vs.
-          # --mount. Confirmed against a real run's own reported Output
-          # path: .../oh-my-agentic-coder/strix_runs/target_<id>.
+          # job's default workspace root), as a sibling of target/ and
+          # staging/ -- NOT nested inside the scanned tree, regardless of
+          # --target vs. --mount. Confirmed against a real run's own reported
+          # Output path: .../oh-my-agentic-coder/strix_runs/target_<id>.
           #
           # nullglob + array, not `ls glob | head`: under bash -e + pipefail
           # (this shell's default), a non-matching glob inside `$(...)`

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,22 +1,13 @@
 # Security scan: runs `strix` (an LLM-driven pentest agent) against this
-# repo. Scheduled weekly and available on demand (including as a manual
-# pre-release check before cutting a release tag).
+# repo. Scheduled weekly, and available on demand as a pre-release check.
 #
-# Disclosure model: this workflow's own job log and step summary NEVER
-# contain finding titles, descriptions, or PoCs -- strix's full output is
-# redirected straight to a file and never printed to the console, because
-# this is a public repo and both the job log and (if used) upload-artifact
-# would be publicly downloadable. Full reports are pushed to a private
-# companion repo instead, and only aggregate severity/dedupe counts -- plus
-# the scan's exit code, duration, log size and finding count, which are numbers
-# about the run rather than anything it found -- reach the public step summary.
-# The finding count is published because it is the one thing that distinguishes
-# a partial scan worth reading from a run that achieved nothing, and the log
-# that would say so is deliberately never printed here. A human
-# reviews the private repo and decides what -- if anything -- becomes a public
-# GitHub issue. The private artifact repo is named by the
-# SECURITY_ARCHIVE_REPO secret (kept out of public source); see it for the
-# artifact history.
+# Disclosure model: this is a public repo, so the job log and the step summary
+# never carry finding titles, descriptions or PoCs. strix's output goes
+# straight to a file and is pushed to a private companion repo, named by the
+# SECURITY_ARCHIVE_REPO secret so the name stays out of public source. Only
+# numbers about the run -- exit code, duration, log size, finding count -- and
+# aggregate severity/dedupe counts reach the public summary. A human reads the
+# private repo and decides what, if anything, becomes a public GitHub issue.
 name: Security Scan
 
 on:
@@ -54,13 +45,11 @@ jobs:
   scan:
     name: Strix security scan
     runs-on: ubuntu-latest
-    # Sized against the scan budget below, not the other way round: strix is
+    # Sized above the scan budget below, not the other way round: strix is
     # stopped by its own `timeout` with time to spare, so this ceiling should
-    # never be the thing that ends the job. It used to be 180, which cut the
-    # 2026-09-08 run off mid-scan at exactly 3h -- and a job GitHub cancels
-    # skips straight past the archive step's inputs, so three hours of findings
-    # were left on the runner's disk and thrown away with it. 350 is just under
-    # the 360-minute hosted-runner ceiling.
+    # never be what ends the job. When it is, GitHub cancels the job mid-step
+    # and everything after it either skips or reads outputs that were never
+    # written. 350 is just under the 360-minute hosted-runner ceiling.
     timeout-minutes: 350
     env:
       # SKAINET_INTERNAL is the same secret e2e.yml uses for the model
@@ -68,13 +57,12 @@ jobs:
       LLM_API_BASE: ${{ secrets.SKAINET_INTERNAL }}
       LLM_API_KEY: ${{ secrets.SKAINET_TOKEN }}
       GH_TOKEN: ${{ github.token }}
-      # Read by scripts/probe-model.sh below. The scan pins its own model rather
-      # than inheriting opencode's harness pin from internal/e2e/versions.go:
-      # that pin exists to track what the *harnesses* are tested against, and
-      # letting the pentest agent drift along with it meant nobody chose the
-      # model doing the scanning. The literal is repeated in the `model` input's
-      # default above so the dispatch form shows what it is about to run --
-      # change both together.
+      # Read by scripts/probe-model.sh below. The scan pins its own model
+      # rather than following opencode's harness pin in
+      # internal/e2e/versions.go, which tracks what the *harnesses* are tested
+      # against: the model doing the scanning is chosen here. The same literal
+      # is the `model` input's default above, so the dispatch form shows what
+      # is about to run -- change both together.
       E2E_MODEL: ${{ inputs.model || 'zai-org/GLM-5.3' }}
     steps:
       - name: Checkout target repo
@@ -84,18 +72,16 @@ jobs:
 
       - name: Preflight archive credential
         id: archive
-        # The whole point of this job is the report it pushes to the private
-        # archive repo, so a credential that cannot write there makes the scan
-        # below wasted compute -- and until 2026-09 it failed exactly that way
-        # every week, three hours in, with nothing but "exit code 128" against a
-        # redacted URL to explain it. Check first, and say what to fix.
+        # The point of this job is the report it pushes to the private archive
+        # repo, so a credential that cannot write there makes hours of scanning
+        # wasted compute. Check that in the first ten seconds, and say what to
+        # grant.
         #
         # GitHub authorizes the ref advertisement, so asking for the
-        # git-receive-pack advertisement is a read-only probe of *write* access:
-        # 200 means the push will be allowed, 403 means the token is valid but
-        # read-only on that repo, 401 means it is expired or malformed, and 404
-        # means it cannot see the repo at all. `git ls-remote` cannot tell these
-        # apart -- it only ever exercises upload-pack.
+        # git-receive-pack one is a read-only probe of *write* access: 200
+        # writable, 403 valid but read-only, 401 expired or malformed, 404 not
+        # visible to this token. `git ls-remote` cannot tell those apart, since
+        # it only ever exercises upload-pack.
         env:
           SECURITY_SCAN_PAT: ${{ secrets.SECURITY_SCAN_PAT }}
           ARCHIVE_REPO: ${{ secrets.SECURITY_ARCHIVE_REPO }}
@@ -105,7 +91,7 @@ jobs:
             echo "::warning::SECURITY_ARCHIVE_REPO or SECURITY_SCAN_PAT secret missing — the scan will run but its report cannot be archived"
             exit 0
           fi
-          # -u keeps the token out of the URL, so it stays out of any error curl
+          # -u keeps the token out of the URL, and so out of anything curl
           # prints. Only the status code is captured.
           code=$(curl -sS -o /dev/null -w '%{http_code}' \
             -u "x-access-token:${SECURITY_SCAN_PAT}" \
@@ -127,7 +113,7 @@ jobs:
               exit 1
               ;;
             *)
-              echo "::error title=Archive preflight inconclusive::Probing the archive repo returned HTTP ${code}. Not starting a three-hour scan whose report may be undeliverable."
+              echo "::error title=Archive preflight inconclusive::Probing the archive repo returned HTTP ${code}. Not starting a multi-hour scan whose report may be undeliverable."
               exit 1
               ;;
           esac
@@ -139,41 +125,34 @@ jobs:
 
       - name: Install strix
         run: |
-          # No --user: actions/setup-python's toolcached interpreter is
-          # already user-writable and its bin/ is on PATH, so --user risks
-          # installing the console script somewhere PATH doesn't cover.
+          # No --user: actions/setup-python's interpreter is already
+          # user-writable and its bin/ is on PATH, so --user risks installing
+          # the console script somewhere PATH doesn't cover.
           #
-          # openai==2.44.0 pinned deliberately: strix-agent==1.0.4's own
-          # constraints let pip resolve openai==2.45.0, which changes the
-          # response shape openai-agents==0.14.6 parses just enough that
-          # `Usage(input_tokens_details=...)` fails pydantic validation
-          # (missing `cache_write_tokens`) against Skainet/litellm's
-          # translated response -- confirmed by reproducing locally and
-          # bisecting to this one package. Revisit this pin whenever
-          # strix-agent/openai-agents get bumped upstream.
+          # openai is pinned because strix-agent==1.0.4's own constraints also
+          # allow openai==2.45.0, whose response shape fails pydantic
+          # validation in openai-agents==0.14.6 (`Usage.input_tokens_details`
+          # without `cache_write_tokens`) against Skainet/litellm's translated
+          # response. Revisit when either package is bumped.
           pip install strix-agent==1.0.4 openai==2.44.0
           # Safe to print -- version string only, no scan content.
           strix --version
 
       - name: Start context-compaction proxy
         id: proxy
-        # strix resends the whole conversation on every request and has no
-        # context compaction, so a long scan overflows the model window
-        # and every request then 422s with
-        # context_length_exceeded -- silently truncating results (a partial run
-        # dir survives, so the scan can look finished). This local proxy
-        # compacts requests in flight (summarising the oldest exchanges); strix
-        # is repointed at it below. See
+        # strix resends the whole conversation on every request and does not
+        # compact context, so a long scan overflows the model window and every
+        # later request 422s with context_length_exceeded -- leaving a partial
+        # run directory that still looks finished. This local proxy summarises
+        # the oldest exchanges in flight; strix is pointed at it below. See
         # target/.github/scripts/security_scan/skainet_proxy.py.
         env:
           SKAINET_PROXY_PORT: '8899'
         run: |
           set -euo pipefail
-          # Split the gateway base into host + path suffix so the proxy forwards
-          # to the host and preserves whatever chat path strix used (with or
-          # without a /v1 prefix). LLM_API_BASE here is still the job-level
-          # gateway URL; the scan step below points strix at the proxy instead.
-          # Values are secret-derived -- never echoed.
+          # Split the gateway base into host + path suffix so the proxy
+          # forwards to the host and keeps whatever chat path strix uses (with
+          # or without a /v1 prefix). Secret-derived, so never echoed.
           host=$(printf '%s' "$LLM_API_BASE" | sed -E 's#(https?://[^/]+).*#\1#')
           suffix=$(printf '%s' "$LLM_API_BASE" | sed -E 's#https?://[^/]+##; s#/$##')
           nohup env \
@@ -199,13 +178,12 @@ jobs:
         id: model
         run: |
           set -euo pipefail
-          # This workflow's own base/-TEE probe used to live here inline. It is
-          # now target/scripts/probe-model.sh, shared with every other LLM
-          # workflow (#184): same bidirectional variant flip, plus a GET /models
-          # listing to order candidates and a configured fallback family. The
-          # resolver reads versions.go relative to itself, so the target/
-          # checkout path needs no extra wiring. Model names aren't secret; the
-          # bearer in the header is and is never printed.
+          # probe-model.sh is shared with the other LLM workflows (#184): it
+          # flips the -TEE variant either way, orders candidates against a GET
+          # /models listing, and falls back to a configured family. It reads
+          # versions.go relative to itself, so the target/ checkout needs no
+          # extra wiring. Model names aren't secret; the bearer in the header
+          # is, and is never printed.
           chosen=$(target/scripts/probe-model.sh opencode --github-output)
           echo "selected model: ${chosen}"
           echo "strix_llm=openai/${chosen}" >> "$GITHUB_OUTPUT"
@@ -229,36 +207,28 @@ jobs:
           run_label="$(date -u +%Y%m%d-%H%M%S)"
           echo "run_label=$run_label" >> "$GITHUB_OUTPUT"
 
-          # Stage a symlink-free copy of the checkout, and scan THAT.
+          # Stage a symlink-free copy of the checkout, and scan THAT: strix's
+          # --target copy walks the tree with O_NOFOLLOW and aborts on the
+          # first symlink it meets (openai-agents,
+          # agents/sandbox/entries/artifacts.py). Its exception carries only
+          # the target path, not the reason or the file, so it surfaces as a
+          # bare "failed to read local dir artifact" -- one symlink anywhere in
+          # the repo kills the scan before its first agent turn.
           #
-          # strix's --target copy walks the tree with O_NOFOLLOW and aborts on
-          # the first symlink it meets -- "symlink_not_supported", raised in
-          # openai-agents' agents/sandbox/entries/artifacts.py. The exception's
-          # message carries only the target path, not the reason or the offending
-          # file, so it surfaces as a bare "failed to read local dir artifact".
+          # Dereference rather than delete: CLAUDE.md is a symlink to AGENTS.md
+          # so that tools looking for either name find the same file, the
+          # scanner should see the content those tools read, and the next
+          # symlink somebody commits will not silently kill the scan either.
           #
-          # This repo has had exactly one symlink, CLAUDE.md -> AGENTS.md, since
-          # 2026-07-16 -- two days after this workflow was added. Every scan
-          # since has died here, before its first agent turn, having spent zero
-          # tokens.
+          # staging/target keeps the basename, because strix names its run
+          # directory after it (strix_runs/<basename>_<id>).
           #
-          # Dereferencing rather than deleting the symlink: CLAUDE.md exists so
-          # that tools looking for either name find the same file, the scanner
-          # should see the content those tools actually read, and this way the
-          # next symlink somebody commits does not silently kill the scan again.
-          #
-          # Staged at staging/target, keeping the basename, because strix names
-          # its run directory after it (strix_runs/<basename>_<id>) and the
-          # archive history is easier to read if that stays "target".
-          #
-          # Unresolvable links are checked for first, because cp -L fails on one
-          # with a message about the copy rather than about the repo.
-          #
-          # `find -type l` lists symlinks without stat'ing their targets, then
-          # readlink -e resolves each. Deliberately NOT `find -xtype l`: that
-          # stats the target, so a symlink LOOP makes find exit non-zero having
-          # printed nothing to stdout, and the guard would abort the job with no
-          # message at all. readlink -e reports broken links and loops alike.
+          # Unresolvable links are rejected before the copy, because cp -L
+          # fails on one with a message about the copy rather than the repo.
+          # `find -type l` deliberately, not `-xtype l`: -xtype stats the
+          # target, so a symlink loop makes find exit non-zero having printed
+          # nothing, aborting the job with no message at all. readlink -e
+          # reports broken links and loops alike.
           links=""
           unresolvable=""
           while IFS= read -r -d '' link; do
@@ -272,47 +242,38 @@ jobs:
           fi
           rm -rf staging
           mkdir -p staging
-          # -L dereferences. A symlink pointing outside the repo would pull that
-          # content into the scan; none does today, which is what the list of
-          # flattened links printed below is for.
+          # -L dereferences. A symlink pointing outside the repo would pull
+          # that content into the scan, which is what the list of flattened
+          # links printed below makes visible.
           cp -rL target staging/target
           echo "staged a symlink-free copy of the checkout; flattened: ${links:-none}"
 
-          # --target, not --mount: the PyPI release (strix-agent, pinned
-          # below) doesn't have --mount or --max-budget-usd -- those only
-          # exist in unreleased commits ahead of the 1.0.4 tag. --target
-          # copies the checkout into the sandbox rather than a read-only
-          # bind-mount; no cost cap beyond this job's timeout-minutes.
+          # --target, not --mount: the pinned PyPI release (strix-agent 1.0.4)
+          # has neither --mount nor --max-budget-usd -- both exist only in
+          # unreleased commits. --target copies the tree into the sandbox
+          # instead of bind-mounting it read-only.
           #
-          # Redirected to a file, NEVER printed to this (public) job log --
-          # strix's console output includes full vulnerability detail and
+          # Output goes to a file and is NEVER printed to this (public) job
+          # log: strix's console output carries full vulnerability detail and
           # working PoCs once findings surface.
           #
-          # The exit code is recorded rather than discarded. It used to be
-          # thrown away with `|| true`, which meant a strix that died on
-          # startup was indistinguishable from one that ran for hours and found
-          # nothing -- every scheduled run from 2026-08-15 to 2026-09-05
-          # "succeeded" after ~105 seconds without writing a findings file (the
-          # symlink abort above; the ~105 seconds were the docker image pull).
-          # It is not asserted on here on its own, because a non-zero exit from an
-          # otherwise complete scan should not discard the findings; the check
-          # below combines it with whether a result was actually produced.
+          # `|| rc=$?` keeps the exit code. It is not asserted on by itself --
+          # a non-zero exit from an otherwise complete scan should not discard
+          # the findings -- so the check further down combines it with whether
+          # a result was actually produced.
           #
-          # Run strix under its OWN deadline, comfortably inside the job's
-          # timeout-minutes, so that a scan which does not finish is stopped by
-          # this step rather than by GitHub. The difference matters: when the
-          # job hits timeout-minutes the runner cancels it, every later step is
-          # skipped or runs with the outputs this one never got to write, and
-          # the run directory is destroyed with the runner. That is exactly how
-          # the 2026-09-08 run lost a scan that had already reported 22
-          # findings. Under `timeout` the same overrun is an ordinary exit code:
-          # the guards, the triage and the archive below all still run.
+          # `timeout` gives strix its own deadline, comfortably inside the
+          # job's timeout-minutes, so an overrun is an ordinary exit code and
+          # the guards, the triage and the archive below all still run. Hitting
+          # timeout-minutes instead means GitHub cancels the job: later steps
+          # are skipped or read outputs this step never wrote, and the run
+          # directory is destroyed with the runner.
           #
           # -s INT rather than the default TERM: SIGINT is the signal an
-          # interactive strix already handles, so it gets the chance to flush
-          # its run directory. -k gives it two minutes to do that before SIGKILL.
-          # 124 = killed at the deadline, 130 = exited on the SIGINT itself;
-          # both mean "ran out of time", which is a partial scan, not a failure.
+          # interactive strix already handles, so it gets a chance to flush its
+          # run directory, and -k gives it two minutes before SIGKILL. 124
+          # (killed at the deadline) and 130 (exited on the SIGINT) both mean a
+          # partial scan, not a failure.
           budget="${{ inputs.scan_budget_minutes || '300' }}"
           case "$budget" in
             ''|*[!0-9]*) echo "::error::scan_budget_minutes must be a whole number of minutes, got '$budget'"; exit 1 ;;
@@ -331,16 +292,13 @@ jobs:
           fi
           echo "partial=$partial" >> "$GITHUB_OUTPUT"
 
-          # strix_runs/ lands relative to strix's OWN invocation cwd (this
-          # job's default workspace root), as a sibling of target/ and
-          # staging/ -- NOT nested inside the scanned tree, regardless of
-          # --target vs. --mount. Confirmed against a real run's own reported
-          # Output path: .../oh-my-agentic-coder/strix_runs/target_<id>.
+          # strix_runs/ lands relative to strix's own cwd (this job's
+          # workspace root), as a sibling of target/ and staging/, not inside
+          # the scanned tree.
           #
-          # nullglob + array, not `ls glob | head`: under bash -e + pipefail
-          # (this shell's default), a non-matching glob inside `$(...)`
-          # aborts the script with ls's own exit code, skipping the
-          # friendly ::error:: below entirely.
+          # nullglob + array, not `ls glob | head`: the step's shell is
+          # `bash -e`, so a non-matching glob inside `$(...)` aborts the script
+          # with ls's own exit code, skipping the friendly ::error:: below.
           shopt -s nullglob
           run_dirs=(strix_runs/*/)
           shopt -u nullglob
@@ -350,34 +308,30 @@ jobs:
           fi
           echo "run_dir=${run_dirs[-1]}" >> "$GITHUB_OUTPUT"
 
-          # The proxy in front should keep every request under the model window.
-          # If it ever fails to, the scan overflows and every subsequent request
-          # 422s with context_length_exceeded -- but a partial run dir still
-          # exists, so WITHOUT this guard the truncated scan would be reported as
-          # successful and triaged as if complete. Fail loudly instead. grep -q:
-          # never print the log, it can contain scan content on this public
-          # runner (the full log is in the private artifact repo).
+          # The proxy should keep every request under the model window. If it
+          # ever fails to, the scan overflows and leaves a partial run
+          # directory that would otherwise be triaged as a complete scan, so
+          # fail loudly. grep -q because the log is never printed here -- it
+          # can contain scan content.
           if grep -q "context_length_exceeded" strix_scan.log; then
             echo "::error::strix hit context_length_exceeded -- scan truncated despite compaction; inspect proxy.log / strix_scan.log in the private artifact repo. Failing so a partial scan is not reported as complete."
             exit 1
           fi
 
-          # How long the scan ran and how much it wrote. Both are counts, not
-          # content, so they are safe on this public summary -- and they are the
-          # cheapest way to spot a scan that did not really happen: a `deep`
-          # scan of this repo takes hours and writes megabytes, so two minutes
-          # and a few kilobytes means something went wrong even when every
-          # guard above is satisfied. Published here because the log that would
-          # explain it only ever reaches the private archive repo.
+          # Duration and log size are counts, not content, so they are safe on
+          # the public summary -- and they are the cheapest way to spot a scan
+          # that did not really happen: a `deep` scan of this repo takes hours
+          # and writes megabytes, so two minutes and a few kilobytes means
+          # something went wrong even with every guard above satisfied.
           log_bytes=$(wc -c < strix_scan.log)
 
-          # How many findings strix actually reported, counted off the log's own
-          # report banners rather than the findings file. A scan stopped at its
-          # budget often has no vulnerabilities.json -- strix writes that at the
-          # end -- while the log already holds every finding it reported in
-          # full. Publishing the COUNT (a number, not a finding) is what tells a
-          # human whether a partial run is worth reading: "PARTIAL, 22 findings
-          # in the log" is a very different message from "FAILED".
+          # Count findings off the log's own report banners rather than the
+          # findings file: a scan stopped at its budget often has no
+          # vulnerabilities.json, which strix writes at the end, while the log
+          # already holds every finding it reported. The count is a number, not
+          # a finding, and it is what tells a human whether a partial run is
+          # worth reading -- "PARTIAL, 22 findings in the log" says something
+          # very different from "FAILED".
           vuln_count=$(grep -cE '^╭─ VULN-[0-9]+' strix_scan.log || true)
           have_vulns=false
           [ -f "${run_dirs[-1]}vulnerabilities.json" ] && have_vulns=true
@@ -388,17 +342,16 @@ jobs:
           echo "log_bytes=$log_bytes" >> "$GITHUB_OUTPUT"
           echo "strix exited $rc after ${elapsed}s, wrote ${log_bytes} bytes of log, reported ${vuln_count} findings"
 
-          # A non-zero exit AND no findings file means there is no evidence the
-          # scan produced a result at all -- fail, rather than triaging an empty
-          # run as a clean bill of health. A findings-free scan that exits 0 is
-          # still allowed through (#194): that is a real result.
+          # A non-zero exit AND no findings file means there is no evidence
+          # the scan produced a result at all -- fail, rather than triaging an
+          # empty run as a clean bill of health. A findings-free scan that
+          # exits 0 still passes (#194): that is a real result.
           #
-          # A scan stopped at its budget is exempt when it reported findings:
-          # those are a real (incomplete) result, and failing the step here
-          # would be the old bug in a new place -- discarding hours of work
-          # because the last file was never written. It still fails when it
-          # reported nothing at all, which is indistinguishable from a scan that
-          # never got going.
+          # A scan stopped at its budget is exempt when it reported findings in
+          # the log, since those are a real if incomplete result and failing
+          # here would discard hours of work over the one file strix never got
+          # to write. It still fails when it reported nothing at all, which is
+          # indistinguishable from a scan that never got going.
           if [ "$rc" -ne 0 ] && [ "$have_vulns" != true ]; then
             if [ "$partial" = true ] && [ "$vuln_count" -gt 0 ]; then
               echo "::notice title=Partial scan kept::stopped at its budget with no vulnerabilities.json, but ${vuln_count} findings are in the log -- archiving as PARTIAL rather than discarding them."
@@ -409,10 +362,9 @@ jobs:
           fi
 
       - name: Dedupe against open issues + build triage report
-        # Gated on a findings file existing, not on the scan step succeeding.
-        # A scan stopped at its budget still deserves a triage report for what
-        # it did find, and a scan that failed a completeness guard may have
-        # written one too.
+        # Gated on a findings file existing, not on the scan step succeeding:
+        # a scan stopped at its budget, or one that failed a completeness
+        # guard, may still have written one.
         if: always() && steps.scan.outputs.have_vulns == 'true'
         env:
           STRIX_LLM: ${{ steps.model.outputs.strix_llm }}
@@ -424,9 +376,9 @@ jobs:
             --summary-out step-summary.md
 
       - name: Public summary (counts only, no exploit detail)
-        # Runs whenever the scan step got far enough to publish its numbers, so
-        # a partial or failed run says so here instead of leaving a blank
-        # summary for someone to interpret from a red X.
+        # Runs whenever the scan step got far enough to publish its numbers,
+        # so a partial or failed run says so here instead of leaving a blank
+        # summary behind a red X.
         if: always() && steps.scan.outputs.exit_code != ''
         run: |
           if [ -f step-summary.md ]; then
@@ -454,15 +406,14 @@ jobs:
         run: kill "$(cat proxy.pid)" 2>/dev/null || true
 
       - name: Push full report to private artifact repo
-        # Runs even when the scan step failed: strix_scan.log is the only
-        # way to debug a startup failure, and it must never be printed to
-        # this (public) job log -- the private repo is the one place it's
-        # safe to look, whether or not the scan actually produced findings.
+        # Runs even when the scan step failed: strix_scan.log is the only way
+        # to debug a startup failure, and it must never be printed to this
+        # (public) job log, so the private repo is the one place it is safe to
+        # look.
         #
-        # Skipped only when the preflight itself failed. There is nothing to
-        # push in that case -- the scan never started -- and attempting it would
-        # stack a second, misleading error on top of the one that already said
-        # exactly what to fix.
+        # Skipped only when the preflight itself failed: nothing was scanned,
+        # and pushing anyway would stack a second, misleading error on the one
+        # that already said exactly what to fix.
         if: always() && steps.archive.outcome == 'success'
         env:
           SECURITY_SCAN_PAT: ${{ secrets.SECURITY_SCAN_PAT }}
@@ -475,10 +426,10 @@ jobs:
             echo "## Security scan: report push SKIPPED (SECURITY_ARCHIVE_REPO unset)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          # The preflight at the top of the job already established that this
-          # credential can write the archive repo, so anything failing here is
-          # something else -- a protected default branch, a mid-run token
-          # revocation. Name that, instead of leaving a bare "exit code 128"
+          # The preflight at the top of the job established that this
+          # credential can write the archive repo, so a failure here is
+          # something else -- a protected default branch, a token revoked
+          # mid-run. Name that, instead of leaving a bare "exit code 128"
           # against a redacted URL for someone to guess at.
           archive_failed() {
             echo "::error title=Report archiving failed::The scan itself is not what failed here -- pushing its report to the private archive repo did, after the preflight had confirmed write access. Check the archive repo for a protected default branch, or a token revoked mid-run. The report for this run was NOT stored."
@@ -494,24 +445,20 @@ jobs:
           else
             status=FAILED
           fi
-          # Fall back to a timestamp: run_label is written at the very top of
-          # the scan step, so it survives almost anything, but an unnamed
-          # directory is still better than a path beginning "-manual-FAILED".
+          # run_label is written at the very top of the scan step, so it
+          # survives almost anything; the timestamp fallback keeps a path from
+          # beginning "-manual-FAILED".
           run_label="${{ steps.scan.outputs.run_label }}"
           scan_dir="$dest/scans/${run_label:-$(date -u +%Y%m%d-%H%M%S)}-${{ inputs.reason || 'scheduled' }}-${status}"
           mkdir -p "$scan_dir"
 
-          # Find the run directory on disk rather than trusting the scan step's
-          # output for it.
-          #
-          # This is the fix for the 2026-09-08 loss. run_dir is written to
-          # $GITHUB_OUTPUT only AFTER strix returns, so every way the scan step
-          # can end early -- job timeout, cancellation, a guard's exit 1, the
-          # runner going away -- leaves it empty, and this step then silently
-          # copied nothing while reporting success. The directory was there the
-          # whole time. Anything this step can rediscover for itself, it should:
-          # it is the last thing standing between hours of scanning and an empty
-          # commit.
+          # Find the run directory on disk rather than trusting the scan
+          # step's output for it: run_dir reaches $GITHUB_OUTPUT only AFTER
+          # strix returns, so every way that step can end early -- a guard's
+          # exit 1, a cancellation, the runner going away -- leaves it empty
+          # while the directory itself is sitting right there. This step is the
+          # last thing between hours of scanning and an empty commit, so
+          # anything it can rediscover for itself, it should.
           run_dir="${{ steps.scan.outputs.run_dir }}"
           if [ -z "$run_dir" ] || [ ! -d "$run_dir" ]; then
             shopt -s nullglob
@@ -530,16 +477,16 @@ jobs:
           [ -f triage-report.md ] && cp triage-report.md "$scan_dir"/
           [ -f strix_scan.log ] && cp strix_scan.log "$scan_dir"/
           # proxy.log holds the compaction telemetry (which requests were
-          # compacted, before/after token estimates) -- useful for debugging an
-          # overflow that slipped past compaction. Safe: it logs counts, not
-          # message content.
+          # compacted, token estimates before and after), which is what
+          # explains an overflow that slipped past compaction. Safe to archive:
+          # counts, not message content.
           [ -f proxy.log ] && cp proxy.log "$scan_dir"/
           cd "$dest"
           git config user.name "strix-ci-bot"
           git config user.email "actions@users.noreply.github.com"
           git add .
-          # Nothing staged means nothing ran -- don't let `git commit`'s "nothing
-          # to commit" exit code surface as an archiving failure.
+          # Nothing staged means nothing ran -- don't let `git commit`'s
+          # "nothing to commit" exit code surface as an archiving failure.
           if git diff --cached --quiet; then
             echo "::warning::nothing to archive for this run"
             exit 0


### PR DESCRIPTION
**Issue:** Refs #281

## What

- Probe the archive credential in the first ten seconds of the job instead of discovering it is read-only three hours later, and name the permission to grant.
- Keep strix's exit code instead of discarding it with `|| true`, so a scan that dies on startup can no longer pass as a clean one.
- Put the scan's exit code, duration and log size on the public step summary.
- Pin the scan's **own** model, at `zai-org/GLM-5.3` — it had none, and used a different one on a scheduled run than on a manual one.
- Stop the job timeout from **destroying** a scan's results: strix gets its own budget, and the archive rediscovers the run directory instead of trusting a step output the failure path never writes.
- Scan a symlink-free copy of the checkout — `strix --target` refuses any tree containing a symlink, which is why the scan has never actually run. See the comment thread for the root cause.

Does **not** fix the token itself — that is a secret change outside this repo. See Follow-up.

## Why

Every scheduled run since the workflow was added has failed, for two reasons the job reported as one opaque exit code:

| Run | Date | Scan duration | Result |
|---|---|---|---|
| [31873510508](https://github.com/TNG/oh-my-agentic-coder/actions/runs/31873510508) | 2026-08-15 | 105s | failure |
| [32561281623](https://github.com/TNG/oh-my-agentic-coder/actions/runs/32561281623) | 2026-08-22 | 109s | failure |
| [33242172274](https://github.com/TNG/oh-my-agentic-coder/actions/runs/33242172274) | 2026-08-29 | 103s | failure |
| [33954142544](https://github.com/TNG/oh-my-agentic-coder/actions/runs/33954142544) | 2026-09-05 | 111s | failure |

**The red X** is the archive push. `SECURITY_SCAN_PAT` can read the private archive repo but not write it:

```
remote: Write access to repository not granted.
fatal: unable to access 'https://github.com/***.git/': The requested URL returned error: 403
##[error]Process completed with exit code 128.
```

**Underneath it**, the scan never ran. A `--scan-mode deep` pentest finishing in ~105 seconds with no `vulnerabilities.json` is not a findings-free scan. It passed anyway because `|| true` threw away the exit code, and the two completeness guards — a run directory exists, the log has no `context_length_exceeded` — are both satisfied by a process that died on startup.

So fixing the token on its own would have turned the job **green while it scanned nothing**, which is worse than the red X. Both had to move together.

The log that would explain the short scan is deliberately never printed publicly, and its only other destination is the archive repo the push fails on — so it has never been written anywhere. Breaking that circularity is the point of the preflight.

## How

- **`Preflight archive credential`** (new step, after checkout): asks for the `git-receive-pack` ref advertisement. GitHub authorizes that advertisement, so it is a read-only probe of *write* access — 200 writable, 403 read-only, 401 expired, 404 invisible. `git ls-remote` cannot tell those apart; it only ever exercises upload-pack. The token goes in `curl -u`, not the URL, so it stays out of anything curl prints.
- **`Run strix scan`**: `|| true` → `|| rc=$?`, plus `$SECONDS` around the call. Fails when strix exited non-zero **and** wrote no findings file — no evidence of a result at all. A findings-free scan that exits 0 still passes, preserving #194.
- **`Push full report`**: gated on the preflight having passed, so a bad token yields one actionable error rather than two, and `git commit`'s nothing-to-commit is no longer reported as an archiving failure. An `ERR` trap explains a push that fails *after* the preflight said it would not (protected branch, mid-run revocation).
- Disclosure model unchanged: exit code, duration and log byte count are numbers about the run, not about what it found. The header comment says so explicitly.

## Added: the scan now pins its own model, at GLM 5.3

Folded in here rather than onto a branch of its own: it is a second concern, but it edits the same file and a parallel branch would only conflict.

The scan had **no model of its own**, and ran a different one depending on how it started:

| Trigger | `E2E_MODEL` | Model actually used |
|---|---|---|
| schedule (weekly) | empty | `zai-org/GLM-5.2` — opencode's *harness* pin in `internal/e2e/versions.go` |
| workflow_dispatch | input default | `deepseek-ai/DeepSeek-V4-Flash` — the head of the **fallback** chain |

So the weekly scan silently tracked whatever the harness matrix happened to be tested against, and a manual scan was not comparable to it. Both now resolve to `zai-org/GLM-5.3`, which the gateway advertises.

`internal/e2e/versions.go` is deliberately **not** touched, so no e2e leg changes model. Resolution is otherwise unchanged: `E2E_MODEL_OPENCODE` still wins, the `-TEE` variant flip and the fallback chain still apply, and a value typed into the dispatch form still overrides the pin for that run. The triage step follows the same model via `STRIX_LLM`, so it moves too.

```
$ E2E_MODEL='zai-org/GLM-5.3' scripts/resolve-model.sh opencode
zai-org/GLM-5.3
$ E2E_MODEL='zai-org/GLM-5.3' scripts/probe-model.sh opencode      # no gateway creds -> passthrough
probe-model: no gateway base URL / token on the env - using 'zai-org/GLM-5.3' unprobed
zai-org/GLM-5.3
$ env -u E2E_MODEL scripts/resolve-model.sh opencode               # harness pin untouched
zai-org/GLM-5.2
$ E2E_MODEL='tngtech/DeepSeek-TNG-R1T2-Chimera' scripts/resolve-model.sh opencode
tngtech/DeepSeek-TNG-R1T2-Chimera
$ go test -tags e2e_fast ./internal/e2e/ -run 'Model|Version|Candidate|Fallback' -count=1
ok      github.com/TNG/oh-my-agentic-coder/internal/e2e 0.007s
```

## Added: a scan that runs out of time now keeps what it found

The previous commit got strix past startup, and the first real `deep` run
([34258819205](https://github.com/TNG/oh-my-agentic-coder/actions/runs/34258819205))
answered the open question in Follow-up below: **the 180-minute budget does not
hold.** It also exposed something worse than the overrun.

That run reached **22 findings** and archived **none** of them.

| | |
|---|---|
| Job | `17:43:38Z → 20:44:39Z`, exactly `timeout-minutes: 180`, conclusion `cancelled` |
| Step 8 `Run strix scan` | `cancelled` mid-scan |
| Steps 9–10 triage/summary | `skipped` |
| Step 12 `Push full report` | `success` — and pushed `strix_scan.log` + `proxy.log` **only** |

Two independent causes:

**1. The job's own ceiling ended the scan.** `timeout-minutes: 180` is enforced
by GitHub cancelling the job, which is the worst possible way for a long scan to
end: the step never finishes, every later step is skipped or reads outputs it
never wrote, and the runner is torn down with the run directory still on it.

strix now runs under `timeout -s INT -k 120s "${budget}m"`, sized by a new
`scan_budget_minutes` input (default 300), with `timeout-minutes` raised to 350
— just under the 360-minute hosted-runner ceiling — so the job's ceiling is no
longer the thing that ends a scan. An overrun becomes an ordinary exit code
*inside* the step, and the guards, triage and archive below all still run.
`-s INT` rather than the default `TERM` because SIGINT is the signal an
interactive strix already handles, so it gets a chance to flush; `-k` gives it
two minutes before SIGKILL.

**2. The archive could only find the run directory through a step output.**
`run_dir` is written to `$GITHUB_OUTPUT` *after* strix returns, so every way the
scan step can end early leaves it empty — and `Push full report` then copied
nothing while reporting success. The directory was on disk the whole time. It
now rediscovers `strix_runs/*/` itself and warns that it had to. **That one
change alone would have saved the lost run.**

### Partial is reported as partial, not as failure

A three-hour scan cut off with 22 findings was filed as `-FAILED` next to runs
that died in 105 seconds. Now:

- a third archive status, `PARTIAL`, distinct from `ok` and `FAILED`;
- triage gated on a findings file *existing* rather than on the scan step
  succeeding, so a partial run still gets a triage report;
- the **finding count** parsed off the log's own `╭─ VULN-NNNN` banners. strix
  writes `vulnerabilities.json` only at the end, but the log carries every
  finding it reported in full — that count is the one thing that separates
  "PARTIAL, 22 findings to read" from "achieved nothing". It is a number about
  the run, not a finding, so it is safe on the public summary; the header
  comment says so.

A budget stop that found *nothing* still fails, exactly as before — that is
indistinguishable from a scan that never got going, which is the regression the
first commit exists to prevent.

### Verification

`run:` blocks all parse (`bash -n`, `scripts/check-workflow-shell.py`: *8
workflow file(s): all run blocks are valid bash*). The scan guards and the
archive step were extracted and driven against stubs under
`bash --noprofile --norc -e -o pipefail` — GitHub's own shell flags, which the
earlier round of stub testing did not use:

```
case=overrun budget=2s   rc=0  partial=true   exit=124  vulns=3  have=false
       ::notice title=Partial scan kept
       ::warning title=Scan stopped at its budget
case=quiet   budget=2s   rc=1  partial=true   exit=124  vulns=0  have=false
       ::error::strix exited 124 ... and wrote no vulnerabilities.json
case=clean   budget=5s   rc=0  partial=false  exit=0    vulns=1  have=true
case=crash   budget=5s   rc=1  partial=false  exit=3    vulns=0  have=false
case=clean   budget=5x   rc=1  ::error::scan_budget_minutes must be a whole number
```

Archive step, with a stub `git`/`mktemp` and a run directory on disk:

```
outcome=cancelled  run_dir output=''   -> ::warning title=Recovered the run directory
                                          20260908-174410-manual-FAILED/
                                          {run.json,vulnerabilities.json,strix_scan.log,proxy.log}
outcome=success    partial=false       -> 20260909-120000-manual-ok
outcome=success    partial=true        -> 20260909-130000-manual-PARTIAL
outcome=cancelled  run_label=''        -> falls back to a timestamp
```

The first line is the 2026-09-08 shape: same inputs, results kept instead of
discarded.

## Verification

`strix` and the archive repo cannot be reached from a dev machine, so each `run:` block was extracted from the YAML and driven against stubs.

**YAML and shell parse** — every `run:` block, GHA expressions stubbed:

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/security-scan.yml'))"   # ok
$ bash -n <each run: block>
OK Preflight archive credential / Install strix / Start context-compaction proxy
OK Resolve and verify model / Run strix scan / Dedupe against open issues
OK Public summary / Stop context-compaction proxy / Push full report
```

**Preflight**, against a stub `curl` returning each status:

```
[200] rc=0 :: archive repo is writable
[403] rc=1 :: ::error title=Archive repo is read-only::...Grant the token Contents: read and write...
[401] rc=1 :: ::error title=Archive credential rejected::...expired or malformed...
[404] rc=1 :: ::error title=Archive repo not reachable::...
[000] rc=1 :: ::error title=Archive preflight inconclusive::...
[unset] rc=0 :: ::warning::SECURITY_ARCHIVE_REPO or SECURITY_SCAN_PAT secret missing
```

**Scan guards**, against a stub `strix` (this is the regression that mattered — case 1 is today's green no-op, case 2 is what it should have been):

```
1. exit 0, run dir, no findings   -> rc=0  PASS   (findings-free run, #194)
2. exit 1, run dir, no findings   -> rc=1  FAIL   ::error::strix exited 1 after 0s and wrote no vulnerabilities.json
3. exit 1, run dir, WITH findings -> rc=0  PASS   (findings not discarded over a non-zero exit)
4. exit 0, no run dir             -> rc=1  FAIL   ::error::strix produced no run directory
5. context_length_exceeded in log -> rc=1  FAIL   ::error::strix hit context_length_exceeded
```

Cases 4 and 5 are the pre-existing guards, confirmed still firing.

**Push step**, against a local bare repo standing in for the archive:

```
a. happy path            -> rc=0, archived: scans/20260908-120000-scheduled-ok/{agent.log,strix_scan.log,triage-report.md}
b. push refused (chmod)  -> rc=1, ::error title=Report archiving failed::The scan itself is not what failed here...
c. nothing staged        -> rc=0, ::warning::nothing to archive for this run
```

Also confirmed that bash's `ERR` trap keeps `set -e`'s exemption for the `[ -f x ] && cp` idiom the step already used, so the trap does not misfire on an absent `triage-report.md` or `proxy.log`.

## Follow-up

- `SECURITY_SCAN_PAT` **has been rotated and works** — the preflight passed and `strix_scan.log` reached the archive repo, which is how the root cause below was found.
- `.github/workflows/e2e-smoke.yml:1166` uses the same secret; its `Record & report` job fails the same way ([33954821483](https://github.com/TNG/oh-my-agentic-coder/actions/runs/33954821483)) and is fixed by the same token change.
- ~~Why strix dies after ~105 seconds is still unknown~~ **Answered and fixed in this PR** — `strix --target` aborts on the repo's `CLAUDE.md -> AGENTS.md` symlink, added two days after this workflow, so the scan has never once run. Root cause and verification in the comment thread.
- ~~Still unknown: whether the 180-minute budget and the compaction proxy hold up under a full scan~~ **The budget did not** — run [34258819205](https://github.com/TNG/oh-my-agentic-coder/actions/runs/34258819205) was cancelled at exactly 3h with 22 findings reported; addressed above. The compaction proxy held: no `context_length_exceeded` in that run's log.
- Still unknown: whether a scan reaches the end inside the new 300-minute budget, and what a *complete* run reports. The 22 findings from the cut-off run have been verified separately (19 stand, 2 rejected as by-design, 1 disputed) in the private archive repo.
- #281 could not be self-assigned — the sidecar exposes no assignee route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
