### PR TITLE
docs: improve kernel upgrade error message for WSL

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -47,7 +47,7 @@ sudo dnf install bubblewrap zenity libnotify libsecret
 
 ### WSL2 (Ubuntu)
 
-Update your WSL2 if you encounter kernel problems from a Windows PowerShell via `wsl --update` (create a backup before).
+Update your WSL2 if you encounter kernel problems (omac needs Landlock ABI >= 4, i.e. a Linux kernel 6.7 or newer, for kernel-enforced network filtering) from a Windows PowerShell via `wsl --update` (create a backup before).
 Afterward, you should run `sudo apt-get update && sudo apt-get upgrade -y` from your WSL terminal.
 
 WSL2 does not run a keychain daemon by default, so the secret storage setup needs extra steps compared to native Linux.

--- a/internal/sandboxrun/doctor_linux.go
+++ b/internal/sandboxrun/doctor_linux.go
@@ -5,6 +5,7 @@ package sandboxrun
 import (
 	"fmt"
 
+	"github.com/TNG/oh-my-agentic-coder/internal/osinfo"
 	"github.com/TNG/oh-my-agentic-coder/internal/sandboxprofile"
 )
 
@@ -28,9 +29,17 @@ func DoctorNotes() []string {
 			"[warn] Landlock ABI %d (%s): network enforcement needs ABI %d (Linux >= 6.7,"+
 				" e.g. Ubuntu 24.04 LTS, Fedora 40+); omac start will fail with the default profile.",
 			abi, kernelVersionString(), landlockNetABI),
-		"       Fix A: upgrade to a kernel >= 6.7.",
+		landlockFixA(osinfo.Detect()),
 		"       Fix B: set enforcement to env-only in ~/.config/omac/sandbox-profiles/default.json:",
 		`         {"network": {"enforcement": "env-only"}}`,
 		"       (env-only: filtering via the omac proxy, not the kernel — advisory only)",
 	}
+}
+
+func landlockFixA(host osinfo.OS) string {
+	if host == osinfo.WSL {
+		return "       Fix A: run `wsl --update` from Windows PowerShell to get a newer WSL kernel (>= 6.7),\n" +
+			"       then restart your WSL session."
+	}
+	return "       Fix A: upgrade to a kernel >= 6.7."
 }

--- a/internal/sandboxrun/doctor_linux_test.go
+++ b/internal/sandboxrun/doctor_linux_test.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package sandboxrun
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TNG/oh-my-agentic-coder/internal/osinfo"
+)
+
+func TestLandlockFixA(t *testing.T) {
+	if got := landlockFixA(osinfo.WSL); !strings.Contains(got, "wsl --update") {
+		t.Errorf("WSL fix A = %q, want it to mention `wsl --update`", got)
+	}
+	if got := landlockFixA(osinfo.Linux); strings.Contains(got, "wsl") {
+		t.Errorf("Linux fix A = %q, should not be WSL-specific", got)
+	}
+}


### PR DESCRIPTION
<!--
Keep this PR **concise**. See ../COLLABORATION.md for the full spec.
Conventional-Commit title with scope, e.g. fix(sandbox): protect docker.sock by default.
Resolve review comments as you address them (reply required only if you deviated).
-->

**Issue:** Closes #264 <!-- REQUIRED: no PR without an issue. Use Closes/Refs #NN. -->

## What
<!-- 1-4 bullets. Summarize the change at a glance — do NOT restate
     what is clearly readable in the diff. -->
- Improve error message on kernel problems for WSL.

## Why
<!-- Motivation — failing CI run, security gap, related issue -->
- Previous message only instructs to update, which would hint towards apt update instead of a wsl update.

## How
<!-- Implementation approach, per bullet with code refs if useful -->
- Make error message os-dependent.
- Add note to docs on the landlock error message.

## Verification
<!-- Commands run (go build / go test / ...) with pass status.
     No claim of "done" without this. -->
- `gofmt -l internal/sandboxrun/ && go vet ./internal/sandboxrun/ && go test ./internal/sandboxrun/ -run TestLandlockFixA -v`
-> no files reformatted, vet clean, `--- PASS: TestLandlockFixA`

## Follow-up
<!-- Optional next steps or linked issues -->
None.