### PR TITLE
fix(cli): harness-key autoRegister entries to prevent cross-harness c…

### DIFF
--- a/internal/cli/autoregister_multiharness_test.go
+++ b/internal/cli/autoregister_multiharness_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/TNG/oh-my-agentic-coder/internal/registry"
+	"github.com/TNG/oh-my-agentic-coder/internal/skillsource"
+)
+
+func seedHarnessKeyedEntry(t *testing.T, workdir, name, skillDir, bundle string) {
+	t.Helper()
+	if err := registry.WithLock(workdir, func() error {
+		reg, err := registry.Load(workdir)
+		if err != nil {
+			return err
+		}
+		reg.Upsert(registry.Entry{
+			Name:         name,
+			Harness:      "opencode",
+			SkillDir:     skillDir,
+			BundleHash:   bundle,
+			RegisteredAt: time.Now().UTC(),
+		})
+		return registry.Save(workdir, reg)
+	}); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+}
+
+func assertUnclobbered(t *testing.T, workdir, bundle string) {
+	t.Helper()
+	reg, err := registry.Load(workdir)
+	if err != nil {
+		t.Fatalf("registry.Load: %v", err)
+	}
+	oc, _ := reg.FindForHarness("slack", "opencode")
+	if oc == nil {
+		t.Fatal("opencode-keyed entry was clobbered by autoRegister")
+	}
+	if oc.SkillDir != ".opencode/skills/slack" {
+		t.Errorf("opencode entry SkillDir = %q, want .opencode/skills/slack", oc.SkillDir)
+	}
+	if oc.BundleHash != bundle {
+		t.Errorf("opencode entry BundleHash = %q, want %q", oc.BundleHash, bundle)
+	}
+}
+
+func stageMultiHarnessSlack(t *testing.T, workdir string) (sharedDir, ocBundle string) {
+	t.Helper()
+	stageHarnessSkillBody(t, workdir, "opencode", "slack", "# opencode copy\n")
+	stageHarnessSkillBody(t, workdir, "agents", "slack", "# shared copy, different bytes\n")
+	return filepath.Join(workdir, ".agents", "skills", "slack"),
+		bundleHashOf(t, filepath.Join(workdir, ".opencode", "skills", "slack"))
+}
+
+// Bypasses the name-only guard on purpose: the guard reads the registry
+// outside the lock, so a concurrent register can put a harness-keyed
+// entry of the same name in place before autoRegister's Upsert runs.
+func TestServeAutoRegisterDoesNotClobberHarnessKeyedEntry(t *testing.T) {
+	isolateHome(t)
+	wd := t.TempDir()
+	sharedDir, ocBundle := stageMultiHarnessSlack(t, wd)
+	seedHarnessKeyedEntry(t, wd, "slack", ".opencode/skills/slack", ocBundle)
+
+	s := &serveServer{harness: claudeHarness(t)}
+	ne, err := s.autoRegister(wd, skillsource.Entry{Name: "slack", Dir: sharedDir, Kind: "workdir"})
+	if err != nil {
+		t.Fatalf("autoRegister: %v", err)
+	}
+	if ne == nil || ne.Harness != "claude-code" {
+		t.Errorf("autoRegister returned entry %v, want a claude-code-keyed entry", ne)
+	}
+	assertUnclobbered(t, wd, ocBundle)
+}
+
+func TestStartAutoRegisterOneDoesNotClobberHarnessKeyedEntry(t *testing.T) {
+	isolateHome(t)
+	wd := t.TempDir()
+	sharedDir, ocBundle := stageMultiHarnessSlack(t, wd)
+	seedHarnessKeyedEntry(t, wd, "slack", ".opencode/skills/slack", ocBundle)
+
+	ne, err := startAutoRegisterOne(wd, claudeHarness(t), skillsource.Entry{Name: "slack", Dir: sharedDir, Kind: "workdir"})
+	if err != nil {
+		t.Fatalf("startAutoRegisterOne: %v", err)
+	}
+	if ne == nil || ne.Harness != "claude-code" {
+		t.Errorf("startAutoRegisterOne returned entry %v, want a claude-code-keyed entry", ne)
+	}
+	assertUnclobbered(t, wd, ocBundle)
+}
+
+// Pins the name-only guard: an entry under ANY harness key counts as
+// registered. Switching the guard to FindForHarness must stay
+// consistent with the harness-keyed Upserts.
+func TestStartAutoRegisterGuardSkipsCrossHarnessNames(t *testing.T) {
+	isolateHome(t)
+	wd := t.TempDir()
+	_, _ = stageMultiHarnessSlack(t, wd)
+
+	reg := &registry.Registry{Registered: []registry.Entry{{
+		Name:       "slack",
+		Harness:    "opencode",
+		SkillDir:   ".opencode/skills/slack",
+		BundleHash: "stale",
+	}}}
+	done, errs := runAutoRegisterWorkdirSkills(t, makeEnv(wd), claudeHarness(t), reg, false)
+	if len(errs) > 0 {
+		t.Fatalf("startAutoRegisterWorkdirSkills diagnostics: %v", errs)
+	}
+	for _, name := range done {
+		if name == "slack" {
+			t.Error("slack was re-registered although an opencode-keyed entry exists")
+		}
+	}
+	if cc, _ := reg.FindForHarness("slack", "claude-code"); cc != nil {
+		t.Error("guard registered a claude-code entry for an already-registered name")
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1429,8 +1429,11 @@ func (s *serveServer) autoRegister(absDir string, ent skillsource.Entry) (*regis
 		if rel, rerr := filepath.Rel(absDir, ent.Dir); rerr == nil {
 			stored = rel
 		}
+		// Harness-keyed: a legacy (Harness "") Upsert keys by name only
+		// and would clobber another harness's entry of the same name.
 		reg.Upsert(registry.Entry{
 			Name:                ent.Name,
+			Harness:             s.harness.Name,
 			SkillDir:            stored,
 			BundleHash:          bundle,
 			RegisteredAt:        time.Now().UTC(),
@@ -1439,7 +1442,7 @@ func (s *serveServer) autoRegister(absDir string, ent skillsource.Entry) (*regis
 		if err := registry.Save(absDir, reg); err != nil {
 			return err
 		}
-		e, _ := reg.Find(ent.Name)
+		e, _ := reg.FindForHarness(ent.Name, s.harness.Name)
 		out = e
 		return nil
 	})

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -1274,7 +1274,7 @@ func startAutoRegisterWorkdirSkills(env *Env, harness config.Harness, reg *regis
 			// the findUnregisteredSkills gate below still surfaces it.
 			continue
 		}
-		if _, err := startAutoRegisterOne(env.Workdir, ent); err != nil {
+		if _, err := startAutoRegisterOne(env.Workdir, harness, ent); err != nil {
 			errs = append(errs, fmt.Sprintf("%s: %v", ent.Name, err))
 			continue
 		}
@@ -1351,7 +1351,7 @@ func secretRequired(m *config.Meta, name string) bool {
 
 // startAutoRegisterOne writes a registry entry for a discovered
 // workdir-local skill without prompting, mirroring serve.go's autoRegister.
-func startAutoRegisterOne(workdir string, ent skillsource.Entry) (*registry.Entry, error) {
+func startAutoRegisterOne(workdir string, harness config.Harness, ent skillsource.Entry) (*registry.Entry, error) {
 	bundle, err := config.BundleHash(ent.Dir)
 	if err != nil {
 		return nil, err
@@ -1374,8 +1374,11 @@ func startAutoRegisterOne(workdir string, ent skillsource.Entry) (*registry.Entr
 		if rel, rerr := filepath.Rel(workdir, ent.Dir); rerr == nil {
 			stored = rel
 		}
+		// Harness-keyed: a legacy (Harness "") Upsert keys by name only
+		// and would clobber another harness's entry of the same name.
 		reg.Upsert(registry.Entry{
 			Name:                ent.Name,
+			Harness:             harness.Name,
 			SkillDir:            stored,
 			BundleHash:          bundle,
 			RegisteredAt:        time.Now().UTC(),
@@ -1384,7 +1387,7 @@ func startAutoRegisterOne(workdir string, ent skillsource.Entry) (*registry.Entr
 		if err := registry.Save(workdir, reg); err != nil {
 			return err
 		}
-		e, _ := reg.Find(ent.Name)
+		e, _ := reg.FindForHarness(ent.Name, harness.Name)
 		out = e
 		return nil
 	})


### PR DESCRIPTION
<!--
Keep this PR **concise**. See ../COLLABORATION.md for the full spec.
Conventional-Commit title with scope, e.g. fix(sandbox): protect docker.sock by default.
Resolve review comments as you address them (reply required only if you deviated).
-->

**Issue:** Closes #69 <!-- REQUIRED: no PR without an issue. Use Closes/Refs #NN. -->

## What
<!-- 1-4 bullets. Summarize the change at a glance — do NOT restate
     what is clearly readable in the diff. -->
- `serve`'s autoRegister and `start`'s `startAutoRegisterOne` now write harness-keyed registry entries (`Harness: <active harness>.Name`) instead of legacy (`Harness: ""`) ones.
- Regression tests pin that auto-registering never clobbers another harness's entry of the same name, and that the name-only "already registered" guard keeps skipping cross-harness names.

## Why
<!-- Motivation — failing CI run, security gap, related issue -->
An auto-register `Upsert` with an empty `Harness` hits `registry.Upsert`'s name-only legacy path ([internal/registry/registry.go:245](https://github.com/TNG/oh-my-agentic-coder/blob/fix/autoregister-harness-key/internal/registry/registry.go#L245)) and overwrites a same-name entry keyed to a *different* harness — e.g. one written by `omac register slack --harness opencode`. The name-only guards usually prevent this, but they read the registry outside the lock, so a concurrent `omac register` can slip an entry in before the `Upsert` runs. Raised on #58 .

## How
<!-- Implementation approach, per bullet with code refs if useful -->
- [internal/cli/serve.go:1432](https://github.com/TNG/oh-my-agentic-coder/blob/fix/autoregister-harness-key/internal/cli/serve.go#L1432) `autoRegister`: set `Harness: s.harness.Name` on the Upsert entry; the post-Upsert lookup uses `FindForHarness` so it returns the entry just written, not another harness's.
- [internal/cli/start.go:1354](https://github.com/TNG/oh-my-agentic-coder/blob/fix/autoregister-harness-key/internal/cli/start.go#L1354) `startAutoRegisterOne`: same change; gained a `harness` param from its only caller.
- Deliberately unchanged: the guards, `registry.Upsert` semantics (`omac register`'s "skill moved to the shared base" upgrade depends on the name-only legacy path), and `skillsource`.

## Verification
<!-- Commands run (go build / go test / ...) with pass status.
     No claim of "done" without this. -->
- `go build ./...` — pass.
- `go vet ./internal/cli/` — pass.
- `go test ./internal/cli/ -run 'ClobberHarnessKeyed' -count=1 -v` — new tests fail on the pre-fix code, pass after.
- `go test ./internal/registry/ ./internal/cli/ -count=1` — pass.

## Follow-up
<!-- Optional next steps or linked issues -->
None